### PR TITLE
fix(#58): Wire SkillOutcomeTracker.maybe_evaluate() 和 SkillEvolutionHook

### DIFF
--- a/loom/core/cognition/counter_factual.py
+++ b/loom/core/cognition/counter_factual.py
@@ -304,18 +304,23 @@ class SkillEvolutionHook:
         """
         Check all active skills and trigger evolution for those that qualify.
 
+        Runs sequentially so the caller can await completion before closing
+        DB connections (e.g. in ``LoomSession.stop()``).
+
         Returns the number of skills that received evolution hints.
         """
         skills = await self._procedural.list_active()
         count = 0
         for skill in skills:
             if self._should_evolve(skill):
-                task = asyncio.create_task(
-                    self._evolve(skill),
-                    name=f"skill_evolve:{skill.name}",
-                )
-                task.add_done_callback(_on_evolve_done)
-                count += 1
+                try:
+                    await self._evolve(skill)
+                    count += 1
+                except Exception as exc:
+                    logger.debug(
+                        "Skill evolution failed for '%s': %s: %s",
+                        skill.name, type(exc).__name__, exc,
+                    )
         return count
 
     def _should_evolve(self, skill) -> bool:

--- a/loom/core/memory/semantic.py
+++ b/loom/core/memory/semantic.py
@@ -236,6 +236,28 @@ class SemanticMemory:
             for r in rows
         ]
 
+    async def list_by_prefix(self, prefix: str, limit: int = 10) -> list[SemanticEntry]:
+        """Return entries whose key starts with *prefix*, newest first.
+
+        Used by skill evolution hints to query entries matching
+        ``skill:<name>:evolution_hint:*`` without full-text search overhead.
+        """
+        cursor = await self._db.execute(
+            "SELECT id, key, value, confidence, source, metadata, created_at, updated_at "
+            "FROM semantic_entries WHERE key LIKE ? ORDER BY updated_at DESC LIMIT ?",
+            (f"{prefix}%", limit),
+        )
+        rows = await cursor.fetchall()
+        return [
+            SemanticEntry(
+                id=r[0], key=r[1], value=r[2], confidence=r[3],
+                source=r[4], metadata=json.loads(r[5]),
+                created_at=datetime.fromisoformat(r[6]),
+                updated_at=datetime.fromisoformat(r[7]),
+            )
+            for r in rows
+        ]
+
     async def prune_decayed(
         self,
         threshold: float = 0.1,

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -585,6 +585,8 @@ class LoomSession:
         self.registry.register(make_load_skill_tool(
             self._procedural, skills_dirs,
             outcome_tracker=self._skill_outcome_tracker,
+            semantic=self._semantic,
+            turn_index_fn=lambda: self._turn_index,
         ))
 
         # Register web tools (Phase 5D)
@@ -678,6 +680,23 @@ class LoomSession:
             )
             if count:
                 console.print(f"[dim]  Saved {count} fact(s) to semantic memory.[/dim]")
+
+            # Issue #58: trigger evolution analysis for low-confidence skills
+            if self._procedural is not None and self._semantic is not None:
+                try:
+                    from loom.core.cognition.counter_factual import SkillEvolutionHook
+                    evolution_hook = SkillEvolutionHook(
+                        router=self.router, model=self.model,
+                        procedural=self._procedural, semantic=self._semantic,
+                    )
+                    evolved = await evolution_hook.check_all_skills()
+                    if evolved:
+                        console.print(
+                            f"[dim]  Queued evolution analysis for {evolved} skill(s).[/dim]"
+                        )
+                except Exception:
+                    pass  # evolution failure must never block shutdown
+
             if self._session_log is not None:
                 first_user = next(
                     (m["content"] for m in self.messages if m["role"] == "user"), None
@@ -902,6 +921,9 @@ class LoomSession:
             if response.stop_reason == "end_turn":
                 self._turn_index += 1
 
+                # Issue #58: trigger skill self-assessment before TurnDone
+                self._trigger_skill_assessment()
+
                 # Mid-session episodic compression: configurable via loom.toml
                 # [memory] episodic_compress_threshold (default 30).
                 try:
@@ -1030,6 +1052,8 @@ class LoomSession:
                         self._cancel_requested = False
                         self._last_think = "".join(_think_parts).strip()
                         self._turn_index += 1
+                        # Issue #58: trigger skill self-assessment before TurnDone
+                        self._trigger_skill_assessment()
                         yield TurnDone(
                             tool_count=tool_count,
                             input_tokens=input_tokens,
@@ -1042,11 +1066,50 @@ class LoomSession:
 
         self._last_think = "".join(_think_parts).strip()
         self._turn_index += 1
+        # Issue #58: trigger skill self-assessment before TurnDone
+        self._trigger_skill_assessment()
         yield TurnDone(
             tool_count=tool_count,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             elapsed_ms=(time.monotonic() - t0) * 1000,
+        )
+
+    # ------------------------------------------------------------------
+    # Issue #58: Skill self-assessment trigger
+    # ------------------------------------------------------------------
+
+    def _trigger_skill_assessment(self) -> None:
+        """
+        Fire-and-forget: schedule skill self-assessment if a skill was
+        activated during this session.
+
+        Called at each TurnDone point in stream_turn(). The LLM self-assessment
+        runs as a background task and never blocks the conversation.
+        """
+        if (
+            self._skill_outcome_tracker is None
+            or not self._skill_outcome_tracker.has_active_skills()
+        ):
+            return
+
+        # Extract last assistant message as turn summary
+        turn_summary = ""
+        for msg in reversed(self.messages):
+            if msg.get("role") == "assistant":
+                content = msg.get("content", "")
+                if isinstance(content, str):
+                    turn_summary = content[:2000]
+                break
+
+        if not turn_summary:
+            return
+
+        self._skill_outcome_tracker.maybe_evaluate(
+            router=self.router,
+            model=self.model,
+            turn_index=self._turn_index,
+            turn_summary=turn_summary,
         )
 
     # ------------------------------------------------------------------

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -629,6 +629,8 @@ def make_load_skill_tool(
     procedural: "ProceduralMemory",
     skills_dirs: list[Path] | None = None,
     outcome_tracker: "SkillOutcomeTracker | None" = None,
+    semantic: "SemanticMemory | None" = None,
+    turn_index_fn: "Callable[[], int] | None" = None,
 ) -> ToolDefinition:
     """
     Create a SAFE ``load_skill`` tool that loads full skill instructions.
@@ -693,7 +695,7 @@ def make_load_skill_tool(
         lines = [f'<skill_content name="{name}">']
 
         # Evolution hints (from semantic memory, if available)
-        evolution_hints = await _get_evolution_hints(procedural, name)
+        evolution_hints = await _get_evolution_hints(procedural, semantic, name)
         if evolution_hints:
             lines.append("<evolution_hints>")
             for hint in evolution_hints:
@@ -724,8 +726,8 @@ def make_load_skill_tool(
         # Record activation
         _loaded_this_session.add(name)
         if outcome_tracker is not None:
-            # Use a placeholder turn_index; the actual turn is tracked by session
-            outcome_tracker.record_activation(name, 0)
+            _turn = turn_index_fn() if turn_index_fn else 0
+            outcome_tracker.record_activation(name, _turn)
 
         return ToolResult(
             call_id=call.id, tool_name=call.tool_name,
@@ -804,24 +806,40 @@ def _find_skill_resources(
 
 
 async def _get_evolution_hints(
-    procedural: "ProceduralMemory", skill_name: str,
+    procedural: "ProceduralMemory",
+    semantic: "SemanticMemory | None",
+    skill_name: str,
 ) -> list[str]:
-    """Fetch evolution hints from semantic memory for a skill."""
-    # Evolution hints are written by SkillEvolutionHook as semantic entries
-    # with key pattern: skill:<name>:evolution_hint:*
-    # Since we can't do wildcard queries on semantic memory easily here,
-    # we check the skill's confidence and return a hint if it's low.
-    skill = await procedural.get(skill_name)
-    if skill is None:
-        return []
+    """Fetch evolution hints for a skill.
 
+    Reads real evolution hints written by ``SkillEvolutionHook`` from
+    SemanticMemory (key pattern ``skill:<name>:evolution_hint:*``).
+    Falls back to a confidence-based generic warning if no stored hints.
+    """
     hints: list[str] = []
-    if skill.confidence < 0.6 and skill.usage_count >= 3:
-        hints.append(
-            f"⚠ This skill's confidence is {skill.confidence:.2f} "
-            f"(usage: {skill.usage_count}×). "
-            f"Consider reviewing recent outcomes and improving the workflow."
-        )
+
+    # Query real evolution hints from semantic memory
+    if semantic is not None:
+        try:
+            entries = await semantic.list_by_prefix(
+                f"skill:{skill_name}:evolution_hint:", limit=3,
+            )
+            for entry in entries:
+                hints.append(entry.value)
+        except Exception:
+            pass  # semantic query failure must never block load_skill
+
+    # Fallback: confidence-based warning if no stored hints
+    if not hints:
+        skill = await procedural.get(skill_name)
+        if (skill is not None
+                and skill.confidence < 0.6
+                and skill.usage_count >= 3):
+            hints.append(
+                f"⚠ This skill's confidence is {skill.confidence:.2f} "
+                f"(usage: {skill.usage_count}×). "
+                f"Consider reviewing recent outcomes and improving the workflow."
+            )
     return hints
 
 

--- a/tests/test_skill_tools.py
+++ b/tests/test_skill_tools.py
@@ -350,3 +350,267 @@ class TestSkillEvolutionHook:
         skill.usage_count = 1  # too few uses
 
         assert hook._should_evolve(skill) is False
+
+
+# ---------------------------------------------------------------------------
+# Issue #58: Gap-specific tests
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeEvaluateTrigger:
+    """Test that maybe_evaluate fires only when skills are active."""
+
+    @pytest.mark.asyncio
+    async def test_fires_on_active_skills(self):
+        from loom.core.memory.skill_outcome import SkillOutcomeTracker
+
+        tracker = SkillOutcomeTracker(
+            procedural=MagicMock(),
+            semantic=MagicMock(),
+            session_id="test-session",
+        )
+        tracker.record_activation("test-skill", 1)
+        tracker.record_tool_usage()
+
+        # Mock router to verify LLM call is scheduled
+        mock_router = MagicMock()
+        mock_router.chat = AsyncMock()
+
+        # maybe_evaluate should schedule a task (not raise)
+        tracker.maybe_evaluate(
+            router=mock_router,
+            model="test-model",
+            turn_index=1,
+            turn_summary="Completed the test task.",
+        )
+        # After evaluation, the skill should be removed from activated
+        assert "test-skill" not in tracker._activated
+
+    def test_skips_when_no_skills(self):
+        from loom.core.memory.skill_outcome import SkillOutcomeTracker
+
+        tracker = SkillOutcomeTracker(
+            procedural=MagicMock(),
+            semantic=MagicMock(),
+            session_id="test-session",
+        )
+        # No skills activated — should be a no-op
+        mock_router = MagicMock()
+        tracker.maybe_evaluate(
+            router=mock_router,
+            model="test-model",
+            turn_index=1,
+            turn_summary="Some text.",
+        )
+        # No tasks should have been created
+        assert not tracker.has_active_skills()
+
+
+class TestEvolutionHintsFromSemantic:
+    """Test that _get_evolution_hints reads from SemanticMemory."""
+
+    @pytest.mark.asyncio
+    async def test_reads_real_hints(self):
+        from loom.platform.cli.tools import _get_evolution_hints
+        from loom.core.memory.semantic import SemanticEntry
+
+        mock_procedural = AsyncMock()
+        mock_semantic = AsyncMock()
+
+        # Simulate stored evolution hints
+        mock_semantic.list_by_prefix = AsyncMock(return_value=[
+            SemanticEntry(
+                key="skill:test-skill:evolution_hint:2026-04-07",
+                value="Consider adding error handling for edge cases.",
+            ),
+        ])
+
+        hints = await _get_evolution_hints(mock_procedural, mock_semantic, "test-skill")
+        assert len(hints) == 1
+        assert "error handling" in hints[0]
+        mock_semantic.list_by_prefix.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_confidence(self):
+        from loom.platform.cli.tools import _get_evolution_hints
+
+        mock_procedural = AsyncMock()
+        mock_semantic = AsyncMock()
+
+        # No stored hints
+        mock_semantic.list_by_prefix = AsyncMock(return_value=[])
+
+        # Low confidence skill
+        mock_skill = MagicMock()
+        mock_skill.confidence = 0.4
+        mock_skill.usage_count = 5
+        mock_procedural.get = AsyncMock(return_value=mock_skill)
+
+        hints = await _get_evolution_hints(mock_procedural, mock_semantic, "test-skill")
+        assert len(hints) == 1
+        assert "0.40" in hints[0]
+
+    @pytest.mark.asyncio
+    async def test_no_hints_high_confidence(self):
+        from loom.platform.cli.tools import _get_evolution_hints
+
+        mock_procedural = AsyncMock()
+        mock_semantic = AsyncMock()
+        mock_semantic.list_by_prefix = AsyncMock(return_value=[])
+
+        mock_skill = MagicMock()
+        mock_skill.confidence = 0.9
+        mock_skill.usage_count = 10
+        mock_procedural.get = AsyncMock(return_value=mock_skill)
+
+        hints = await _get_evolution_hints(mock_procedural, mock_semantic, "test-skill")
+        assert len(hints) == 0
+
+    @pytest.mark.asyncio
+    async def test_works_without_semantic(self):
+        """When semantic is None (e.g. not connected), fallback still works."""
+        from loom.platform.cli.tools import _get_evolution_hints
+
+        mock_procedural = AsyncMock()
+        mock_skill = MagicMock()
+        mock_skill.confidence = 0.3
+        mock_skill.usage_count = 5
+        mock_procedural.get = AsyncMock(return_value=mock_skill)
+
+        hints = await _get_evolution_hints(mock_procedural, None, "test-skill")
+        assert len(hints) == 1
+
+
+class TestListByPrefix:
+    """Test SemanticMemory.list_by_prefix."""
+
+    @pytest.mark.asyncio
+    async def test_returns_matching_entries(self, tmp_path):
+        import aiosqlite
+        from loom.core.memory.store import SQLiteStore
+        from loom.core.memory.semantic import SemanticMemory, SemanticEntry
+
+        store = SQLiteStore(str(tmp_path / "test.db"))
+        await store.initialize()
+        async with store.connect() as db:
+            sem = SemanticMemory(db)
+
+            # Insert entries with matching and non-matching keys
+            await sem.upsert(SemanticEntry(
+                key="skill:test:evolution_hint:2026-01",
+                value="Hint A",
+            ))
+            await sem.upsert(SemanticEntry(
+                key="skill:test:evolution_hint:2026-02",
+                value="Hint B",
+            ))
+            await sem.upsert(SemanticEntry(
+                key="skill:other:evolution_hint:2026-01",
+                value="Other hint",
+            ))
+            await sem.upsert(SemanticEntry(
+                key="unrelated:key",
+                value="Not a hint",
+            ))
+
+            results = await sem.list_by_prefix("skill:test:evolution_hint:")
+            assert len(results) == 2
+            values = {r.value for r in results}
+            assert "Hint A" in values
+            assert "Hint B" in values
+
+    @pytest.mark.asyncio
+    async def test_empty_prefix_returns_nothing(self, tmp_path):
+        import aiosqlite
+        from loom.core.memory.store import SQLiteStore
+        from loom.core.memory.semantic import SemanticMemory
+
+        store = SQLiteStore(str(tmp_path / "test.db"))
+        await store.initialize()
+        async with store.connect() as db:
+            sem = SemanticMemory(db)
+            results = await sem.list_by_prefix("nonexistent:")
+            assert results == []
+
+
+class TestRecordActivationTurnIndex:
+    """Test that record_activation receives correct turn_index."""
+
+    def test_turn_index_fn_called(self):
+        from loom.core.memory.skill_outcome import SkillOutcomeTracker
+
+        tracker = SkillOutcomeTracker(
+            procedural=MagicMock(),
+            semantic=MagicMock(),
+            session_id="test-session",
+        )
+
+        # Simulate what make_load_skill_tool does with turn_index_fn
+        turn_index = 7
+        tracker.record_activation("my-skill", turn_index)
+
+        assert tracker._activated["my-skill"] == 7
+
+    @pytest.mark.asyncio
+    async def test_activated_at_correct_turn(self):
+        from loom.core.memory.skill_outcome import SkillOutcomeTracker
+
+        tracker = SkillOutcomeTracker(
+            procedural=MagicMock(),
+            semantic=MagicMock(),
+            session_id="test-session",
+        )
+
+        tracker.record_activation("skill-a", 3)
+        tracker.record_activation("skill-b", 5)
+
+        # maybe_evaluate at turn 4 should only pick up skill-a
+        mock_router = MagicMock()
+        mock_router.chat = AsyncMock()
+
+        tracker.maybe_evaluate(
+            router=mock_router,
+            model="test",
+            turn_index=4,
+            turn_summary="Turn 4 summary.",
+        )
+        # skill-a should be consumed, skill-b still pending
+        assert "skill-a" not in tracker._activated
+        assert "skill-b" in tracker._activated
+
+
+class TestCheckAllSkillsSequential:
+    """Test that check_all_skills runs sequentially (not fire-and-forget)."""
+
+    @pytest.mark.asyncio
+    async def test_sequential_execution(self):
+        from loom.core.cognition.counter_factual import SkillEvolutionHook
+
+        mock_procedural = AsyncMock()
+        mock_semantic = AsyncMock()
+
+        # Create a skill that qualifies for evolution
+        mock_skill = MagicMock()
+        mock_skill.name = "test-skill"
+        mock_skill.confidence = 0.3
+        mock_skill.usage_count = 5
+        mock_skill.success_rate = 0.3
+        mock_procedural.list_active = AsyncMock(return_value=[mock_skill])
+
+        mock_router = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = "Improve step 3 by validating input first."
+        mock_router.chat = AsyncMock(return_value=mock_response)
+
+        hook = SkillEvolutionHook(
+            router=mock_router,
+            model="test",
+            procedural=mock_procedural,
+            semantic=mock_semantic,
+        )
+
+        count = await hook.check_all_skills()
+        assert count == 1
+        # Verify semantic.upsert was called (evolution hint written)
+        assert mock_semantic.upsert.called
+


### PR DESCRIPTION
## 背景
PR #57 實作了 skill lifecycle 的 outcome tracking 和 evolution hook，但 4 個 wiring gap 導致功能從未實際運作。

## 修復的 4 個 Gap

### Gap 1 — maybe_evaluate() 從未被呼叫 ✅
- 新增 `_trigger_skill_assessment()` helper 方法
- 在 `stream_turn()` 的 **3 個 TurnDone yield 點** 前都呼叫
- 提取最後一個 assistant message 作為 `turn_summary`

### Gap 2 — SkillEvolutionHook 從未被實例化 ✅
- 在 `stop()` 的 session compression 後呼叫 `check_all_skills()`
- 改 `check_all_skills()` 為 sequential await（避免 DB close 前 task 未完成）

### Gap 3 — _get_evolution_hints() 沒有讀 SemanticMemory ✅
- `SemanticMemory` 新增 `list_by_prefix()` 方法
- `_get_evolution_hints()` 查詢 `skill:<name>:evolution_hint:*`
- 無 stored hints 時 fallback 到 confidence 閾值警告
- `make_load_skill_tool()` 接收 `semantic` 參數

### Gap 4 — record_activation() hardcode turn_index=0 ✅
- `make_load_skill_tool()` 新增 `turn_index_fn` callback
- 註冊時傳入 `lambda: self._turn_index`

## 測試
\\\
369 passed, 0 failures (including 11 new gap-specific tests)
\\\

Closes #58