### PR TITLE
feat(harness): scope-aware confirm + legacy contraction + spinner fix (#45 Phase C+D)

### DIFF
--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -208,6 +208,12 @@ class BlastRadiusMiddleware(Middleware):
         """
         Return True if exec_auto mode can skip confirmation for this call.
 
+        .. deprecated:: Phase D (Issue #45)
+            ``enable_exec_auto()`` now injects a scope grant, so tools with
+            a ``scope_resolver`` are handled by the scope-aware path.  This
+            method only fires for legacy tools (no resolver) with EXEC
+            capability.  Remove once all EXEC tools have scope resolvers.
+
         Conditions (all must hold):
         1. User has toggled exec_auto on this session.
         2. The tool has EXEC capability (currently: run_bash).
@@ -249,17 +255,27 @@ class BlastRadiusMiddleware(Middleware):
         call.metadata["scope_diff"] = diff
         call.metadata["scope_verdict"] = verdict
 
+    # Informational constraint keys that should NOT be copied to grants.
+    # These describe the *request* but are not actionable authorization limits.
+    _INFORMATIONAL_CONSTRAINTS = frozenset({"scope_unknown", "has_absolute_paths"})
+
     def _request_to_grants(self, scope_request: Any, source: str = "manual_confirm") -> None:
         """Convert a scope request's requirements into grants on the PermissionContext."""
         from .scope import ScopeGrant
         import time
         now = time.time()
         for req in scope_request.requirements:
+            # Filter out informational constraints — only preserve actionable
+            # ones (remaining_budget, max_calls, etc.)
+            grant_constraints = {
+                k: v for k, v in req.constraints.items()
+                if k not in self._INFORMATIONAL_CONSTRAINTS
+            }
             self._perm.grant(ScopeGrant(
                 resource=req.resource,
                 action=req.action,
                 selector=req.selector,
-                constraints=req.constraints,
+                constraints=grant_constraints,
                 source=source,
                 granted_at=now,
             ))
@@ -665,7 +681,7 @@ class LifecycleMiddleware(Middleware):
         tool_def = self._registry.get(call.tool_name)
         intent = ActionIntent(
             intent_summary=f"{call.tool_name}({', '.join(f'{k}=...' for k in call.args)})",
-            scope=getattr(tool_def, "scope", "general") if tool_def else "general",
+            scope=getattr(tool_def, "impact_scope", "general") if tool_def else "general",
             preconditions=list(getattr(tool_def, "preconditions", [])) if tool_def else [],
         )
 

--- a/loom/core/harness/permissions.py
+++ b/loom/core/harness/permissions.py
@@ -92,9 +92,23 @@ class PermissionContext:
 
     def enable_exec_auto(self) -> None:
         self.exec_auto = True
+        # Phase D (Issue #45): inject a scope grant so scope-aware tools
+        # can auto-approve workspace-confined exec without the legacy path.
+        from .scope import ScopeGrant
+        import time as _time
+        self.grant(ScopeGrant(
+            resource="exec",
+            action="execute",
+            selector="workspace",
+            constraints={"absolute_paths": "deny"},
+            source="exec_auto",
+            granted_at=_time.time(),
+        ))
 
     def disable_exec_auto(self) -> None:
         self.exec_auto = False
+        # Phase D: revoke exec_auto grants
+        self.revoke_matching(lambda g: g.source == "exec_auto")
 
     def is_authorized(self, tool_name: str, trust_level: TrustLevel) -> bool:
         if trust_level == TrustLevel.SAFE:

--- a/loom/core/harness/registry.py
+++ b/loom/core/harness/registry.py
@@ -32,7 +32,7 @@ class ToolDefinition:
     `preconditions` — human-readable descriptions of required preconditions.
     `rollback_fn`   — async function to undo the tool's effect on failure.
     `post_validator` — async function to verify the tool's effect after execution.
-    `scope`         — impact scope classification for the tool.
+    `impact_scope`  — impact scope classification for the tool.
     """
     name: str
     description: str
@@ -58,7 +58,14 @@ class ToolDefinition:
     """
     rollback_fn: Callable[[ToolCall, ToolResult], Awaitable[ToolResult]] | None = None
     post_validator: Callable[[ToolCall, ToolResult], Awaitable[bool]] | None = None
-    scope: str = "general"
+    impact_scope: str = "general"
+    """
+    Impact scope classification for lifecycle audit (Issue #42).
+
+    Renamed from ``scope`` in Phase D (Issue #45) to avoid confusion with
+    the scope-aware permission fields (``scope_resolver``, ``scope_descriptions``).
+    Values: "filesystem", "shell", "network", "memory", "agent", "general".
+    """
 
     # --- Scope-aware permission (Issue #45 Phase A) ---
     scope_descriptions: list[str] = field(default_factory=list)

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1708,10 +1708,19 @@ class LoomSession:
         scope_req: ScopeRequest | None = call.metadata.get("scope_request")
 
         if verdict is None or scope_req is None:
-            # Legacy path — no scope metadata available
+            # Legacy path — no scope metadata available.
+            # Format args with smart truncation so long paths remain readable.
+            arg_lines: list[str] = []
+            for k, v in call.args.items():
+                if isinstance(v, str):
+                    display = v if len(v) <= 120 else v[:40] + "…" + v[-40:]
+                    arg_lines.append(f"  [cyan]{k}[/cyan]: {display}")
+                else:
+                    arg_lines.append(f"  [cyan]{k}[/cyan]: {v!r}")
+            args_display = "\n".join(arg_lines) if arg_lines else "  (no args)"
             return (
                 f"[bold]{call.tool_name}[/bold]  {call.trust_level.label}\n"
-                f"[dim]args: {call.args}[/dim]"
+                f"{args_display}"
             )
 
         # --- Verdict-aware header ---
@@ -1770,10 +1779,12 @@ class LoomSession:
 
         # Stop any running spinner before printing the confirm panel so the
         # spinner animation doesn't overwrite the prompt input line.
-        _CLEAR_LINE = "\r\033[K"  # ANSI: carriage-return + erase to end of line
+        # Write \r\033[K directly to stdout — Rich Console.print strips \r.
+        import sys
         if self._cancel_spinner_fn is not None:
             self._cancel_spinner_fn()
-            console.print(_CLEAR_LINE, end="")  # clear spinner line
+            sys.stdout.write("\r\033[K")
+            sys.stdout.flush()
         console.print()
 
         # Determine panel styling from verdict

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1691,8 +1691,83 @@ class LoomSession:
                 )
             )
 
+    @staticmethod
+    def _format_scope_panel(call: ToolCall) -> str:
+        """
+        Build a Rich-formatted string describing scope verdict + diff.
+
+        Phase C (Issue #45): when scope metadata is available, the confirm
+        prompt shows structured information instead of raw args.
+        """
+        from loom.core.harness.scope import (
+            DiffReason, PermissionVerdict, ScopeDiff, ScopeRequest,
+        )
+
+        verdict = call.metadata.get("scope_verdict")
+        diff: ScopeDiff | None = call.metadata.get("scope_diff")
+        scope_req: ScopeRequest | None = call.metadata.get("scope_request")
+
+        if verdict is None or scope_req is None:
+            # Legacy path — no scope metadata available
+            return (
+                f"[bold]{call.tool_name}[/bold]  {call.trust_level.label}\n"
+                f"[dim]args: {call.args}[/dim]"
+            )
+
+        # --- Verdict-aware header ---
+        _REASON_LABELS: dict[DiffReason, str] = {
+            DiffReason.FIRST_TIME: "First time accessing this resource",
+            DiffReason.SELECTOR_EXPANSION: "Expanding beyond previously approved scope",
+            DiffReason.CONSTRAINT_EXPANSION: "Exceeding previously approved limits",
+            DiffReason.RESOURCE_TYPE_NEW: "New resource type not previously authorized",
+        }
+
+        _VERDICT_TITLES: dict[PermissionVerdict, tuple[str, str]] = {
+            PermissionVerdict.CONFIRM: ("Tool requires confirmation", "yellow"),
+            PermissionVerdict.EXPAND_SCOPE: ("Scope expansion required", "red"),
+        }
+        title_text, border = _VERDICT_TITLES.get(
+            verdict, ("Tool requires confirmation", "yellow"),
+        )
+
+        lines: list[str] = [
+            f"[bold]{call.tool_name}[/bold]  {call.trust_level.label}",
+        ]
+
+        # Scope summary: what the tool wants to access
+        for req in scope_req.requirements:
+            lines.append(
+                f"  [cyan]{req.resource}[/cyan]:{req.action} → "
+                f"[bold]{req.selector}[/bold]"
+            )
+            if req.constraints.get("scope_unknown"):
+                lines.append("  [yellow]⚠ scope could not be fully resolved[/yellow]")
+
+        # Diff reason
+        if diff is not None and not diff.is_fully_covered:
+            reason_label = _REASON_LABELS.get(diff.reason, str(diff.reason.value))
+            lines.append(f"\n[dim]{reason_label}[/dim]")
+
+            # Show what's already covered vs missing
+            if diff.covered:
+                covered_selectors = ", ".join(r.selector for r in diff.covered)
+                lines.append(f"[green]✓ covered:[/green] {covered_selectors}")
+            if diff.missing:
+                missing_selectors = ", ".join(r.selector for r in diff.missing)
+                lines.append(f"[yellow]● new:[/yellow] {missing_selectors}")
+
+        return "\n".join(lines)
+
     async def _confirm_tool_cli(self, call: ToolCall) -> bool:
-        """CLI-specific confirmation prompt (stdin / Rich panel)."""
+        """
+        CLI-specific confirmation prompt (stdin / Rich panel).
+
+        Phase C (Issue #45): when scope metadata is present in call.metadata,
+        the prompt shows verdict + diff info (resource, selector, expansion
+        reason) instead of raw args.
+        """
+        from loom.core.harness.scope import PermissionVerdict
+
         # Stop any running spinner before printing the confirm panel so the
         # spinner animation doesn't overwrite the prompt input line.
         _CLEAR_LINE = "\r\033[K"  # ANSI: carriage-return + erase to end of line
@@ -1700,12 +1775,21 @@ class LoomSession:
             self._cancel_spinner_fn()
             console.print(_CLEAR_LINE, end="")  # clear spinner line
         console.print()
+
+        # Determine panel styling from verdict
+        verdict = call.metadata.get("scope_verdict")
+        if verdict == PermissionVerdict.EXPAND_SCOPE:
+            title = "[red]⚠ Scope expansion required[/red]"
+            border_style = "red"
+        else:
+            title = "[yellow]  Tool requires confirmation[/yellow]"
+            border_style = "yellow"
+
         console.print(
             Panel(
-                f"[bold]{call.tool_name}[/bold]  {call.trust_level.label}\n"
-                f"[dim]args: {call.args}[/dim]",
-                title="[yellow]  Tool requires confirmation[/yellow]",
-                border_style="yellow",
+                self._format_scope_panel(call),
+                title=title,
+                border_style=border_style,
             )
         )
         # Use prompt_toolkit so the prompt renders correctly on all terminals.

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -66,7 +66,7 @@ from loom.platform.cli.ui import (
     TurnDone,
     TurnDropped,
     TurnPaused,
-    clear_line_escape,
+    clear_line,
     make_prompt_session,
     render_cursor,
     render_header,
@@ -854,7 +854,7 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
 
     def _print_spinner() -> None:
         nonlocal frame_index
-        console.print(clear_line_escape(), end="")
+        clear_line()
         console.print(tool_running_line(active_tool or "", frame_index), end="")
         frame_index = (frame_index + 1) % 4
 
@@ -875,7 +875,7 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
         async for event in session.stream_turn(user_input):
             if isinstance(event, TextChunk):
                 # Clear cursor from previous position
-                console.print(clear_line_escape(), end="")
+                clear_line()
                 # Print text chunk
                 console.print(event.text, end="", markup=False, highlight=False)
                 text_buffer += event.text
@@ -885,7 +885,7 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
 
             elif isinstance(event, ThinkCollapsed):
                 # Show condensed reasoning summary inline; use /think for full content.
-                console.print(clear_line_escape(), end="")
+                clear_line()
                 if not at_line_start:
                     console.print()
                 console.print(
@@ -909,7 +909,7 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
             elif isinstance(event, ToolEnd):
                 # Cancel spinner and clear its line
                 _cancel_spinner()
-                console.print(clear_line_escape(), end="")
+                clear_line()
                 console.print(
                     tool_end_line(event.name, event.success, event.duration_ms)
                 )
@@ -920,7 +920,7 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
             elif isinstance(event, TurnPaused):
                 # ── HITL pause ────────────────────────────────────────────
                 _cancel_spinner()
-                console.print(clear_line_escape(), end="")
+                clear_line()
                 if not at_line_start:
                     console.print()
                 console.print(
@@ -952,7 +952,7 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
             elif isinstance(event, TurnDone):
                 # Cancel any running spinner and clear cursor
                 _cancel_spinner()
-                console.print(clear_line_escape(), end="")
+                clear_line()
                 if not at_line_start:
                     console.print()
                 elapsed = time.monotonic() - t0
@@ -968,7 +968,7 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
 
     except Exception as exc:
         _cancel_spinner()
-        console.print(clear_line_escape(), end="")
+        clear_line()
         console.print()
         console.print(f"[red]Error: {exc}[/red]")
 

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -159,7 +159,7 @@ def _make_run_bash_resolver(workspace: Path):
     """
     import os.path
 
-    _SCOPE_UNKNOWN_PATTERNS = re.compile(r'[\|`]|\$\(|\$\{|\$[A-Za-z]|<<')
+    _SCOPE_UNKNOWN_PATTERNS = re.compile(r'[\|`]|\$\(|\$\{|\$[A-Za-z]|<<|&&|\|\|')
 
     def _resolve(call: ToolCall) -> ScopeRequest:
         command = call.args.get("command", "")
@@ -370,7 +370,7 @@ def make_filesystem_tools(workspace: Path) -> list["ToolDefinition"]:
             },
             executor=_read_file,
             tags=["filesystem", "read"],
-            scope="filesystem",
+            impact_scope="filesystem",
         ),
         ToolDefinition(
             name="write_file",
@@ -391,7 +391,7 @@ def make_filesystem_tools(workspace: Path) -> list["ToolDefinition"]:
             },
             executor=_write_file,
             tags=["filesystem", "write"],
-            scope="filesystem",
+            impact_scope="filesystem",
             rollback_fn=_write_file_rollback,
             preconditions=["target directory must be writable"],
             scope_descriptions=["writes under requested workspace path"],
@@ -414,7 +414,7 @@ def make_filesystem_tools(workspace: Path) -> list["ToolDefinition"]:
             },
             executor=_list_dir,
             tags=["filesystem", "read"],
-            scope="filesystem",
+            impact_scope="filesystem",
         ),
     ]
 
@@ -512,7 +512,7 @@ def make_run_bash_tool(workspace: Path, strict_sandbox: bool = False) -> ToolDef
         },
         executor=_run_bash,
         tags=["shell"],
-        scope="shell",
+        impact_scope="shell",
         scope_descriptions=[
             "executes shell commands within workspace sandbox",
             "scope unknown for pipes, subshells, or variable expansion",
@@ -590,7 +590,7 @@ def make_recall_tool(search: "MemorySearch") -> ToolDefinition:
         },
         executor=_recall,
         tags=["memory", "search", "recall"],
-        scope="memory",
+        impact_scope="memory",
     )
 
 
@@ -690,7 +690,7 @@ def make_memorize_tool(
         },
         executor=_memorize,
         tags=["memory", "write", "memorize"],
-        scope="memory",
+        impact_scope="memory",
         rollback_fn=_memorize_rollback,
     )
 
@@ -765,7 +765,7 @@ def make_relate_tool(relational: "RelationalMemory") -> ToolDefinition:
         },
         executor=_relate,
         tags=["memory", "write", "relational"],
-        scope="memory",
+        impact_scope="memory",
         rollback_fn=_relate_rollback,
     )
 
@@ -814,7 +814,7 @@ def make_query_relations_tool(relational: "RelationalMemory") -> ToolDefinition:
         },
         executor=_query_relations,
         tags=["memory", "search", "relational"],
-        scope="memory",
+        impact_scope="memory",
     )
 
 
@@ -1053,7 +1053,7 @@ def make_load_skill_tool(
         },
         executor=_load_skill,
         tags=["skill", "memory", "activation"],
-        scope="memory",
+        impact_scope="memory",
     )
 
 
@@ -1112,7 +1112,7 @@ def make_unload_skill_tool(
         },
         executor=_unload_skill,
         tags=["skill", "memory"],
-        scope="memory",
+        impact_scope="memory",
     )
 
 
@@ -1266,7 +1266,7 @@ def make_fetch_url_tool() -> ToolDefinition:
         },
         executor=_fetch_url,
         tags=["web", "fetch"],
-        scope="network",
+        impact_scope="network",
         scope_descriptions=["connects to the requested URL domain"],
         scope_resolver=_fetch_url_resolver,
     )
@@ -1347,7 +1347,7 @@ def make_web_search_tool(brave_api_key: str) -> ToolDefinition:
         },
         executor=_web_search,
         tags=["web", "search"],
-        scope="network",
+        impact_scope="network",
         scope_descriptions=["connects to Brave Search API"],
         scope_resolver=_web_search_resolver,
     )
@@ -1442,7 +1442,7 @@ def make_spawn_agent_tool(parent_session: Any) -> "ToolDefinition":
         },
         executor=_spawn_agent,
         tags=["agent", "spawn"],
-        scope="agent",
+        impact_scope="agent",
         scope_descriptions=["spawns one sub-agent"],
         scope_resolver=_spawn_agent_resolver,
     )

--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -288,15 +288,34 @@ def status_bar(
     )
 
 
-def _format_args(args: dict[str, Any]) -> str:
+def _smart_truncate(value: str, max_len: int = 80) -> str:
+    """
+    Truncate a string, preserving start and end for readability.
+
+    For path-like values (containing /), keeps the first component and
+    last components visible: ``/Users/…/cli/tools.py``.
+    For other strings, keeps the first ``max_len`` characters.
+    """
+    if len(value) <= max_len:
+        return value
+    # Path-like: keep leading prefix + trailing meaningful portion
+    if "/" in value or "\\" in value:
+        # Reserve space for "…" connector
+        head_budget = max_len // 3
+        tail_budget = max_len - head_budget - 1  # -1 for "…"
+        return value[:head_budget] + "…" + value[-tail_budget:]
+    return value[:max_len] + "…"
+
+
+def _format_args(args: dict[str, Any], max_value_len: int = 80) -> str:
     """Compact one-line preview of tool arguments."""
     if not args:
         return ""
     parts: list[str] = []
     for k, v in args.items():
         if isinstance(v, str):
-            snippet = v[:40].replace("\n", "↵")
-            parts.append(f'{k}="{snippet}{"…" if len(v) > 40 else ""}"')
+            snippet = _smart_truncate(v.replace("\n", "↵"), max_value_len)
+            parts.append(f'{k}="{snippet}"')
         elif isinstance(v, (dict, list)):
             parts.append(f"{k}={{…}}")
         else:

--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -175,8 +175,8 @@ def response_panel(
     )
 
 
-# ASCII spinner frames (cp950 safe)
-_SPINNER_FRAMES = ["-", "\\", "|", "/"]
+# ASCII spinner frames (cp950 safe, Rich-markup safe — no backslash)
+_SPINNER_FRAMES = ["-", "~", "|", "+"]
 
 def tool_spinner_line(name: str, args: dict[str, Any], frame_index: int = 0) -> Text:
     """
@@ -239,6 +239,19 @@ def streaming_cursor() -> str:
 def clear_line_escape() -> str:
     """Return ANSI escape to clear the current line."""
     return "\r\033[K"
+
+
+def clear_line() -> None:
+    """
+    Write \\r\\033[K directly to stdout, bypassing Rich Console.
+
+    Rich's ``Console.print`` strips the \\r (carriage return), which
+    prevents the cursor from returning to column 0.  Writing directly
+    to ``sys.stdout`` preserves the full escape sequence.
+    """
+    import sys
+    sys.stdout.write("\r\033[K")
+    sys.stdout.flush()
 
 
 def render_cursor() -> Text:

--- a/tests/test_scope_phase_cd.py
+++ b/tests/test_scope_phase_cd.py
@@ -107,7 +107,8 @@ class TestFormatScopePanel:
         # No scope metadata → legacy format
         result = fmt(call)
         assert "write_file" in result
-        assert "args:" in result
+        assert "path" in result
+        assert "doc/test.md" in result
 
     def test_confirm_first_time(self):
         fmt = self._import_format()

--- a/tests/test_scope_phase_cd.py
+++ b/tests/test_scope_phase_cd.py
@@ -1,0 +1,427 @@
+"""
+Tests for Issue #45 Phase C + D.
+
+Phase C: Structured confirm (scope-aware CLI prompt)
+Phase D: Legacy contraction (exec_auto → grant, impact_scope rename,
+         informational constraint filtering, &&/|| scope_unknown)
+
+Coverage:
+  1. _format_scope_panel output for different verdicts/diffs
+  2. _confirm_tool_cli panel styling (EXPAND_SCOPE vs CONFIRM)
+  3. exec_auto grant injection and revocation
+  4. Informational constraint filtering in _request_to_grants
+  5. &&/|| detection in run_bash resolver
+  6. impact_scope rename (ToolDefinition field)
+  7. ExecMatcher + exec_auto grant integration
+"""
+
+import asyncio
+import re
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import pytest
+
+from loom.core.harness.middleware import BlastRadiusMiddleware, ToolCall, ToolResult
+from loom.core.harness.permissions import PermissionContext, ToolCapability, TrustLevel
+from loom.core.harness.registry import ToolDefinition, ToolRegistry
+from loom.core.harness.scope import (
+    DiffReason,
+    ExecMatcher,
+    PermissionVerdict,
+    ScopeDiff,
+    ScopeGrant,
+    ScopeRequirement,
+    ScopeRequest,
+)
+from loom.platform.cli.tools import (
+    _make_run_bash_resolver,
+    _make_write_file_resolver,
+)
+
+
+_WORKSPACE = Path("/tmp/test_workspace")
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+def _call(tool_name, args=None, trust=TrustLevel.GUARDED, caps=ToolCapability.NONE):
+    return ToolCall(
+        tool_name=tool_name,
+        args=args or {},
+        trust_level=trust,
+        session_id="test",
+        capabilities=caps,
+    )
+
+
+def _ok_result(call):
+    return ToolResult(call_id=call.id, tool_name=call.tool_name, success=True, output="ok")
+
+
+def _make_registry(*tool_defs):
+    reg = ToolRegistry()
+    for td in tool_defs:
+        reg.register(td)
+    return reg
+
+
+def _tool_def(name, trust=TrustLevel.GUARDED, caps=ToolCapability.NONE, scope_resolver=None):
+    return ToolDefinition(
+        name=name,
+        description=f"test {name}",
+        trust_level=trust,
+        input_schema={},
+        executor=AsyncMock(return_value=ToolResult(call_id="x", tool_name=name, success=True)),
+        capabilities=caps,
+        scope_resolver=scope_resolver,
+    )
+
+
+async def _run_middleware(perm, call, confirm_result=True, registry=None):
+    confirm_fn = AsyncMock(return_value=confirm_result)
+    handler = AsyncMock(return_value=_ok_result(call))
+    mw = BlastRadiusMiddleware(
+        perm_ctx=perm, confirm_fn=confirm_fn, registry=registry,
+    )
+    result = await mw.process(call, handler)
+    return result, confirm_fn, handler
+
+
+# =====================================================================
+# 1. Phase C — _format_scope_panel
+# =====================================================================
+
+class TestFormatScopePanel:
+    """Test _format_scope_panel produces correct Rich markup."""
+
+    def _import_format(self):
+        # Import the static method from LoomSession
+        from loom.core.session import LoomSession
+        return LoomSession._format_scope_panel
+
+    def test_legacy_no_metadata(self):
+        fmt = self._import_format()
+        call = _call("write_file", {"path": "doc/test.md"}, caps=ToolCapability.MUTATES)
+        # No scope metadata → legacy format
+        result = fmt(call)
+        assert "write_file" in result
+        assert "args:" in result
+
+    def test_confirm_first_time(self):
+        fmt = self._import_format()
+        call = _call("write_file", {"path": "doc/test.md"}, caps=ToolCapability.MUTATES)
+        call.metadata["scope_verdict"] = PermissionVerdict.CONFIRM
+        call.metadata["scope_request"] = ScopeRequest(
+            tool_name="write_file",
+            capabilities=ToolCapability.MUTATES,
+            requirements=[
+                ScopeRequirement(
+                    resource="path", action="write", selector="/tmp/test_workspace/doc",
+                    tool_name="write_file", capabilities=ToolCapability.MUTATES,
+                ),
+            ],
+        )
+        call.metadata["scope_diff"] = ScopeDiff(
+            missing=[call.metadata["scope_request"].requirements[0]],
+            covered=[],
+            reason=DiffReason.FIRST_TIME,
+        )
+        result = fmt(call)
+        assert "path" in result
+        assert "write" in result
+        assert "/tmp/test_workspace/doc" in result
+        assert "First time" in result
+
+    def test_expand_scope_shows_reason(self):
+        fmt = self._import_format()
+        call = _call("write_file", {"path": "loom/core.py"}, caps=ToolCapability.MUTATES)
+        existing_req = ScopeRequirement(
+            resource="path", action="write", selector="/tmp/test_workspace/doc",
+            tool_name="write_file", capabilities=ToolCapability.MUTATES,
+        )
+        new_req = ScopeRequirement(
+            resource="path", action="write", selector="/tmp/test_workspace/loom",
+            tool_name="write_file", capabilities=ToolCapability.MUTATES,
+        )
+        call.metadata["scope_verdict"] = PermissionVerdict.EXPAND_SCOPE
+        call.metadata["scope_request"] = ScopeRequest(
+            tool_name="write_file",
+            capabilities=ToolCapability.MUTATES,
+            requirements=[new_req],
+        )
+        call.metadata["scope_diff"] = ScopeDiff(
+            missing=[new_req],
+            covered=[existing_req],
+            reason=DiffReason.SELECTOR_EXPANSION,
+        )
+        result = fmt(call)
+        assert "Expanding beyond" in result
+        assert "new:" in result
+        assert "covered:" in result
+
+    def test_scope_unknown_warning(self):
+        fmt = self._import_format()
+        call = _call("run_bash", {"command": "ls | grep foo"}, caps=ToolCapability.EXEC)
+        call.metadata["scope_verdict"] = PermissionVerdict.CONFIRM
+        call.metadata["scope_request"] = ScopeRequest(
+            tool_name="run_bash",
+            capabilities=ToolCapability.EXEC,
+            requirements=[
+                ScopeRequirement(
+                    resource="exec", action="execute", selector="workspace",
+                    constraints={"scope_unknown": True},
+                    tool_name="run_bash", capabilities=ToolCapability.EXEC,
+                ),
+            ],
+            metadata={"scope_unknown": True},
+        )
+        call.metadata["scope_diff"] = ScopeDiff(
+            missing=[call.metadata["scope_request"].requirements[0]],
+            covered=[], reason=DiffReason.FIRST_TIME,
+        )
+        result = fmt(call)
+        assert "scope could not be fully resolved" in result
+
+
+# =====================================================================
+# 2. Phase D — exec_auto grant injection
+# =====================================================================
+
+class TestExecAutoGrantInjection:
+    def test_enable_injects_grant(self):
+        perm = PermissionContext(session_id="test")
+        assert len(perm.grants) == 0
+        perm.enable_exec_auto()
+        assert perm.exec_auto is True
+        assert len(perm.grants) == 1
+        g = perm.grants[0]
+        assert g.resource == "exec"
+        assert g.action == "execute"
+        assert g.selector == "workspace"
+        assert g.constraints.get("absolute_paths") == "deny"
+        assert g.source == "exec_auto"
+
+    def test_disable_revokes_grant(self):
+        perm = PermissionContext(session_id="test")
+        perm.enable_exec_auto()
+        assert len(perm.grants) == 1
+        perm.disable_exec_auto()
+        assert perm.exec_auto is False
+        assert len(perm.grants) == 0
+
+    def test_disable_only_revokes_exec_auto(self):
+        perm = PermissionContext(session_id="test")
+        # Add a manual grant first
+        perm.grant(ScopeGrant(
+            resource="path", action="write", selector="/tmp/doc",
+            source="manual_confirm",
+        ))
+        perm.enable_exec_auto()
+        assert len(perm.grants) == 2
+        perm.disable_exec_auto()
+        # Only the exec_auto grant should be removed
+        assert len(perm.grants) == 1
+        assert perm.grants[0].resource == "path"
+
+    async def test_exec_auto_grant_allows_workspace_commands(self):
+        """exec_auto grant should allow workspace-confined commands via scope-aware path."""
+        perm = PermissionContext(session_id="test")
+        perm.enable_exec_auto()
+
+        reg = _make_registry(_tool_def(
+            "run_bash", caps=ToolCapability.EXEC,
+            scope_resolver=_make_run_bash_resolver(_WORKSPACE),
+        ))
+        call = _call("run_bash", {"command": "pytest tests/"}, caps=ToolCapability.EXEC)
+        result, confirm_fn, handler = await _run_middleware(perm, call, registry=reg)
+
+        assert result.success
+        confirm_fn.assert_not_called()  # auto-approved via exec_auto grant
+        handler.assert_called_once()
+
+    async def test_exec_auto_denies_absolute_path_commands(self):
+        """exec_auto grant has absolute_paths=deny — commands with abs paths need confirm."""
+        perm = PermissionContext(session_id="test")
+        perm.enable_exec_auto()
+
+        reg = _make_registry(_tool_def(
+            "run_bash", caps=ToolCapability.EXEC,
+            scope_resolver=_make_run_bash_resolver(_WORKSPACE),
+        ))
+        call = _call("run_bash", {"command": "cat /etc/passwd"}, caps=ToolCapability.EXEC)
+        result, confirm_fn, handler = await _run_middleware(
+            perm, call, confirm_result=True, registry=reg,
+        )
+
+        assert result.success
+        # Should need confirmation because absolute path escapes workspace
+        confirm_fn.assert_called_once()
+
+
+# =====================================================================
+# 3. Phase D — Informational constraint filtering
+# =====================================================================
+
+class TestInformationalConstraintFiltering:
+    async def test_scope_unknown_not_copied_to_grant(self):
+        """scope_unknown is informational — should not be in grants."""
+        perm = PermissionContext(session_id="test")
+        reg = _make_registry(_tool_def(
+            "run_bash", caps=ToolCapability.EXEC,
+            scope_resolver=_make_run_bash_resolver(_WORKSPACE),
+        ))
+        call = _call("run_bash", {"command": "ls | grep foo"}, caps=ToolCapability.EXEC)
+        await _run_middleware(perm, call, confirm_result=True, registry=reg)
+
+        # Grant should exist but without scope_unknown
+        assert len(perm.grants) >= 1
+        for g in perm.grants:
+            assert "scope_unknown" not in g.constraints
+
+    async def test_has_absolute_paths_not_copied_to_grant(self):
+        """has_absolute_paths is informational — should not be in grants."""
+        perm = PermissionContext(session_id="test")
+        reg = _make_registry(_tool_def(
+            "run_bash", caps=ToolCapability.EXEC,
+            scope_resolver=_make_run_bash_resolver(_WORKSPACE),
+        ))
+        call = _call("run_bash", {"command": "cat /etc/passwd"}, caps=ToolCapability.EXEC)
+        await _run_middleware(perm, call, confirm_result=True, registry=reg)
+
+        for g in perm.grants:
+            assert "has_absolute_paths" not in g.constraints
+
+    async def test_actionable_constraints_preserved(self):
+        """remaining_budget and max_calls should be preserved in grants."""
+        perm = PermissionContext(session_id="test")
+
+        def _budget_resolver(call):
+            return ScopeRequest(
+                tool_name=call.tool_name,
+                capabilities=call.capabilities,
+                requirements=[
+                    ScopeRequirement(
+                        resource="agent", action="spawn", selector="default",
+                        constraints={
+                            "spawn_count": 1,
+                            "remaining_budget": 3,
+                            "scope_unknown": True,  # should be filtered
+                        },
+                        tool_name=call.tool_name, capabilities=call.capabilities,
+                    ),
+                ],
+            )
+
+        reg = _make_registry(_tool_def(
+            "spawn_agent", caps=ToolCapability.AGENT_SPAN,
+            scope_resolver=_budget_resolver,
+        ))
+        call = _call("spawn_agent", {"task": "x"}, caps=ToolCapability.AGENT_SPAN)
+        await _run_middleware(perm, call, confirm_result=True, registry=reg)
+
+        assert len(perm.grants) >= 1
+        g = perm.grants[-1]
+        assert g.constraints.get("remaining_budget") == 3
+        assert g.constraints.get("spawn_count") == 1
+        assert "scope_unknown" not in g.constraints
+
+
+# =====================================================================
+# 4. Phase D — &&/|| in scope_unknown patterns
+# =====================================================================
+
+_bash_resolver = _make_run_bash_resolver(_WORKSPACE)
+
+
+class TestBashResolverExtendedPatterns:
+    def test_and_chain_marks_scope_unknown(self):
+        call = _call("run_bash", {"command": "cd /tmp && ls"}, caps=ToolCapability.EXEC)
+        req = _bash_resolver(call)
+        assert req.metadata.get("scope_unknown") is True
+
+    def test_or_chain_marks_scope_unknown(self):
+        call = _call("run_bash", {"command": "test -f x || echo missing"}, caps=ToolCapability.EXEC)
+        req = _bash_resolver(call)
+        assert req.metadata.get("scope_unknown") is True
+
+    def test_simple_command_still_works(self):
+        call = _call("run_bash", {"command": "pytest tests/"}, caps=ToolCapability.EXEC)
+        req = _bash_resolver(call)
+        assert not req.metadata.get("scope_unknown")
+
+
+# =====================================================================
+# 5. Phase D — impact_scope rename
+# =====================================================================
+
+class TestImpactScopeRename:
+    def test_tool_definition_has_impact_scope(self):
+        td = ToolDefinition(
+            name="test",
+            description="test",
+            trust_level=TrustLevel.SAFE,
+            input_schema={},
+            executor=AsyncMock(),
+            impact_scope="filesystem",
+        )
+        assert td.impact_scope == "filesystem"
+
+    def test_default_impact_scope_is_general(self):
+        td = ToolDefinition(
+            name="test",
+            description="test",
+            trust_level=TrustLevel.SAFE,
+            input_schema={},
+            executor=AsyncMock(),
+        )
+        assert td.impact_scope == "general"
+
+    def test_old_scope_field_does_not_exist(self):
+        """The old 'scope' field should no longer exist on ToolDefinition."""
+        td = ToolDefinition(
+            name="test",
+            description="test",
+            trust_level=TrustLevel.SAFE,
+            input_schema={},
+            executor=AsyncMock(),
+        )
+        # If the old field still exists, this would return a non-default value
+        # after setting it. Since it's removed, hasattr should be False for
+        # 'scope' or it should not be in the dataclass fields.
+        from dataclasses import fields
+        field_names = {f.name for f in fields(td)}
+        assert "scope" not in field_names
+
+
+# =====================================================================
+# 6. ExecMatcher + exec_auto grant integration
+# =====================================================================
+
+class TestExecMatcherWithExecAutoGrant:
+    """Verify ExecMatcher correctly handles exec_auto grants."""
+
+    def test_workspace_grant_covers_workspace_req(self):
+        matcher = ExecMatcher()
+        grant = ScopeGrant(
+            resource="exec", action="execute", selector="workspace",
+            constraints={"absolute_paths": "deny"}, source="exec_auto",
+        )
+        req = ScopeRequirement(
+            resource="exec", action="execute", selector="workspace",
+            constraints={"has_absolute_paths": False},
+        )
+        assert matcher.covers(grant, req) is True
+
+    def test_workspace_grant_denies_absolute_paths(self):
+        matcher = ExecMatcher()
+        grant = ScopeGrant(
+            resource="exec", action="execute", selector="workspace",
+            constraints={"absolute_paths": "deny"}, source="exec_auto",
+        )
+        req = ScopeRequirement(
+            resource="exec", action="execute", selector="workspace",
+            constraints={"has_absolute_paths": True},
+        )
+        assert matcher.covers(grant, req) is False


### PR DESCRIPTION
## Summary
- **Phase C**: structured scope confirm — verdict + diff info in CLI panel
- **Phase D**: `exec_auto` → grant injection; `scope`→`impact_scope`; informational constraint filter; `&&`/`||` scope_unknown
- **Spinner fix**: `\r` stripped by Console.print + backslash breaks Rich markup
- **Display fix**: smart truncation for long paths (40→80 chars, head+tail preservation); confirm panel per-arg formatting; `\r` fix in confirm prompt

## Commits (5)

| Commit | Description |
|--------|-------------|
| `72a6e47` | Phase C+D: scope-aware confirm + legacy contraction |
| `926a0bd` | Spinner fix: markup leak + line accumulation |
| `1ea769b` | Phase C+D tests (20 new) |
| `b20e273` | Display: smart truncation + clear_line in confirm |

## Breaking changes
- `ToolDefinition.scope` → `ToolDefinition.impact_scope`

## Test plan
- [x] 635 total tests pass — zero regressions
- [x] Smart truncation: 53-char paths fully visible, 127-char paths show head+tail

Refs #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)