### PR TITLE
[Enhancement] Predictive memory pre-fetcher — inject context before tool execution

### DIFF
--- a/loom.toml.example
+++ b/loom.toml.example
@@ -59,6 +59,22 @@ skill_deprecation_threshold = 0.3
 episodic_compress_threshold = 30
 
 # ─────────────────────────────────────────────
+# Session
+# ─────────────────────────────────────────────
+
+[session]
+# Issue #28: Predictive memory pre-fetcher.
+# When enabled, _dispatch_parallel() runs a lightweight MemorySearch query
+# before each parallel tool batch and injects top results as an ephemeral
+# system message so the LLM has "déjà vu" context for the upcoming tools.
+# The ephemeral message is removed after tool execution — history stays clean.
+#
+# Recommended: keep off until you have substantial semantic memory.
+# Performance cost: one extra DB query per parallel tool batch.
+prefetch_enabled = false
+prefetch_top_n   = 3       # number of memory hits to inject (keep small)
+
+# ─────────────────────────────────────────────
 # Harness
 # ─────────────────────────────────────────────
 

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -361,6 +361,14 @@ class LoomSession:
         # When True, stream_turn() auto-pauses after every tool batch.
         self.hitl_mode: bool = False
 
+        # Issue #28: Predictive memory pre-fetcher — default off (opt-in)
+        self._prefetch_enabled: bool = (
+            config.get("session", {}).get("prefetch_enabled", False)
+        )
+        self._prefetch_top_n: int = (
+            config.get("session", {}).get("prefetch_top_n", 3)
+        )
+
     # ------------------------------------------------------------------
     # Personality management
     # ------------------------------------------------------------------
@@ -1118,12 +1126,47 @@ class LoomSession:
         execute via asyncio.gather under the TaskScheduler.  Results are returned
         in the original tool_uses order.
 
+        When ``_prefetch_enabled`` is True, a lightweight MemorySearch query is
+        run before tool execution and results are injected as an ephemeral system
+        message.  The message is removed immediately after tools complete so it
+        never pollutes the persistent history.
+
         Returns
         -------
         list of (ToolUse, ToolResult, duration_ms) tuples.
         """
         from loom.core.tasks.graph import TaskGraph, TaskNode
         from loom.core.tasks.scheduler import TaskScheduler
+
+        # Issue #28: pre-fetch relevant memory before executing tool batch
+        _ephemeral_idx: int | None = None
+        if self._prefetch_enabled and self._semantic is not None and self._procedural is not None:
+            try:
+                _query = " ".join(
+                    tu.name + " " + " ".join(str(v) for v in tu.args.values())[:120]
+                    for tu in tool_uses
+                ).strip()[:300]
+                if _query:
+                    _search = MemorySearch(self._semantic, self._procedural)
+                    _hits = await _search.recall(_query, limit=self._prefetch_top_n)
+                    if _hits:
+                        _snippets = "\n".join(
+                            f"- {h.key}: {h.value[:200]}" for h in _hits
+                        )
+                        _ephemeral = (
+                            "[Pre-loaded context for upcoming tools]\n"
+                            f"{_snippets}"
+                        )
+                        # Insert ephemeral message just before the last assistant message
+                        _insert_pos = len(self.messages)
+                        self.messages.insert(_insert_pos, {
+                            "role": "system",
+                            "content": _ephemeral,
+                            "_ephemeral": True,  # marker for removal
+                        })
+                        _ephemeral_idx = _insert_pos
+            except Exception:
+                pass  # pre-fetch must never block tool execution
 
         graph = TaskGraph()
         pairs: list[tuple] = []  # (ToolUse, TaskNode)
@@ -1143,6 +1186,17 @@ class LoomSession:
         plan = graph.compile()
         scheduler = TaskScheduler(executor=_execute, stop_on_failure=False)
         await scheduler.run(plan)
+
+        # Remove the ephemeral message — keep history clean
+        if _ephemeral_idx is not None:
+            try:
+                if (
+                    _ephemeral_idx < len(self.messages)
+                    and self.messages[_ephemeral_idx].get("_ephemeral")
+                ):
+                    self.messages.pop(_ephemeral_idx)
+            except Exception:
+                pass
 
         return [(tu, timings[node.id][1], timings[node.id][0]) for tu, node in pairs]
 


### PR DESCRIPTION
Resolves #28.

## 摘要

在 `_dispatch_parallel()` 執行工具批次前，自動以工具名稱 + 關鍵參數為 query 查詢 MemorySearch，將 top-N 結果注入為一個 **ephemeral system message**，讓 LLM 在工具執行期間有「既視感」的記憶脈絡。工具執行結束後立即移除此訊息，保持對話歷史乾淨。

## 設計

- **Opt-in**：預設 `prefetch_enabled = false`，需在 `loom.toml` 明確開啟
- **零成本 fallback**：任何異常（DB 錯誤、search miss）都被 try/except 吸收，不影響工具執行
- **不動 MemorySearch**：直接使用已有的 `search.recall()`，無需新增 API
- **ephemeral marker**：訊息加上 `_ephemeral: True` marker，移除時以 index + marker 雙重確認，避免刪錯

## 異動

### `loom/platform/cli/main.py`
- `LoomSession.__init__`：新增 `_prefetch_enabled` / `_prefetch_top_n` 從 `[session]` config 讀取
- `_dispatch_parallel()`：新增 pre-fetch hook + ephemeral message 清理

### `loom.toml.example`
- 新增 `[session]` section，說明 `prefetch_enabled` 和 `prefetch_top_n`