### PR TITLE
[Enhancement] Normalize session_log.content: raw_json column + role index

### DIFF
--- a/loom/core/memory/session_log.py
+++ b/loom/core/memory/session_log.py
@@ -51,20 +51,31 @@ class SessionLog:
         role: str,
         content: str,
         metadata: dict[str, Any] | None = None,
+        raw_json: str | None = None,
     ) -> None:
-        """Append one message row.  Swallows all exceptions — never blocks the loop."""
+        """Append one message row.  Swallows all exceptions — never blocks the loop.
+
+        Parameters
+        ----------
+        raw_json:
+            For ``role="assistant"`` messages that contain tool_call blocks, pass the
+            full serialised ``raw_message`` JSON here so it can be stored in the
+            dedicated ``raw_json`` column (rather than the human-readable ``content``).
+            ``load_messages()`` will prefer this column for assistant-message replay.
+        """
         try:
             await self._db.execute(
                 """
                 INSERT INTO session_log
-                    (session_id, turn_index, role, content, metadata, created_at)
-                VALUES (?, ?, ?, ?, ?, ?)
+                    (session_id, turn_index, role, content, raw_json, metadata, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     session_id,
                     turn_index,
                     role,
                     content,
+                    raw_json,
                     json.dumps(metadata or {}, ensure_ascii=False),
                     datetime.now(UTC).isoformat(),
                 ),
@@ -126,8 +137,8 @@ class SessionLog:
         await self._db.execute(
             """
             INSERT INTO session_log
-                (session_id, turn_index, role, content, metadata, created_at)
-            SELECT ?, turn_index, role, content, metadata, created_at
+                (session_id, turn_index, role, content, raw_json, metadata, created_at)
+            SELECT ?, turn_index, role, content, raw_json, metadata, created_at
             FROM session_log
             WHERE session_id = ? AND turn_index <= ?
             """,
@@ -183,10 +194,16 @@ class SessionLog:
 
         System messages are excluded — the system prompt is always rebuilt
         fresh from PromptStack + MemoryIndex on resume.
+
+        Reconstruction priority for each row:
+        1. ``raw_json`` column (non-NULL) — parsed directly; preserves tool_calls.
+        2. ``metadata.format == "raw_message"`` — legacy fallback; ``content`` is
+           the full JSON blob (written before the raw_json column existed).
+        3. Plain text reconstruction (user / tool messages).
         """
         cursor = await self._db.execute(
             """
-            SELECT role, content, metadata
+            SELECT role, content, raw_json, metadata
             FROM session_log
             WHERE session_id = ? AND role != 'system'
             ORDER BY turn_index ASC, id ASC
@@ -195,12 +212,19 @@ class SessionLog:
         )
         rows = await cursor.fetchall()
         result: list[dict[str, Any]] = []
-        for role, content, metadata_raw in rows:
+        for role, content, raw_json, metadata_raw in rows:
             meta: dict[str, Any] = json.loads(metadata_raw)
 
+            # Priority 1: raw_json column (structured, new path)
+            if raw_json:
+                try:
+                    result.append(json.loads(raw_json))
+                    continue
+                except Exception:
+                    pass  # fall through to legacy / plain-text path
+
+            # Priority 2: legacy raw_message stored in content column
             if role == "assistant" and meta.get("format") == "raw_message":
-                # Full raw_message was stored as JSON — parse it back directly so
-                # tool_calls, content lists, etc. are all intact for the API.
                 try:
                     msg = json.loads(content)
                     result.append(msg)
@@ -208,6 +232,7 @@ class SessionLog:
                 except Exception:
                     pass  # fall through to plain text reconstruction
 
+            # Priority 3: plain text
             msg: dict[str, Any] = {"role": role, "content": content}
             # Re-attach tool_call_id for tool messages (required by OpenAI format)
             if role == "tool" and "tool_call_id" in meta:

--- a/loom/core/memory/store.py
+++ b/loom/core/memory/store.py
@@ -104,11 +104,13 @@ CREATE TABLE IF NOT EXISTS session_log (
     turn_index  INTEGER NOT NULL,
     role        TEXT NOT NULL,
     content     TEXT NOT NULL,
+    raw_json    TEXT,             -- tool_use/tool_result blocks preserved as JSON; NULL for plain text
     metadata    TEXT NOT NULL DEFAULT '{}',
     created_at  TEXT NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_session_log_session ON session_log(session_id, turn_index);
+CREATE INDEX IF NOT EXISTS idx_session_log_role    ON session_log(session_id, role);
 CREATE INDEX IF NOT EXISTS idx_sessions_active     ON sessions(last_active DESC);
 """
 
@@ -132,16 +134,29 @@ class SQLiteStore:
         async with aiosqlite.connect(self.path) as db:
             await db.executescript(SCHEMA)
             await db.commit()
-            # Runtime migration: add `embedding` column to existing databases.
+            # Runtime migrations: ALTER TABLE for columns added in later versions.
             # SQLite doesn't support IF NOT EXISTS on ALTER TABLE, so we
-            # attempt the ALTER and silently ignore the "duplicate column" error.
-            try:
-                await db.execute(
-                    "ALTER TABLE semantic_entries ADD COLUMN embedding TEXT"
-                )
-                await db.commit()
-            except Exception:
-                pass  # Column already exists — this is expected on all but the first run
+            # attempt each ALTER and silently ignore "duplicate column" errors.
+            for _migration in [
+                "ALTER TABLE semantic_entries ADD COLUMN embedding TEXT",
+                # Issue #11: add raw_json column to capture tool_use/tool_result
+                # blocks separately from the human-readable content field.
+                "ALTER TABLE session_log ADD COLUMN raw_json TEXT",
+            ]:
+                try:
+                    await db.execute(_migration)
+                    await db.commit()
+                except Exception:
+                    pass  # Column already exists — expected on all but the first run
+            # Ensure new indexes exist even on pre-existing databases.
+            for _index_sql in [
+                "CREATE INDEX IF NOT EXISTS idx_session_log_role ON session_log(session_id, role)",
+            ]:
+                try:
+                    await db.execute(_index_sql)
+                    await db.commit()
+                except Exception:
+                    pass
 
     @asynccontextmanager
     async def connect(self):

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -691,11 +691,19 @@ class LoomSession:
             output_tokens += response.output_tokens
 
             # Log the full raw_message as JSON so tool_calls are preserved for resume.
-            # format="raw_message" signals load_messages() to parse it back directly.
+            # New path: raw_message goes into the dedicated `raw_json` column.
+            # The content field gets a plain-text representation for human readability
+            # (e.g. in observability queries). Legacy format=raw_message flag is
+            # preserved so old rows can still be replayed without migration.
+            _raw_json_str = json.dumps(response.raw_message, ensure_ascii=False)
+            _content_text = (
+                response.text or "[tool_use]"
+            )
             asyncio.ensure_future(self._log_message(
                 "assistant",
-                json.dumps(response.raw_message, ensure_ascii=False),
+                _content_text,
                 {"format": "raw_message"},
+                raw_json=_raw_json_str,
             ))
 
             if response.stop_reason == "end_turn":
@@ -991,13 +999,15 @@ class LoomSession:
             i -= 1
 
     async def _log_message(
-        self, role: str, content: str, metadata: dict | None = None
+        self, role: str, content: str, metadata: dict | None = None,
+        raw_json: str | None = None,
     ) -> None:
         """Fire-and-forget session_log write. Exceptions are swallowed inside log_message."""
         if self._session_log is None:
             return
         await self._session_log.log_message(
-            self.session_id, self._turn_index, role, content, metadata or {}
+            self.session_id, self._turn_index, role, content, metadata or {},
+            raw_json=raw_json,
         )
 
     async def _dispatch(self, tool_name: str, args: dict, call_id: str) -> ToolResult:


### PR DESCRIPTION
Resolves #11.

## 摘要

將 `session_log` 的結構化工具呼叫資料從混合 JSON 字串升級為專屬欄位，並新增觀測性索引。

## 異動

### `loom/core/memory/store.py`
- `session_log` schema 新增 `raw_json TEXT` 欄位：存放 tool_use/tool_result 的完整 JSON，與人類可讀的 `content` 欄位分離
- 新增 `idx_session_log_role (session_id, role)` 索引，支援「顯示 session X 所有工具呼叫」等觀測性查詢
- `initialize()` migration loop：自動對現有 DB 執行 ALTER TABLE + CREATE INDEX，向前相容

### `loom/core/memory/session_log.py`
- `log_message()`：新增 `raw_json: str | None` 參數
- `load_messages()`：新增三層重建邏輯：`raw_json` 欄位（新路徑）→ `format=raw_message` metadata（舊路徑）→ plain text
- `fork_session()`：INSERT SELECT 帶入 `raw_json` 欄位

### `loom/platform/cli/main.py`
- 助理訊息 log：`content` 存人類可讀文字，`raw_json` 存完整 raw_message JSON
- `_log_message()`：新增 `raw_json` 關鍵字參數

## 向前相容

- 舊有 DB row 的 `raw_json` 為 NULL，`load_messages()` 自動 fallback 到舊邏輯
- Migration 用 try/except 包裝，不影響全新安裝或已升級的資料庫