### PR TITLE
[Enhancement] Add JSONSchema type validation middleware

### DIFF
--- a/loom/core/agent/subagent.py
+++ b/loom/core/agent/subagent.py
@@ -73,6 +73,7 @@ async def run_subagent(
         MiddlewarePipeline, TraceMiddleware, BlastRadiusMiddleware,
         ToolCall, ToolResult,
     )
+    from loom.core.harness.validation import SchemaValidationMiddleware
     from loom.core.harness.permissions import PermissionContext, TrustLevel
     from loom.core.memory.episodic import EpisodicEntry
     from loom.core.memory.semantic import SemanticEntry
@@ -157,6 +158,7 @@ async def run_subagent(
 
     pipeline = MiddlewarePipeline([
         TraceMiddleware(on_trace=on_trace),
+        SchemaValidationMiddleware(registry=child_registry),
         BlastRadiusMiddleware(perm_ctx=perm, confirm_fn=auto_confirm),
     ])
 

--- a/loom/core/harness/__init__.py
+++ b/loom/core/harness/__init__.py
@@ -1,9 +1,11 @@
 from .middleware import Middleware, MiddlewarePipeline, ToolCall, ToolResult
 from .permissions import TrustLevel, PermissionContext
 from .registry import ToolDefinition, ToolRegistry
+from .validation import SchemaValidationMiddleware
 
 __all__ = [
     "Middleware", "MiddlewarePipeline", "ToolCall", "ToolResult",
     "TrustLevel", "PermissionContext",
     "ToolDefinition", "ToolRegistry",
+    "SchemaValidationMiddleware",
 ]

--- a/loom/core/harness/validation.py
+++ b/loom/core/harness/validation.py
@@ -1,0 +1,84 @@
+"""
+Middleware for runtime validation of Tool arguments against their JSON Schema.
+"""
+
+from typing import Any
+import jsonschema
+
+from .middleware import Middleware, ToolCall, ToolResult, ToolHandler
+from .registry import ToolRegistry
+
+
+class SchemaValidationMiddleware(Middleware):
+    """
+    Validates tool arguments against the tool's defined JSON schema before execution.
+    If the arguments are structurally incompatible, execution is short-circuited
+    and a validation error is returned to the LLM.
+    """
+
+    def __init__(self, registry: ToolRegistry) -> None:
+        self._registry = registry
+
+    def _coerce_args(self, args: dict[str, Any], schema: dict[str, Any]) -> dict[str, Any]:
+        """Attempt safe type coercions where possible (e.g. string to int)."""
+        properties = schema.get("properties", {})
+        
+        coerced = dict(args)
+        for key, expected_type_def in properties.items():
+            if key not in coerced:
+                continue
+            
+            val = coerced[key]
+            expected_type = expected_type_def.get("type")
+            if not expected_type:
+                # E.g. anything allowed or missing type
+                continue
+                
+            if expected_type == "string" and not isinstance(val, str):
+                coerced[key] = str(val)
+            elif expected_type == "integer" and isinstance(val, str):
+                try:
+                    coerced[key] = int(val)
+                except ValueError:
+                    pass
+            elif expected_type == "number" and isinstance(val, str):
+                try:
+                    coerced[key] = float(val)
+                except ValueError:
+                    pass
+            elif expected_type == "boolean" and isinstance(val, str):
+                lower_val = val.lower()
+                if lower_val in ("true", "1", "yes"):
+                    coerced[key] = True
+                elif lower_val in ("false", "0", "no"):
+                    coerced[key] = False
+            elif expected_type == "array" and not isinstance(val, list):
+                # We do not coerce scalar -> list. They should supply array.
+                pass
+                    
+        return coerced
+
+    async def process(self, call: ToolCall, next: ToolHandler) -> ToolResult:
+        tool_def = self._registry.get(call.tool_name)
+        if tool_def is None:
+            return await next(call)
+            
+        schema = tool_def.input_schema
+        if not schema:
+            return await next(call)
+
+        try:
+            coerced_args = self._coerce_args(call.args, schema)
+            jsonschema.validate(instance=coerced_args, schema=schema)
+            call.args = coerced_args
+        except jsonschema.ValidationError as e:
+            path_str = " -> ".join(str(p) for p in e.path) if e.path else "root"
+            return ToolResult(
+                call_id=call.id,
+                tool_name=call.tool_name,
+                success=False,
+                error=f"Argument type mismatch: {e.message} at path [{path_str}]",
+                failure_type="validation_error",
+            )
+            
+        return await next(call)

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -61,6 +61,7 @@ from loom.core.harness.middleware import (
     ToolResult,
     TraceMiddleware,
 )
+from loom.core.harness.validation import SchemaValidationMiddleware
 from loom.core.harness.permissions import PermissionContext, TrustLevel
 from loom.core.harness.registry import ToolRegistry
 from loom.core.memory.embeddings import build_embedding_provider
@@ -469,6 +470,7 @@ class LoomSession:
         self._pipeline = MiddlewarePipeline(
             [
                 TraceMiddleware(on_trace=self._on_trace),
+                SchemaValidationMiddleware(registry=self.registry),
                 BlastRadiusMiddleware(
                     perm_ctx=self.perm,
                     confirm_fn=self._confirm_tool,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "prompt_toolkit>=3.0",
     "textual>=0.60.0",
     "httpx>=0.27.0",
+    "jsonschema>=4.0.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Resolves #24.

This PR adds `SchemaValidationMiddleware` using `jsonschema` to enforce runtime type matching before executing a tool. This intercepts hallucinated parameters and protects the execution pipelines from unchecked KeyErrors.

### Features:
- Implements safely coerced boolean/integer checks inside `loom.core.harness.validation`.
- Validates incoming `call.args` directly against the tool's defined JSON schema.
- Automatically injected into the Main CLI pipeline and Sub-agent worker pipelines.