### PR TITLE
feat(#50): Control-first Action Lifecycle

### DIFF
--- a/loom/core/harness/__init__.py
+++ b/loom/core/harness/__init__.py
@@ -1,6 +1,6 @@
 from .middleware import (
     Middleware, MiddlewarePipeline, ToolCall, ToolResult,
-    LifecycleMiddleware,
+    LifecycleMiddleware, LifecycleGateMiddleware,
 )
 from .permissions import TrustLevel, PermissionContext
 from .registry import ToolDefinition, ToolRegistry
@@ -8,14 +8,16 @@ from .validation import SchemaValidationMiddleware
 from .lifecycle import (
     ActionState, ActionIntent, ActionRecord,
     ExecutionEnvelope, StateTransition,
+    LifecycleContext, LIFECYCLE_CTX_KEY,
 )
 
 __all__ = [
     "Middleware", "MiddlewarePipeline", "ToolCall", "ToolResult",
-    "LifecycleMiddleware",
+    "LifecycleMiddleware", "LifecycleGateMiddleware",
     "TrustLevel", "PermissionContext",
     "ToolDefinition", "ToolRegistry",
     "SchemaValidationMiddleware",
     "ActionState", "ActionIntent", "ActionRecord",
     "ExecutionEnvelope", "StateTransition",
+    "LifecycleContext", "LIFECYCLE_CTX_KEY",
 ]

--- a/loom/core/harness/lifecycle.py
+++ b/loom/core/harness/lifecycle.py
@@ -132,6 +132,90 @@ class ActionIntent:
 
 
 # ---------------------------------------------------------------------------
+# LifecycleContext — shared state for real-time lifecycle coordination
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LifecycleContext:
+    """
+    Shared context injected into ``ToolCall.metadata["_lifecycle_ctx"]``.
+
+    Purpose: enable **two** middleware layers plus downstream middleware
+    (BlastRadiusMiddleware) to coordinate lifecycle state transitions in
+    real time through a single shared object.
+
+    Participants:
+        LifecycleMiddleware (outer)
+            Creates this context, attaches it to the call.
+            After the inner pipeline returns, drives post-OBSERVED states
+            (VALIDATED, COMMITTED, REVERTING, REVERTED, MEMORIALIZED).
+
+        LifecycleGateMiddleware (inner, just before handler)
+            Reads authorization_result from BlastRadius.
+            Fires AUTHORIZED → PREPARED → EXECUTING → OBSERVED as real
+            control gates.
+
+        BlastRadiusMiddleware
+            Writes authorization_result / reason at the moment the
+            auth decision is made.
+
+    The ``transition()`` and ``memorialize()`` helpers centralize all
+    state-change bookkeeping so every call site is a single line.
+    """
+    record: ActionRecord = field(repr=False)
+    """The ActionRecord being tracked (reference, not copy)."""
+
+    authorization_result: bool | None = None
+    """
+    Set by BlastRadiusMiddleware:
+      True  → tool was authorized (pre-auth, exec_auto, or user confirmed)
+      False → user denied execution
+      None  → not yet decided (default)
+    """
+
+    authorization_reason: str | None = None
+    """Human-readable reason for the authorization decision."""
+
+    # --- Internal callbacks (set by LifecycleMiddleware, used by all) ---
+    _on_state_change: Any = field(default=None, repr=False)
+    """Callable[[ActionRecord, str, str], Awaitable[None]] | None"""
+
+    _on_lifecycle: Any = field(default=None, repr=False)
+    """Callable[[ActionRecord], Awaitable[None]] | None"""
+
+    async def transition(
+        self, new_state: ActionState, reason: str | None = None,
+    ) -> None:
+        """
+        Transition the record to *new_state* and fire the UI callback.
+
+        One-liner replacement for the old three-line pattern of
+        saving old state, calling record.transition(), and firing
+        the state change callback.
+        """
+        old = self.record.state.value
+        self.record.transition(new_state, reason=reason)
+        if self._on_state_change is not None:
+            try:
+                await self._on_state_change(self.record, old, self.record.state.value)
+            except Exception:
+                pass  # UI callback must never crash the pipeline
+
+    async def memorialize(self, reason: str) -> None:
+        """Transition to MEMORIALIZED and fire the on_lifecycle callback."""
+        await self.transition(ActionState.MEMORIALIZED, reason=reason)
+        if self._on_lifecycle is not None:
+            try:
+                await self._on_lifecycle(self.record)
+            except Exception:
+                pass  # lifecycle callback must never crash the pipeline
+
+
+# Metadata key for LifecycleContext in ToolCall.metadata
+LIFECYCLE_CTX_KEY = "_lifecycle_ctx"
+
+
+# ---------------------------------------------------------------------------
 # ActionRecord — single tool call lifecycle
 # ---------------------------------------------------------------------------
 

--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -5,7 +5,8 @@ Every tool call flows through this pipeline before and after execution.
 Middleware is composable: add, remove, or reorder without touching tool code.
 
 Execution order (outermost → innermost):
-    LogMiddleware → TraceMiddleware → BlastRadiusMiddleware → tool handler
+    LifecycleMiddleware → TraceMiddleware → SchemaValidationMiddleware
+    → BlastRadiusMiddleware → LifecycleGateMiddleware → tool handler
 """
 
 import asyncio
@@ -212,16 +213,37 @@ class BlastRadiusMiddleware(Middleware):
             return False   # escape detected — fall through to confirmation
         return True
 
+    def _notify_lifecycle(self, call: ToolCall, result: bool, reason: str) -> None:
+        """
+        Write authorization decision to LifecycleContext (Issue #50).
+
+        If the call carries a LifecycleContext (injected by LifecycleMiddleware),
+        record the real-time auth result so the lifecycle state machine can
+        transition DECLARED → AUTHORIZED (or → DENIED) at the moment the
+        decision is actually made — not retroactively.
+
+        When no LifecycleContext is present (e.g. sub-agent pipeline),
+        this is a no-op — full backward compatibility.
+        """
+        from .lifecycle import LIFECYCLE_CTX_KEY
+        ctx = call.metadata.get(LIFECYCLE_CTX_KEY)
+        if ctx is not None:
+            ctx.authorization_result = result
+            ctx.authorization_reason = reason
+
     async def process(self, call: ToolCall, next: ToolHandler) -> ToolResult:
         if self._perm.is_authorized(call.tool_name, call.trust_level):
+            self._notify_lifecycle(call, True, "pre-authorized")
             return await next(call)
 
         # exec_auto: session-level pre-authorization for sandboxed shell commands
         if self._exec_auto_approved(call):
+            self._notify_lifecycle(call, True, "exec_auto")
             return await next(call)
 
         allowed = await self._confirm(call)
         if not allowed:
+            self._notify_lifecycle(call, False, "user denied")
             return ToolResult(
                 call_id=call.id,
                 tool_name=call.tool_name,
@@ -229,6 +251,8 @@ class BlastRadiusMiddleware(Middleware):
                 error="User denied tool execution.",
                 failure_type="permission_denied",
             )
+
+        self._notify_lifecycle(call, True, "user confirmed")
 
         # EXEC and AGENT_SPAN tools re-confirm on every call (like CRITICAL).
         # Other GUARDED tools are pre-authorized for the rest of this session.
@@ -241,28 +265,226 @@ class BlastRadiusMiddleware(Middleware):
 
 
 # ---------------------------------------------------------------------------
-# Action Lifecycle Middleware (Issue #42)
+# Action Lifecycle Middleware — two-layer architecture (Issue #42 + #50)
+#
+# The lifecycle is split into TWO cooperating middleware layers:
+#
+#   Pipeline order:
+#     LifecycleMiddleware (outer)          ← DECLARED, post-OBSERVED states
+#       → TraceMiddleware
+#       → SchemaValidationMiddleware
+#       → BlastRadiusMiddleware
+#       → LifecycleGateMiddleware (inner)  ← AUTHORIZED → PREPARED → EXECUTING → OBSERVED
+#         → handler (tool executor)
+#
+#   Why two layers?
+#     A single middleware cannot intercept both BEFORE and AT the moment
+#     the tool executor runs.  ``next(call)`` fires the entire remaining
+#     chain as one opaque call — the outermost middleware has no way to
+#     inject logic immediately before the handler.
+#
+#     The outer layer creates the ActionRecord and handles states that
+#     occur after execution (validation, rollback, memorialized).
+#     The inner layer sits right before the handler and fires EXECUTING
+#     at the exact dispatch moment, with abort-signal racing.
+#
+#   They share state through LifecycleContext in call.metadata.
 # ---------------------------------------------------------------------------
+
+
+class LifecycleGateMiddleware(Middleware):
+    """
+    Inner lifecycle middleware — real-time control gates.
+
+    Sits at the innermost position in the pipeline, just before the tool
+    executor (handler).  When ``process(call, next)`` is called, ``next``
+    is the actual tool executor function.
+
+    Responsibilities:
+        AUTHORIZED  — read from LifecycleContext (set by BlastRadiusMiddleware)
+        PREPARED    — evaluate ToolDefinition.precondition_checks[]
+        EXECUTING   — fire at the exact moment ``next(call)`` is invoked
+                      race abort_signal for real-time abort
+        OBSERVED    — fire when the executor returns
+
+    When no LifecycleContext is present (e.g. sub-agent pipeline without
+    LifecycleMiddleware), this middleware is a transparent pass-through.
+    """
+
+    def __init__(self, registry: Any) -> None:
+        self._registry = registry
+
+    async def process(self, call: ToolCall, next: ToolHandler) -> ToolResult:
+        from .lifecycle import LIFECYCLE_CTX_KEY, ActionState
+
+        ctx = call.metadata.get(LIFECYCLE_CTX_KEY)
+        if ctx is None:
+            # No lifecycle context → pass through (sub-agent, plugin, etc.)
+            return await next(call)
+
+        record = ctx.record
+        tool_def = self._registry.get(call.tool_name)
+
+        # ── AUTHORIZED ────────────────────────────────────────────────
+        # BlastRadiusMiddleware already wrote authorization_result to ctx
+        # at the moment the decision was made.  We now fire the state
+        # transition.  If it didn't write (SAFE tool, auto-authorized),
+        # treat as authorized.
+        auth_reason = ctx.authorization_reason or "passed blast radius"
+        await ctx.transition(ActionState.AUTHORIZED, reason=auth_reason)
+
+        # ── PREPARED — callable precondition gates ────────────────────
+        precondition_checks = (
+            getattr(tool_def, "precondition_checks", []) if tool_def else []
+        )
+        precondition_descs = (
+            getattr(tool_def, "preconditions", []) if tool_def else []
+        )
+
+        for i, check in enumerate(precondition_checks):
+            try:
+                passed = await check(call)
+            except Exception as exc:
+                _log.warning(
+                    "precondition_check[%d] for %r raised: %s — treating as failed",
+                    i, call.tool_name, exc,
+                )
+                passed = False
+
+            if not passed:
+                desc = (
+                    precondition_descs[i]
+                    if i < len(precondition_descs)
+                    else f"precondition_check[{i}]"
+                )
+                await ctx.transition(
+                    ActionState.ABORTED,
+                    reason=f"Precondition failed: {desc}",
+                )
+                result = ToolResult(
+                    call_id=call.id,
+                    tool_name=call.tool_name,
+                    success=False,
+                    error=f"Precondition failed: {desc}",
+                    failure_type="execution_error",
+                )
+                record.result = result
+                await ctx.memorialize("precondition_failed")
+                return result
+
+        await ctx.transition(ActionState.PREPARED)
+
+        # ── EXECUTING — fire at the exact dispatch moment ─────────────
+        await ctx.transition(ActionState.EXECUTING)
+
+        # Race executor against abort signal for real-time cancellation
+        if call.abort_signal is not None and call.abort_signal.is_set():
+            # Already aborted before we started
+            await ctx.transition(
+                ActionState.ABORTED, reason="abort signal (pre-execution)",
+            )
+            result = ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error="Aborted before execution.",
+                failure_type="execution_error",
+            )
+            record.result = result
+            await ctx.memorialize("aborted")
+            return result
+
+        if call.abort_signal is not None:
+            exec_task = asyncio.create_task(next(call))
+            abort_task = asyncio.create_task(call.abort_signal.wait())
+            done, pending = await asyncio.wait(
+                {exec_task, abort_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for p in pending:
+                p.cancel()
+                try:
+                    await p
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+            if exec_task in done:
+                result = exec_task.result()
+            else:
+                # Abort signal fired during execution
+                await ctx.transition(
+                    ActionState.ABORTED,
+                    reason="abort signal during execution",
+                )
+                result = ToolResult(
+                    call_id=call.id, tool_name=call.tool_name,
+                    success=False, error="Execution aborted by signal.",
+                    failure_type="execution_error",
+                )
+                record.result = result
+                await ctx.memorialize("aborted")
+                return result
+        else:
+            result = await next(call)
+
+        # ── OBSERVED — executor returned ──────────────────────────────
+        # If the handler returned a timeout result, do NOT transition to
+        # OBSERVED — leave at EXECUTING so the outer LifecycleMiddleware
+        # can correctly drive EXECUTING → TIMED_OUT.
+        if result.failure_type == "timeout":
+            record.result = result
+            return result
+
+        await ctx.transition(ActionState.OBSERVED)
+        record.result = result
+        return result
+
 
 class LifecycleMiddleware(Middleware):
     """
-    Outermost middleware that wraps every tool call in an ActionRecord
-    and drives the full lifecycle state machine.
+    Outer lifecycle middleware — ActionRecord bookends and post-execution flow.
 
-    Lifecycle flow:
-    1. DECLARED — ActionRecord created from incoming ToolCall
-    2. Inner pipeline runs (Authorization → Schema validation → Execution)
-    3. OBSERVED — Raw result captured
-    4. VALIDATED — post_validator called (if defined on ToolDefinition)
-    5. COMMITTED or REVERTING → REVERTED (if validation fails + rollback_fn exists)
-    6. MEMORIALIZED — on_lifecycle callback fires
+    Sits at the outermost position in the middleware pipeline.  Wraps every
+    tool call in an ActionRecord and drives the lifecycle state machine.
 
-    When no post_validator or rollback_fn is defined on the ToolDefinition,
-    the lifecycle collapses to: DECLARED → OBSERVED → COMMITTED → MEMORIALIZED,
-    preserving backward-compatible behavior.
+    Architecture (Issue #50: Control-first Lifecycle)
+    -------------------------------------------------
+    Phase 1 (Issue #42) stamped states retroactively after the inner
+    pipeline completed.  Phase 2 makes each state a genuine gate by
+    splitting the lifecycle into two cooperating middleware layers.
 
-    The ``on_state_change`` callback fires on each state transition for UI
-    updates (e.g. TUI tool block state visualization).
+    This outer layer handles:
+        DECLARED        — create ActionRecord, inject LifecycleContext
+        post-OBSERVED   — VALIDATED, COMMITTED, REVERTING, REVERTED
+        MEMORIALIZED    — trace written to audit / episodic
+        failure paths   — DENIED, ABORTED (from inner middleware)
+
+    The inner layer (LifecycleGateMiddleware) handles:
+        AUTHORIZED → PREPARED → EXECUTING → OBSERVED
+
+    ┌─────────────────────────────────────────────────────────────────┐
+    │ LifecycleMiddleware (outer)                                     │
+    │   DECLARED — ActionRecord created, LifecycleContext injected   │
+    │                                                                 │
+    │   ↓ inner pipeline                                             │
+    │     TraceMiddleware → SchemaValidation → BlastRadius           │
+    │                                                                 │
+    │   ↓ LifecycleGateMiddleware (inner)                            │
+    │     AUTHORIZED ← BlastRadius wrote to LifecycleContext         │
+    │     PREPARED   ← precondition_checks[] evaluated               │
+    │     EXECUTING  ← fires at exact dispatch + abort racing        │
+    │     OBSERVED   ← executor returned                             │
+    │                                                                 │
+    │   ↑ back to this outer layer                                   │
+    │   VALIDATED → COMMITTED  or  REVERTING → REVERTED              │
+    │   MEMORIALIZED                                                  │
+    └─────────────────────────────────────────────────────────────────┘
+
+    Terminal failure states: DENIED, ABORTED, TIMED_OUT.
+
+    Backward compatibility
+    ----------------------
+    Tools with no precondition_checks, post_validator, or rollback_fn
+    follow: DECLARED → AUTHORIZED → PREPARED → EXECUTING → OBSERVED
+    → COMMITTED → MEMORIALIZED — identical to Phase 1 happy path.
     """
 
     def __init__(
@@ -271,30 +493,26 @@ class LifecycleMiddleware(Middleware):
         on_lifecycle: Callable[["ActionRecord"], Awaitable[None]] | None = None,
         on_state_change: Callable[["ActionRecord", str, str], Awaitable[None]] | None = None,
     ) -> None:
-        from .lifecycle import ActionRecord, ActionIntent, ActionState
+        from .lifecycle import (
+            ActionRecord, ActionIntent, ActionState,
+            LifecycleContext, LIFECYCLE_CTX_KEY,
+        )
         self._registry = registry
         self._on_lifecycle = on_lifecycle
         self._on_state_change = on_state_change
-        # Store references to avoid circular imports at call time
+        # Store class references to avoid circular imports at call time
         self._ActionRecord = ActionRecord
         self._ActionIntent = ActionIntent
         self._ActionState = ActionState
-
-    async def _fire_state_change(
-        self, record: "ActionRecord", old_state: str, new_state: str
-    ) -> None:
-        if self._on_state_change is not None:
-            try:
-                await self._on_state_change(record, old_state, new_state)
-            except Exception:
-                pass  # state change notifications must never crash the pipeline
+        self._LifecycleContext = LifecycleContext
+        self._CTX_KEY = LIFECYCLE_CTX_KEY
 
     async def process(self, call: ToolCall, next: ToolHandler) -> ToolResult:
         ActionRecord = self._ActionRecord
         ActionIntent = self._ActionIntent
         ActionState = self._ActionState
 
-        # --- Build intent from tool definition ---
+        # ── Build intent from tool definition ─────────────────────────
         tool_def = self._registry.get(call.tool_name)
         intent = ActionIntent(
             intent_summary=f"{call.tool_name}({', '.join(f'{k}=...' for k in call.args)})",
@@ -302,100 +520,97 @@ class LifecycleMiddleware(Middleware):
             preconditions=list(getattr(tool_def, "preconditions", [])) if tool_def else [],
         )
 
-        # --- DECLARED ---
+        # ── DECLARED ──────────────────────────────────────────────────
         record = ActionRecord(call=call, intent=intent)
 
-        # --- Run inner pipeline (handles Authorization, Validation, Execution) ---
+        # Inject LifecycleContext with shared callbacks
+        ctx = self._LifecycleContext(
+            record=record,
+            _on_state_change=self._on_state_change,
+            _on_lifecycle=self._on_lifecycle,
+        )
+        call.metadata[self._CTX_KEY] = ctx
+
+        # ── Run inner pipeline ────────────────────────────────────────
+        # The chain: Trace → SchemaValidation → BlastRadius →
+        # LifecycleGateMiddleware → handler.
+        #
+        # LifecycleGateMiddleware drives AUTHORIZED → PREPARED →
+        # EXECUTING → OBSERVED as real control gates.
+        # BlastRadiusMiddleware writes auth decisions to ctx.
         result = await next(call)
 
-        # Determine if it was denied (permission_denied) or failed
-        if not result.success and result.failure_type == "permission_denied":
-            old = record.state.value
-            record.transition(ActionState.DENIED, reason=result.error)
-            await self._fire_state_change(record, old, record.state.value)
-            record.result = result
-            # Memorialize denied actions
-            old = record.state.value
-            record.transition(ActionState.MEMORIALIZED, reason="denied")
-            await self._fire_state_change(record, old, record.state.value)
-            if self._on_lifecycle is not None:
-                await self._on_lifecycle(record)
+        # ── Post-pipeline analysis ────────────────────────────────────
+        # If the record already reached a terminal state (precondition
+        # failure, abort during execution), everything is done.
+        if record.is_terminal:
             return result
 
-        if not result.success and result.failure_type == "validation_error":
-            old = record.state.value
-            record.transition(ActionState.AUTHORIZED, reason="passed blast radius")
-            await self._fire_state_change(record, old, record.state.value)
-            old = record.state.value
-            record.transition(ActionState.ABORTED, reason=result.error)
-            await self._fire_state_change(record, old, record.state.value)
-            record.result = result
-            old = record.state.value
-            record.transition(ActionState.MEMORIALIZED, reason="validation_error")
-            await self._fire_state_change(record, old, record.state.value)
-            if self._on_lifecycle is not None:
-                await self._on_lifecycle(record)
-            return result
+        # ── Handle failures from inner middleware ─────────────────────
+        # These come from SchemaValidation or BlastRadius, BEFORE
+        # LifecycleGateMiddleware ever ran.
+
+        if not result.success and result.failure_type == "permission_denied":
+            if record.state == ActionState.DECLARED:
+                await ctx.transition(ActionState.DENIED, reason=result.error)
+                record.result = result
+                await ctx.memorialize("denied")
+                return result
 
         if not result.success and result.failure_type == "tool_not_found":
+            if record.state == ActionState.DECLARED:
+                record.result = result
+                await ctx.transition(ActionState.DENIED, reason="tool not found")
+                await ctx.memorialize("tool_not_found")
+                return result
+
+        if not result.success and result.failure_type == "validation_error":
+            # Schema validation failed AFTER authorization passed
+            auth_reason = ctx.authorization_reason or "passed blast radius"
+            await ctx.transition(ActionState.AUTHORIZED, reason=auth_reason)
+            await ctx.transition(ActionState.ABORTED, reason=result.error)
             record.result = result
-            old = record.state.value
-            record.transition(ActionState.DENIED, reason="tool not found")
-            await self._fire_state_change(record, old, record.state.value)
-            old = record.state.value
-            record.transition(ActionState.MEMORIALIZED, reason="tool_not_found")
-            await self._fire_state_change(record, old, record.state.value)
-            if self._on_lifecycle is not None:
-                await self._on_lifecycle(record)
+            await ctx.memorialize("validation_error")
             return result
 
         if not result.success and result.failure_type == "timeout":
-            old = record.state.value
-            record.transition(ActionState.AUTHORIZED, reason="passed blast radius")
-            await self._fire_state_change(record, old, record.state.value)
-            old = record.state.value
-            record.transition(ActionState.PREPARED)
-            await self._fire_state_change(record, old, record.state.value)
-            old = record.state.value
-            record.transition(ActionState.EXECUTING)
-            await self._fire_state_change(record, old, record.state.value)
-            old = record.state.value
-            record.transition(ActionState.TIMED_OUT, reason=result.error)
-            await self._fire_state_change(record, old, record.state.value)
-            record.result = result
-            old = record.state.value
-            record.transition(ActionState.MEMORIALIZED, reason="timed_out")
-            await self._fire_state_change(record, old, record.state.value)
-            if self._on_lifecycle is not None:
-                await self._on_lifecycle(record)
+            # Timeout from the handler (e.g. run_bash timeout).
+            # LifecycleGateMiddleware already transitioned through
+            # AUTHORIZED → PREPARED → EXECUTING.
+            if record.state == ActionState.EXECUTING:
+                await ctx.transition(ActionState.TIMED_OUT, reason=result.error)
+                record.result = result
+                await ctx.memorialize("timed_out")
+                return result
+            # Fallback: force through remaining states
+            if not record.state.is_terminal:
+                if record.state == ActionState.DECLARED:
+                    await ctx.transition(ActionState.AUTHORIZED, reason="passed blast radius")
+                if record.state == ActionState.AUTHORIZED:
+                    await ctx.transition(ActionState.PREPARED)
+                if record.state == ActionState.PREPARED:
+                    await ctx.transition(ActionState.EXECUTING)
+                await ctx.transition(ActionState.TIMED_OUT, reason=result.error)
+                record.result = result
+                await ctx.memorialize("timed_out")
             return result
 
-        # --- Happy path: tool executed (success or execution_error) ---
-        # Reconstruct lifecycle states retroactively (inner pipeline has
-        # already executed by the time we get here).
+        # ── Happy path: OBSERVED already fired by LifecycleGateMiddleware ─
+        if record.state != ActionState.OBSERVED:
+            # Safety fallback: if LifecycleGateMiddleware didn't run
+            # (shouldn't happen in production), gracefully stamp states.
+            if record.state == ActionState.DECLARED:
+                auth_reason = ctx.authorization_reason or "passed blast radius"
+                await ctx.transition(ActionState.AUTHORIZED, reason=auth_reason)
+            if record.state == ActionState.AUTHORIZED:
+                await ctx.transition(ActionState.PREPARED)
+            if record.state == ActionState.PREPARED:
+                await ctx.transition(ActionState.EXECUTING)
+            if record.state == ActionState.EXECUTING:
+                await ctx.transition(ActionState.OBSERVED)
+            record.result = result
 
-        # DECLARED → AUTHORIZED
-        old = record.state.value
-        record.transition(ActionState.AUTHORIZED, reason="passed blast radius")
-        await self._fire_state_change(record, old, record.state.value)
-
-        # AUTHORIZED → PREPARED
-        old = record.state.value
-        record.transition(ActionState.PREPARED)
-        await self._fire_state_change(record, old, record.state.value)
-
-        # PREPARED → EXECUTING
-        old = record.state.value
-        record.transition(ActionState.EXECUTING)
-        await self._fire_state_change(record, old, record.state.value)
-
-        # EXECUTING → OBSERVED
-        old = record.state.value
-        record.transition(ActionState.OBSERVED)
-        await self._fire_state_change(record, old, record.state.value)
-        record.result = result
-
-        # --- Post-validation (if post_validator is defined) ---
+        # ── Post-validation (if post_validator defined) ───────────────
         post_validator = getattr(tool_def, "post_validator", None) if tool_def else None
         rollback_fn = getattr(tool_def, "rollback_fn", None) if tool_def else None
 
@@ -411,22 +626,16 @@ class LifecycleMiddleware(Middleware):
 
             if validated:
                 # OBSERVED → VALIDATED → COMMITTED
-                old = record.state.value
-                record.transition(ActionState.VALIDATED)
-                await self._fire_state_change(record, old, record.state.value)
-                old = record.state.value
-                record.transition(ActionState.COMMITTED)
-                await self._fire_state_change(record, old, record.state.value)
+                await ctx.transition(ActionState.VALIDATED)
+                await ctx.transition(ActionState.COMMITTED)
             else:
                 # OBSERVED → VALIDATED (fail) → REVERTING → REVERTED
-                old = record.state.value
-                record.transition(ActionState.VALIDATED)
-                await self._fire_state_change(record, old, record.state.value)
+                await ctx.transition(ActionState.VALIDATED)
 
                 if rollback_fn is not None:
-                    old = record.state.value
-                    record.transition(ActionState.REVERTING, reason="post-validation failed")
-                    await self._fire_state_change(record, old, record.state.value)
+                    await ctx.transition(
+                        ActionState.REVERTING, reason="post-validation failed",
+                    )
                     try:
                         rb_result = await rollback_fn(call, result)
                         record.rollback_result = rb_result
@@ -437,41 +646,26 @@ class LifecycleMiddleware(Middleware):
                             success=False,
                             error=f"Rollback failed: {exc}",
                         )
-                    old = record.state.value
-                    record.transition(ActionState.REVERTED)
-                    await self._fire_state_change(record, old, record.state.value)
+                    await ctx.transition(ActionState.REVERTED)
                     # Modify the result to indicate rollback
                     result = ToolResult(
                         call_id=result.call_id,
                         tool_name=result.tool_name,
                         success=False,
-                        error=f"Post-validation failed; action rolled back.",
+                        error="Post-validation failed; action rolled back.",
                         failure_type="execution_error",
                         duration_ms=result.duration_ms,
                         metadata={**result.metadata, "rolled_back": True},
                     )
                     record.result = result
                 else:
-                    # No rollback_fn: validation failed but can't revert → commit anyway
-                    old = record.state.value
-                    record.transition(ActionState.COMMITTED)
-                    await self._fire_state_change(record, old, record.state.value)
+                    # No rollback_fn: can't revert → commit anyway
+                    await ctx.transition(ActionState.COMMITTED)
         else:
             # No post_validator → skip VALIDATED, go directly to COMMITTED
-            old = record.state.value
-            record.transition(ActionState.COMMITTED)
-            await self._fire_state_change(record, old, record.state.value)
+            await ctx.transition(ActionState.COMMITTED)
 
-        # --- MEMORIALIZED ---
-        old = record.state.value
-        record.transition(ActionState.MEMORIALIZED)
-        await self._fire_state_change(record, old, record.state.value)
-
-        if self._on_lifecycle is not None:
-            try:
-                await self._on_lifecycle(record)
-            except Exception:
-                pass  # lifecycle callback must never crash the pipeline
+        # ── MEMORIALIZED ──────────────────────────────────────────────
+        await ctx.memorialize(record.state.value)
 
         return result
-

--- a/loom/core/harness/registry.py
+++ b/loom/core/harness/registry.py
@@ -39,6 +39,18 @@ class ToolDefinition:
 
     # --- Action Lifecycle (Issue #42) ---
     preconditions: list[str] = field(default_factory=list)
+    precondition_checks: list[Callable[[ToolCall], Awaitable[bool]]] = field(default_factory=list)
+    """
+    Callable gates evaluated before tool dispatch (Issue #50).
+
+    Each check receives the ToolCall and returns True (pass) or False (fail).
+    ALL checks must pass for the tool to proceed to EXECUTING.
+    Failure → ABORTED with no tool call made.
+
+    These complement ``preconditions`` (human-readable strings kept for
+    documentation and audit trail).  Tools with no checks behave
+    identically to the Phase 1 lifecycle.
+    """
     rollback_fn: Callable[[ToolCall, ToolResult], Awaitable[ToolResult]] | None = None
     post_validator: Callable[[ToolCall, ToolResult], Awaitable[bool]] | None = None
     scope: str = "general"

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -57,6 +57,7 @@ from loom.core.cognition.reflection import ReflectionAPI
 from loom.core.cognition.router import LLMRouter
 from loom.core.harness.middleware import (
     BlastRadiusMiddleware,
+    LifecycleGateMiddleware,
     LifecycleMiddleware,
     LogMiddleware,
     MiddlewarePipeline,
@@ -627,6 +628,7 @@ class LoomSession:
                     confirm_fn=self._confirm_tool,
                     exec_escape_fn=_exec_escape_fn,
                 ),
+                LifecycleGateMiddleware(registry=self.registry),
             ]
         )
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,714 @@
+"""
+Tests for Control-first Action Lifecycle (Issue #50).
+
+Verifies that lifecycle state transitions fire as real-time control gates,
+not retroactive labels.  Covers both the outer LifecycleMiddleware and
+inner LifecycleGateMiddleware.
+
+References
+----------
+- loom/core/harness/middleware.py (LifecycleMiddleware, LifecycleGateMiddleware)
+- loom/core/harness/lifecycle.py  (ActionState, ActionRecord, LifecycleContext)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from loom.core.harness.lifecycle import (
+    ActionRecord,
+    ActionState,
+    LifecycleContext,
+    LIFECYCLE_CTX_KEY,
+)
+from loom.core.harness.middleware import (
+    BlastRadiusMiddleware,
+    LifecycleGateMiddleware,
+    LifecycleMiddleware,
+    MiddlewarePipeline,
+    ToolCall,
+    ToolResult,
+)
+from loom.core.harness.permissions import PermissionContext, TrustLevel
+from loom.core.harness.registry import ToolDefinition, ToolRegistry
+from loom.core.harness.validation import SchemaValidationMiddleware
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_registry(*tools: ToolDefinition) -> ToolRegistry:
+    """Build a ToolRegistry with pre-registered tools."""
+    reg = ToolRegistry()
+    for t in tools:
+        reg.register(t)
+    return reg
+
+
+def _make_call(tool_name: str = "echo", **kwargs) -> ToolCall:
+    return ToolCall(
+        tool_name=tool_name,
+        args=kwargs.get("args", {}),
+        trust_level=kwargs.get("trust_level", TrustLevel.SAFE),
+        session_id="test-session",
+        abort_signal=kwargs.get("abort_signal", None),
+    )
+
+
+async def _echo_handler(call: ToolCall) -> ToolResult:
+    """Trivial handler that echoes args."""
+    return ToolResult(
+        call_id=call.id, tool_name=call.tool_name,
+        success=True, output=call.args,
+    )
+
+
+async def _slow_handler(call: ToolCall) -> ToolResult:
+    """Handler that takes a long time (for abort testing)."""
+    await asyncio.sleep(10)
+    return ToolResult(
+        call_id=call.id, tool_name=call.tool_name,
+        success=True, output="done",
+    )
+
+
+async def _failing_handler(call: ToolCall) -> ToolResult:
+    """Handler that returns an error."""
+    return ToolResult(
+        call_id=call.id, tool_name=call.tool_name,
+        success=False, error="tool exploded",
+        failure_type="execution_error",
+    )
+
+
+async def _timeout_handler(call: ToolCall) -> ToolResult:
+    """Handler that returns a timeout result."""
+    return ToolResult(
+        call_id=call.id, tool_name=call.tool_name,
+        success=False, error="timed out after 30s",
+        failure_type="timeout",
+    )
+
+
+def _build_pipeline(
+    registry: ToolRegistry,
+    confirm_fn=None,
+    on_lifecycle=None,
+    on_state_change=None,
+) -> MiddlewarePipeline:
+    """
+    Build a production-like pipeline:
+    LifecycleMiddleware → SchemaValidation → BlastRadius → LifecycleGateMiddleware
+    """
+    perm = PermissionContext(session_id="test-session")
+    if confirm_fn is None:
+        confirm_fn = AsyncMock(return_value=True)
+    return MiddlewarePipeline([
+        LifecycleMiddleware(
+            registry=registry,
+            on_lifecycle=on_lifecycle,
+            on_state_change=on_state_change,
+        ),
+        SchemaValidationMiddleware(registry=registry),
+        BlastRadiusMiddleware(perm_ctx=perm, confirm_fn=confirm_fn),
+        LifecycleGateMiddleware(registry=registry),
+    ])
+
+
+# ---------------------------------------------------------------------------
+# LifecycleContext unit tests
+# ---------------------------------------------------------------------------
+
+class TestLifecycleContext:
+    def test_defaults(self):
+        """LifecycleContext fields default to None."""
+        record = MagicMock()
+        ctx = LifecycleContext(record=record)
+        assert ctx.authorization_result is None
+        assert ctx.authorization_reason is None
+
+    @pytest.mark.asyncio
+    async def test_transition_fires_callback(self):
+        """transition() calls _on_state_change and updates record."""
+        record = MagicMock()
+        record.state = ActionState.DECLARED
+        record.transition = MagicMock()
+
+        cb = AsyncMock()
+        ctx = LifecycleContext(record=record, _on_state_change=cb)
+        await ctx.transition(ActionState.AUTHORIZED, reason="test")
+
+        record.transition.assert_called_once_with(ActionState.AUTHORIZED, reason="test")
+        cb.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_transition_tolerates_callback_error(self):
+        """transition() must not crash if the callback raises."""
+        record = MagicMock()
+        record.state = ActionState.DECLARED
+        record.transition = MagicMock()
+
+        cb = AsyncMock(side_effect=RuntimeError("boom"))
+        ctx = LifecycleContext(record=record, _on_state_change=cb)
+        # Should not raise
+        await ctx.transition(ActionState.AUTHORIZED)
+
+    @pytest.mark.asyncio
+    async def test_memorialize_fires_both_callbacks(self):
+        """memorialize() fires state change AND on_lifecycle."""
+        record = MagicMock()
+        record.state = ActionState.COMMITTED
+        record.transition = MagicMock()
+
+        state_cb = AsyncMock()
+        lifecycle_cb = AsyncMock()
+        ctx = LifecycleContext(
+            record=record,
+            _on_state_change=state_cb,
+            _on_lifecycle=lifecycle_cb,
+        )
+        await ctx.memorialize("committed")
+        lifecycle_cb.assert_awaited_once_with(record)
+
+
+# ---------------------------------------------------------------------------
+# Happy path: full pipeline
+# ---------------------------------------------------------------------------
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_states_ordered(self):
+        """
+        Happy path: states fire in order
+        DECLARED → AUTHORIZED → PREPARED → EXECUTING → OBSERVED → COMMITTED → MEMORIALIZED
+        """
+        states: list[tuple[str, str]] = []
+
+        async def track_state(record, old, new):
+            states.append((old, new))
+
+        tool = ToolDefinition(
+            name="echo", description="echo tool",
+            input_schema={}, executor=_echo_handler,
+            trust_level=TrustLevel.SAFE,
+        )
+        reg = _make_registry(tool)
+        pipeline = _build_pipeline(reg, on_state_change=track_state)
+        call = _make_call("echo")
+
+        result = await pipeline.execute(call, _echo_handler)
+        assert result.success
+
+        expected = [
+            ("declared", "authorized"),
+            ("authorized", "prepared"),
+            ("prepared", "executing"),
+            ("executing", "observed"),
+            ("observed", "committed"),
+            ("committed", "memorialized"),
+        ]
+        assert states == expected
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_callback_fires(self):
+        """on_lifecycle callback fires at MEMORIALIZED."""
+        lifecycle_cb = AsyncMock()
+        tool = ToolDefinition(
+            name="echo", description="echo tool",
+            input_schema={}, executor=_echo_handler,
+            trust_level=TrustLevel.SAFE,
+        )
+        reg = _make_registry(tool)
+        pipeline = _build_pipeline(reg, on_lifecycle=lifecycle_cb)
+        call = _make_call("echo")
+
+        await pipeline.execute(call, _echo_handler)
+        lifecycle_cb.assert_awaited_once()
+        record = lifecycle_cb.call_args[0][0]
+        assert isinstance(record, ActionRecord)
+
+    @pytest.mark.asyncio
+    async def test_backward_compat_no_preconditions(self):
+        """Tools with no preconditions/validators behave identically to Phase 1."""
+        tool = ToolDefinition(
+            name="simple", description="no frills",
+            input_schema={}, executor=_echo_handler,
+            trust_level=TrustLevel.SAFE,
+        )
+        reg = _make_registry(tool)
+        pipeline = _build_pipeline(reg)
+        call = _make_call("simple")
+
+        result = await pipeline.execute(call, _echo_handler)
+        assert result.success
+        # Should complete without error — no preconditions, no validators
+
+
+# ---------------------------------------------------------------------------
+# AUTHORIZED driven by BlastRadiusMiddleware
+# ---------------------------------------------------------------------------
+
+class TestAuthorizedGate:
+    @pytest.mark.asyncio
+    async def test_authorized_from_blast_radius_pre_auth(self):
+        """SAFE tools get AUTHORIZED with 'pre-authorized' reason."""
+        states = []
+
+        async def track(record, old, new):
+            if new == "authorized":
+                ctx = record.call.metadata.get(LIFECYCLE_CTX_KEY)
+                states.append(ctx.authorization_reason)
+
+        tool = ToolDefinition(
+            name="safe_tool", description="",
+            input_schema={}, executor=_echo_handler,
+            trust_level=TrustLevel.SAFE,
+        )
+        reg = _make_registry(tool)
+        pipeline = _build_pipeline(reg, on_state_change=track)
+        call = _make_call("safe_tool")
+
+        await pipeline.execute(call, _echo_handler)
+        assert states == ["pre-authorized"]
+
+    @pytest.mark.asyncio
+    async def test_denied_fires_from_blast_radius(self):
+        """When user denies, DENIED state is driven by BlastRadius."""
+        states = []
+
+        async def track(record, old, new):
+            states.append(new)
+
+        tool = ToolDefinition(
+            name="danger", description="",
+            input_schema={}, executor=_echo_handler,
+            trust_level=TrustLevel.GUARDED,
+        )
+        reg = _make_registry(tool)
+        confirm_fn = AsyncMock(return_value=False)
+        pipeline = _build_pipeline(reg, confirm_fn=confirm_fn, on_state_change=track)
+        call = _make_call("danger", trust_level=TrustLevel.GUARDED)
+
+        result = await pipeline.execute(call, _echo_handler)
+        assert not result.success
+        assert result.failure_type == "permission_denied"
+        assert "denied" in states
+        assert "memorialized" in states
+
+    @pytest.mark.asyncio
+    async def test_blast_radius_no_lifecycle_context(self):
+        """BlastRadiusMiddleware works fine without LifecycleContext (sub-agent)."""
+        perm = PermissionContext(session_id="test-session")
+        blast = BlastRadiusMiddleware(
+            perm_ctx=perm,
+            confirm_fn=AsyncMock(return_value=True),
+        )
+        # No LifecycleMiddleware to inject context
+        call = _make_call("test_tool", trust_level=TrustLevel.SAFE)
+        result = await blast.process(call, _echo_handler)
+        assert result.success
+
+
+# ---------------------------------------------------------------------------
+# PREPARED — precondition gates
+# ---------------------------------------------------------------------------
+
+class TestPreconditionGates:
+    @pytest.mark.asyncio
+    async def test_precondition_failure_aborts_before_execution(self):
+        """Callable precondition returns False → ABORTED, no tool call made."""
+        handler_called = False
+
+        async def tracked_handler(call):
+            nonlocal handler_called
+            handler_called = True
+            return await _echo_handler(call)
+
+        async def failing_check(call):
+            return False
+
+        tool = ToolDefinition(
+            name="guarded_tool", description="",
+            input_schema={}, executor=tracked_handler,
+            trust_level=TrustLevel.SAFE,
+            preconditions=["workspace must be clean"],
+            precondition_checks=[failing_check],
+        )
+        reg = _make_registry(tool)
+        pipeline = _build_pipeline(reg)
+        call = _make_call("guarded_tool")
+
+        result = await pipeline.execute(call, tracked_handler)
+        assert not result.success
+        assert "Precondition failed" in result.error
+        assert "workspace must be clean" in result.error
+        assert not handler_called  # Tool was never invoked!
+
+    @pytest.mark.asyncio
+    async def test_precondition_checks_all_must_pass(self):
+        """Multiple preconditions: first failure aborts."""
+        call_order = []
+
+        async def check_a(call):
+            call_order.append("a")
+            return True
+
+        async def check_b(call):
+            call_order.append("b")
+            return False
+
+        async def check_c(call):
+            call_order.append("c")
+            return True
+
+        tool = ToolDefinition(
+            name="multi_check", description="",
+            input_schema={}, executor=_echo_handler,
+            trust_level=TrustLevel.SAFE,
+            preconditions=["check a", "check b", "check c"],
+            precondition_checks=[check_a, check_b, check_c],
+        )
+        reg = _make_registry(tool)
+        pipeline = _build_pipeline(reg)
+        call = _make_call("multi_check")
+
+        result = await pipeline.execute(call, _echo_handler)
+        assert not result.success
+        assert call_order == ["a", "b"]  # c was never evaluated
+        assert "check b" in result.error
+
+    @pytest.mark.asyncio
+    async def test_precondition_exception_treated_as_failure(self):
+        """If precondition_check raises, treat as failure (not crash)."""
+        async def exploding_check(call):
+            raise ValueError("unexpected")
+
+        tool = ToolDefinition(
+            name="bomb", description="",
+            input_schema={}, executor=_echo_handler,
+            trust_level=TrustLevel.SAFE,
+            precondition_checks=[exploding_check],
+        )
+        reg = _make_registry(tool)
+        pipeline = _build_pipeline(reg)
+        call = _make_call("bomb")
+
+        result = await pipeline.execute(call, _echo_handler)
+        assert not result.success
+        assert "Precondition failed" in result.error
+
+    @pytest.mark.asyncio
+    async def test_all_preconditions_pass_proceeds(self):
+        """All preconditions pass → tool executes normally."""
+        async def ok_check(call):
+            return True
+
+        tool = ToolDefinition(
+            name="ok_tool", description="",
+            input_schema={}, executor=_echo_handler,
+            trust_level=TrustLevel.SAFE,
+            precondition_checks=[ok_check, ok_check],
+        )
+        reg = _make_registry(tool)
+        pipeline = _build_pipeline(reg)
+        call = _make_call("ok_tool")
+
+        result = await pipeline.execute(call, _echo_handler)
+        assert result.success
+
+
+# ---------------------------------------------------------------------------
+# EXECUTING — fires at exact dispatch moment
+# ---------------------------------------------------------------------------
+
+class TestExecutingGate:
+    @pytest.mark.asyncio
+    async def test_executing_fires_at_dispatch_moment(self):
+        """EXECUTING state fires exactly when executor is about to be invoked."""
+        state_when_handler_ran = None
+
+        async def spy_handler(call):
+            nonlocal state_when_handler_ran
+            ctx = call.metadata.get(LIFECYCLE_CTX_KEY)
+            if ctx:
+                state_when_handler_ran = ctx.record.state
+            return await _echo_handler(call)
+
+        tool = ToolDefinition(
+            name="spy", description="",
+            input_schema={}, executor=spy_handler,
+            trust_level=TrustLevel.SAFE,
+        )
+        reg = _make_registry(tool)
+        pipeline = _build_pipeline(reg)
+        call = _make_call("spy")
+
+        result = await pipeline.execute(call, spy_handler)
+        assert result.success
+        assert state_when_handler_ran == ActionState.EXECUTING
+
+
+# ---------------------------------------------------------------------------
+# Abort signal during execution
+# ---------------------------------------------------------------------------
+
+class TestAbortDuringExecution:
+    @pytest.mark.asyncio
+    async def test_abort_before_execution_pre_set(self):
+        """abort_signal already set → ABORTED before execution."""
+        signal = asyncio.Event()
+        signal.set()  # Pre-set
+
+        tool = ToolDefinition(
+            name="abortable", description="",
+            input_schema={}, executor=_slow_handler,
+            trust_level=TrustLevel.SAFE,
+        )
+        reg = _make_registry(tool)
+        pipeline = _build_pipeline(reg)
+        call = _make_call("abortable", abort_signal=signal)
+
+        result = await pipeline.execute(call, _slow_handler)
+        assert not result.success
+        assert "Aborted" in result.error
+
+    @pytest.mark.asyncio
+    async def test_abort_during_execution_produces_aborted(self):
+        """abort_signal fires during EXECUTING → ABORTED."""
+        signal = asyncio.Event()
+        states = []
+
+        async def track(record, old, new):
+            states.append(new)
+
+        tool = ToolDefinition(
+            name="slow_tool", description="",
+            input_schema={}, executor=_slow_handler,
+            trust_level=TrustLevel.SAFE,
+        )
+        reg = _make_registry(tool)
+        pipeline = _build_pipeline(reg, on_state_change=track)
+        call = _make_call("slow_tool", abort_signal=signal)
+
+        async def fire_abort():
+            await asyncio.sleep(0.05)
+            signal.set()
+
+        asyncio.ensure_future(fire_abort())
+        result = await pipeline.execute(call, _slow_handler)
+
+        assert not result.success
+        assert "aborted" in states
+        assert "memorialized" in states
+
+    @pytest.mark.asyncio
+    async def test_no_abort_signal_runs_normally(self):
+        """No abort_signal → normal execution."""
+        tool = ToolDefinition(
+            name="normal", description="",
+            input_schema={}, executor=_echo_handler,
+            trust_level=TrustLevel.SAFE,
+        )
+        reg = _make_registry(tool)
+        pipeline = _build_pipeline(reg)
+        call = _make_call("normal")
+
+        result = await pipeline.execute(call, _echo_handler)
+        assert result.success
+
+
+# ---------------------------------------------------------------------------
+# Timeout handling
+# ---------------------------------------------------------------------------
+
+class TestTimeoutHandling:
+    @pytest.mark.asyncio
+    async def test_timeout_produces_timed_out(self):
+        """Timeout result from handler → TIMED_OUT state."""
+        states = []
+
+        async def track(record, old, new):
+            states.append(new)
+
+        tool = ToolDefinition(
+            name="slow", description="",
+            input_schema={}, executor=_timeout_handler,
+            trust_level=TrustLevel.SAFE,
+        )
+        reg = _make_registry(tool)
+        pipeline = _build_pipeline(reg, on_state_change=track)
+        call = _make_call("slow")
+
+        result = await pipeline.execute(call, _timeout_handler)
+        assert not result.success
+        assert "timed_out" in states
+        assert "memorialized" in states
+
+
+# ---------------------------------------------------------------------------
+# Validation error handling
+# ---------------------------------------------------------------------------
+
+class TestValidationError:
+    @pytest.mark.asyncio
+    async def test_validation_error_produces_aborted(self):
+        """Schema validation failure → AUTHORIZED → ABORTED → MEMORIALIZED."""
+        states = []
+
+        async def track(record, old, new):
+            states.append(new)
+
+        tool = ToolDefinition(
+            name="strict", description="",
+            input_schema={"properties": {"x": {"type": "string"}}, "required": ["x"]},
+            executor=_echo_handler,
+            trust_level=TrustLevel.SAFE,
+        )
+        reg = _make_registry(tool)
+        pipeline = _build_pipeline(reg, on_state_change=track)
+        call = _make_call("strict", args={})  # Missing required 'x'
+
+        result = await pipeline.execute(call, _echo_handler)
+        assert not result.success
+        assert result.failure_type == "validation_error"
+        assert "authorized" in states
+        assert "aborted" in states
+        assert "memorialized" in states
+
+
+# ---------------------------------------------------------------------------
+# Post-validation and rollback
+# ---------------------------------------------------------------------------
+
+class TestPostValidation:
+    @pytest.mark.asyncio
+    async def test_post_validator_pass_commits(self):
+        """post_validator returns True → VALIDATED → COMMITTED."""
+        states = []
+
+        async def track(record, old, new):
+            states.append(new)
+
+        async def validator(call, result):
+            return True
+
+        tool = ToolDefinition(
+            name="validated", description="",
+            input_schema={}, executor=_echo_handler,
+            trust_level=TrustLevel.SAFE,
+            post_validator=validator,
+        )
+        reg = _make_registry(tool)
+        pipeline = _build_pipeline(reg, on_state_change=track)
+        call = _make_call("validated")
+
+        result = await pipeline.execute(call, _echo_handler)
+        assert result.success
+        assert "validated" in states
+        assert "committed" in states
+
+    @pytest.mark.asyncio
+    async def test_post_validator_fail_with_rollback(self):
+        """post_validator returns False + rollback_fn → REVERTING → REVERTED."""
+        states = []
+
+        async def track(record, old, new):
+            states.append(new)
+
+        async def validator(call, result):
+            return False
+
+        async def rollback(call, result):
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=True, output="rolled back",
+            )
+
+        tool = ToolDefinition(
+            name="rollbackable", description="",
+            input_schema={}, executor=_echo_handler,
+            trust_level=TrustLevel.SAFE,
+            post_validator=validator,
+            rollback_fn=rollback,
+        )
+        reg = _make_registry(tool)
+        pipeline = _build_pipeline(reg, on_state_change=track)
+        call = _make_call("rollbackable")
+
+        result = await pipeline.execute(call, _echo_handler)
+        assert not result.success
+        assert "rolled back" in result.error
+        assert "reverting" in states
+        assert "reverted" in states
+
+
+# ---------------------------------------------------------------------------
+# LifecycleGateMiddleware pass-through
+# ---------------------------------------------------------------------------
+
+class TestGatePassThrough:
+    @pytest.mark.asyncio
+    async def test_gate_no_context_passthrough(self):
+        """
+        LifecycleGateMiddleware with no LifecycleContext in metadata
+        is a transparent pass-through (sub-agent compatibility).
+        """
+        reg = _make_registry()
+        gate = LifecycleGateMiddleware(registry=reg)
+        call = _make_call("test")
+        # No LifecycleContext injected — call.metadata is empty
+
+        result = await gate.process(call, _echo_handler)
+        assert result.success
+
+
+# ---------------------------------------------------------------------------
+# Tool not found
+# ---------------------------------------------------------------------------
+
+class TestToolNotFound:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_denied_pre_pipeline(self):
+        """
+        Unknown tool with pipeline short-circuiting → DENIED → MEMORIALIZED.
+
+        In production, _dispatch() returns an error BEFORE the pipeline runs.
+        If the pipeline somehow receives the error (e.g. via a middleware that
+        catches it), the outer middleware handles DECLARED → DENIED.
+        """
+        states = []
+
+        async def track(record, old, new):
+            states.append(new)
+
+        # Simulate _dispatch()-level rejection: the handler is never called
+        # because SchemaValidationMiddleware returns tool_not_found.
+        reg = _make_registry()  # empty registry
+
+        # Build pipeline WITHOUT LifecycleGateMiddleware to simulate
+        perm = PermissionContext(session_id="test-session")
+        pipeline = MiddlewarePipeline([
+            LifecycleMiddleware(
+                registry=reg,
+                on_state_change=track,
+            ),
+            SchemaValidationMiddleware(registry=reg),
+            BlastRadiusMiddleware(perm_ctx=perm, confirm_fn=AsyncMock(return_value=True)),
+        ])
+        call = _make_call("nonexistent")
+
+        async def not_found_handler(c):
+            return ToolResult(
+                call_id=c.id, tool_name=c.tool_name,
+                success=False, error="Unknown tool: nonexistent",
+                failure_type="tool_not_found",
+            )
+
+        result = await pipeline.execute(call, not_found_handler)
+        assert not result.success
+        assert "denied" in states
+


### PR DESCRIPTION
## Summary

Phase 2 of the Action Lifecycle (Issue #42 -> #50). Converts the retroactive state-stamping architecture into **real-time control gates**.

## Architecture — Two-layer Middleware

The lifecycle is split into two cooperating middleware layers that share state through LifecycleContext in call.metadata:

| Layer | Position | Responsibilities |
|-------|----------|-----------------|
| **LifecycleMiddleware** | Outermost | DECLARED, post-OBSERVED states (VALIDATED, COMMITTED, REVERTING, REVERTED), MEMORIALIZED, failure paths |
| **LifecycleGateMiddleware** | Innermost (before handler) | AUTHORIZED -> PREPARED -> EXECUTING -> OBSERVED as real-time control gates |

### Why two layers?
A single middleware cannot intercept both BEFORE and AT the moment the tool executor runs. next(call) fires the entire remaining chain as one opaque call — the outermost middleware has no way to inject logic immediately before the handler.

## Key Changes

### LifecycleContext (lifecycle.py)
- Shared context injected into ToolCall.metadata
- Carries transition() and memorialize() helpers with shared callbacks
- BlastRadiusMiddleware writes authorization decisions to it at decision time

### BlastRadiusMiddleware (middleware.py)
- New _notify_lifecycle() method writes auth result to LifecycleContext
- Full backward compatibility — no-op when no LifecycleContext present (sub-agents)

### ToolDefinition.precondition_checks (registry.py)
- New callable gate field evaluated sequentially before dispatch; ALL must pass
- Failure -> ABORTED with no tool call made
- Complements existing preconditions (human-readable strings) for docs/audit

### LifecycleGateMiddleware (middleware.py) [NEW]
- AUTHORIZED: reads from LifecycleContext (set by BlastRadiusMiddleware)
- PREPARED: evaluates precondition_checks
- EXECUTING: fires at exact dispatch moment + races abort_signal
- OBSERVED: fires when executor returns

### Abort Signal Racing
- Pre-set abort_signal -> ABORTED before execution
- Signal during execution -> asyncio.wait() races executor vs. signal -> ABORTED
- Timeout result from handler -> stays at EXECUTING -> outer middleware drives TIMED_OUT

## Backward Compatibility
Tools with no precondition_checks, post_validator, or rollback_fn follow:
DECLARED -> AUTHORIZED -> PREPARED -> EXECUTING -> OBSERVED -> COMMITTED -> MEMORIALIZED
— identical to Phase 1 happy path.

## Tests
- **24 new lifecycle tests** covering: LifecycleContext, happy path, AUTHORIZED gate, PREPARED precondition gates, EXECUTING gate, abort signal racing, timeout, validation error, post-validation/rollback, gate pass-through, tool-not-found
- **49 existing tests** pass unchanged (73 total)

Closes #50
