### PR TITLE
feat(skills): Issue #64 Phase B — skill precondition checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,13 @@ Drop a `SKILL.md` into the `skills/` directory — Loom auto-imports it at sessi
 name: loom-engineer
 description: Full implementation cycle from issue to PR.
 tags: [git, python, engineering]
+precondition_checks:
+  - ref: checks.require_git_repo
+    applies_to: [run_bash, write_file]
+    description: "Must be inside a git repository"
+  - ref: checks.reject_force_push
+    applies_to: [run_bash]
+    description: "Block git push --force"
 ---
 
 # Loom Engineer
@@ -262,6 +269,73 @@ load_skill() → Agent executes task → TurnDone
 At session end, `SkillEvolutionHook` analyses low-confidence skills (confidence < 0.6, usage ≥ 3) and writes improvement suggestions. Next `load_skill()` surfaces these as `<evolution_hints>`.
 
 Skills whose `confidence` drops below `skill_deprecation_threshold` (default 0.3) are automatically deprecated and removed from the Tier 1 catalog.
+
+### Skill Precondition Checks — Framework-Enforced Safety Rails
+
+SKILL.md tells the LLM what it *should* do. But LLMs are probabilistic — a strongly worded "never run `rm -rf`" in a skill document is a suggestion, not a guarantee. **Precondition checks** close this gap by moving safety rules from text into code that the framework executes before every tool call.
+
+**Why this matters:**
+
+| Without precondition checks | With precondition checks |
+|----------------------------|--------------------------|
+| "Don't run destructive commands" — LLM *might* comply | `reject_destructive_commands()` — framework **blocks** `rm -rf` before shell sees it |
+| "This skill is read-only" — LLM *usually* respects it | `reject_write_operations()` — `write_file` is **impossible** while skill is loaded |
+| "Only modify files in skills/" — LLM *tries* to follow | `require_skills_dir_target()` — paths outside `skills/` are **rejected** at PREPARED gate |
+
+**How it works:**
+
+Skills declare checks in their SKILL.md frontmatter. Each check is an async Python function in the skill's `checks.py` that returns `True` (allow) or `False` (block):
+
+```yaml
+# skills/security_assessment/SKILL.md
+---
+name: security_assessment
+precondition_checks:
+  - ref: checks.reject_destructive_commands
+    applies_to: [run_bash]
+    description: "Block rm -rf, DROP TABLE, dd, etc."
+  - ref: checks.reject_production_env
+    applies_to: [run_bash]
+    description: "Block execution in production environments"
+---
+```
+
+```python
+# skills/security_assessment/checks.py
+async def reject_destructive_commands(call) -> bool:
+    cmd = call.args.get("command", "")
+    destructive = ["rm -rf", "DROP TABLE", "dd if="]
+    return not any(p in cmd.lower() for p in destructive)
+```
+
+**Lifecycle integration:**
+
+```
+load_skill("security_assessment")
+  → First load: user sees confirmation panel listing all checks → approves
+  → Approval stored in RelationalMemory (one-time)
+  → checks.py functions mounted onto target ToolDefinitions
+  → Every run_bash call now passes through PREPARED gate checks
+
+load_skill("loom_engineer")
+  → Previous skill's checks auto-unmounted (no cross-skill contamination)
+  → loom_engineer's own checks mounted instead
+```
+
+Checks are evaluated at the `PREPARED` stage of the [Action Lifecycle](#action-lifecycle) — after authorization but before execution. All checks must pass; any failure aborts the tool call with zero side effects.
+
+**Built-in skill checks:**
+
+| Skill | Check | Protects against |
+|-------|-------|-----------------|
+| `loom_engineer` | `require_git_repo` | Running git commands outside a repository |
+| `loom_engineer` | `reject_force_push` | Accidental `git push --force` |
+| `systematic_code_analyst` | `reject_write_operations` | Analysis skill writing files |
+| `meta-skill-engineer` | `require_skills_dir_target` | Skill engineer modifying framework code |
+| `security_assessment` | `reject_destructive_commands` | Destructive commands during security scans |
+| `security_assessment` | `reject_production_env` | Running scans in production |
+| `memory_hygiene` | `require_memory_backup` | Cleanup without backup |
+| `memory_hygiene` | `reject_direct_db_mutation` | Bypassing framework APIs with raw SQL |
 
 ---
 

--- a/loom/core/harness/skill_checks.py
+++ b/loom/core/harness/skill_checks.py
@@ -1,0 +1,253 @@
+"""
+Skill Precondition Check Manager — Issue #64 Phase B.
+
+Dynamically mounts/unmounts skill-declared precondition checks onto
+ToolDefinitions at ``load_skill()`` time.
+
+Design:
+    - Each skill's SKILL.md frontmatter can declare ``precondition_checks``
+      referencing Python callables in the skill's directory.
+    - On ``load_skill()``, callables are resolved (imported) and appended
+      to the target ToolDefinition.precondition_checks list.
+    - Default behavior: loading a new skill auto-unmounts the previous
+      skill's checks (A).  ``keep_existing=True`` overrides this.
+    - Explicit ``unmount()`` is available for manual control (B).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Awaitable, Callable, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .registry import ToolRegistry
+
+_log = logging.getLogger(__name__)
+
+
+@dataclass
+class SkillPreconditionRef:
+    """One precondition check declaration from SKILL.md frontmatter."""
+    ref: str
+    """Dotted reference: ``module.function`` relative to skill directory."""
+    applies_to: list[str]
+    """Tool names this check should be mounted on."""
+    description: str
+    """Human-readable description shown in audit trail."""
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> SkillPreconditionRef:
+        """Parse from a frontmatter dict entry."""
+        ref = d.get("ref", "")
+        applies_to = d.get("applies_to", [])
+        if isinstance(applies_to, str):
+            applies_to = [applies_to]
+        description = d.get("description", ref)
+        return cls(ref=ref, applies_to=applies_to, description=description)
+
+
+# Internal record of a single mounted check — used for unmounting.
+@dataclass
+class _MountedCheck:
+    tool_name: str
+    check_fn: Callable
+    description: str
+
+
+class SkillCheckManager:
+    """
+    Manages the lifecycle of skill-declared precondition checks.
+
+    Instantiated once per session in ``LoomSession.start()``.
+    """
+
+    def __init__(self, registry: "ToolRegistry") -> None:
+        self._registry = registry
+        # skill_name → list of mounted checks
+        self._mounted: dict[str, list[_MountedCheck]] = {}
+        self._active_skill: str | None = None
+
+    @property
+    def active_skill(self) -> str | None:
+        """The skill whose checks are currently mounted."""
+        return self._active_skill
+
+    def mounted_skills(self) -> list[str]:
+        """List of all skills with currently mounted checks."""
+        return list(self._mounted.keys())
+
+    # ------------------------------------------------------------------
+    # Mount / Unmount
+    # ------------------------------------------------------------------
+
+    def mount(
+        self,
+        skill_name: str,
+        refs: list[SkillPreconditionRef],
+        callables: dict[str, Callable],
+        keep_existing: bool = False,
+    ) -> list[str]:
+        """
+        Mount precondition checks for *skill_name* onto ToolDefinitions.
+
+        Args:
+            skill_name: Name of the skill being loaded.
+            refs: Parsed precondition_check_refs from SkillGenome.
+            callables: Mapping of ref string → resolved async callable.
+            keep_existing: If False (default), auto-unmount the previous
+                active skill's checks before mounting.
+
+        Returns:
+            List of human-readable descriptions of successfully mounted checks.
+        """
+        # A: auto-unmount previous skill
+        if not keep_existing and self._active_skill and self._active_skill != skill_name:
+            self.unmount(self._active_skill)
+
+        # If this skill already has checks mounted, unmount first (re-mount)
+        if skill_name in self._mounted:
+            self.unmount(skill_name)
+
+        mounted: list[_MountedCheck] = []
+        descriptions: list[str] = []
+
+        for ref in refs:
+            fn = callables.get(ref.ref)
+            if fn is None:
+                _log.warning(
+                    "Skipping unresolved ref %r for skill %r", ref.ref, skill_name,
+                )
+                continue
+
+            for tool_name in ref.applies_to:
+                tool_def = self._registry.get(tool_name)
+                if tool_def is None:
+                    _log.warning(
+                        "Skill %r: tool %r not found in registry, skipping",
+                        skill_name, tool_name,
+                    )
+                    continue
+
+                tool_def.precondition_checks.append(fn)
+                tool_def.preconditions.append(ref.description)
+                mounted.append(_MountedCheck(
+                    tool_name=tool_name,
+                    check_fn=fn,
+                    description=ref.description,
+                ))
+                descriptions.append(f"{tool_name}: {ref.description}")
+
+        self._mounted[skill_name] = mounted
+        self._active_skill = skill_name
+
+        _log.info(
+            "Mounted %d precondition check(s) for skill %r",
+            len(mounted), skill_name,
+        )
+        return descriptions
+
+    def unmount(self, skill_name: str) -> int:
+        """
+        Remove all precondition checks previously mounted by *skill_name*.
+
+        Returns the number of checks removed.
+        """
+        checks = self._mounted.pop(skill_name, [])
+        removed = 0
+
+        for mc in checks:
+            tool_def = self._registry.get(mc.tool_name)
+            if tool_def is None:
+                continue
+            # Remove by identity — we stored the exact function reference
+            try:
+                tool_def.precondition_checks.remove(mc.check_fn)
+                removed += 1
+            except ValueError:
+                pass  # already removed (shouldn't happen)
+            try:
+                tool_def.preconditions.remove(mc.description)
+            except ValueError:
+                pass
+
+        if self._active_skill == skill_name:
+            self._active_skill = None
+
+        _log.info(
+            "Unmounted %d precondition check(s) for skill %r",
+            removed, skill_name,
+        )
+        return removed
+
+    def unmount_all(self) -> None:
+        """Remove all skill-mounted checks (called on session stop)."""
+        for name in list(self._mounted):
+            self.unmount(name)
+
+    # ------------------------------------------------------------------
+    # Callable resolution
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def resolve_callable(skill_dir: Path, ref: str) -> Callable:
+        """
+        Resolve a dotted ref to an async callable from the skill directory.
+
+        ``ref`` format: ``module.function_name``
+        e.g. ``checks.require_not_production`` →
+             import ``skill_dir/checks.py``, get ``require_not_production``.
+
+        Raises FileNotFoundError, AttributeError, or TypeError on failure.
+        """
+        parts = ref.rsplit(".", 1)
+        if len(parts) != 2:
+            raise ValueError(
+                f"Invalid ref format: {ref!r}. Expected 'module.function'."
+            )
+        module_name, func_name = parts
+
+        module_path = skill_dir / f"{module_name}.py"
+        if not module_path.is_file():
+            raise FileNotFoundError(
+                f"Check module not found: {module_path}"
+            )
+
+        spec = importlib.util.spec_from_file_location(
+            f"loom_skill_check_{skill_dir.name}_{module_name}",
+            module_path,
+        )
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot create module spec for {module_path}")
+
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        fn = getattr(module, func_name, None)
+        if fn is None:
+            raise AttributeError(
+                f"Function {func_name!r} not found in {module_path}"
+            )
+        if not callable(fn):
+            raise TypeError(f"{ref!r} resolved to a non-callable: {type(fn)}")
+
+        return fn
+
+    @classmethod
+    def resolve_all(
+        cls,
+        skill_dir: Path,
+        refs: list[SkillPreconditionRef],
+    ) -> dict[str, Callable]:
+        """
+        Resolve all refs for a skill.  Returns {ref_string: callable}.
+
+        Raises on the first unresolvable ref.
+        """
+        result: dict[str, Callable] = {}
+        for ref in refs:
+            if ref.ref not in result:
+                result[ref.ref] = cls.resolve_callable(skill_dir, ref.ref)
+        return result

--- a/loom/core/memory/procedural.py
+++ b/loom/core/memory/procedural.py
@@ -34,6 +34,13 @@ class SkillGenome:
     parent_skill: str | None = None    # Inheritance lineage
     deprecation_threshold: float = 0.3
     tags: list[str] = field(default_factory=list)
+    precondition_check_refs: list[dict] = field(default_factory=list)
+    """
+    Skill-declared precondition check references (Issue #64 Phase B).
+
+    Each dict: {"ref": "checks.fn_name", "applies_to": ["run_bash"], "description": "..."}
+    Parsed from SKILL.md frontmatter, resolved to callables at load_skill() time.
+    """
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
@@ -92,17 +99,18 @@ class ProceduralMemory:
             INSERT INTO skill_genomes
                 (id, name, version, confidence, usage_count, success_rate,
                  parent_skill, deprecation_threshold, tags, body,
-                 created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 precondition_check_refs, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(name) DO UPDATE SET
-                version               = excluded.version,
-                confidence            = excluded.confidence,
-                usage_count           = excluded.usage_count,
-                success_rate          = excluded.success_rate,
-                deprecation_threshold = excluded.deprecation_threshold,
-                tags                  = excluded.tags,
-                body                  = excluded.body,
-                updated_at            = excluded.updated_at
+                version                = excluded.version,
+                confidence             = excluded.confidence,
+                usage_count            = excluded.usage_count,
+                success_rate           = excluded.success_rate,
+                deprecation_threshold  = excluded.deprecation_threshold,
+                tags                   = excluded.tags,
+                body                   = excluded.body,
+                precondition_check_refs = excluded.precondition_check_refs,
+                updated_at             = excluded.updated_at
             """,
             (
                 skill.id, skill.name, skill.version, skill.confidence,
@@ -110,6 +118,7 @@ class ProceduralMemory:
                 skill.deprecation_threshold,
                 json.dumps(skill.tags, ensure_ascii=False),
                 skill.body,
+                json.dumps(skill.precondition_check_refs, ensure_ascii=False),
                 skill.created_at.isoformat(), now,
             ),
         )
@@ -118,7 +127,8 @@ class ProceduralMemory:
     async def get(self, name: str) -> SkillGenome | None:
         cursor = await self._db.execute(
             "SELECT id, name, version, confidence, usage_count, success_rate, "
-            "parent_skill, deprecation_threshold, tags, body, created_at, updated_at "
+            "parent_skill, deprecation_threshold, tags, body, "
+            "precondition_check_refs, created_at, updated_at "
             "FROM skill_genomes WHERE name = ?",
             (name,),
         )
@@ -129,15 +139,17 @@ class ProceduralMemory:
             id=row[0], name=row[1], version=row[2], confidence=row[3],
             usage_count=row[4], success_rate=row[5], parent_skill=row[6],
             deprecation_threshold=row[7], tags=json.loads(row[8]),
-            body=row[9], created_at=datetime.fromisoformat(row[10]),
-            updated_at=datetime.fromisoformat(row[11]),
+            body=row[9], precondition_check_refs=json.loads(row[10]),
+            created_at=datetime.fromisoformat(row[11]),
+            updated_at=datetime.fromisoformat(row[12]),
         )
 
     async def list_active(self) -> list[SkillGenome]:
         """Return all non-deprecated skills ordered by confidence."""
         cursor = await self._db.execute(
             "SELECT id, name, version, confidence, usage_count, success_rate, "
-            "parent_skill, deprecation_threshold, tags, body, created_at, updated_at "
+            "parent_skill, deprecation_threshold, tags, body, "
+            "precondition_check_refs, created_at, updated_at "
             "FROM skill_genomes "
             "WHERE confidence > deprecation_threshold "
             "   OR usage_count < ? "
@@ -150,8 +162,9 @@ class ProceduralMemory:
                 id=r[0], name=r[1], version=r[2], confidence=r[3],
                 usage_count=r[4], success_rate=r[5], parent_skill=r[6],
                 deprecation_threshold=r[7], tags=json.loads(r[8]),
-                body=r[9], created_at=datetime.fromisoformat(r[10]),
-                updated_at=datetime.fromisoformat(r[11]),
+                body=r[9], precondition_check_refs=json.loads(r[10]),
+                created_at=datetime.fromisoformat(r[11]),
+                updated_at=datetime.fromisoformat(r[12]),
             )
             for r in rows
         ]

--- a/loom/core/memory/store.py
+++ b/loom/core/memory/store.py
@@ -196,6 +196,8 @@ class SQLiteStore:
                 "ALTER TABLE session_log ADD COLUMN raw_json TEXT",
                 # Issue #43: governance events stored in audit_log.details
                 "ALTER TABLE audit_log ADD COLUMN details TEXT NOT NULL DEFAULT '{}'",
+                # Issue #64: skill-declared precondition check references
+                "ALTER TABLE skill_genomes ADD COLUMN precondition_check_refs TEXT NOT NULL DEFAULT '[]'",
             ]:
                 try:
                     await db.execute(_migration)

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -233,28 +233,29 @@ def _load_env(project_root: Path | None = None) -> dict[str, str]:
     return {}
 
 
-def _parse_skill_frontmatter(raw: str) -> tuple[str, str, list[str]]:
+def _parse_skill_frontmatter(raw: str) -> tuple[str, str, list[str], list[dict]]:
     """
     Parse YAML frontmatter from a SKILL.md file.
 
-    Returns (name, description, tags).  On parse failure returns empty strings.
+    Returns (name, description, tags, precondition_check_refs).
+    On parse failure returns empty strings/lists.
     Follows Agent Skills spec lenient validation: best-effort parsing.
     """
     if not raw.startswith("---"):
-        return "", "", []
+        return "", "", [], []
 
     parts = raw.split("---", 2)
     if len(parts) < 3:
-        return "", "", []
+        return "", "", [], []
 
     yaml_text = parts[1].strip()
     try:
         import yaml
         data = yaml.safe_load(yaml_text)
         if not isinstance(data, dict):
-            return "", "", []
+            return "", "", [], []
     except Exception:
-        return "", "", []
+        return "", "", [], []
 
     name = str(data.get("name", "")).strip()
     description = str(data.get("description", "")).strip()
@@ -264,7 +265,17 @@ def _parse_skill_frontmatter(raw: str) -> tuple[str, str, list[str]]:
     elif not isinstance(tags, list):
         tags = []
 
-    return name, description, tags
+    # Issue #64 Phase B: skill-declared precondition checks
+    pc_refs = data.get("precondition_checks", [])
+    if not isinstance(pc_refs, list):
+        pc_refs = []
+    # Validate each entry has at minimum 'ref' and 'applies_to'
+    valid_refs: list[dict] = []
+    for entry in pc_refs:
+        if isinstance(entry, dict) and entry.get("ref") and entry.get("applies_to"):
+            valid_refs.append(entry)
+
+    return name, description, tags, valid_refs
 
 
 def build_router() -> LLMRouter:
@@ -450,6 +461,10 @@ class LoomSession:
         self._turn_index: int = 0  # increments once per completed stream_turn()
         self._last_think: str = ""  # accumulated <think>…</think> content from the last turn
         self._cancel_spinner_fn: "Callable[[], None] | None" = None  # injected by CLI run loop
+        # Platform-swappable confirmation callback.  Defaults to CLI prompt.
+        # TUI replaces with InlineConfirmWidget; Discord replaces with button view.
+        # Used by BlastRadiusMiddleware AND skill check approval.
+        self._confirm_fn: "Callable[[ToolCall], Any] | None" = None  # set in start()
         # Issue #56: Skill outcome tracking
         self._skill_outcome_tracker: "SkillOutcomeTracker | None" = None
         self._mcp_clients: list[Any] = []
@@ -595,11 +610,31 @@ class LoomSession:
             self.workspace / "skills",
             Path.home() / ".loom" / "skills",
         ]
+
+        # Issue #64 Phase B: SkillCheckManager for dynamic precondition mounting
+        from loom.core.harness.skill_checks import SkillCheckManager
+        self._skill_check_manager = SkillCheckManager(self.registry)
+
+        # Platform-swappable confirm — defaults to CLI.  TUI/Discord replace
+        # this after start() via ``session._confirm_fn = <their_version>``.
+        # BlastRadiusMiddleware._confirm is also patched by TUI/Discord;
+        # skill check approval uses _confirm_fn so both paths stay in sync.
+        self._confirm_fn = self._confirm_tool_cli
+
         self.registry.register(make_load_skill_tool(
             self._procedural, skills_dirs,
             outcome_tracker=self._skill_outcome_tracker,
             semantic=self._semantic,
             turn_index_fn=lambda: self._turn_index,
+            skill_check_manager=self._skill_check_manager,
+            relational=self._relational,
+            confirm_fn=lambda call: self._confirm_fn(call),
+        ))
+
+        # Issue #64 Phase B: Register unload_skill tool
+        from loom.platform.cli.tools import make_unload_skill_tool
+        self.registry.register(make_unload_skill_tool(
+            self._skill_check_manager,
         ))
 
         # Register web tools (Phase 5D)
@@ -650,7 +685,7 @@ class LoomSession:
                 SchemaValidationMiddleware(registry=self.registry),
                 BlastRadiusMiddleware(
                     perm_ctx=self.perm,
-                    confirm_fn=self._confirm_tool,
+                    confirm_fn=self._confirm_tool_cli,
                     exec_escape_fn=_exec_escape_fn,
                 ),
                 LifecycleGateMiddleware(registry=self.registry),
@@ -694,6 +729,9 @@ class LoomSession:
     async def stop(self) -> None:
         if self._db is None:
             return
+        # Issue #64: unmount all skill-declared checks before closing
+        if hasattr(self, "_skill_check_manager"):
+            self._skill_check_manager.unmount_all()
         # Grab the connection reference and immediately clear self._db so any
         # concurrent or re-entrant call (e.g. /new → on_unmount) hits the guard above.
         db, self._db = self._db, None
@@ -1267,7 +1305,7 @@ class LoomSession:
                     continue
 
                 # Parse YAML frontmatter
-                name, description, tags = _parse_skill_frontmatter(raw)
+                name, description, tags, pc_refs = _parse_skill_frontmatter(raw)
                 if not name:
                     # Fallback: use directory name
                     name = skill_dir.name
@@ -1301,6 +1339,7 @@ class LoomSession:
                         usage_count=existing.usage_count if existing else 0,
                         success_rate=existing.success_rate if existing else 0.0,
                         tags=tags or (existing.tags if existing else []),
+                        precondition_check_refs=pc_refs,
                     )
                     await self._procedural.upsert(genome)
                     logger.debug("Auto-imported skill '%s' from %s", name, skill_md)
@@ -1651,7 +1690,8 @@ class LoomSession:
                 )
             )
 
-    async def _confirm_tool(self, call: ToolCall) -> bool:
+    async def _confirm_tool_cli(self, call: ToolCall) -> bool:
+        """CLI-specific confirmation prompt (stdin / Rich panel)."""
         # Stop any running spinner before printing the confirm panel so the
         # spinner animation doesn't overwrite the prompt input line.
         _CLEAR_LINE = "\r\033[K"  # ANSI: carriage-return + erase to end of line

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -792,6 +792,8 @@ async def _chat_tui(model: str, db: str, resume_session_id: str | None = None) -
             if isinstance(mw, BlastRadiusMiddleware):
                 mw._confirm = _tui_confirm
                 break
+        # Also patch skill check approval so it uses TUI confirm widgets
+        session._confirm_fn = _tui_confirm
 
         result = await app.run_async()
         # /sessions exits with a session_id string → resume that session.
@@ -1660,6 +1662,8 @@ async def _discord_with_autonomy(
         if isinstance(_mw, _BRM):
             _mw._confirm = _confirm_fn
             break
+    # Also patch skill check approval so it uses Discord confirm buttons
+    session._confirm_fn = _confirm_fn
 
     daemon = AutonomyDaemon(
         notify_router=notify_router,

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -24,8 +24,14 @@ import httpx
 from loom.core.harness.middleware import ToolCall, ToolResult
 from loom.core.harness.permissions import ToolCapability, TrustLevel
 
+import logging
+
+_log = logging.getLogger(__name__)
+
 if TYPE_CHECKING:
-    from loom.core.memory.procedural import ProceduralMemory
+    from collections.abc import Callable
+    from loom.core.harness.skill_checks import SkillCheckManager
+    from loom.core.memory.procedural import ProceduralMemory, SkillGenome
     from loom.core.memory.relational import RelationalMemory
     from loom.core.memory.search import MemorySearch
     from loom.core.memory.semantic import SemanticMemory
@@ -655,6 +661,9 @@ def make_load_skill_tool(
     outcome_tracker: "SkillOutcomeTracker | None" = None,
     semantic: "SemanticMemory | None" = None,
     turn_index_fn: "Callable[[], int] | None" = None,
+    skill_check_manager: "SkillCheckManager | None" = None,
+    relational: "RelationalMemory | None" = None,
+    confirm_fn: "Callable | None" = None,
 ) -> ToolDefinition:
     """
     Create a SAFE ``load_skill`` tool that loads full skill instructions.
@@ -664,6 +673,7 @@ def make_load_skill_tool(
     - Lists bundled resources (scripts/, references/, assets/)
     - Attaches evolution hints if available
     - Deduplicates: returns a short note on second activation in same session
+    - Issue #64 Phase B: mounts skill-declared precondition checks
     """
     from loom.core.memory.procedural import ProceduralMemory  # type: ignore[attr-defined]
 
@@ -673,6 +683,7 @@ def make_load_skill_tool(
 
     async def _load_skill(call: ToolCall) -> ToolResult:
         name = call.args.get("name", "").strip()
+        keep_existing = call.args.get("keep_existing", False)
         if not name:
             return ToolResult(
                 call_id=call.id, tool_name=call.tool_name,
@@ -743,6 +754,18 @@ def make_load_skill_tool(
                 lines.append(f"  <file>{res}</file>")
             lines.append("</skill_resources>")
 
+        # Issue #64 Phase B: mount skill-declared precondition checks
+        checks_summary = await _mount_skill_checks(
+            name, skill, skill_dir, skill_check_manager, relational,
+            keep_existing=keep_existing,
+        )
+        if checks_summary:
+            lines.append("")
+            lines.append("<mounted_precondition_checks>")
+            for desc in checks_summary:
+                lines.append(f"  {desc}")
+            lines.append("</mounted_precondition_checks>")
+
         lines.append("</skill_content>")
 
         output = "\n".join(lines)
@@ -759,6 +782,81 @@ def make_load_skill_tool(
             metadata={"skill_name": name, "skill_confidence": skill.confidence},
         )
 
+    async def _mount_skill_checks(
+        name: str,
+        skill: "SkillGenome",
+        skill_dir_str: str | None,
+        manager: "SkillCheckManager | None",
+        rel: "RelationalMemory | None",
+        keep_existing: bool = False,
+    ) -> list[str]:
+        """Resolve and mount precondition checks for a skill. Returns descriptions."""
+        if manager is None or not skill.precondition_check_refs:
+            return []
+
+        from loom.core.harness.skill_checks import SkillPreconditionRef, SkillCheckManager
+
+        refs = [SkillPreconditionRef.from_dict(d) for d in skill.precondition_check_refs]
+
+        # Approval gate: first-time approval via RelationalMemory
+        rel_key = f"skill_checks:{name}"
+        approved = False
+        if rel is not None:
+            entry = await rel.get(rel_key, "approved")
+            approved = entry is not None and entry.object == "true"
+
+        if not approved:
+            # Build a description of what the skill wants to mount
+            check_lines = []
+            for ref in refs:
+                tools_str = ", ".join(ref.applies_to)
+                check_lines.append(f"  {ref.ref} → [{tools_str}]: {ref.description}")
+            check_preview = "\n".join(check_lines)
+
+            if confirm_fn is not None:
+                # Use the platform-aware confirm callback (works on CLI, TUI, Discord)
+                from loom.core.harness.middleware import ToolCall as _ToolCall
+                from loom.core.harness.registry import TrustLevel
+                synthetic_call = _ToolCall(
+                    tool_name=f"load_skill({name})",
+                    args={"action": "mount_precondition_checks", "checks": check_preview},
+                    trust_level=TrustLevel.GUARDED,
+                    session_id="",
+                )
+                try:
+                    user_ok = await confirm_fn(synthetic_call)
+                except (EOFError, KeyboardInterrupt):
+                    user_ok = False
+            else:
+                user_ok = False
+
+            if not user_ok:
+                return []
+
+            # Persist approval
+            if rel is not None:
+                from loom.core.memory.relational import RelationalEntry
+                await rel.upsert(RelationalEntry(
+                    subject=rel_key,
+                    predicate="approved",
+                    object="true",
+                    source="user",
+                ))
+
+        # Resolve callables from skill directory
+        if not skill_dir_str:
+            return []
+
+        skill_dir_path = Path(skill_dir_str)
+        try:
+            callables = SkillCheckManager.resolve_all(skill_dir_path, refs)
+        except (FileNotFoundError, AttributeError, ImportError, ValueError) as exc:
+            _log.warning("Failed to resolve checks for skill %r: %s", name, exc)
+            return []
+
+        # Mount
+        return manager.mount(name, refs, callables, keep_existing=keep_existing)
+
     return ToolDefinition(
         name="load_skill",
         description=(
@@ -774,11 +872,79 @@ def make_load_skill_tool(
                     "type": "string",
                     "description": "Name of the skill to load (from <available_skills>)",
                 },
+                "keep_existing": {
+                    "type": "boolean",
+                    "description": (
+                        "If true, keep the previous skill's precondition checks "
+                        "mounted alongside the new skill's. Default: false "
+                        "(auto-unmount previous skill's checks)."
+                    ),
+                    "default": False,
+                },
             },
             "required": ["name"],
         },
         executor=_load_skill,
         tags=["skill", "memory", "activation"],
+        scope="memory",
+    )
+
+
+def make_unload_skill_tool(
+    skill_check_manager: "SkillCheckManager",
+) -> ToolDefinition:
+    """
+    Create a SAFE ``unload_skill`` tool for explicit skill check removal.
+
+    Issue #64 Phase B: allows the agent (or user) to manually unmount
+    a skill's precondition checks without loading a replacement skill.
+    """
+    async def _unload_skill(call: ToolCall) -> ToolResult:
+        name = call.args.get("name", "").strip()
+        if not name:
+            # No name → list currently mounted skills
+            mounted = skill_check_manager.mounted_skills()
+            if not mounted:
+                return ToolResult(
+                    call_id=call.id, tool_name=call.tool_name,
+                    success=True,
+                    output="No skill precondition checks are currently mounted.",
+                )
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=True,
+                output=f"Skills with mounted checks: {', '.join(mounted)}",
+            )
+
+        removed = skill_check_manager.unmount(name)
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=True,
+            output=(
+                f"Unmounted {removed} precondition check(s) for skill '{name}'."
+                if removed > 0
+                else f"Skill '{name}' had no mounted precondition checks."
+            ),
+        )
+
+    return ToolDefinition(
+        name="unload_skill",
+        description=(
+            "Remove a skill's precondition checks from the tool pipeline. "
+            "Call with no name to list skills with mounted checks."
+        ),
+        trust_level=TrustLevel.SAFE,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the skill to unload checks for",
+                },
+            },
+        },
+        executor=_unload_skill,
+        tags=["skill", "memory"],
         scope="memory",
     )
 

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -360,6 +360,8 @@ class LoomDiscordBot:
             if isinstance(mw, BlastRadiusMiddleware):
                 mw._confirm = confirm_fn
                 break
+        # Also patch skill check approval so it uses Discord confirm buttons
+        session._confirm_fn = confirm_fn
 
         self._sessions[thread_id] = session
         return session

--- a/skills/loom_engineer/SKILL.md
+++ b/skills/loom_engineer/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: loom_engineer
 description: "Loom 框架的實作技能，覆蓋從 issue 分析到 PR 產出的完整實作迴圈。當使用者要求「幫我修這個 issue」、「這個 PR 要怎麼 review」、「幫我寫一個功能」、「debug 這個問題」時使用。是 systematic_code_analyst 的下游：分析完成後的實作、驗證與產出由本技能負責。"
+precondition_checks:
+  - ref: checks.require_git_repo
+    applies_to: [run_bash, write_file]
+    description: "必須在 git repository 內操作"
+  - ref: checks.reject_force_push
+    applies_to: [run_bash]
+    description: "禁止 git push --force，防止歷史被覆寫"
 ---
 
 # Loom Engineer

--- a/skills/loom_engineer/checks.py
+++ b/skills/loom_engineer/checks.py
@@ -1,0 +1,43 @@
+"""
+Precondition checks for loom_engineer skill (Issue #64 Phase B).
+
+loom_engineer is an implementation skill — it modifies code, runs tests,
+and produces commits.  These checks enforce safety invariants that the
+SKILL.md describes as discipline but cannot enforce at the framework level.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+
+async def require_git_repo(call) -> bool:
+    """Ensure we're inside a git repository before modifying anything.
+
+    loom_engineer's entire workflow (branch, commit, PR) assumes git.
+    Running outside a repo would produce broken output.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        "git", "rev-parse", "--is-inside-work-tree",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await proc.communicate()
+    return proc.returncode == 0
+
+
+async def reject_force_push(call) -> bool:
+    """Block ``git push --force`` and variants to prevent history rewrite.
+
+    loom_engineer principle #6: "review 先於 commit".
+    Force-pushing bypasses review and can destroy others' work.
+    """
+    cmd = call.args.get("command", "")
+    if "push" not in cmd:
+        return True
+    # Check for --force, -f, --force-with-lease (all are force variants)
+    tokens = cmd.split()
+    for i, token in enumerate(tokens):
+        if token in ("--force", "-f", "--force-with-lease"):
+            return False
+    return True

--- a/skills/memory_hygiene/SKILL.md
+++ b/skills/memory_hygiene/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: memory_hygiene
+description: "記憶系統衛生維護技能。整理、驗證、清理 Loom 自身的記憶系統，包括 semantic memory 去重、episodic 過期清理、relational 一致性檢查、skill confidence 漂移偵測。當使用者要求「整理記憶」、「清理過期記憶」、「記憶體健康檢查」、「memory cleanup」、「記憶診斷」時使用。"
+tags: [memory, maintenance, hygiene, cleanup, diagnosis, governance]
+precondition_checks:
+  - ref: checks.require_memory_backup
+    applies_to: [run_bash]
+    description: "執行清理操作前必須確認 memory.db 有備份"
+  - ref: checks.reject_direct_db_mutation
+    applies_to: [run_bash]
+    description: "禁止直接 SQL 修改記憶體資料庫，必須透過框架 API"
+---
+
+# Memory Hygiene
+
+Loom 記憶系統的衛生維護技能。作為 memory-native 框架，記憶品質直接影響決策品質。
+
+---
+
+## 核心原則
+
+1. **先診斷後治療** — 不做「預防性清理」，先有數據證明需要清理再動手
+2. **備份先行** — 任何修改性操作前必須確認備份存在
+3. **透過框架操作** — 永遠不直接操作 SQLite，使用 recall/memorize/relate API
+4. **報告每一步** — 使用者必須看到「清理了什麼、為什麼、影響多少筆」
+
+---
+
+## 工作流程（四階段）
+
+### 階段 1：健康診斷
+
+**目標：建立記憶系統的健康快照**
+
+使用 `recall` 和 `run_bash` 收集以下指標：
+
+- **Semantic memory**：總筆數、confidence 分布、最舊條目日期
+- **Episodic memory**：未壓縮 session 數、平均每 session 條目數
+- **Relational memory**：總三元組數、孤立節點數
+- **Skill genomes**：各技能 confidence、是否有技能低於 deprecation_threshold
+- **資料庫大小**：memory.db 檔案大小、WAL 大小
+
+**輸出格式：**
+```markdown
+## Memory Health Report
+
+| 指標 | 數值 | 狀態 |
+|------|------|------|
+| Semantic 條目數 | {N} | {OK/WARNING/CRITICAL} |
+| 低 confidence 條目 (<0.3) | {N} | {OK/WARNING} |
+| 未壓縮 episodic sessions | {N} | {OK/WARNING} |
+| Relational 孤立節點 | {N} | {OK/WARNING} |
+| Skill 低信心 (<0.5) | {names} | {OK/WARNING} |
+| DB 大小 | {MB} | {OK/WARNING} |
+```
+
+### 階段 2：問題識別
+
+**目標：從健康快照中識別具體問題**
+
+常見問題模式：
+
+| 問題 | 偵測方式 | 嚴重度 |
+|------|---------|--------|
+| 語義重複 | 相似度 > 0.9 的 key pairs | MEDIUM |
+| 信心衰減 | confidence < 0.1 且超過 90 天未更新 | LOW |
+| 矛盾事實 | 同 key 不同 value 且 metadata.history > 3 | HIGH |
+| 技能漂移 | skill confidence 持續下降但 usage_count 增加 | HIGH |
+| 記憶膨脹 | semantic 條目超過 1000 | MEDIUM |
+| 孤立關係 | relational entry 的 subject/object 在其他表中不存在 | LOW |
+
+### 階段 3：清理執行
+
+**目標：針對識別的問題執行修復**
+
+每個清理操作必須：
+1. 說明要清理什麼、為什麼
+2. 確認使用者同意
+3. 使用框架 API 執行（memorize 覆寫、relate 更新）
+4. 報告清理結果
+
+**清理策略：**
+
+- **語義去重**：保留 confidence 較高的條目，刪除重複
+- **過期清理**：confidence 衰減到 < 0.05 的自動刪除
+- **矛盾解決**：呈現矛盾雙方，讓使用者決定保留哪個
+- **技能復健**：低信心技能建議觸發 meta-skill-engineer 重新評估
+
+### 階段 4：報告與建議
+
+**目標：輸出清理報告並給出長期建議**
+
+```markdown
+## Memory Hygiene Report
+
+### 執行摘要
+- 清理 {N} 筆過期 semantic 條目
+- 合併 {N} 組重複條目
+- 解決 {N} 個矛盾
+- 標記 {N} 個技能需要復健
+
+### 詳細變更
+[每個操作的 before/after]
+
+### 長期建議
+- [基於觀察到的模式給出建議]
+```
+
+---
+
+## 工具使用策略
+
+| 工具 | 使用時機 |
+|------|---------|
+| `recall` | 查詢記憶內容、偵測重複和矛盾 |
+| `memorize` | 覆寫過期或重複的條目 |
+| `relate` | 更新或清理關係三元組 |
+| `query_relations` | 偵測孤立節點和循環引用 |
+| `run_bash` | 查看 DB 大小、WAL 狀態、備份確認 |
+| `read_file` | 讀取 memory.db 的 schema 或設定 |
+
+---
+
+## 紀律提醒
+
+- **不做盲目清理** — 「記憶太多了所以刪一半」不是策略
+- **不跳過備份** — precondition check 會強制確認，但心態上也要重視
+- **不直接 SQL** — `sqlite3 memory.db "DELETE FROM ..."` 絕對禁止
+- **矛盾讓使用者決定** — 兩個矛盾的事實，agent 不應該自行判定誰對
+- **清理後驗證** — 清理完再跑一次診斷，確認沒有副作用
+
+---
+
+## Skill Genome 整合提示
+
+- 此技能由 ProceduralMemory 管理
+- 觸發關鍵詞：「記憶清理」「memory cleanup」「記憶健康」「整理記憶」「記憶診斷」
+- 每次成功清理後 confidence 提升
+- 若清理導致資料遺失（使用者回報），confidence 大幅下降

--- a/skills/memory_hygiene/checks.py
+++ b/skills/memory_hygiene/checks.py
@@ -1,0 +1,78 @@
+"""
+Precondition checks for memory_hygiene skill (Issue #64 Phase B).
+
+memory_hygiene maintains Loom's memory system health.  Because it deals
+with the agent's long-term memory, safety is paramount:
+- A backup must exist before any cleanup runs
+- Direct SQL mutation is forbidden — all writes go through framework APIs
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+async def require_memory_backup(call) -> bool:
+    """Ensure a recent memory.db backup exists before cleanup operations.
+
+    Checks for the existence of a backup file at ~/.loom/memory.db.bak
+    or ~/.loom/backups/memory.db.*.  If no backup exists, the check
+    fails — the user (or agent) must create one first.
+
+    Read-only commands (ls, du, cat, sqlite3 ... .schema) are allowed
+    without backup.
+    """
+    cmd = call.args.get("command", "")
+
+    # Allow read-only diagnostic commands without backup
+    readonly_prefixes = [
+        "ls ", "du ", "stat ", "wc ", "file ",
+        "cat ", "head ", "tail ",
+        "sqlite3 ",  # Will be further checked by reject_direct_db_mutation
+    ]
+    cmd_stripped = cmd.strip()
+    if any(cmd_stripped.startswith(p) for p in readonly_prefixes):
+        # sqlite3 read-only queries are OK
+        if cmd_stripped.startswith("sqlite3 "):
+            readonly_sql = [".schema", ".tables", "SELECT", "PRAGMA", ".mode", ".headers"]
+            if any(kw in cmd for kw in readonly_sql):
+                return True
+        else:
+            return True
+
+    # For non-read-only commands, require backup
+    loom_dir = Path.home() / ".loom"
+    backup_paths = [
+        loom_dir / "memory.db.bak",
+        loom_dir / "backups",
+    ]
+
+    for bp in backup_paths:
+        if bp.is_file():
+            return True
+        if bp.is_dir() and any(bp.iterdir()):
+            return True
+
+    return False
+
+
+async def reject_direct_db_mutation(call) -> bool:
+    """Block direct SQL mutation commands on memory.db.
+
+    All memory writes must go through framework APIs (memorize, relate,
+    etc.) which enforce governance, contradiction checks, and audit trails.
+    Direct SQL bypasses all of these.
+    """
+    cmd = call.args.get("command", "").upper()
+
+    # Only check commands that touch sqlite3
+    if "SQLITE3" not in cmd and "MEMORY.DB" not in cmd:
+        return True
+
+    # Block mutation SQL keywords
+    mutation_keywords = [
+        "INSERT", "UPDATE", "DELETE", "DROP", "ALTER",
+        "REPLACE", "TRUNCATE", "CREATE TABLE",
+    ]
+    return not any(kw in cmd for kw in mutation_keywords)

--- a/skills/meta-skill-engineer/SKILL.md
+++ b/skills/meta-skill-engineer/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: meta-skill-engineer
 description: "元技能工程師：系統化建立、評估、迭代改進 Loom 技能的技能。當使用者要求「建立一個新技能」、「改善現有技能」、「評估技能表現」、「跑技能對比測試」、「系統化迭代技能」時使用。本技能為 Skill Genome 提供評估閉環——Grader 的 pass/fail 分數直接寫入 SkillGenome.confidence，形成測試→記憶→演化的完整循環。"
+precondition_checks:
+  - ref: checks.require_skills_dir_target
+    applies_to: [write_file]
+    description: "只能寫入 skills/ 目錄，不可修改框架或使用者程式碼"
 ---
 
 # Meta Skill Engineer
@@ -52,7 +56,7 @@ description: "元技能工程師：系統化建立、評估、迭代改進 Loom 
 4. **能力邊界**：什麼情況下技能不應該被使用？
 5. **既有假設**：這個技能依賴 Loom 哪些現有工具？
 
-**產出：** 一段「技能意圖說明書」（不超過 200 字）
+**產出：** 一段「技能意圖說明書」（不超過 200 字），包含：風險面初步識別（這個技能可能造成什麼損害？）
 
 ---
 
@@ -68,6 +72,14 @@ description: "元技能工程師：系統化建立、評估、迭代改進 Loom 
 ---
 name: [skill-name]
 description: "[觸發描述]。當使用者要求[場景]時使用。"
+tags: [tag1, tag2, ...]
+precondition_checks:                          # ← 安全護欄（見下方說明）
+  - ref: checks.[function_name]
+    applies_to: [run_bash]                    # 目標工具名
+    description: "這個檢查做什麼"
+  - ref: checks.[another_function]
+    applies_to: [write_file]
+    description: "這個檢查做什麼"
 ---
 
 # [技能名稱]
@@ -121,7 +133,100 @@ description: "[觸發描述]。當使用者要求[場景]時使用。"
 - [這個技能的常見錯誤]
 ```
 
-**產出：** `skills/[skill-name]/SKILL.md`
+**產出：**
+- `skills/[skill-name]/SKILL.md`
+- `skills/[skill-name]/checks.py`（若有 precondition_checks）
+
+---
+
+## 階段 2.5：Precondition Checks 設計
+
+**目標：為技能建立框架層級的安全護欄**
+
+每個技能在執行工具時可能帶有風險。Precondition checks 是在工具真正執行前（PREPARED gate）由框架自動評估的 async 函式，全部通過才放行，任一失敗則 ABORT——不依賴 SKILL.md 文字紀律，而是用程式碼強制執行。
+
+### 設計流程
+
+1. **識別風險面** — 這個技能會用哪些工具？每個工具最壞情況能造成什麼？
+
+   | 風險模式 | 常見場景 | 典型護欄 |
+   |---------|---------|---------|
+   | 破壞性指令 | `run_bash` 執行 `rm -rf`、`DROP TABLE` | `reject_destructive_commands` |
+   | 環境錯誤 | 在生產環境跑測試工具 | `reject_production_env` |
+   | 越界寫入 | 技能修改了不該碰的檔案 | `require_skills_dir_target` |
+   | 資料遺失 | 清理操作前無備份 | `require_memory_backup` |
+   | 唯讀違反 | 分析型技能不應寫檔 | `reject_write_operations` |
+
+2. **定義檢查函式** — 在 `skills/[name]/checks.py` 中實作：
+
+   ```python
+   # skills/my-skill/checks.py
+   async def my_precondition(call) -> bool:
+       """Return True to allow, False to block."""
+       cmd = call.args.get("command", "")
+       # 你的檢查邏輯
+       return True
+   ```
+
+   **函式簽名規則：**
+   - 參數：`call`（ToolCall mock，通過 `call.args` 取得工具參數）
+   - 回傳：`bool`（True = 放行，False = 阻擋）
+   - 必須是 `async def`
+   - 不可有副作用（不寫檔、不改狀態）
+
+3. **宣告到 frontmatter** — 在 SKILL.md 的 YAML 區塊中引用：
+
+   ```yaml
+   precondition_checks:
+     - ref: checks.my_precondition
+       applies_to: [run_bash]
+       description: "說明這個檢查在做什麼"
+   ```
+
+   - `ref`：`checks.` 前綴 + 函式名（對應 `checks.py` 中的函式）
+   - `applies_to`：要掛載到哪些工具（`run_bash`、`write_file` 等）
+   - `description`：給使用者看的說明（首次載入時會顯示）
+
+4. **寫測試** — 在 `tests/test_skill_preconditions.py` 中驗證：
+
+   ```python
+   async def test_my_check_blocks_dangerous():
+       from skills.my_skill.checks import my_precondition
+       call = _make_call(command="dangerous command")
+       assert await my_precondition(call) is False
+
+   async def test_my_check_allows_safe():
+       from skills.my_skill.checks import my_precondition
+       call = _make_call(command="safe command")
+       assert await my_precondition(call) is True
+   ```
+
+### 判斷是否需要 Precondition Checks
+
+- **需要**：技能使用 `run_bash`（幾乎所有技能都應該有）、技能修改檔案但有邊界限制、技能操作敏感資源
+- **不需要**：純對話型技能（不使用任何工具）、只用 `read_file` + `recall` 的純查詢技能
+
+### 現有技能的 Checks 參考
+
+| 技能 | Checks | 對應工具 | 設計理由 |
+|------|--------|---------|---------|
+| `loom_engineer` | `require_git_repo`, `reject_force_push` | `run_bash`, `write_file` | 工程技能必須在 git repo 中操作，禁止 force push |
+| `systematic_code_analyst` | `reject_write_operations` | `write_file` | 分析技能是唯讀的，絕不寫檔 |
+| `meta-skill-engineer` | `require_skills_dir_target` | `write_file` | 只能修改 skills/ 目錄，不碰框架程式碼 |
+| `security_assessment` | `reject_destructive_commands`, `reject_production_env` | `run_bash` | 資安掃描不可破壞、不可在生產環境 |
+| `memory_hygiene` | `require_memory_backup`, `reject_direct_db_mutation` | `run_bash` | 清理前必須有備份、禁止直接 SQL 修改 |
+
+### 執行時機（框架行為）
+
+```
+load_skill("my-skill")
+  → 讀取 SkillGenome.precondition_check_refs
+  → 首次載入：顯示確認面板，列出所有 checks → 使用者批准
+  → 批准後：resolve checks.py → mount 到目標 ToolDefinition
+  → 卸載時機：load 另一個 skill 時自動卸載（除非 keep_existing=true）
+```
+
+**產出：** `skills/[skill-name]/checks.py` + SKILL.md frontmatter 更新
 
 ---
 
@@ -366,7 +471,8 @@ context: {output_a_path, output_b_path, eval_prompt, expectations}
 Loom（使用本技能）：
   → 階段 1：意圖確認（5 個問題）
   → 階段 2：生成 SKILL.md
-  → 階段 3：建立 5 個測試案例
+  → 階段 2.5：設計 precondition checks（識別風險面 → 寫 checks.py → 宣告 frontmatter）
+  → 階段 3：建立 5 個測試案例（含 checks 單元測試）
   → 階段 4：Grader 評估
   → 階段 7：SkillGenome 寫入 + 重寫 → 完成
 ```
@@ -427,3 +533,5 @@ loom review {skill-name}
 - **Comparator 永遠不能知道誰是 A/B** — 揭盲之前的偏見是最難發現的
 - **Grader 要批判測試本身** — 通過了弱 assertion 比失敗更危險
 - **每次 Grader 後必須寫 SkillGenome** — 否則數據就散了，閉環就斷了
+- **用 `run_bash` 的技能必須有 checks** — SKILL.md 的文字紀律是給 LLM 看的，precondition_checks 是給框架執行的；兩者缺一不可
+- **checks 不可有副作用** — 純判斷、純回傳 bool，不寫檔、不改狀態、不發請求

--- a/skills/meta-skill-engineer/checks.py
+++ b/skills/meta-skill-engineer/checks.py
@@ -1,0 +1,25 @@
+"""
+Precondition checks for meta-skill-engineer skill (Issue #64 Phase B).
+
+meta-skill-engineer creates and iterates SKILL.md files and test cases.
+Its write scope must be limited to skills/ directories — it should never
+modify framework code, user code, or system files.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+async def require_skills_dir_target(call) -> bool:
+    """Ensure write_file targets a skills/ directory.
+
+    meta-skill-engineer only produces SKILL.md files, test cases, and
+    agent prompts — all within skills/.  Writing outside this boundary
+    is a scope violation.
+    """
+    path = call.args.get("path", "")
+    # Normalize path for consistent checking
+    normalized = os.path.normpath(path)
+    # Accept both absolute and relative paths containing /skills/ or starting with skills/
+    return "/skills/" in normalized or normalized.startswith("skills/") or normalized.startswith("skills" + os.sep)

--- a/skills/security_assessment/SKILL.md
+++ b/skills/security_assessment/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: security_assessment
+description: "資安評估技能。覆蓋滲透測試、程式碼安全 review、風險評估與合規檢查四大場景。觸發時機：使用者說「幫我掃描資安」、「security review」、「資安風險評估」、「檢查這個專案的安全」、「滲透測試」時使用。本技能也負責 Loom 自身的資安自我檢測，是「資安 Agent」的第一線。"
+tags: [security, pentest, code-review, risk-assessment, compliance, OWASP, CWE]
+confidence: 0.7
+precondition_checks:
+  - ref: checks.reject_destructive_commands
+    applies_to: [run_bash]
+    description: "禁止破壞性指令（rm -rf, DROP TABLE 等）"
+  - ref: checks.reject_production_env
+    applies_to: [run_bash]
+    description: "禁止在生產環境中執行任何指令"
+---
+
+# Security Assessment Skill
+
+資安評估技能 — 從自我檢測到面對各種資安疑難雜症。
+
+---
+
+## 📁 技能結構
+
+```
+skills/security_assessment/
+├── SKILL.md           ← 本技能定義
+└── tests/
+    └── test_security_assessment.py
+```
+
+---
+
+## 🎯 核心原則
+
+1. **自我檢測優先** — 第一個評估目標永遠是 Loom 自身；自己都破還想保護別人？
+2. **有事實才有發現** — 每個 Finding 必須有具體證據（截圖、路徑、程式碼片段），不說「可能」
+3. **攻擊者視角** — 先問「壞人會怎麼利用」，再問「程式怎麼寫的」
+4. **風險分級是紀律** — 每個發現必須附上 CRITICAL / HIGH / MEDIUM / LOW / INFO，不得跳級
+5. **復原力優先於完美** — 修復建議優先考量 Reversibility（可撤回），其次才是防護強度
+6. **不只找洞，要測試鏈** — 單一漏洞意義有限，找出攻擊鏈（Kill Chain）才有實質價值
+
+---
+
+## 🔍 評估框架（ATT&CK-Inspired Lifecycle）
+
+```
+Reconnaissance → Weaponization → Delivery → Exploitation → C2 → Exfiltration
+     ↑                ↑            ↑            ↑           ↑      ↑
+  資訊收集         威脅建模      評估攻擊面    驗證漏洞     持久化   影響範圍
+```
+
+每次評估都必須覆蓋這六個階段，缺一不可。
+
+---
+
+## 🛡️ 四大評估模式
+
+### Mode 1：Self-Assessment（自我資安檢測）
+
+**觸發時機**：系統啟動時、被要求「自我檢測」時、長期未進行資安評估時
+
+**範圍**：
+- `SOUL.md` / `Agent.md` — 身份設定是否被污染
+- `loom.toml` — 設定檔權限與內容安全
+- `loom/core/` — 核心模組是否被植入後門
+- `tools/` — 工具是否被替換或挾持
+- `memory/` — 記憶體資料庫是否被篡改
+- `skills/` — 技能是否被恶意修改
+- 網路請求 — 對外發出的請求是否包含敏感資訊
+
+**自我檢測清單**（每次啟動時快速走查）：
+1. 設定檔完整性（hash 比對或版本控制狀態）
+2. 工具鏈是否為預期版本
+3. 對外請求的 header/ payload 有無外洩風險
+4. 資料庫存取是否恰當隔離
+5. 日誌是否記錄了不該記錄的內容（密碼、API key）
+
+### Mode 2：Code Security Review
+
+**觸發時機**：「幫我 review 資安」、「這段程式碼有沒有漏洞」
+
+**掃描維度**（OWASP Top 10 + CWE Top 25）：
+
+| 維度 | 對應威脅 | 檢查重點 |
+|------|---------|---------|
+| Injection | SQLi, XSS, Command Injection, LDAPi | 使用者輸入是否經過驗證/消毒 |
+| Auth & Session | 認証失效、Session 挾持 | Token/Session 管理機制 |
+| Sensitive Data | 機密資料外洩 | 密碼、API Key、Personal Data 是否暴露 |
+| Access Control | 越權存取 | 權限檢查是否存在且完整 |
+| Security Misconfig | 錯誤設定 | CORS、Header、Debug 模式、生產環境設定 |
+| Cryptographic Failures | 加密失效 | 演算法強度、金鑰管理 |
+| Insecure Deserialization | 反序列化攻擊 | 輸入是否為可信來源 |
+| Supply Chain | 第三方依賴 | 已知 CVE、維護狀態、版本新舊 |
+| Logging & Monitoring | 偵測失效 | 是否有 Audit Trail、報警機制 |
+
+**輸出格式**：
+```markdown
+## Finding #[N]
+
+**檔案**: `src/path/to/file.py`
+**行數**: L12-L18
+**維度**: [對應 OWASP/CWE]
+**風險等級**: [CRITICAL|HIGH|MEDIUM|LOW|INFO]
+
+### 描述
+[問題說明]
+
+### 證據
+```
+[程式碼片段或截圖]
+```
+
+### 攻擊鏈分析
+[壞人如何利用這個漏洞]
+
+### 修復建議
+1. [優先] [短期修復]
+2. [其次] [長期改善]
+
+### 參考
+- CWE-89 / OWASP A03:2021
+```
+
+### Mode 3：Penetration Testing
+
+**觸發時機**：「滲透測試」、「幫我掃描這個網站的安全性」
+
+**Pentest 流程**：
+```
+1. Reconnaissance（蒐集）
+   - 被動：WHOIS、DNS、公開資料庫（NVD、CVE）
+   - 主動：端口掃描、路徑發現、指紋識別
+
+2. Threat Modeling（威脅建模）
+   - 攻擊面識別：哪些是公開端點？哪些需要認証？
+   - 信任邊界：哪些資料/功能是高價值的？
+
+3. Vulnerability Assessment（漏洞評估）
+   - 工具輔助：OWASP ZAP、Burp Suite、Nuclei
+   - 手動驗證：工具發現不等於可利用
+
+4. Exploitation（利用驗證）
+   - POC 製作：確認漏洞可被利用（不破壞）
+   - 攻擊鏈建構：單一漏洞 → 組合攻擊
+
+5. Reporting（報告）
+   - 攻擊鏈視角呈現
+   - 風險分級 + 商業影響
+   - 修復優先順序（依 CRITICAL > HIGH > MEDIUM）
+```
+
+**注意**：未取得授權的系統絕對不進行主動掃描，僅做被動資訊收集。
+
+### Mode 4：Risk Assessment & Compliance
+
+**觸發時機**：「資安風險評估」、「合規檢查」
+
+**風險矩陣**：
+```
+                    Impact
+              Low    Medium   High    Critical
+Likelihood
+Low            Low     Low    Medium    High
+Medium         Low    Medium   High    Critical
+High          Medium   High   Critical  Critical
+```
+
+**合規框架對照**：
+- OWASP ASVS（應用程式安全驗證標準）
+- NIST CSF（資安框架）
+- GDPR / 個資法合規檢查點
+- ISO 27001 控制項對照
+
+---
+
+## ⚡ 快速啟動流程
+
+### Step 1：Scope Definition（範圍確認）
+
+遇到資安需求時，先問：
+1. 評估範圍是什麼？（全專案？特定模組？特定功能？）
+2. 有沒有已知的攻擊面？（哪些是公開的？哪些是內部的？）
+3. 有沒有歷史事件或已知的疑慮點？
+4. 修復的時間框架是什麼？
+
+### Step 2：Mode Selection（模式選擇）
+
+```
+有程式碼 → Code Review（必要） + 視情況加 Pentest
+沒有原始碼，只有 URL → Pentest 被動掃描
+需要整體態勢評估 → Risk Assessment
+需要合規証明 → Compliance Mode
+```
+
+### Step 3：Execution（執行）
+
+使用對應模式的流程與清單，系統性執行。
+
+### Step 4：Reporting（報告）
+
+每次評估結束後，統一輸出以下結構：
+```markdown
+# 資安評估報告 — [目標]
+
+**評估日期**: [timestamp]
+**評估模式**: [SelfAssessment|CodeReview|Pentest|RiskAssessment]
+**評估範圍**: [scope]
+**總發現數**: N
+  - CRITICAL: N
+  - HIGH: N
+  - MEDIUM: N
+  - LOW: N
+  - INFO: N
+
+## 執行摘要
+[用一句話說結論]
+
+## 詳細發現
+[Findings 清單]
+
+## 修復優先順序
+[依風險分級排列]
+
+## 備註
+[限制、假設、後續建議]
+```
+
+### Step 5：Memory & Closure（記憶與閉環）
+
+評估完成後：
+1. 將關鍵發現寫入記憶：`memorize("security:recent_finding", "...")`
+2. 若發現新攻擊手法或模式，更新技能本身：`relate("skill:security_assessment", "detects", "[新威脅類型]")`
+3. 若發現需要技能改進的地方，触发 meta-skill-engineer 迭代
+
+---
+
+## 📌 常用工具整合
+
+| 工具 | 用途 | 觸發語 |
+|------|------|--------|
+| OWASP ZAP | Web 漏洞掃描 | 被動/主動掃描 |
+| Nuclei | 已知漏洞模板掃描 | 快速 CVE 比對 |
+| Semgrep | 程式碼靜態分析 | 自定義規則 |
+| builtwith / Wappalyzer | 技術指紋識別 | 被動識別 |
+| CVE / NVD | 漏洞資料庫查詢 | 漏洞情報 |
+
+---
+
+## ⚠️ 紅線（絕對不可觸碰）
+
+1. **未獲授權的系統** — 不進行任何主動掃描或利用
+2. **生產環境** — 所有測試必須在隔離環境進行
+3. **破壞性操作** — Exploitation 階段嚴禁造成資料損失或服務中斷
+4. **偽造結果** — 不因時間壓力而淡化或忽略發現
+5. **個資蒐集** — 不主動收集、儲存、或外洩任何個人識別資訊
+
+---
+
+## 🔄 技能迭代觸發條件
+
+當發生以下任一情況時，触发 meta-skill-engineer 迭代本技能：
+- 發現新的攻擊類型不在目前覆蓋範圍內
+- 現有規則/清單導致漏測（False Negative）
+- 使用者回饋評估結果不符預期
+- OWASP/CWE 更新主要版本
+
+---
+
+*本技能版本：1.0.0 | 最後更新：2026-04-06*

--- a/skills/security_assessment/checks.py
+++ b/skills/security_assessment/checks.py
@@ -1,0 +1,57 @@
+"""
+Precondition checks for security_assessment skill (Issue #64 Phase B).
+
+security_assessment performs penetration testing, code review, and risk
+assessment.  These checks enforce the skill's red lines at the framework
+level — particularly the prohibition on destructive commands and
+production environment operations.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+async def reject_destructive_commands(call) -> bool:
+    """Block destructive shell commands during security assessment.
+
+    Red line #3: "Exploitation 階段嚴禁造成資料損失或服務中斷".
+    This check catches common destructive patterns.  It is not
+    exhaustive — defense in depth with BlastRadiusMiddleware.
+    """
+    cmd = call.args.get("command", "")
+    if not cmd:
+        return True
+
+    destructive_patterns = [
+        "rm -rf",
+        "rm -r /",
+        "DROP TABLE",
+        "DROP DATABASE",
+        "DELETE FROM",
+        "TRUNCATE",
+        "mkfs",
+        "dd if=",
+        "> /dev/sd",
+        "format c:",
+        ":(){:|:&};:",   # fork bomb
+    ]
+    cmd_lower = cmd.lower()
+    return not any(pattern.lower() in cmd_lower for pattern in destructive_patterns)
+
+
+async def reject_production_env(call) -> bool:
+    """Block command execution in production environments.
+
+    Red line #2: "所有測試必須在隔離環境進行".
+    Checks LOOM_ENV and common production indicators.
+    """
+    env = os.environ.get("LOOM_ENV", "").lower()
+    if env == "production":
+        return False
+
+    node_env = os.environ.get("NODE_ENV", "").lower()
+    if node_env == "production":
+        return False
+
+    return True

--- a/skills/systematic_code_analyst/SKILL.md
+++ b/skills/systematic_code_analyst/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: systematic_code_analyst
 description: "系統化程式碼分析技能。透過結構化的多層次掃描（結構→依賴→行為→評估）快速理解陌生程式碼庫，輸出架構快照、依賴拓撲、觀察優缺點、學習點與適用場景。當使用者要求「分析這個專案」、「幫我 review code」、「說說這個架構」、「评估開源專案」時使用。"
+precondition_checks:
+  - ref: checks.reject_write_operations
+    applies_to: [write_file]
+    description: "分析技能為唯讀模式，禁止寫入任何檔案"
 ---
 
 # 系統化程式碼分析技能（Systematic Code Analyst）

--- a/skills/systematic_code_analyst/checks.py
+++ b/skills/systematic_code_analyst/checks.py
@@ -1,0 +1,19 @@
+"""
+Precondition checks for systematic_code_analyst skill (Issue #64 Phase B).
+
+systematic_code_analyst is a **read-only** analysis skill.  It must never
+modify the codebase it's analyzing.  This check elevates the SKILL.md
+discipline rule ("不要幫忙重構，除非使用者明確要求") from a suggestion
+into a framework-enforced hard gate.
+"""
+
+from __future__ import annotations
+
+
+async def reject_write_operations(call) -> bool:
+    """Block all write_file calls.  Analysis skill is strictly read-only.
+
+    The analyst's job is to observe and report, never to modify.
+    If modification is needed, the user should switch to loom_engineer.
+    """
+    return False

--- a/tests/test_skill_checks.py
+++ b/tests/test_skill_checks.py
@@ -1,0 +1,499 @@
+"""
+Tests for Issue #64 Phase B: Skill-declared precondition checks.
+
+Covers:
+- SkillPreconditionRef parsing
+- SkillCheckManager mount/unmount/auto-unmount
+- Callable resolution from skill directories
+- Frontmatter parsing with precondition_checks
+- SkillGenome persistence of precondition_check_refs
+"""
+
+import asyncio
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, AsyncMock
+
+from loom.core.harness.skill_checks import (
+    SkillCheckManager,
+    SkillPreconditionRef,
+)
+from loom.core.harness.registry import ToolDefinition, ToolRegistry
+from loom.core.harness.permissions import TrustLevel
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_registry_with_tools(*tool_names: str) -> ToolRegistry:
+    """Create a registry with dummy tool definitions."""
+    registry = ToolRegistry()
+    for name in tool_names:
+        registry.register(ToolDefinition(
+            name=name,
+            description=f"Dummy {name}",
+            trust_level=TrustLevel.SAFE,
+            input_schema={"type": "object"},
+            executor=AsyncMock(),
+        ))
+    return registry
+
+
+async def _always_pass(call):
+    return True
+
+async def _always_fail(call):
+    return False
+
+async def _env_check(call):
+    import os
+    return os.environ.get("LOOM_ENV") != "production"
+
+
+# ---------------------------------------------------------------------------
+# SkillPreconditionRef
+# ---------------------------------------------------------------------------
+
+
+class TestSkillPreconditionRef:
+    def test_from_dict_full(self):
+        ref = SkillPreconditionRef.from_dict({
+            "ref": "checks.require_not_production",
+            "applies_to": ["run_bash"],
+            "description": "Not in production",
+        })
+        assert ref.ref == "checks.require_not_production"
+        assert ref.applies_to == ["run_bash"]
+        assert ref.description == "Not in production"
+
+    def test_from_dict_string_applies_to(self):
+        """applies_to as a single string should be wrapped in a list."""
+        ref = SkillPreconditionRef.from_dict({
+            "ref": "checks.fn",
+            "applies_to": "run_bash",
+            "description": "desc",
+        })
+        assert ref.applies_to == ["run_bash"]
+
+    def test_from_dict_no_description(self):
+        """Missing description should default to ref name."""
+        ref = SkillPreconditionRef.from_dict({
+            "ref": "checks.fn",
+            "applies_to": ["run_bash"],
+        })
+        assert ref.description == "checks.fn"
+
+
+# ---------------------------------------------------------------------------
+# SkillCheckManager — mount / unmount
+# ---------------------------------------------------------------------------
+
+
+class TestSkillCheckManagerMount:
+    def test_mount_adds_checks_to_tool(self):
+        registry = _make_registry_with_tools("run_bash")
+        manager = SkillCheckManager(registry)
+
+        refs = [SkillPreconditionRef(
+            ref="checks.fn",
+            applies_to=["run_bash"],
+            description="Test check",
+        )]
+
+        descs = manager.mount("skill_a", refs, {"checks.fn": _always_pass})
+
+        tool = registry.get("run_bash")
+        assert len(tool.precondition_checks) == 1
+        assert tool.precondition_checks[0] is _always_pass
+        assert "Test check" in tool.preconditions
+        assert manager.active_skill == "skill_a"
+        assert len(descs) == 1
+
+    def test_mount_multiple_tools(self):
+        registry = _make_registry_with_tools("run_bash", "write_file")
+        manager = SkillCheckManager(registry)
+
+        refs = [SkillPreconditionRef(
+            ref="checks.fn",
+            applies_to=["run_bash", "write_file"],
+            description="Shared check",
+        )]
+
+        manager.mount("skill_a", refs, {"checks.fn": _always_pass})
+
+        assert len(registry.get("run_bash").precondition_checks) == 1
+        assert len(registry.get("write_file").precondition_checks) == 1
+
+    def test_mount_skips_unknown_tool(self):
+        registry = _make_registry_with_tools("run_bash")
+        manager = SkillCheckManager(registry)
+
+        refs = [SkillPreconditionRef(
+            ref="checks.fn",
+            applies_to=["nonexistent_tool"],
+            description="Won't mount",
+        )]
+
+        descs = manager.mount("skill_a", refs, {"checks.fn": _always_pass})
+        assert len(descs) == 0
+
+    def test_mount_skips_unresolved_ref(self):
+        registry = _make_registry_with_tools("run_bash")
+        manager = SkillCheckManager(registry)
+
+        refs = [SkillPreconditionRef(
+            ref="checks.missing",
+            applies_to=["run_bash"],
+            description="Missing callable",
+        )]
+
+        descs = manager.mount("skill_a", refs, {})  # no callables
+        assert len(descs) == 0
+        assert len(registry.get("run_bash").precondition_checks) == 0
+
+
+class TestSkillCheckManagerUnmount:
+    def test_unmount_removes_checks(self):
+        registry = _make_registry_with_tools("run_bash")
+        manager = SkillCheckManager(registry)
+
+        refs = [SkillPreconditionRef(
+            ref="checks.fn",
+            applies_to=["run_bash"],
+            description="Test check",
+        )]
+        manager.mount("skill_a", refs, {"checks.fn": _always_pass})
+
+        removed = manager.unmount("skill_a")
+
+        assert removed == 1
+        assert len(registry.get("run_bash").precondition_checks) == 0
+        assert len(registry.get("run_bash").preconditions) == 0
+        assert manager.active_skill is None
+
+    def test_unmount_nonexistent_skill(self):
+        registry = _make_registry_with_tools("run_bash")
+        manager = SkillCheckManager(registry)
+
+        removed = manager.unmount("nonexistent")
+        assert removed == 0
+
+    def test_unmount_all(self):
+        registry = _make_registry_with_tools("run_bash")
+        manager = SkillCheckManager(registry)
+
+        refs = [SkillPreconditionRef(
+            ref="checks.fn",
+            applies_to=["run_bash"],
+            description="Check A",
+        )]
+        manager.mount("skill_a", refs, {"checks.fn": _always_pass}, keep_existing=True)
+        manager.mount("skill_b", refs, {"checks.fn": _always_fail}, keep_existing=True)
+
+        manager.unmount_all()
+
+        assert len(registry.get("run_bash").precondition_checks) == 0
+        assert manager.mounted_skills() == []
+
+
+class TestSkillCheckManagerAutoUnmount:
+    """Test the A strategy: loading a new skill auto-unmounts the previous one."""
+
+    def test_auto_unmount_on_new_skill(self):
+        registry = _make_registry_with_tools("run_bash")
+        manager = SkillCheckManager(registry)
+
+        ref_a = [SkillPreconditionRef(
+            ref="checks.fn_a",
+            applies_to=["run_bash"],
+            description="Check from A",
+        )]
+        ref_b = [SkillPreconditionRef(
+            ref="checks.fn_b",
+            applies_to=["run_bash"],
+            description="Check from B",
+        )]
+
+        manager.mount("skill_a", ref_a, {"checks.fn_a": _always_pass})
+        assert len(registry.get("run_bash").precondition_checks) == 1
+        assert registry.get("run_bash").precondition_checks[0] is _always_pass
+
+        # Loading skill_b should auto-unmount skill_a
+        manager.mount("skill_b", ref_b, {"checks.fn_b": _always_fail})
+        assert len(registry.get("run_bash").precondition_checks) == 1
+        assert registry.get("run_bash").precondition_checks[0] is _always_fail
+        assert manager.active_skill == "skill_b"
+
+    def test_keep_existing_preserves_previous(self):
+        registry = _make_registry_with_tools("run_bash")
+        manager = SkillCheckManager(registry)
+
+        ref_a = [SkillPreconditionRef(
+            ref="checks.fn_a",
+            applies_to=["run_bash"],
+            description="Check from A",
+        )]
+        ref_b = [SkillPreconditionRef(
+            ref="checks.fn_b",
+            applies_to=["run_bash"],
+            description="Check from B",
+        )]
+
+        manager.mount("skill_a", ref_a, {"checks.fn_a": _always_pass})
+        manager.mount("skill_b", ref_b, {"checks.fn_b": _always_fail}, keep_existing=True)
+
+        # Both checks should be mounted
+        assert len(registry.get("run_bash").precondition_checks) == 2
+        assert manager.active_skill == "skill_b"
+        assert set(manager.mounted_skills()) == {"skill_a", "skill_b"}
+
+    def test_remount_same_skill(self):
+        """Re-mounting the same skill should replace (not double) checks."""
+        registry = _make_registry_with_tools("run_bash")
+        manager = SkillCheckManager(registry)
+
+        refs = [SkillPreconditionRef(
+            ref="checks.fn",
+            applies_to=["run_bash"],
+            description="Check",
+        )]
+
+        manager.mount("skill_a", refs, {"checks.fn": _always_pass})
+        manager.mount("skill_a", refs, {"checks.fn": _always_fail})
+
+        assert len(registry.get("run_bash").precondition_checks) == 1
+        assert registry.get("run_bash").precondition_checks[0] is _always_fail
+
+
+# ---------------------------------------------------------------------------
+# Callable resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCallable:
+    def test_resolve_valid(self, tmp_path):
+        # Create a checks.py module in a temp skill dir
+        checks_py = tmp_path / "checks.py"
+        checks_py.write_text(
+            "async def require_ok(call):\n    return True\n"
+        )
+
+        fn = SkillCheckManager.resolve_callable(tmp_path, "checks.require_ok")
+        assert callable(fn)
+        assert fn.__name__ == "require_ok"
+
+    def test_resolve_missing_module(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            SkillCheckManager.resolve_callable(tmp_path, "missing.fn")
+
+    def test_resolve_missing_function(self, tmp_path):
+        checks_py = tmp_path / "checks.py"
+        checks_py.write_text("x = 42\n")
+
+        with pytest.raises(AttributeError):
+            SkillCheckManager.resolve_callable(tmp_path, "checks.nonexistent")
+
+    def test_resolve_invalid_format(self, tmp_path):
+        with pytest.raises(ValueError):
+            SkillCheckManager.resolve_callable(tmp_path, "no_dot_here")
+
+    def test_resolve_all(self, tmp_path):
+        checks_py = tmp_path / "checks.py"
+        checks_py.write_text(
+            "async def fn_a(call):\n    return True\n\n"
+            "async def fn_b(call):\n    return False\n"
+        )
+
+        refs = [
+            SkillPreconditionRef(ref="checks.fn_a", applies_to=["run_bash"], description="A"),
+            SkillPreconditionRef(ref="checks.fn_b", applies_to=["run_bash"], description="B"),
+        ]
+
+        callables = SkillCheckManager.resolve_all(tmp_path, refs)
+        assert "checks.fn_a" in callables
+        assert "checks.fn_b" in callables
+        assert callables["checks.fn_a"].__name__ == "fn_a"
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parsing with precondition_checks
+# ---------------------------------------------------------------------------
+
+
+class TestFrontmatterPreconditionChecks:
+    def test_parses_precondition_checks(self):
+        from loom.core.session import _parse_skill_frontmatter
+
+        raw = """---
+name: security_assessment
+description: Security assessment skill.
+precondition_checks:
+  - ref: checks.require_not_production
+    applies_to: [run_bash]
+    description: Not in production
+  - ref: checks.require_authorization
+    applies_to: [run_bash, write_file]
+    description: Must have authorization
+---
+
+# Security Assessment
+"""
+        name, desc, tags, pc_refs = _parse_skill_frontmatter(raw)
+        assert name == "security_assessment"
+        assert len(pc_refs) == 2
+        assert pc_refs[0]["ref"] == "checks.require_not_production"
+        assert pc_refs[0]["applies_to"] == ["run_bash"]
+        assert pc_refs[1]["applies_to"] == ["run_bash", "write_file"]
+
+    def test_no_precondition_checks(self):
+        from loom.core.session import _parse_skill_frontmatter
+
+        raw = """---
+name: simple
+description: A simple skill.
+---
+Body.
+"""
+        name, desc, tags, pc_refs = _parse_skill_frontmatter(raw)
+        assert pc_refs == []
+
+    def test_invalid_precondition_checks_ignored(self):
+        from loom.core.session import _parse_skill_frontmatter
+
+        raw = """---
+name: bad
+description: Bad skill.
+precondition_checks:
+  - just_a_string
+  - ref: valid.fn
+    applies_to: [run_bash]
+  - ref: no_applies_to
+---
+Body.
+"""
+        name, desc, tags, pc_refs = _parse_skill_frontmatter(raw)
+        # Only the valid entry should survive
+        assert len(pc_refs) == 1
+        assert pc_refs[0]["ref"] == "valid.fn"
+
+
+# ---------------------------------------------------------------------------
+# SkillGenome persistence
+# ---------------------------------------------------------------------------
+
+
+class TestSkillGenomePreconditionRefs:
+    @pytest.mark.asyncio
+    async def test_upsert_and_get_with_refs(self, tmp_path):
+        from loom.core.memory.store import SQLiteStore
+        from loom.core.memory.procedural import ProceduralMemory, SkillGenome
+
+        store = SQLiteStore(str(tmp_path / "test.db"))
+        await store.initialize()
+        async with store.connect() as db:
+            proc = ProceduralMemory(db)
+
+            refs = [
+                {"ref": "checks.fn_a", "applies_to": ["run_bash"], "description": "A"},
+                {"ref": "checks.fn_b", "applies_to": ["write_file"], "description": "B"},
+            ]
+            genome = SkillGenome(
+                name="test_skill",
+                body="# Test Skill\nBody.",
+                precondition_check_refs=refs,
+            )
+            await proc.upsert(genome)
+
+            loaded = await proc.get("test_skill")
+            assert loaded is not None
+            assert len(loaded.precondition_check_refs) == 2
+            assert loaded.precondition_check_refs[0]["ref"] == "checks.fn_a"
+            assert loaded.precondition_check_refs[1]["applies_to"] == ["write_file"]
+
+    @pytest.mark.asyncio
+    async def test_empty_refs_default(self, tmp_path):
+        from loom.core.memory.store import SQLiteStore
+        from loom.core.memory.procedural import ProceduralMemory, SkillGenome
+
+        store = SQLiteStore(str(tmp_path / "test.db"))
+        await store.initialize()
+        async with store.connect() as db:
+            proc = ProceduralMemory(db)
+
+            genome = SkillGenome(name="no_refs", body="Body.")
+            await proc.upsert(genome)
+
+            loaded = await proc.get("no_refs")
+            assert loaded.precondition_check_refs == []
+
+    @pytest.mark.asyncio
+    async def test_list_active_includes_refs(self, tmp_path):
+        from loom.core.memory.store import SQLiteStore
+        from loom.core.memory.procedural import ProceduralMemory, SkillGenome
+
+        store = SQLiteStore(str(tmp_path / "test.db"))
+        await store.initialize()
+        async with store.connect() as db:
+            proc = ProceduralMemory(db)
+
+            refs = [{"ref": "checks.fn", "applies_to": ["run_bash"], "description": "D"}]
+            await proc.upsert(SkillGenome(
+                name="with_refs", body="Body.",
+                precondition_check_refs=refs,
+            ))
+            await proc.upsert(SkillGenome(
+                name="without_refs", body="Body.",
+            ))
+
+            active = await proc.list_active()
+            names = {s.name for s in active}
+            assert "with_refs" in names
+            assert "without_refs" in names
+
+            with_refs = next(s for s in active if s.name == "with_refs")
+            assert len(with_refs.precondition_check_refs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration: mount → lifecycle gate evaluation
+# ---------------------------------------------------------------------------
+
+
+class TestMountedCheckIntegration:
+    """Verify that mounted checks are actually evaluated by LifecycleGateMiddleware."""
+
+    @pytest.mark.asyncio
+    async def test_mounted_check_blocks_tool(self):
+        """A mounted failing check should cause tool execution to be aborted."""
+        registry = _make_registry_with_tools("run_bash")
+        manager = SkillCheckManager(registry)
+
+        refs = [SkillPreconditionRef(
+            ref="checks.fail",
+            applies_to=["run_bash"],
+            description="Always fails",
+        )]
+        manager.mount("strict_skill", refs, {"checks.fail": _always_fail})
+
+        tool = registry.get("run_bash")
+        # Directly verify the check is in the list and would fail
+        assert len(tool.precondition_checks) == 1
+        result = await tool.precondition_checks[0](MagicMock())
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_mounted_check_passes_tool(self):
+        registry = _make_registry_with_tools("run_bash")
+        manager = SkillCheckManager(registry)
+
+        refs = [SkillPreconditionRef(
+            ref="checks.pass",
+            applies_to=["run_bash"],
+            description="Always passes",
+        )]
+        manager.mount("permissive_skill", refs, {"checks.pass": _always_pass})
+
+        tool = registry.get("run_bash")
+        result = await tool.precondition_checks[0](MagicMock())
+        assert result is True

--- a/tests/test_skill_preconditions.py
+++ b/tests/test_skill_preconditions.py
@@ -1,0 +1,225 @@
+"""
+Tests for skill-specific precondition checks (Issue #64 Phase B).
+
+Each skill's checks.py is tested against realistic tool call scenarios.
+"""
+
+import os
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+def _make_call(**args):
+    """Create a mock ToolCall with given args."""
+    call = MagicMock()
+    call.args = args
+    return call
+
+
+# ---------------------------------------------------------------------------
+# loom_engineer checks
+# ---------------------------------------------------------------------------
+
+
+class TestLoomEngineerChecks:
+
+    @pytest.mark.asyncio
+    async def test_require_git_repo_in_repo(self):
+        """Should pass when inside a git repo (this test runs in one)."""
+        from skills.loom_engineer.checks import require_git_repo
+        call = _make_call(command="git status")
+        assert await require_git_repo(call) is True
+
+    @pytest.mark.asyncio
+    async def test_reject_force_push_blocks(self):
+        from skills.loom_engineer.checks import reject_force_push
+
+        assert await reject_force_push(_make_call(command="git push --force origin main")) is False
+        assert await reject_force_push(_make_call(command="git push -f origin main")) is False
+        assert await reject_force_push(_make_call(command="git push --force-with-lease")) is False
+
+    @pytest.mark.asyncio
+    async def test_reject_force_push_allows_normal(self):
+        from skills.loom_engineer.checks import reject_force_push
+
+        assert await reject_force_push(_make_call(command="git push origin main")) is True
+        assert await reject_force_push(_make_call(command="git status")) is True
+        assert await reject_force_push(_make_call(command="pytest tests/")) is True
+
+
+# ---------------------------------------------------------------------------
+# systematic_code_analyst checks
+# ---------------------------------------------------------------------------
+
+
+class TestSystematicCodeAnalystChecks:
+
+    @pytest.mark.asyncio
+    async def test_reject_write_always_blocks(self):
+        """Analysis skill is read-only — all writes must be blocked."""
+        from skills.systematic_code_analyst.checks import reject_write_operations
+
+        assert await reject_write_operations(_make_call(path="/any/file.py")) is False
+        assert await reject_write_operations(_make_call(path="README.md")) is False
+        assert await reject_write_operations(_make_call()) is False
+
+
+# ---------------------------------------------------------------------------
+# meta-skill-engineer checks
+# ---------------------------------------------------------------------------
+
+
+class TestMetaSkillEngineerChecks:
+
+    @pytest.mark.asyncio
+    async def test_require_skills_dir_allows(self):
+        """Paths containing /skills/ should pass."""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "meta_checks",
+            str(Path(__file__).parents[1] / "skills" / "meta-skill-engineer" / "checks.py"),
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        assert await mod.require_skills_dir_target(
+            _make_call(path="skills/my-skill/SKILL.md")
+        ) is True
+        assert await mod.require_skills_dir_target(
+            _make_call(path="/home/user/project/skills/test/test-01.md")
+        ) is True
+
+    @pytest.mark.asyncio
+    async def test_require_skills_dir_blocks(self):
+        """Paths outside skills/ should fail."""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "meta_checks",
+            str(Path(__file__).parents[1] / "skills" / "meta-skill-engineer" / "checks.py"),
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        assert await mod.require_skills_dir_target(
+            _make_call(path="loom/core/session.py")
+        ) is False
+        assert await mod.require_skills_dir_target(
+            _make_call(path="/etc/passwd")
+        ) is False
+
+
+# ---------------------------------------------------------------------------
+# security_assessment checks
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityAssessmentChecks:
+
+    @pytest.mark.asyncio
+    async def test_reject_destructive_blocks(self):
+        from skills.security_assessment.checks import reject_destructive_commands
+
+        assert await reject_destructive_commands(_make_call(command="rm -rf /")) is False
+        assert await reject_destructive_commands(_make_call(command='sqlite3 db "DROP TABLE users"')) is False
+        assert await reject_destructive_commands(_make_call(command="dd if=/dev/zero of=/dev/sda")) is False
+
+    @pytest.mark.asyncio
+    async def test_reject_destructive_allows_safe(self):
+        from skills.security_assessment.checks import reject_destructive_commands
+
+        assert await reject_destructive_commands(_make_call(command="nmap -sV target.com")) is True
+        assert await reject_destructive_commands(_make_call(command="semgrep --config=auto .")) is True
+        assert await reject_destructive_commands(_make_call(command="ls -la")) is True
+
+    @pytest.mark.asyncio
+    async def test_reject_production_env(self):
+        from skills.security_assessment.checks import reject_production_env
+
+        # Should pass in test environment
+        call = _make_call(command="nmap localhost")
+        original = os.environ.get("LOOM_ENV")
+        try:
+            os.environ.pop("LOOM_ENV", None)
+            assert await reject_production_env(call) is True
+
+            os.environ["LOOM_ENV"] = "production"
+            assert await reject_production_env(call) is False
+
+            os.environ["LOOM_ENV"] = "development"
+            assert await reject_production_env(call) is True
+        finally:
+            if original is not None:
+                os.environ["LOOM_ENV"] = original
+            else:
+                os.environ.pop("LOOM_ENV", None)
+
+
+# ---------------------------------------------------------------------------
+# memory_hygiene checks
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryHygieneChecks:
+
+    @pytest.mark.asyncio
+    async def test_reject_direct_db_mutation_blocks(self):
+        from skills.memory_hygiene.checks import reject_direct_db_mutation
+
+        assert await reject_direct_db_mutation(
+            _make_call(command='sqlite3 ~/.loom/memory.db "DELETE FROM semantic_entries"')
+        ) is False
+        assert await reject_direct_db_mutation(
+            _make_call(command='sqlite3 memory.db "DROP TABLE skill_genomes"')
+        ) is False
+        assert await reject_direct_db_mutation(
+            _make_call(command='sqlite3 memory.db "INSERT INTO audit_log VALUES (...)"')
+        ) is False
+
+    @pytest.mark.asyncio
+    async def test_reject_direct_db_mutation_allows_reads(self):
+        from skills.memory_hygiene.checks import reject_direct_db_mutation
+
+        assert await reject_direct_db_mutation(
+            _make_call(command='sqlite3 memory.db ".schema"')
+        ) is True
+        assert await reject_direct_db_mutation(
+            _make_call(command="ls -la ~/.loom/")
+        ) is True
+
+    @pytest.mark.asyncio
+    async def test_require_memory_backup_allows_readonly(self):
+        from skills.memory_hygiene.checks import require_memory_backup
+
+        # Read-only commands should always pass
+        assert await require_memory_backup(
+            _make_call(command="ls -la ~/.loom/")
+        ) is True
+        assert await require_memory_backup(
+            _make_call(command="du -sh ~/.loom/memory.db")
+        ) is True
+
+    @pytest.mark.asyncio
+    async def test_require_memory_backup_blocks_without_backup(self, tmp_path, monkeypatch):
+        from skills.memory_hygiene.checks import require_memory_backup
+
+        # Point HOME to tmp_path so no backup exists
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / ".loom").mkdir()
+
+        assert await require_memory_backup(
+            _make_call(command="python cleanup_script.py")
+        ) is False
+
+    @pytest.mark.asyncio
+    async def test_require_memory_backup_passes_with_backup(self, tmp_path, monkeypatch):
+        from skills.memory_hygiene.checks import require_memory_backup
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        loom_dir = tmp_path / ".loom"
+        loom_dir.mkdir()
+        (loom_dir / "memory.db.bak").write_text("backup")
+
+        assert await require_memory_backup(
+            _make_call(command="python cleanup_script.py")
+        ) is True

--- a/tests/test_skill_tools.py
+++ b/tests/test_skill_tools.py
@@ -37,10 +37,11 @@ description: Full implementation cycle from issue to PR.
 
 Some body content here.
 """
-        name, desc, tags = _parse_skill_frontmatter(raw)
+        name, desc, tags, pc_refs = _parse_skill_frontmatter(raw)
         assert name == "loom-engineer"
         assert "implementation" in desc.lower() or "PR" in desc
         assert isinstance(tags, list)
+        assert pc_refs == []
 
     def test_frontmatter_with_tags(self):
         from loom.core.session import _parse_skill_frontmatter
@@ -54,14 +55,14 @@ tags:
 ---
 Body.
 """
-        name, desc, tags = _parse_skill_frontmatter(raw)
+        name, desc, tags, pc_refs = _parse_skill_frontmatter(raw)
         assert name == "test-skill"
         assert tags == ["coding", "testing"]
 
     def test_no_frontmatter(self):
         from loom.core.session import _parse_skill_frontmatter
 
-        name, desc, tags = _parse_skill_frontmatter("# Just a markdown file")
+        name, desc, tags, pc_refs = _parse_skill_frontmatter("# Just a markdown file")
         assert name == ""
         assert desc == ""
 
@@ -75,7 +76,7 @@ description: Use this when: the user asks
 Body.
 """
         # Should handle colons in description gracefully or fail gracefully
-        name, desc, tags = _parse_skill_frontmatter(raw)
+        name, desc, tags, pc_refs = _parse_skill_frontmatter(raw)
         # Either parses or returns empty — both are acceptable
         assert isinstance(name, str)
         assert isinstance(desc, str)
@@ -88,7 +89,7 @@ name: no-desc
 ---
 Body.
 """
-        name, desc, tags = _parse_skill_frontmatter(raw)
+        name, desc, tags, pc_refs = _parse_skill_frontmatter(raw)
         assert name == "no-desc"
         assert desc == ""
 


### PR DESCRIPTION
## Summary

- **Skills can now declare framework-enforced safety rails** via `precondition_checks` in SKILL.md frontmatter + `checks.py` Python modules
- Checks are evaluated at the `PREPARED` gate before tool execution — all must pass or tool is `ABORTED` with zero side effects
- **5 skills upgraded**: `loom_engineer`, `systematic_code_analyst`, `meta-skill-engineer`, `security_assessment`, `memory_hygiene` (new)
- **Cross-platform confirm**: skill check approval now works correctly on CLI, TUI (InlineConfirmWidget), and Discord (button view) — fixes the TUI hang and Discord falling through to CLI stdin

## Why

LLMs are probabilistic. A SKILL.md saying "never run `rm -rf`" is a suggestion, not a guarantee. Precondition checks move safety from text (which LLMs might ignore) to code (which the framework enforces). This closes the gap between skill discipline and actual runtime behavior.

## What changed

| Area | Change |
|------|--------|
| Framework | `SkillCheckManager` (mount/unmount/resolve), DB migration, frontmatter parser, load/unload_skill tools |
| Session | Platform-swappable `_confirm_fn` used by both BlastRadiusMiddleware and skill check approval |
| TUI/Discord | Patch `session._confirm_fn` alongside `mw._confirm` so skill checks use native UI |
| Skills | 5 skills with 8 checks total (see commit message for details) |
| meta-skill-engineer | New Stage 2.5 teaches the precondition checks mechanism for future skill creation |
| README | New "Skill Precondition Checks" section documenting rationale + usage |
| Tests | 40 new tests (26 framework + 14 skill-specific), 492 total passing |

## Test plan

- [x] `python -m pytest tests/ --ignore=tests/test_cognition.py` — 492 passed
- [x] TUI: `loom chat --tui` → `load_skill("security_assessment")` → confirm widget appears correctly
- [x] Skill check approval persisted in RelationalMemory (one-time)
- [x] Auto-unmount on new skill load verified

Closes #64 Phase B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)