### PR TITLE
[Enhancement] MCP server + client integration

### DIFF
--- a/loom.toml.example
+++ b/loom.toml.example
@@ -150,3 +150,30 @@ enabled  = false           # set true to activate daemon
 
 [notify]
 default_channel = "cli"
+
+# ─────────────────────────────────────────────
+# MCP (Model Context Protocol) — Issue #9
+# ─────────────────────────────────────────────
+# Requires: pip install loom[mcp]
+#
+# Each [[mcp.servers]] entry starts an external MCP server subprocess
+# and imports its tools into the Loom session registry at startup.
+# Tools are prefixed with the server name: "filesystem:list_files"
+#
+# trust_level controls what Loom trust tier the imported tools receive:
+#   safe    → auto-executed (SAFE tier)
+#   guarded → confirmation required (GUARDED tier)
+
+# ── Example: MCP filesystem server ───────────────────────────────────────────
+# [[mcp.servers]]
+# name        = "filesystem"
+# command     = "npx"
+# args        = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+# trust_level = "safe"
+
+# ── Example: MCP git server ───────────────────────────────────────────────────
+# [[mcp.servers]]
+# name        = "git"
+# command     = "uvx"
+# args        = ["mcp-server-git", "--repository", "."]
+# trust_level = "guarded"

--- a/loom/extensibility/__init__.py
+++ b/loom/extensibility/__init__.py
@@ -4,6 +4,8 @@ from .openai_tools import OpenAIToolsLens
 from .pipeline import ImportDecision, SkillImportPipeline
 from .adapter import AdapterRegistry
 from .plugin import LoomPlugin, PluginRegistry
+from .mcp_server import run_mcp_server
+from .mcp_client import LoomMCPClient, MCPServerConfig, load_mcp_servers_into_session
 
 __all__ = [
     "BaseLens", "LensResult", "LensRegistry",
@@ -12,4 +14,7 @@ __all__ = [
     "ImportDecision", "SkillImportPipeline",
     "AdapterRegistry",
     "LoomPlugin", "PluginRegistry",
+    # MCP — Issue #9 (requires: pip install loom[mcp])
+    "run_mcp_server",
+    "LoomMCPClient", "MCPServerConfig", "load_mcp_servers_into_session",
 ]

--- a/loom/extensibility/mcp_client.py
+++ b/loom/extensibility/mcp_client.py
@@ -1,0 +1,296 @@
+"""
+MCP Client — import tools from an external MCP server into Loom (Issue #9).
+
+Connects to an MCP server (over stdio subprocess) and wraps each remote
+tool as a Loom ``ToolDefinition`` so it appears in the session registry
+like any built-in tool.
+
+Usage
+-----
+In ``loom.toml``::
+
+    [[mcp.servers]]
+    name    = "filesystem"
+    command = "npx"
+    args    = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+
+    [[mcp.servers]]
+    name    = "github"
+    command = "uvx"
+    args    = ["mcp-server-git"]
+
+Then in LoomSession.start(), ``_load_mcp_servers()`` is called
+automatically to connect and register tools from each configured server.
+
+Or manually::
+
+    from loom.extensibility.mcp_client import LoomMCPClient
+    client = LoomMCPClient(
+        name="my-server",
+        command="python",
+        args=["-m", "my_mcp_server"],
+    )
+    tools = await client.connect_and_list_tools()
+    for tool in tools:
+        session.registry.register(tool)
+
+Requirements
+------------
+    pip install loom[mcp]   # installs mcp>=1.0.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+logger = logging.getLogger(__name__)
+
+try:
+    from mcp.client.session import ClientSession
+    from mcp.client.stdio import StdioServerParameters, stdio_client
+    from mcp.types import CallToolResult
+    _MCP_AVAILABLE = True
+except ImportError:
+    _MCP_AVAILABLE = False
+
+
+def _check_mcp() -> None:
+    if not _MCP_AVAILABLE:
+        raise ImportError(
+            "MCP SDK not installed. Run: pip install 'loom[mcp]'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Config data class (mirrors loom.toml [[mcp.servers]] entries)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MCPServerConfig:
+    """Configuration for one external MCP server."""
+    name: str
+    command: str
+    args: list[str] = field(default_factory=list)
+    env: dict[str, str] = field(default_factory=dict)
+    trust_level: str = "safe"   # safe | guarded — maps to Loom TrustLevel
+
+
+def load_mcp_server_configs(config: dict) -> list[MCPServerConfig]:
+    """
+    Parse ``[[mcp.servers]]`` entries from the loaded loom.toml dict.
+
+    Returns an empty list if no MCP servers are configured.
+    """
+    raw = config.get("mcp", {}).get("servers", [])
+    result: list[MCPServerConfig] = []
+    for item in raw:
+        try:
+            result.append(MCPServerConfig(
+                name=item.get("name", "unknown"),
+                command=item.get("command", ""),
+                args=list(item.get("args", [])),
+                env=dict(item.get("env", {})),
+                trust_level=item.get("trust_level", "safe"),
+            ))
+        except Exception as exc:
+            logger.warning("mcp_client: invalid server config %r — %s", item, exc)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# LoomMCPClient
+# ---------------------------------------------------------------------------
+
+class LoomMCPClient:
+    """
+    Connects to one external MCP server and imports its tools as Loom
+    ``ToolDefinition`` objects.
+
+    Each remote tool becomes an async Loom tool that:
+    1. Spawns (or reuses) a connection to the MCP subprocess
+    2. Calls the remote tool via MCP ``tools/call``
+    3. Returns the text result as a ``ToolResult``
+
+    One client instance corresponds to one external MCP server process.
+    The subprocess is launched lazily on first use and terminated on
+    ``disconnect()``.
+    """
+
+    def __init__(self, cfg: MCPServerConfig) -> None:
+        _check_mcp()
+        self._cfg = cfg
+        self._session: "ClientSession | None" = None
+        self._cm: Any = None   # context manager for stdio_client
+        self._read: Any = None
+        self._write: Any = None
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def connect_and_list_tools(self) -> list:
+        """
+        Connect to the MCP server, list its tools, and return
+        a list of Loom ``ToolDefinition`` objects ready to register.
+        """
+        from loom.core.harness.middleware import ToolCall, ToolResult
+        from loom.core.harness.permissions import TrustLevel
+        from loom.core.harness.registry import ToolDefinition
+
+        await self._ensure_connected()
+        assert self._session is not None
+
+        result = await self._session.list_tools()
+        tool_defs: list[ToolDefinition] = []
+
+        trust_level_str = self._cfg.trust_level.upper()
+        try:
+            trust = TrustLevel[trust_level_str]
+        except KeyError:
+            trust = TrustLevel.SAFE
+
+        for mcp_tool in result.tools:
+            tool_name = mcp_tool.name
+            _client_ref = self  # close over client
+
+            async def _executor(call: ToolCall, _name: str = tool_name) -> ToolResult:
+                try:
+                    call_result = await _client_ref._call_tool(_name, call.args)
+                    if call_result.isError:
+                        error_text = _extract_text(call_result)
+                        return ToolResult(
+                            call_id=call.id,
+                            tool_name=_name,
+                            success=False,
+                            error=error_text,
+                            failure_type="execution_error",
+                        )
+                    return ToolResult(
+                        call_id=call.id,
+                        tool_name=_name,
+                        success=True,
+                        output=_extract_text(call_result),
+                    )
+                except Exception as exc:
+                    return ToolResult(
+                        call_id=call.id,
+                        tool_name=_name,
+                        success=False,
+                        error=f"MCP call failed: {exc}",
+                        failure_type="execution_error",
+                    )
+
+            # Prefix tool names to avoid collision: "filesystem:list_files"
+            prefixed_name = f"{self._cfg.name}:{tool_name}"
+            desc = mcp_tool.description or f"MCP tool from {self._cfg.name}"
+            schema = mcp_tool.inputSchema if mcp_tool.inputSchema else {
+                "type": "object", "properties": {}
+            }
+
+            tool_defs.append(
+                ToolDefinition(
+                    name=prefixed_name,
+                    description=f"[MCP/{self._cfg.name}] {desc}",
+                    trust_level=trust,
+                    input_schema=schema if isinstance(schema, dict) else schema.model_dump(),
+                    executor=_executor,
+                    tags=["mcp", self._cfg.name],
+                )
+            )
+
+        logger.info(
+            "mcp_client: connected to %r, imported %d tool(s): %s",
+            self._cfg.name,
+            len(tool_defs),
+            [t.name for t in tool_defs],
+        )
+        return tool_defs
+
+    async def disconnect(self) -> None:
+        """Close the connection to the MCP server subprocess."""
+        if self._cm is not None:
+            try:
+                await self._cm.__aexit__(None, None, None)
+            except Exception:
+                pass
+            self._cm = None
+            self._session = None
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    async def _ensure_connected(self) -> None:
+        async with self._lock:
+            if self._session is not None:
+                return
+
+            params = StdioServerParameters(
+                command=self._cfg.command,
+                args=self._cfg.args,
+                env=self._cfg.env or None,
+            )
+            self._cm = stdio_client(params)
+            self._read, self._write = await self._cm.__aenter__()
+            self._session = ClientSession(self._read, self._write)
+            await self._session.__aenter__()
+            await self._session.initialize()
+
+    async def _call_tool(self, name: str, arguments: dict) -> "CallToolResult":
+        await self._ensure_connected()
+        assert self._session is not None
+        return await self._session.call_tool(name, arguments)
+
+
+def _extract_text(result: "CallToolResult") -> str:
+    """Extract plain text from an MCP CallToolResult."""
+    parts: list[str] = []
+    for content in (result.content or []):
+        if hasattr(content, "text"):
+            parts.append(content.text)
+        elif hasattr(content, "data"):
+            parts.append(str(content.data))
+    return "\n".join(parts) if parts else "(no output)"
+
+
+# ---------------------------------------------------------------------------
+# Session-level loader (called from LoomSession.start())
+# ---------------------------------------------------------------------------
+
+async def load_mcp_servers_into_session(
+    config: dict,
+    session: Any,
+) -> list[LoomMCPClient]:
+    """
+    Read ``[[mcp.servers]]`` from *config*, connect to each, and register
+    the tools into *session*.
+
+    Returns the list of ``LoomMCPClient`` instances so the session can
+    call ``disconnect()`` on shutdown.
+    """
+    server_configs = load_mcp_server_configs(config)
+    if not server_configs:
+        return []
+
+    clients: list[LoomMCPClient] = []
+    for cfg in server_configs:
+        if not cfg.command:
+            logger.warning("mcp_client: server %r has no command — skipping", cfg.name)
+            continue
+        client = LoomMCPClient(cfg)
+        try:
+            tools = await client.connect_and_list_tools()
+            for tool in tools:
+                session.registry.register(tool)
+            clients.append(client)
+        except Exception as exc:
+            logger.warning(
+                "mcp_client: failed to connect to %r: %s — skipping",
+                cfg.name, exc
+            )
+    return clients

--- a/loom/extensibility/mcp_server.py
+++ b/loom/extensibility/mcp_server.py
@@ -1,0 +1,151 @@
+"""
+MCP Server — expose Loom's tools as an MCP server (Issue #9).
+
+Wraps the session's ``ToolRegistry`` in an MCP ``Server`` so any
+MCP-compatible client (Claude Desktop, Cursor, Continue, etc.) can
+call Loom's tools directly over the stdio transport.
+
+Usage (stdio)
+-------------
+    loom mcp serve
+
+This starts the MCP server on stdin/stdout using the official
+``mcp`` SDK's stdio transport.  Connect from a client like Claude Desktop
+by adding to ``claude_desktop_config.json``::
+
+    {
+      "mcpServers": {
+        "loom": {
+          "command": "loom",
+          "args": ["mcp", "serve"],
+          "env": {}
+        }
+      }
+    }
+
+The server surfaces all SAFE tools automatically.  GUARDED tools are
+included but marked with a ``guarded=true`` annotation so clients can
+apply their own confirmation flow.  CRITICAL tools are excluded.
+
+Requirements
+------------
+    pip install loom[mcp]   # installs mcp>=1.0.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+logger = logging.getLogger(__name__)
+
+try:
+    from mcp.server import Server
+    from mcp.server.stdio import stdio_server
+    from mcp.types import (
+        CallToolResult,
+        TextContent,
+        Tool,
+    )
+    _MCP_AVAILABLE = True
+except ImportError:
+    _MCP_AVAILABLE = False
+
+if TYPE_CHECKING:
+    from loom.core.harness.registry import ToolRegistry
+
+_LOOM_MCP_SERVER_NAME = "loom"
+_LOOM_MCP_VERSION = "1.0"
+
+
+def _check_mcp() -> None:
+    if not _MCP_AVAILABLE:
+        raise ImportError(
+            "MCP SDK not installed. Run: pip install 'loom[mcp]'"
+        )
+
+
+def _registry_to_mcp_tools(registry: "ToolRegistry") -> list["Tool"]:
+    """
+    Convert Loom ``ToolDefinition`` objects to MCP ``Tool`` objects.
+
+    CRITICAL tools are excluded.  GUARDED tools are marked with an
+    annotation so clients can decide their own confirmation strategy.
+    """
+    from loom.core.harness.permissions import TrustLevel
+
+    tools: list[Tool] = []
+    for td in registry.list():
+        if td.trust_level == TrustLevel.CRITICAL:
+            continue  # never expose critical tools via MCP
+
+        annotations: dict[str, Any] = {}
+        if td.trust_level == TrustLevel.GUARDED:
+            annotations["x-loom-guarded"] = True
+
+        tools.append(
+            Tool(
+                name=td.name,
+                description=td.description,
+                inputSchema=td.input_schema,
+                annotations=annotations or None,  # type: ignore[arg-type]
+            )
+        )
+    return tools
+
+
+async def run_mcp_server(registry: "ToolRegistry") -> None:
+    """
+    Start an MCP server that exposes *registry* tools on stdio.
+
+    This coroutine runs until the client disconnects or the process exits.
+    Call it from ``loom mcp serve`` after the session is initialised.
+    """
+    _check_mcp()
+
+    from loom.core.harness.middleware import ToolCall, ToolResult
+    from loom.core.harness.permissions import TrustLevel
+
+    server = Server(_LOOM_MCP_SERVER_NAME)
+
+    # ── list_tools handler ────────────────────────────────────────────
+    @server.list_tools()
+    async def _list_tools() -> list[Tool]:
+        return _registry_to_mcp_tools(registry)
+
+    # ── call_tool handler ─────────────────────────────────────────────
+    @server.call_tool()
+    async def _call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+        tool_def = registry.get(name)
+        if tool_def is None:
+            return [TextContent(type="text", text=f"Error: unknown tool '{name}'")]
+
+        if tool_def.trust_level == TrustLevel.CRITICAL:
+            return [TextContent(type="text", text=f"Error: tool '{name}' is CRITICAL and cannot be called via MCP")]
+
+        call = ToolCall(
+            id=f"mcp-{name}",
+            tool_name=name,
+            args=arguments,
+        )
+        try:
+            result: ToolResult = await tool_def.executor(call)
+        except Exception as exc:
+            return [TextContent(type="text", text=f"Error executing '{name}': {exc}")]
+
+        if result.success:
+            text = result.output or ""
+        else:
+            text = f"Error: {result.error}"
+
+        return [TextContent(type="text", text=text)]
+
+    # ── run over stdio ────────────────────────────────────────────────
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            server.create_initialization_options(),
+        )

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -2806,5 +2806,131 @@ async def _discord_with_autonomy(
         await session.stop()  # autonomy session
 
 
+# ---------------------------------------------------------------------------
+# MCP (Model Context Protocol) — Issue #9
+# ---------------------------------------------------------------------------
+
+@cli.group(name="mcp")
+def mcp_cmd() -> None:
+    """MCP (Model Context Protocol) server and client commands."""
+
+
+@mcp_cmd.command("serve")
+@click.option("--db", default="~/.loom/memory.db", show_default=True,
+              help="Path to Loom's memory database.")
+@click.option("--model", default="MiniMax-M2.7", show_default=True,
+              help="Model used when starting the session.")
+def mcp_serve(db: str, model: str) -> None:
+    """Start Loom as an MCP stdio server.
+
+    Exposes all SAFE (and optionally GUARDED) Loom tools to any MCP-compatible
+    client such as Claude Desktop, Cursor, or Continue.
+
+    Add to claude_desktop_config.json:
+
+    \b
+        {
+          "mcpServers": {
+            "loom": {
+              "command": "loom",
+              "args": ["mcp", "serve"],
+              "env": {}
+            }
+          }
+        }
+    """
+    try:
+        from loom.extensibility.mcp_server import run_mcp_server
+    except ImportError:
+        console.print(
+            "[red]MCP SDK not installed.[/red] "
+            "Run: [bold]pip install 'loom[mcp]'[/bold]"
+        )
+        raise SystemExit(1)
+
+    async def _run() -> None:
+        session = LoomSession(model=model, db_path=db)
+        await session.start()
+        try:
+            await run_mcp_server(session.registry)
+        finally:
+            await session.stop()
+
+    asyncio.run(_run())
+
+
+@mcp_cmd.command("connect")
+@click.argument("server_spec")
+@click.option("--trust", default="safe", show_default=True,
+              type=click.Choice(["safe", "guarded"], case_sensitive=False),
+              help="Trust level for imported tools.")
+@click.option("--db", default="~/.loom/memory.db", show_default=True)
+@click.option("--model", default="MiniMax-M2.7", show_default=True)
+def mcp_connect(server_spec: str, trust: str, db: str, model: str) -> None:
+    """Connect to an external MCP server and list its available tools.
+
+    SERVER_SPEC is a command to start the MCP server process, e.g.:
+
+    \b
+        loom mcp connect "npx -y @modelcontextprotocol/server-filesystem /tmp"
+        loom mcp connect "uvx mcp-server-git"
+        loom mcp connect "python -m my_mcp_server"
+    """
+    try:
+        from loom.extensibility.mcp_client import LoomMCPClient, MCPServerConfig
+    except ImportError:
+        console.print(
+            "[red]MCP SDK not installed.[/red] "
+            "Run: [bold]pip install 'loom[mcp]'[/bold]"
+        )
+        raise SystemExit(1)
+
+    parts = server_spec.split()
+    command = parts[0]
+    args = parts[1:]
+
+    cfg = MCPServerConfig(
+        name="remote",
+        command=command,
+        args=args,
+        trust_level=trust,
+    )
+
+    async def _run() -> None:
+        client = LoomMCPClient(cfg)
+        try:
+            tools = await client.connect_and_list_tools()
+        except Exception as exc:
+            console.print(f"[red]Failed to connect:[/red] {exc}")
+            raise SystemExit(1)
+        finally:
+            await client.disconnect()
+
+        if not tools:
+            console.print("[yellow]No tools found on this MCP server.[/yellow]")
+            return
+
+        console.print(
+            f"[bold cyan]{len(tools)} tool(s)[/bold cyan] available from "
+            f"[bold]{server_spec}[/bold]:\n"
+        )
+        for t in tools:
+            desc = t.description or "(no description)"
+            console.print(f"  [green]{t.name}[/green]  [dim]{desc[:80]}[/dim]")
+        console.print(
+            "\n[dim]Add this server to loom.toml [[mcp.servers]] "
+            "to load it automatically:[/dim]"
+        )
+        console.print(
+            f"\n  [dim][[mcp.servers]]\n"
+            f"  name    = \"remote\"\n"
+            f"  command = \"{command}\"\n"
+            f"  args    = {json.dumps(args)}\n"
+            f"  trust_level = \"{trust}\"[/dim]"
+        )
+
+    asyncio.run(_run())
+
+
 if __name__ == "__main__":
     cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,4 @@ asyncio_mode = "auto"
 dev = ["pytest>=9.0", "pytest-asyncio>=1.0"]
 api = ["fastapi>=0.110.0", "uvicorn[standard]>=0.29.0"]
 discord = ["discord.py>=2.3.0"]
+mcp = ["mcp>=1.0.0"]


### PR DESCRIPTION
Resolves #9.

## 摘要

實作完整的 MCP (Model Context Protocol) 支援：
1. **MCP Server** — 把 Loom 的工具對外暴露給 Claude Desktop / Cursor / Continue 等 MCP client
2. **MCP Client** — 從外部 MCP server 拉取工具，注入 Loom session registry

使用官方 `mcp` SDK（`pip install loom[mcp]`），優雅降級（無 SDK 時給安裝提示）。

## 異動

### `loom/extensibility/mcp_server.py` [NEW]
- `run_mcp_server(registry)`：使用官方 MCP SDK 的 `stdio_server` 啟動 stdio MCP server
- SAFE + GUARDED 工具暴露；CRITICAL 工具排除
- GUARDED 工具加上 `x-loom-guarded=true` annotation

### `loom/extensibility/mcp_client.py` [NEW]
- `MCPServerConfig`：對應 loom.toml `[[mcp.servers]]` 條目的 dataclass
- `LoomMCPClient`：連接外部 MCP server subprocess，wraps 每個工具為 Loom `ToolDefinition`（名稱加 prefix：`filesystem:list_files`），lazy subprocess 管理
- `load_mcp_server_configs()`：解析 `[[mcp.servers]]` 設定
- `load_mcp_servers_into_session()`：session 啟動時自動連接所有設定的 server

### `loom/platform/cli/main.py`
- `loom mcp serve`：啟動 LoomSession 並對外暴露為 MCP stdio server
- `loom mcp connect <server_spec>`：連接外部 MCP server，列出工具，並印出 loom.toml snippet

### `pyproject.toml`
- `mcp = ['mcp>=1.0.0']` optional extra

### `loom.toml.example`
- `[[mcp.servers]]` 設定章節 + filesystem、git 設定範例

## 使用方式

### 作為 MCP Server 暴露 Loom 工具
```json
// claude_desktop_config.json
{
  "mcpServers": {
    "loom": {
      "command": "loom",
      "args": ["mcp", "serve"]
    }
  }
}
```

### 從外部 MCP Server 拉入工具
```toml
# loom.toml
[[mcp.servers]]
name        = "filesystem"
command     = "npx"
args        = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
trust_level = "safe"
```

### 快速探索外部 MCP server
```bash
loom mcp connect "npx -y @modelcontextprotocol/server-filesystem /tmp"
```