### PR TITLE
feat(harness): Action Lifecycle Management — Issue #42

### DIFF
--- a/loom/autonomy/daemon.py
+++ b/loom/autonomy/daemon.py
@@ -107,6 +107,8 @@ class AutonomyDaemon:
                 # Collect streaming text without importing platform event types
                 if hasattr(event, "text") and isinstance(event.text, str):
                     output_chunks.append(event.text)
+                # ActionStateChange / ActionRolledBack events are silently
+                # consumed — daemon doesn't need lifecycle visualization.
 
             thread_id = plan.context.get("notify_thread_id", 0)
             response = "".join(output_chunks).strip()

--- a/loom/core/harness/__init__.py
+++ b/loom/core/harness/__init__.py
@@ -1,11 +1,21 @@
-from .middleware import Middleware, MiddlewarePipeline, ToolCall, ToolResult
+from .middleware import (
+    Middleware, MiddlewarePipeline, ToolCall, ToolResult,
+    LifecycleMiddleware,
+)
 from .permissions import TrustLevel, PermissionContext
 from .registry import ToolDefinition, ToolRegistry
 from .validation import SchemaValidationMiddleware
+from .lifecycle import (
+    ActionState, ActionIntent, ActionRecord,
+    ExecutionEnvelope, StateTransition,
+)
 
 __all__ = [
     "Middleware", "MiddlewarePipeline", "ToolCall", "ToolResult",
+    "LifecycleMiddleware",
     "TrustLevel", "PermissionContext",
     "ToolDefinition", "ToolRegistry",
     "SchemaValidationMiddleware",
+    "ActionState", "ActionIntent", "ActionRecord",
+    "ExecutionEnvelope", "StateTransition",
 ]

--- a/loom/core/harness/lifecycle.py
+++ b/loom/core/harness/lifecycle.py
@@ -1,0 +1,283 @@
+"""
+Action Lifecycle — state machine for tool-call lifecycle management.
+
+Upgrades the binary ToolCall/ToolResult paradigm into a comprehensive
+state machine (ActionRecord / ExecutionEnvelope) that tracks the entire
+lifecycle of an action:
+
+    Declared → Authorized → Prepared → Executing → Observed →
+    Validated → Committed | Reverting → Reverted → Memorialized
+
+Terminal failure states: Denied, Aborted, TimedOut.
+
+Design: ActionRecord *wraps* ToolCall/ToolResult (composition, not
+inheritance), so the existing API is fully backward-compatible.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, UTC
+from enum import Enum
+from typing import Any
+
+from .middleware import ToolCall, ToolResult
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle states
+# ---------------------------------------------------------------------------
+
+class ActionState(Enum):
+    """
+    State machine states for an action's lifecycle.
+
+    Happy path:
+        DECLARED → AUTHORIZED → PREPARED → EXECUTING → OBSERVED →
+        VALIDATED → COMMITTED → MEMORIALIZED
+
+    Rollback path:
+        VALIDATED (fail) → REVERTING → REVERTED → MEMORIALIZED
+
+    Terminal failure states (bypass normal flow):
+        DENIED      — permission denied by user or policy
+        ABORTED     — precondition failed or abort signal fired
+        TIMED_OUT   — execution exceeded time limit
+    """
+    # --- Normal lifecycle ---
+    DECLARED      = "declared"       # ToolCall created from LLM output
+    AUTHORIZED    = "authorized"     # Passed blast-radius / permission check
+    PREPARED      = "prepared"       # Preconditions verified
+    EXECUTING     = "executing"      # Tool executor invoked (in flight)
+    OBSERVED      = "observed"       # Executor returned; raw result captured
+    VALIDATED     = "validated"      # Post-execution validator passed
+    COMMITTED     = "committed"      # Effect persisted, accepted as final
+    REVERTING     = "reverting"      # Rollback in progress
+    REVERTED      = "reverted"       # Rollback completed
+    MEMORIALIZED  = "memorialized"   # Trace written to episodic / audit
+
+    # --- Terminal failure states ---
+    DENIED        = "denied"         # User or policy denied execution
+    ABORTED       = "aborted"        # Precondition failed / abort signal
+    TIMED_OUT     = "timed_out"      # Execution timed out
+
+    @property
+    def is_terminal(self) -> bool:
+        """Return True if this state is final (no further transitions)."""
+        return self in _TERMINAL_STATES
+
+    @property
+    def is_failure(self) -> bool:
+        """Return True if this state represents a failure outcome."""
+        return self in _FAILURE_STATES
+
+
+_TERMINAL_STATES = {
+    ActionState.MEMORIALIZED,
+    ActionState.DENIED,
+    ActionState.ABORTED,
+    ActionState.TIMED_OUT,
+}
+
+_FAILURE_STATES = {
+    ActionState.DENIED,
+    ActionState.ABORTED,
+    ActionState.TIMED_OUT,
+    ActionState.REVERTED,
+}
+
+# Valid state transitions — key can transition to any value in the set.
+_VALID_TRANSITIONS: dict[ActionState, set[ActionState]] = {
+    ActionState.DECLARED:     {ActionState.AUTHORIZED, ActionState.DENIED},
+    ActionState.AUTHORIZED:   {ActionState.PREPARED, ActionState.ABORTED},
+    ActionState.PREPARED:     {ActionState.EXECUTING, ActionState.ABORTED},
+    ActionState.EXECUTING:    {ActionState.OBSERVED, ActionState.TIMED_OUT, ActionState.ABORTED},
+    ActionState.OBSERVED:     {ActionState.VALIDATED, ActionState.COMMITTED, ActionState.MEMORIALIZED},
+    ActionState.VALIDATED:    {ActionState.COMMITTED, ActionState.REVERTING},
+    ActionState.COMMITTED:    {ActionState.MEMORIALIZED},
+    ActionState.REVERTING:    {ActionState.REVERTED},
+    ActionState.REVERTED:     {ActionState.MEMORIALIZED},
+    # Terminal states have no outgoing transitions
+    ActionState.MEMORIALIZED: set(),
+    ActionState.DENIED:       {ActionState.MEMORIALIZED},
+    ActionState.ABORTED:      {ActionState.MEMORIALIZED},
+    ActionState.TIMED_OUT:    {ActionState.MEMORIALIZED},
+}
+
+
+# ---------------------------------------------------------------------------
+# Intent description
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ActionIntent:
+    """
+    Declarative description of what an action intends to do.
+
+    Populated from tool metadata and/or LLM-provided context.
+    Used for audit, observability, and post-execution validation.
+    """
+    intent_summary: str = ""
+    """Natural-language summary (e.g. "Write test results to output.json")."""
+
+    scope: str = "general"
+    """Impact scope classification: filesystem, network, memory, shell, general."""
+
+    expected_effect: str | None = None
+    """Expected observable effect (e.g. "file output.json contains JSON data")."""
+
+    preconditions: list[str] = field(default_factory=list)
+    """List of precondition descriptions from the ToolDefinition."""
+
+
+# ---------------------------------------------------------------------------
+# ActionRecord — single tool call lifecycle
+# ---------------------------------------------------------------------------
+
+@dataclass
+class StateTransition:
+    """One state transition in the lifecycle history."""
+    from_state: ActionState
+    to_state: ActionState
+    timestamp: datetime
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "from": self.from_state.value,
+            "to": self.to_state.value,
+            "ts": self.timestamp.isoformat(),
+            "reason": self.reason,
+        }
+
+
+@dataclass
+class ActionRecord:
+    """
+    Complete lifecycle record for a single tool invocation.
+
+    Wraps ToolCall and ToolResult via composition — the underlying
+    harness types are preserved unchanged for backward compatibility.
+    """
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    state: ActionState = ActionState.DECLARED
+    call: ToolCall | None = None
+    result: ToolResult | None = None
+    intent: ActionIntent = field(default_factory=ActionIntent)
+    state_history: list[StateTransition] = field(default_factory=list)
+    observed_effect: str | None = None
+    rollback_result: ToolResult | None = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def transition(self, new_state: ActionState, reason: str | None = None) -> None:
+        """
+        Transition to a new state, recording the change in history.
+
+        Raises ValueError if the transition is not valid according to the
+        state machine rules.
+        """
+        valid = _VALID_TRANSITIONS.get(self.state, set())
+        if new_state not in valid:
+            raise ValueError(
+                f"Invalid transition: {self.state.value} → {new_state.value}. "
+                f"Valid targets: {', '.join(s.value for s in valid) or '(none)'}"
+            )
+        now = datetime.now(UTC)
+        self.state_history.append(
+            StateTransition(
+                from_state=self.state,
+                to_state=new_state,
+                timestamp=now,
+                reason=reason,
+            )
+        )
+        self.state = new_state
+
+    @property
+    def is_terminal(self) -> bool:
+        """True if the action has reached a final state."""
+        return self.state.is_terminal
+
+    @property
+    def is_failure(self) -> bool:
+        """True if the action ended in a failure state."""
+        return self.state.is_failure
+
+    @property
+    def elapsed_ms(self) -> float:
+        """
+        Wall-clock ms from DECLARED to the current (or last) state.
+
+        If the action is still in progress, returns elapsed so far.
+        """
+        if not self.state_history:
+            return 0.0
+        last_ts = self.state_history[-1].timestamp
+        return (last_ts - self.created_at).total_seconds() * 1000.0
+
+    @property
+    def tool_name(self) -> str:
+        """Convenience accessor for the underlying tool name."""
+        return self.call.tool_name if self.call else "(unknown)"
+
+    @property
+    def final_state(self) -> str:
+        """String value of the current state — for DB storage."""
+        return self.state.value
+
+    def summary(self) -> str:
+        """One-line human-readable summary of this action."""
+        status = self.state.value
+        dur = f"{self.elapsed_ms:.0f}ms" if self.elapsed_ms > 0 else "—"
+        return f"{self.tool_name}: {status} ({dur})"
+
+    def history_dicts(self) -> list[dict[str, Any]]:
+        """Serialize state_history for JSON storage."""
+        return [t.to_dict() for t in self.state_history]
+
+
+# ---------------------------------------------------------------------------
+# ExecutionEnvelope — batch of related ActionRecords
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ExecutionEnvelope:
+    """
+    Groups related ActionRecords from a single tool-use batch.
+
+    One LLM response may request multiple parallel tool calls — these are
+    wrapped in a single envelope for tracking and observability.
+    """
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    session_id: str = ""
+    turn_index: int = 0
+    records: list[ActionRecord] = field(default_factory=list)
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    completed_at: datetime | None = None
+
+    def add(self, record: ActionRecord) -> None:
+        """Add an ActionRecord to this envelope."""
+        self.records.append(record)
+
+    def complete(self) -> None:
+        """Mark the envelope as completed."""
+        self.completed_at = datetime.now(UTC)
+
+    @property
+    def all_terminal(self) -> bool:
+        """True if every record in the envelope has reached a terminal state."""
+        return all(r.is_terminal for r in self.records) if self.records else False
+
+    def summary(self) -> str:
+        """One-line summary of all records in this envelope."""
+        if not self.records:
+            return "empty envelope"
+        # Count by final state
+        counts: dict[str, int] = {}
+        for r in self.records:
+            key = r.state.value
+            counts[key] = counts.get(key, 0) + 1
+        parts = [f"{v} {k}" for k, v in counts.items()]
+        n = len(self.records)
+        return f"{n} action{'s' if n != 1 else ''}: {', '.join(parts)}"

--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -9,8 +9,11 @@ Execution order (outermost → innermost):
 """
 
 import asyncio
+import logging
 import time
 import uuid
+
+_log = logging.getLogger(__name__)
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, UTC
@@ -235,3 +238,240 @@ class BlastRadiusMiddleware(Middleware):
             self._perm.authorize(call.tool_name)
 
         return await next(call)
+
+
+# ---------------------------------------------------------------------------
+# Action Lifecycle Middleware (Issue #42)
+# ---------------------------------------------------------------------------
+
+class LifecycleMiddleware(Middleware):
+    """
+    Outermost middleware that wraps every tool call in an ActionRecord
+    and drives the full lifecycle state machine.
+
+    Lifecycle flow:
+    1. DECLARED — ActionRecord created from incoming ToolCall
+    2. Inner pipeline runs (Authorization → Schema validation → Execution)
+    3. OBSERVED — Raw result captured
+    4. VALIDATED — post_validator called (if defined on ToolDefinition)
+    5. COMMITTED or REVERTING → REVERTED (if validation fails + rollback_fn exists)
+    6. MEMORIALIZED — on_lifecycle callback fires
+
+    When no post_validator or rollback_fn is defined on the ToolDefinition,
+    the lifecycle collapses to: DECLARED → OBSERVED → COMMITTED → MEMORIALIZED,
+    preserving backward-compatible behavior.
+
+    The ``on_state_change`` callback fires on each state transition for UI
+    updates (e.g. TUI tool block state visualization).
+    """
+
+    def __init__(
+        self,
+        registry: Any,
+        on_lifecycle: Callable[["ActionRecord"], Awaitable[None]] | None = None,
+        on_state_change: Callable[["ActionRecord", str, str], Awaitable[None]] | None = None,
+    ) -> None:
+        from .lifecycle import ActionRecord, ActionIntent, ActionState
+        self._registry = registry
+        self._on_lifecycle = on_lifecycle
+        self._on_state_change = on_state_change
+        # Store references to avoid circular imports at call time
+        self._ActionRecord = ActionRecord
+        self._ActionIntent = ActionIntent
+        self._ActionState = ActionState
+
+    async def _fire_state_change(
+        self, record: "ActionRecord", old_state: str, new_state: str
+    ) -> None:
+        if self._on_state_change is not None:
+            try:
+                await self._on_state_change(record, old_state, new_state)
+            except Exception:
+                pass  # state change notifications must never crash the pipeline
+
+    async def process(self, call: ToolCall, next: ToolHandler) -> ToolResult:
+        ActionRecord = self._ActionRecord
+        ActionIntent = self._ActionIntent
+        ActionState = self._ActionState
+
+        # --- Build intent from tool definition ---
+        tool_def = self._registry.get(call.tool_name)
+        intent = ActionIntent(
+            intent_summary=f"{call.tool_name}({', '.join(f'{k}=...' for k in call.args)})",
+            scope=getattr(tool_def, "scope", "general") if tool_def else "general",
+            preconditions=list(getattr(tool_def, "preconditions", [])) if tool_def else [],
+        )
+
+        # --- DECLARED ---
+        record = ActionRecord(call=call, intent=intent)
+
+        # --- Run inner pipeline (handles Authorization, Validation, Execution) ---
+        result = await next(call)
+
+        # Determine if it was denied (permission_denied) or failed
+        if not result.success and result.failure_type == "permission_denied":
+            old = record.state.value
+            record.transition(ActionState.DENIED, reason=result.error)
+            await self._fire_state_change(record, old, record.state.value)
+            record.result = result
+            # Memorialize denied actions
+            old = record.state.value
+            record.transition(ActionState.MEMORIALIZED, reason="denied")
+            await self._fire_state_change(record, old, record.state.value)
+            if self._on_lifecycle is not None:
+                await self._on_lifecycle(record)
+            return result
+
+        if not result.success and result.failure_type == "validation_error":
+            old = record.state.value
+            record.transition(ActionState.AUTHORIZED, reason="passed blast radius")
+            await self._fire_state_change(record, old, record.state.value)
+            old = record.state.value
+            record.transition(ActionState.ABORTED, reason=result.error)
+            await self._fire_state_change(record, old, record.state.value)
+            record.result = result
+            old = record.state.value
+            record.transition(ActionState.MEMORIALIZED, reason="validation_error")
+            await self._fire_state_change(record, old, record.state.value)
+            if self._on_lifecycle is not None:
+                await self._on_lifecycle(record)
+            return result
+
+        if not result.success and result.failure_type == "tool_not_found":
+            record.result = result
+            old = record.state.value
+            record.transition(ActionState.DENIED, reason="tool not found")
+            await self._fire_state_change(record, old, record.state.value)
+            old = record.state.value
+            record.transition(ActionState.MEMORIALIZED, reason="tool_not_found")
+            await self._fire_state_change(record, old, record.state.value)
+            if self._on_lifecycle is not None:
+                await self._on_lifecycle(record)
+            return result
+
+        if not result.success and result.failure_type == "timeout":
+            old = record.state.value
+            record.transition(ActionState.AUTHORIZED, reason="passed blast radius")
+            await self._fire_state_change(record, old, record.state.value)
+            old = record.state.value
+            record.transition(ActionState.PREPARED)
+            await self._fire_state_change(record, old, record.state.value)
+            old = record.state.value
+            record.transition(ActionState.EXECUTING)
+            await self._fire_state_change(record, old, record.state.value)
+            old = record.state.value
+            record.transition(ActionState.TIMED_OUT, reason=result.error)
+            await self._fire_state_change(record, old, record.state.value)
+            record.result = result
+            old = record.state.value
+            record.transition(ActionState.MEMORIALIZED, reason="timed_out")
+            await self._fire_state_change(record, old, record.state.value)
+            if self._on_lifecycle is not None:
+                await self._on_lifecycle(record)
+            return result
+
+        # --- Happy path: tool executed (success or execution_error) ---
+        # Reconstruct lifecycle states retroactively (inner pipeline has
+        # already executed by the time we get here).
+
+        # DECLARED → AUTHORIZED
+        old = record.state.value
+        record.transition(ActionState.AUTHORIZED, reason="passed blast radius")
+        await self._fire_state_change(record, old, record.state.value)
+
+        # AUTHORIZED → PREPARED
+        old = record.state.value
+        record.transition(ActionState.PREPARED)
+        await self._fire_state_change(record, old, record.state.value)
+
+        # PREPARED → EXECUTING
+        old = record.state.value
+        record.transition(ActionState.EXECUTING)
+        await self._fire_state_change(record, old, record.state.value)
+
+        # EXECUTING → OBSERVED
+        old = record.state.value
+        record.transition(ActionState.OBSERVED)
+        await self._fire_state_change(record, old, record.state.value)
+        record.result = result
+
+        # --- Post-validation (if post_validator is defined) ---
+        post_validator = getattr(tool_def, "post_validator", None) if tool_def else None
+        rollback_fn = getattr(tool_def, "rollback_fn", None) if tool_def else None
+
+        if post_validator is not None and result.success:
+            try:
+                validated = await post_validator(call, result)
+            except Exception as _val_exc:
+                _log.warning(
+                    "post_validator for %r raised unexpectedly: %s — treating as passed",
+                    call.tool_name, _val_exc,
+                )
+                validated = True
+
+            if validated:
+                # OBSERVED → VALIDATED → COMMITTED
+                old = record.state.value
+                record.transition(ActionState.VALIDATED)
+                await self._fire_state_change(record, old, record.state.value)
+                old = record.state.value
+                record.transition(ActionState.COMMITTED)
+                await self._fire_state_change(record, old, record.state.value)
+            else:
+                # OBSERVED → VALIDATED (fail) → REVERTING → REVERTED
+                old = record.state.value
+                record.transition(ActionState.VALIDATED)
+                await self._fire_state_change(record, old, record.state.value)
+
+                if rollback_fn is not None:
+                    old = record.state.value
+                    record.transition(ActionState.REVERTING, reason="post-validation failed")
+                    await self._fire_state_change(record, old, record.state.value)
+                    try:
+                        rb_result = await rollback_fn(call, result)
+                        record.rollback_result = rb_result
+                    except Exception as exc:
+                        record.rollback_result = ToolResult(
+                            call_id=call.id,
+                            tool_name=call.tool_name,
+                            success=False,
+                            error=f"Rollback failed: {exc}",
+                        )
+                    old = record.state.value
+                    record.transition(ActionState.REVERTED)
+                    await self._fire_state_change(record, old, record.state.value)
+                    # Modify the result to indicate rollback
+                    result = ToolResult(
+                        call_id=result.call_id,
+                        tool_name=result.tool_name,
+                        success=False,
+                        error=f"Post-validation failed; action rolled back.",
+                        failure_type="execution_error",
+                        duration_ms=result.duration_ms,
+                        metadata={**result.metadata, "rolled_back": True},
+                    )
+                    record.result = result
+                else:
+                    # No rollback_fn: validation failed but can't revert → commit anyway
+                    old = record.state.value
+                    record.transition(ActionState.COMMITTED)
+                    await self._fire_state_change(record, old, record.state.value)
+        else:
+            # No post_validator → skip VALIDATED, go directly to COMMITTED
+            old = record.state.value
+            record.transition(ActionState.COMMITTED)
+            await self._fire_state_change(record, old, record.state.value)
+
+        # --- MEMORIALIZED ---
+        old = record.state.value
+        record.transition(ActionState.MEMORIALIZED)
+        await self._fire_state_change(record, old, record.state.value)
+
+        if self._on_lifecycle is not None:
+            try:
+                await self._on_lifecycle(record)
+            except Exception:
+                pass  # lifecycle callback must never crash the pipeline
+
+        return result
+

--- a/loom/core/harness/registry.py
+++ b/loom/core/harness/registry.py
@@ -21,6 +21,13 @@ class ToolDefinition:
     `capabilities` is an additive set of ToolCapability flags that further
     qualify what the tool does, beyond its TrustLevel tier.  Defaults to NONE
     so existing tool definitions require no changes.
+
+    Action Lifecycle fields (Issue #42)
+    ------------------------------------
+    `preconditions` — human-readable descriptions of required preconditions.
+    `rollback_fn`   — async function to undo the tool's effect on failure.
+    `post_validator` — async function to verify the tool's effect after execution.
+    `scope`         — impact scope classification for the tool.
     """
     name: str
     description: str
@@ -29,6 +36,12 @@ class ToolDefinition:
     executor: Callable[[ToolCall], Awaitable[ToolResult]]
     tags: list[str] = field(default_factory=list)
     capabilities: ToolCapability = field(default_factory=lambda: ToolCapability.NONE)
+
+    # --- Action Lifecycle (Issue #42) ---
+    preconditions: list[str] = field(default_factory=list)
+    rollback_fn: Callable[[ToolCall, ToolResult], Awaitable[ToolResult]] | None = None
+    post_validator: Callable[[ToolCall, ToolResult], Awaitable[bool]] | None = None
+    scope: str = "general"
 
     def to_anthropic_schema(self) -> dict[str, Any]:
         """Serialize to the format expected by the Anthropic messages API."""

--- a/loom/core/memory/semantic.py
+++ b/loom/core/memory/semantic.py
@@ -235,3 +235,17 @@ class SemanticMemory:
             )
             for r in rows
         ]
+
+    async def delete(self, key: str) -> bool:
+        """
+        Delete a semantic entry by key.
+
+        Returns True if an entry was actually deleted, False if no such key.
+        Used by the memorize rollback function (Issue #42).
+        """
+        cursor = await self._db.execute(
+            "DELETE FROM semantic_entries WHERE key = ?", (key,)
+        )
+        await self._db.commit()
+        return (cursor.rowcount or 0) > 0
+

--- a/loom/core/memory/store.py
+++ b/loom/core/memory/store.py
@@ -113,6 +113,27 @@ CREATE INDEX IF NOT EXISTS idx_session_log_session ON session_log(session_id, tu
 CREATE INDEX IF NOT EXISTS idx_session_log_role    ON session_log(session_id, role);
 CREATE INDEX IF NOT EXISTS idx_sessions_active     ON sessions(last_active DESC);
 
+-- Issue #42: Action lifecycle records
+CREATE TABLE IF NOT EXISTS action_records (
+    id             TEXT PRIMARY KEY,
+    envelope_id    TEXT NOT NULL,
+    session_id     TEXT NOT NULL,
+    turn_index     INTEGER NOT NULL,
+    tool_name      TEXT NOT NULL,
+    call_id        TEXT NOT NULL DEFAULT '',
+    final_state    TEXT NOT NULL,
+    intent_summary TEXT,
+    scope          TEXT NOT NULL DEFAULT 'general',
+    duration_ms    REAL NOT NULL DEFAULT 0.0,
+    state_history  TEXT NOT NULL DEFAULT '[]',
+    has_rollback   INTEGER NOT NULL DEFAULT 0,
+    created_at     TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_action_session ON action_records(session_id);
+CREATE INDEX IF NOT EXISTS idx_action_state   ON action_records(final_state);
+CREATE INDEX IF NOT EXISTS idx_action_env     ON action_records(envelope_id);
+
 -- FTS5 Virtual Tables & Sync Triggers
 
 CREATE VIRTUAL TABLE IF NOT EXISTS semantic_fts

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -55,12 +55,14 @@ from loom.core.cognition.reflection import ReflectionAPI
 from loom.core.cognition.router import LLMRouter
 from loom.core.harness.middleware import (
     BlastRadiusMiddleware,
+    LifecycleMiddleware,
     LogMiddleware,
     MiddlewarePipeline,
     ToolCall,
     ToolResult,
     TraceMiddleware,
 )
+from loom.core.harness.lifecycle import ActionRecord, ExecutionEnvelope
 from loom.core.harness.validation import SchemaValidationMiddleware
 from loom.core.harness.permissions import PermissionContext, TrustLevel
 from loom.core.infra import AbortController, wait_aborted
@@ -87,6 +89,8 @@ from loom.platform.cli.tools import (
     make_web_search_tool,
 )
 from loom.platform.cli.ui import (
+    ActionRolledBack,
+    ActionStateChange,
     CompressDone,
     TextChunk,
     ToolBegin,
@@ -365,6 +369,10 @@ class LoomSession:
         # Abort controller for cancellation of in-flight LLM streaming calls.
         self._abort = AbortController()
 
+        # Issue #42: Action lifecycle tracking
+        self._current_envelope: ExecutionEnvelope | None = None
+        self._lifecycle_events: asyncio.Queue = asyncio.Queue()
+
         # Issue #28: Predictive memory pre-fetcher — default off (opt-in)
         self._prefetch_enabled: bool = (
             config.get("session", {}).get("prefetch_enabled", False)
@@ -480,6 +488,11 @@ class LoomSession:
         )
         self._pipeline = MiddlewarePipeline(
             [
+                LifecycleMiddleware(
+                    registry=self.registry,
+                    on_lifecycle=self._on_lifecycle,
+                    on_state_change=self._on_state_change,
+                ),
                 TraceMiddleware(on_trace=self._on_trace),
                 SchemaValidationMiddleware(registry=self.registry),
                 BlastRadiusMiddleware(
@@ -575,7 +588,10 @@ class LoomSession:
         user_input: str,
         *,
         abort_signal: "asyncio.Event | None" = None,
-    ) -> AsyncIterator[TextChunk | ToolBegin | ToolEnd | TurnPaused | TurnDone]:
+    ) -> AsyncIterator[
+        TextChunk | ToolBegin | ToolEnd | TurnPaused | TurnDone
+        | ActionStateChange | ActionRolledBack
+    ]:
         """
         Run one complete agent turn and yield typed UI events.
 
@@ -783,6 +799,9 @@ class LoomSession:
                             duration_ms=duration_ms,
                             call_id=tu.id,
                         )
+                        # Drain lifecycle events queued during dispatch
+                        while not self._lifecycle_events.empty():
+                            yield self._lifecycle_events.get_nowait()
                         self.messages.append(
                             self.router.format_tool_result(
                                 self.model, tu.id, tool_output, result.success,
@@ -821,6 +840,9 @@ class LoomSession:
                             duration_ms=duration_ms,
                             call_id=tu.id,
                         )
+                        # Drain lifecycle events queued during dispatch
+                        while not self._lifecycle_events.empty():
+                            yield self._lifecycle_events.get_nowait()
                         self.messages.append(
                             self.router.format_tool_result(
                                 self.model, tu.id, tool_output, result.success,
@@ -1104,6 +1126,80 @@ class LoomSession:
             and result.failure_type == "execution_error"
         ):
             self._reflector.maybe_reflect(call, result, self.session_id)
+
+    async def _on_lifecycle(self, record: ActionRecord) -> None:
+        """
+        Persist a completed ActionRecord to the action_records table (Issue #42).
+
+        Called by LifecycleMiddleware after an action reaches a terminal state.
+        Stores full state_history as JSON for complete audit trail.
+        """
+        import json as _json
+        try:
+            envelope_id = self._current_envelope.id if self._current_envelope else ""
+            await self._db.execute(
+                """
+                INSERT OR REPLACE INTO action_records
+                    (id, envelope_id, session_id, turn_index, tool_name, call_id,
+                     final_state, intent_summary, scope, duration_ms,
+                     state_history, has_rollback, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.id,
+                    envelope_id,
+                    self.session_id,
+                    self._turn_index,
+                    record.tool_name,
+                    record.call.id if record.call else "",
+                    record.final_state,
+                    record.intent.intent_summary,
+                    record.intent.scope,
+                    record.elapsed_ms,
+                    _json.dumps(record.history_dicts(), ensure_ascii=False),
+                    1 if record.rollback_result is not None else 0,
+                    record.created_at.isoformat(),
+                ),
+            )
+            await self._db.commit()
+        except Exception:
+            pass  # DB write must never crash the pipeline
+
+    async def _on_state_change(
+        self, record: ActionRecord, old_state: str, new_state: str
+    ) -> None:
+        """
+        Enqueue an ActionStateChange event for stream_turn() to yield.
+
+        Called by LifecycleMiddleware on each state transition.
+        Also enqueues ActionRolledBack when transitioning to 'reverted'.
+        """
+        call_id = record.call.id if record.call else ""
+        self._lifecycle_events.put_nowait(
+            ActionStateChange(
+                action_id=record.id,
+                tool_name=record.tool_name,
+                call_id=call_id,
+                old_state=old_state,
+                new_state=new_state,
+                reason=record.state_history[-1].reason if record.state_history else None,
+            )
+        )
+        # Emit a specialized rollback event
+        if new_state == "reverted":
+            rb_success = record.rollback_result.success if record.rollback_result else False
+            rb_msg = ""
+            if record.rollback_result:
+                rb_msg = record.rollback_result.output or record.rollback_result.error or ""
+            self._lifecycle_events.put_nowait(
+                ActionRolledBack(
+                    action_id=record.id,
+                    tool_name=record.tool_name,
+                    call_id=call_id,
+                    rollback_success=rb_success,
+                    message=str(rb_msg)[:200],
+                )
+            )
 
     async def _confirm_tool(self, call: ToolCall) -> bool:
         # Stop any running spinner before printing the confirm panel so the
@@ -1681,6 +1777,8 @@ class LoomChatApp:
             ToolEnd as TuiToolEnd,
             TurnDone as TuiTurnDone,
             TurnPaused as TuiTurnPaused,
+            ActionStateChange as TuiActionStateChange,
+            ActionRolledBack as TuiActionRolledBack,
         )
         from loom.platform.cli.ui import (
             TextChunk,
@@ -1688,6 +1786,8 @@ class LoomChatApp:
             ToolEnd,
             TurnDone,
             TurnPaused,
+            ActionStateChange,
+            ActionRolledBack,
         )
 
         class _App(LoomApp):
@@ -1900,6 +2000,27 @@ class LoomChatApp:
                                     used_tokens=budget.used_tokens,
                                     max_tokens=budget.total_tokens,
                                     think_text=self._session._last_think,
+                                )
+                            )
+                        elif isinstance(ev, ActionStateChange):
+                            await self.dispatch_stream_event(
+                                TuiActionStateChange(
+                                    action_id=ev.action_id,
+                                    tool_name=ev.tool_name,
+                                    call_id=ev.call_id,
+                                    old_state=ev.old_state,
+                                    new_state=ev.new_state,
+                                    reason=ev.reason,
+                                )
+                            )
+                        elif isinstance(ev, ActionRolledBack):
+                            await self.dispatch_stream_event(
+                                TuiActionRolledBack(
+                                    action_id=ev.action_id,
+                                    tool_name=ev.tool_name,
+                                    call_id=ev.call_id,
+                                    rollback_success=ev.rollback_success,
+                                    message=ev.message,
                                 )
                             )
                 except asyncio.CancelledError:

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -121,14 +121,52 @@ def make_filesystem_tools(workspace: Path) -> list["ToolDefinition"]:
         content = call.args.get("content", "")
         path = _resolve_workspace_path(raw, workspace)
         try:
+            # Capture original content for rollback (Issue #42)
+            original_content: str | None = None
+            file_existed = path.exists()
+            if file_existed:
+                try:
+                    original_content = path.read_text(encoding="utf-8")
+                except Exception:
+                    pass  # binary file or unreadable — rollback will delete
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text(content, encoding="utf-8")
-            return ToolResult(call_id=call.id, tool_name=call.tool_name,
-                              success=True,
-                              output=f"Written {len(content)} chars to {path}")
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=True,
+                output=f"Written {len(content)} chars to {path}",
+                metadata={
+                    "_original_content": original_content,
+                    "_file_existed": file_existed,
+                    "_resolved_path": str(path),
+                },
+            )
         except Exception as exc:
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
                               success=False, error=str(exc))
+
+    async def _write_file_rollback(call: ToolCall, result: ToolResult) -> ToolResult:
+        """Restore original file content (or delete if newly created)."""
+        resolved = result.metadata.get("_resolved_path", "")
+        path = Path(resolved) if resolved else _resolve_workspace_path(
+            call.args.get("path", ""), workspace
+        )
+        original = result.metadata.get("_original_content")
+        existed = result.metadata.get("_file_existed", True)
+        try:
+            if not existed:
+                path.unlink(missing_ok=True)
+                msg = f"Rolled back: deleted newly created {path}"
+            elif original is not None:
+                path.write_text(original, encoding="utf-8")
+                msg = f"Rolled back: restored original content of {path}"
+            else:
+                msg = f"Rollback: no original content captured for {path}"
+            return ToolResult(call_id=call.id, tool_name="write_file",
+                              success=True, output=msg)
+        except Exception as exc:
+            return ToolResult(call_id=call.id, tool_name="write_file",
+                              success=False, error=f"Rollback failed: {exc}")
 
     async def _list_dir(call: ToolCall) -> ToolResult:
         raw = call.args.get("path", "")
@@ -164,6 +202,7 @@ def make_filesystem_tools(workspace: Path) -> list["ToolDefinition"]:
             },
             executor=_read_file,
             tags=["filesystem", "read"],
+            scope="filesystem",
         ),
         ToolDefinition(
             name="write_file",
@@ -184,6 +223,9 @@ def make_filesystem_tools(workspace: Path) -> list["ToolDefinition"]:
             },
             executor=_write_file,
             tags=["filesystem", "write"],
+            scope="filesystem",
+            rollback_fn=_write_file_rollback,
+            preconditions=["target directory must be writable"],
         ),
         ToolDefinition(
             name="list_dir",
@@ -202,6 +244,7 @@ def make_filesystem_tools(workspace: Path) -> list["ToolDefinition"]:
             },
             executor=_list_dir,
             tags=["filesystem", "read"],
+            scope="filesystem",
         ),
     ]
 
@@ -299,6 +342,7 @@ def make_run_bash_tool(workspace: Path, strict_sandbox: bool = False) -> ToolDef
         },
         executor=_run_bash,
         tags=["shell"],
+        scope="shell",
     )
 
 
@@ -371,6 +415,7 @@ def make_recall_tool(search: "MemorySearch") -> ToolDefinition:
         },
         executor=_recall,
         tags=["memory", "search", "recall"],
+        scope="memory",
     )
 
 
@@ -400,7 +445,22 @@ def make_memorize_tool(semantic: "SemanticMemory") -> ToolDefinition:
         else:
             msg = f"Memorized: {key!r}"
         return ToolResult(call_id=call.id, tool_name=call.tool_name,
-                          success=True, output=msg)
+                          success=True, output=msg,
+                          metadata={"_memorized_key": key})
+
+    async def _memorize_rollback(call: ToolCall, result: ToolResult) -> ToolResult:
+        """Delete the key that was just memorized."""
+        key = result.metadata.get("_memorized_key") or call.args.get("key", "").strip()
+        if not key:
+            return ToolResult(call_id=call.id, tool_name="memorize",
+                              success=False, error="No key to rollback")
+        try:
+            await semantic.delete(key)
+            return ToolResult(call_id=call.id, tool_name="memorize",
+                              success=True, output=f"Rolled back: deleted key {key!r}")
+        except Exception as exc:
+            return ToolResult(call_id=call.id, tool_name="memorize",
+                              success=False, error=f"Rollback failed: {exc}")
 
     return ToolDefinition(
         name="memorize",
@@ -431,6 +491,8 @@ def make_memorize_tool(semantic: "SemanticMemory") -> ToolDefinition:
         },
         executor=_memorize,
         tags=["memory", "write", "memorize"],
+        scope="memory",
+        rollback_fn=_memorize_rollback,
     )
 
 
@@ -463,7 +525,24 @@ def make_relate_tool(relational: "RelationalMemory") -> ToolDefinition:
         )
         await relational.upsert(entry)
         return ToolResult(call_id=call.id, tool_name=call.tool_name,
-                          success=True, output=f"Stored: {subject!r} {predicate!r} {obj!r}")
+                          success=True, output=f"Stored: {subject!r} {predicate!r} {obj!r}",
+                          metadata={"_subject": subject, "_predicate": predicate})
+
+    async def _relate_rollback(call: ToolCall, result: ToolResult) -> ToolResult:
+        """Delete the triple that was just stored."""
+        subject = result.metadata.get("_subject") or call.args.get("subject", "").strip()
+        predicate = result.metadata.get("_predicate") or call.args.get("predicate", "").strip()
+        if not subject or not predicate:
+            return ToolResult(call_id=call.id, tool_name="relate",
+                              success=False, error="No subject/predicate to rollback")
+        try:
+            await relational.delete(subject, predicate)
+            return ToolResult(call_id=call.id, tool_name="relate",
+                              success=True,
+                              output=f"Rolled back: deleted ({subject!r}, {predicate!r})")
+        except Exception as exc:
+            return ToolResult(call_id=call.id, tool_name="relate",
+                              success=False, error=f"Rollback failed: {exc}")
 
     return ToolDefinition(
         name="relate",
@@ -487,6 +566,8 @@ def make_relate_tool(relational: "RelationalMemory") -> ToolDefinition:
         },
         executor=_relate,
         tags=["memory", "write", "relational"],
+        scope="memory",
+        rollback_fn=_relate_rollback,
     )
 
 
@@ -534,6 +615,7 @@ def make_query_relations_tool(relational: "RelationalMemory") -> ToolDefinition:
         },
         executor=_query_relations,
         tags=["memory", "search", "relational"],
+        scope="memory",
     )
 
 
@@ -603,6 +685,7 @@ def make_fetch_url_tool() -> ToolDefinition:
         },
         executor=_fetch_url,
         tags=["web", "fetch"],
+        scope="network",
     )
 
 
@@ -681,6 +764,7 @@ def make_web_search_tool(brave_api_key: str) -> ToolDefinition:
         },
         executor=_web_search,
         tags=["web", "search"],
+        scope="network",
     )
 
 
@@ -773,6 +857,7 @@ def make_spawn_agent_tool(parent_session: Any) -> "ToolDefinition":
         },
         executor=_spawn_agent,
         tags=["agent", "spawn"],
+        scope="agent",
     )
 
 

--- a/loom/platform/cli/tui/app.py
+++ b/loom/platform/cli/tui/app.py
@@ -49,6 +49,8 @@ from .events import (
     TurnDone,
     TurnPaused,
     BudgetUpdate,
+    ActionStateChange,
+    ActionRolledBack,
 )
 
 if TYPE_CHECKING:
@@ -343,6 +345,10 @@ class LoomApp(App):
             await self._on_turn_done(event)
         elif isinstance(event, BudgetUpdate):
             self._on_budget_update(event)
+        elif isinstance(event, ActionStateChange):
+            self._on_action_state_change(event)
+        elif isinstance(event, ActionRolledBack):
+            self._on_action_rolled_back(event)
 
     async def _on_turn_start(self, event: TurnStart) -> None:
         msg_list = self.query_one("#message-list", MessageList)
@@ -402,6 +408,22 @@ class LoomApp(App):
             error_snippet=error_snippet,
             expanded=not event.success,
         ))
+
+    def _on_action_state_change(self, event: ActionStateChange) -> None:
+        """Update ToolBlock to reflect lifecycle state changes (Issue #42)."""
+        tool_block = self.query_one("#tool-block", ToolBlock)
+        tool_block.update_tool_lifecycle(
+            event.call_id, event.old_state, event.new_state, event.reason
+        )
+
+    def _on_action_rolled_back(self, event: ActionRolledBack) -> None:
+        """Show rollback notification inline in the conversation (Issue #42)."""
+        msg_list = self.query_one("#message-list", MessageList)
+        icon = "✓" if event.rollback_success else "✗"
+        msg_list.stream_text(
+            f"\n  ↩ {icon} {event.tool_name} rolled back"
+            + (f" — {event.message}" if event.message else "")
+        )
 
     async def _on_turn_paused(self, event: TurnPaused) -> None:
         from .components.interactive_widgets import InlinePauseWidget

--- a/loom/platform/cli/tui/components/tool_block.py
+++ b/loom/platform/cli/tui/components/tool_block.py
@@ -33,10 +33,56 @@ class AgentState(Enum):
 
 
 class ToolState(Enum):
-    PENDING = "pending"
-    RUNNING = "running"
-    DONE = "done"
-    FAILED = "failed"
+    PENDING    = "pending"
+    AUTHORIZED = "authorized"    # Issue #42: passed permission check
+    PREPARED   = "prepared"      # Issue #42: preconditions verified
+    RUNNING    = "running"
+    OBSERVED   = "observed"      # Issue #42: executor returned, awaiting validation
+    VALIDATED  = "validated"     # Issue #42: post-validator passed
+    DONE       = "done"
+    REVERTING  = "reverting"     # Issue #42: rollback in progress
+    REVERTED   = "reverted"      # Issue #42: rollback completed
+    FAILED     = "failed"
+    DENIED     = "denied"        # Issue #42: permission denied
+
+    @property
+    def icon(self) -> str:
+        """Lifecycle state icon for TUI display."""
+        return _STATE_ICONS.get(self, "?")
+
+    @property
+    def style(self) -> str:
+        """Rich markup colour for the state."""
+        return _STATE_STYLES.get(self, "dim")
+
+
+_STATE_ICONS: dict[ToolState, str] = {
+    ToolState.PENDING:    "◌",
+    ToolState.AUTHORIZED: "🔓",
+    ToolState.PREPARED:   "📋",
+    ToolState.RUNNING:    "⟳",
+    ToolState.OBSERVED:   "👁",
+    ToolState.VALIDATED:  "✓",
+    ToolState.DONE:       "✓",
+    ToolState.REVERTING:  "↩",
+    ToolState.REVERTED:   "↩✗",
+    ToolState.FAILED:     "✗",
+    ToolState.DENIED:     "🚫",
+}
+
+_STATE_STYLES: dict[ToolState, str] = {
+    ToolState.PENDING:    "dim",
+    ToolState.AUTHORIZED: "#c8a464",
+    ToolState.PREPARED:   "#6a9fcc",
+    ToolState.RUNNING:    "yellow",
+    ToolState.OBSERVED:   "dim",
+    ToolState.VALIDATED:  "#7a9e78",
+    ToolState.DONE:       "#7a9e78",
+    ToolState.REVERTING:  "#c8924a",
+    ToolState.REVERTED:   "#b87060",
+    ToolState.FAILED:     "#b87060",
+    ToolState.DENIED:     "#b87060",
+}
 
 
 @dataclass
@@ -156,6 +202,42 @@ class ToolBlock(Widget):
             self._start_think_animation()
             self.post_message(self.ToolDone(self.completed_tools[-len(completed):]))
 
+        self._update_display()
+
+    def update_tool_lifecycle(
+        self, call_id: str, old_state: str, new_state: str, reason: str | None = None
+    ) -> None:
+        """
+        Update a tool's displayed state from a lifecycle state change event (Issue #42).
+
+        Maps ActionState values to ToolState enum members for visualization.
+        """
+        _MAP = {
+            "authorized": ToolState.AUTHORIZED,
+            "prepared":   ToolState.PREPARED,
+            "executing":  ToolState.RUNNING,
+            "observed":   ToolState.OBSERVED,
+            "validated":  ToolState.VALIDATED,
+            "committed":  ToolState.DONE,
+            "reverting":  ToolState.REVERTING,
+            "reverted":   ToolState.REVERTED,
+            "denied":     ToolState.DENIED,
+            "aborted":    ToolState.FAILED,
+            "timed_out":  ToolState.FAILED,
+        }
+        ts = _MAP.get(new_state)
+        if ts is None:
+            return
+        for tool in self.active_tools:
+            if tool.call_id == call_id:
+                tool.state = ts
+                break
+        else:
+            # Tool might already be in completed list
+            for tool in self.completed_tools:
+                if tool.call_id == call_id:
+                    tool.state = ts
+                    break
         self._update_display()
 
     def clear(self) -> None:

--- a/loom/platform/cli/tui/events.py
+++ b/loom/platform/cli/tui/events.py
@@ -111,3 +111,24 @@ class ErrorOccurred(StreamEvent):
     """An error occurred during streaming."""
 
     message: str
+
+
+@dataclass
+class ActionStateChange(StreamEvent):
+    """An action transitioned to a new lifecycle state (Issue #42)."""
+    action_id: str
+    tool_name: str
+    call_id: str
+    old_state: str
+    new_state: str
+    reason: str | None = None
+
+
+@dataclass
+class ActionRolledBack(StreamEvent):
+    """An action was rolled back after post-validation failure (Issue #42)."""
+    action_id: str
+    tool_name: str
+    call_id: str
+    rollback_success: bool
+    message: str = ""

--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -99,6 +99,27 @@ class TurnDone:
     elapsed_ms: float
 
 
+@dataclass
+class ActionStateChange:
+    """An action transitioned to a new lifecycle state (Issue #42)."""
+    action_id: str
+    tool_name: str
+    call_id: str
+    old_state: str
+    new_state: str
+    reason: str | None = None
+
+
+@dataclass
+class ActionRolledBack:
+    """An action was rolled back after post-validation failure (Issue #42)."""
+    action_id: str
+    tool_name: str
+    call_id: str
+    rollback_success: bool
+    message: str = ""
+
+
 # ---------------------------------------------------------------------------
 # Slash command autocomplete
 # ---------------------------------------------------------------------------

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -66,7 +66,10 @@ except ImportError as exc:  # pragma: no cover
         "Install with:  pip install 'loom[discord]'"
     ) from exc
 
-from loom.platform.cli.ui import CompressDone, TextChunk, ToolBegin, ToolEnd, TurnDone, TurnPaused
+from loom.platform.cli.ui import (
+    ActionRolledBack, ActionStateChange,
+    CompressDone, TextChunk, ToolBegin, ToolEnd, TurnDone, TurnPaused,
+)
 from loom.platform.discord.tools import make_send_discord_file_tool, make_send_discord_embed_tool
 
 if TYPE_CHECKING:
@@ -647,8 +650,15 @@ class LoomDiscordBot:
                             f"-# 🧠 記憶壓縮：{event.fact_count} 條事實已存入語意記憶"
                         )
 
-                    elif isinstance(event, TurnDone):
-                        pass
+                    elif isinstance(event, ActionRolledBack):
+                        icon = "✓" if event.rollback_success else "✗"
+                        tool_buf += f"\n↩ {icon} {event.tool_name} rolled back"
+                        if event.message:
+                            tool_buf += f" — {event.message[:80]}"
+                        await _safe_edit(status_msg, tool_buf.lstrip())
+
+                    elif isinstance(event, (ActionStateChange, TurnDone)):
+                        pass  # ActionStateChange: too granular for Discord display
 
             except asyncio.CancelledError:
                 # /stop — finalize what we have so far


### PR DESCRIPTION
## Epic 1: Action Lifecycle Management

Closes #42

將 Loom 的工具執行從二元式 `ToolCall`/`ToolResult` 升級為完整的狀態機 (`ActionRecord` / `ExecutionEnvelope`)，追蹤 action 的完整生命週期。

### State Machine

```
Declared → Authorized → Prepared → Executing → Observed →
Validated → Committed/Reverted → Memorialized
```

Terminal failure states: `Denied`, `Aborted`, `TimedOut`

### Changes (5 Phases, 14 files, +1078 lines)

**Phase 1: Core Data Models**
- `lifecycle.py` — ActionState (13 states), ActionIntent, ActionRecord, ExecutionEnvelope
- `ToolDefinition` — 新增 `rollback_fn`, `post_validator`, `preconditions`, `scope`
- `LifecycleMiddleware` — 最外層 middleware 驅動狀態機

**Phase 2: Rollback Mechanisms**
- `write_file` — 寫入前備份，rollback 恢復原始內容
- `memorize` — rollback 刪除 key
- `relate` — rollback 刪除 triple
- 所有工具 — scope 分類 (filesystem/shell/memory/network/agent)

**Phase 3: Session Integration**
- `action_records` SQLite 表 — 完整 state_history JSON 持久化
- `_on_lifecycle` — ActionRecord 寫入 DB
- `_on_state_change` — 事件排入 asyncio.Queue，由 stream_turn 排出
- `ActionStateChange` / `ActionRolledBack` 串流事件

**Phase 4: TUI Visualization**
- ToolState 11 態，各有 icon + Parchment palette 顏色
- `update_tool_lifecycle()` 即時狀態更新
- 回滾通知 inline 顯示

**Phase 5: Discord & Autonomy**
- Discord: rollback 訊息 inline 顯示
- Autonomy daemon: 靜默消費 lifecycle 事件

### Backward Compatibility

✅ 所有新欄位都有預設值，現有工具和 plugin **零修改即可運作**。
ActionRecord 透過 composition 包裝 ToolCall/ToolResult，不破壞現有介面。

### Verification

- 7 項自動化測試全數通過（狀態機、rollback、envelope、UI events）
- 完整 import chain 驗證通過