### PR TITLE
[Security] Self-termination guard — block kill/disown targeting Loom (Issue #98)

### DIFF
--- a/loom/core/security/self_termination_guard.py
+++ b/loom/core/security/self_termination_guard.py
@@ -1,0 +1,213 @@
+"""
+Self-termination guard — Issue #98.
+
+Prevents the Agent from executing commands that would kill or otherwise
+terminate the Loom process itself (pkill loom, killall loom, etc.).
+
+Patterns are deliberately narrow: they only match commands that target
+Loom's own process names.  Generic "kill" patterns are NOT included
+because they would produce too many false positives in normal use.
+
+Usage::
+
+    from loom.core.security.self_termination_guard import SelfTerminationGuard
+
+    guard = SelfTerminationGuard()
+    verdict = guard.check("pkill -f loom")
+    if verdict.is_blocked:
+        raise PermissionError(f"Blocked: {verdict.reason}")
+
+The guard is intentionally stateless and has no external dependencies.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+# Process names that, if killed, would terminate Loom itself.
+_PROCESS_NAMES = r"\b(?:hermes|loom|loom\.py|gateway|cli\.py)\b"
+
+# Commands that, when combined with _PROCESS_NAMES, constitute
+# a self-termination threat.
+_KILL_CMDS = r"\b(?:pkill|killall|kill)\b"
+
+
+# ---------------------------------------------------------------------------
+# Pattern groups
+# ---------------------------------------------------------------------------
+
+# 1. Bare kill + target:   pkill loom, killall -f loom, pkill -9 gateway, etc.
+#    Optional flags between command and target are covered.
+_PATTERN_BARE_KILL = re.compile(
+    rf"""^                # anchor to avoid partial-word matches
+    (?:pkill|killall)\s+(?:-\w+\s+)*  # pkill/killall with optional flags
+    ({_PROCESS_NAMES})                   # target process name
+    (?:\s|$|\s+[^\s])                   # followed by space, end, or non-flag arg
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+# 2. kill via command substitution:  kill $(pgrep loom), kill -TERM `pgrep gateway`
+#    We look for the kill command, optional flags, then $(...) or `...` containing
+#    any of the target names.  Simple and correct over exhaustive.
+_PATTERN_KILL_CMD_SUB = re.compile(
+    rf"""(?:\bkill)\s+(?:-\w+\s+)*     # kill with optional flags
+    (?:                                # command substitution:
+        \$ \( [^)]*? ({_PROCESS_NAMES}) [^)]* \)   # $( ... target ... )
+    |
+        ` [^`]*   ({_PROCESS_NAMES})   [^`]* `      # ` ... target ... `
+    )
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+# 3a. Detach operator followed by a Loom target:  nohup gateway run, disown loom
+_PATTERN_DETACH_TARGET = re.compile(
+    rf"""\b(?:nohup|disown|setsid)\b\s+\S*\s*
+    ({_PROCESS_NAMES})""",
+    re.VERBOSE | re.IGNORECASE,
+)
+
+# 3b. Loom process backgrounded at end of command:  gateway run &
+_PATTERN_LOOM_BACKGROUND = re.compile(
+    rf"""^({_PROCESS_NAMES})\b[^\n&]*&\s*$""",
+    re.VERBOSE | re.IGNORECASE,
+)
+
+# 4. Persistence mechanisms (warn only, not block)
+_PATTERN_AUTHORIZED_KEYS = re.compile(
+    r"authorized_keys",
+    re.IGNORECASE,
+)
+_PATTERN_CRONTAB_MODIFY = re.compile(
+    r"crontab\s+-(?:e|l|-r)",
+    re.IGNORECASE,
+)
+_PATTERN_SERVICE_ENABLE = re.compile(
+    r"(?:systemctl\s+(?:enable|start)|service\s+(?:enable|start))\s+",
+    re.IGNORECASE,
+)
+_PATTERN_UPDATE_RC_D = re.compile(
+    r"update-rc\.d",
+    re.IGNORECASE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Guard
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class GuardVerdict:
+    """Result of a self-termination guard check."""
+    is_blocked: bool
+    verdict: str           # "allow" | "block" | "warn"
+    pattern_key: str
+    description: str
+
+
+class SelfTerminationGuard:
+    """
+    Stateless guard that checks a command string for self-termination
+    and related dangerous patterns.
+
+    All patterns are class-level constants, so instantiating the guard
+    has zero overhead and you may reuse a single instance across all calls.
+    """
+
+    __slots__ = ()
+
+    def check(self, command: str) -> GuardVerdict:
+        """
+        Check *command* for self-termination or persistence patterns.
+
+        Returns a ``GuardVerdict``:
+
+        - ``verdict == "block"`` — command matches a self-termination pattern;
+          it MUST NOT be executed.
+        - ``verdict == "warn"`` — command matches a persistence-related pattern;
+          raise a warning but do not automatically block.
+        - ``verdict == "allow"`` — no patterns matched.
+        """
+        if not command or not command.strip():
+            return GuardVerdict(False, "allow", "", "")
+
+        # --- Block patterns ---
+        # 1. Bare pkill/killall targeting Loom processes
+        if _PATTERN_BARE_KILL.search(command):
+            m = _PATTERN_BARE_KILL.search(command)
+            return GuardVerdict(
+                is_blocked=True,
+                verdict="block",
+                pattern_key="bare_kill",
+                description=(
+                    f"Self-termination: command would kill Loom process '{m.group(1)}'. "
+                    f"Matched: {m.group(0)!r}"
+                ),
+            )
+
+        # 2. kill via command substitution $(pgrep loom) / `pgrep gateway`
+        if _PATTERN_KILL_CMD_SUB.search(command):
+            m = _PATTERN_KILL_CMD_SUB.search(command)
+            return GuardVerdict(
+                is_blocked=True,
+                verdict="block",
+                pattern_key="kill_cmd_sub",
+                description=(
+                    f"Self-termination: kill command targets a Loom process via "
+                    f"command substitution. Matched: {m.group(0)!r}"
+                ),
+            )
+
+        # 3. Detach operator targeting Loom:  disown loom, nohup gateway run
+        if _PATTERN_DETACH_TARGET.search(command):
+            m = _PATTERN_DETACH_TARGET.search(command)
+            return GuardVerdict(
+                is_blocked=True,
+                verdict="block",
+                pattern_key="detach_target",
+                description=(
+                    f"Self-termination: detach operator targets Loom process "
+                    f"'{m.group(1)}'. Matched: {m.group(0)!r}"
+                ),
+            )
+
+        # 4. Loom process backgrounded at end of command:  gateway run &
+        if _PATTERN_LOOM_BACKGROUND.search(command):
+            m = _PATTERN_LOOM_BACKGROUND.search(command)
+            return GuardVerdict(
+                is_blocked=True,
+                verdict="block",
+                pattern_key="loom_background",
+                description=(
+                    f"Self-termination: Loom process '{m.group(1)}' "
+                    f"would be backgrounded and detached from supervision. "
+                    f"Matched: {m.group(0)!r}"
+                ),
+            )
+
+        # --- Warn patterns (persistence mechanisms) ---
+        if _PATTERN_AUTHORIZED_KEYS.search(command):
+            return GuardVerdict(False, "warn", "authorized_keys",
+                "Persistence warning: command may modify authorized_keys.")
+        if _PATTERN_CRONTAB_MODIFY.search(command):
+            return GuardVerdict(False, "warn", "crontab_modify",
+                "Persistence warning: command may modify crontab.")
+        if _PATTERN_SERVICE_ENABLE.search(command):
+            return GuardVerdict(False, "warn", "service_enable",
+                "Persistence warning: command may enable/start a system service.")
+        if _PATTERN_UPDATE_RC_D.search(command):
+            return GuardVerdict(False, "warn", "update_rc_d",
+                "Persistence warning: command may modify runlevel links.")
+
+        return GuardVerdict(False, "allow", "", "")
+
+    def is_allowed(self, command: str) -> bool:
+        """Shorthand: returns True only when verdict is "allow"."""
+        return self.check(command).verdict == "allow"
+
+    def is_blocked(self, command: str) -> bool:
+        """Shorthand: returns True when the command MUST NOT execute."""
+        return self.check(command).verdict == "block"

--- a/loom/core/security/self_termination_guard.py
+++ b/loom/core/security/self_termination_guard.py
@@ -15,7 +15,7 @@ Usage::
     guard = SelfTerminationGuard()
     verdict = guard.check("pkill -f loom")
     if verdict.is_blocked:
-        raise PermissionError(f"Blocked: {verdict.reason}")
+        raise PermissionError(f"Blocked: {verdict.description}")
 
 The guard is intentionally stateless and has no external dependencies.
 """
@@ -136,8 +136,8 @@ class SelfTerminationGuard:
 
         # --- Block patterns ---
         # 1. Bare pkill/killall targeting Loom processes
-        if _PATTERN_BARE_KILL.search(command):
-            m = _PATTERN_BARE_KILL.search(command)
+        m = _PATTERN_BARE_KILL.search(command)
+        if m:
             return GuardVerdict(
                 is_blocked=True,
                 verdict="block",
@@ -149,8 +149,8 @@ class SelfTerminationGuard:
             )
 
         # 2. kill via command substitution $(pgrep loom) / `pgrep gateway`
-        if _PATTERN_KILL_CMD_SUB.search(command):
-            m = _PATTERN_KILL_CMD_SUB.search(command)
+        m = _PATTERN_KILL_CMD_SUB.search(command)
+        if m:
             return GuardVerdict(
                 is_blocked=True,
                 verdict="block",
@@ -162,8 +162,8 @@ class SelfTerminationGuard:
             )
 
         # 3. Detach operator targeting Loom:  disown loom, nohup gateway run
-        if _PATTERN_DETACH_TARGET.search(command):
-            m = _PATTERN_DETACH_TARGET.search(command)
+        m = _PATTERN_DETACH_TARGET.search(command)
+        if m:
             return GuardVerdict(
                 is_blocked=True,
                 verdict="block",
@@ -175,8 +175,8 @@ class SelfTerminationGuard:
             )
 
         # 4. Loom process backgrounded at end of command:  gateway run &
-        if _PATTERN_LOOM_BACKGROUND.search(command):
-            m = _PATTERN_LOOM_BACKGROUND.search(command)
+        m = _PATTERN_LOOM_BACKGROUND.search(command)
+        if m:
             return GuardVerdict(
                 is_blocked=True,
                 verdict="block",

--- a/loom/extensibility/mcp_client.py
+++ b/loom/extensibility/mcp_client.py
@@ -18,6 +18,8 @@ In ``loom.toml``::
     name    = "github"
     command = "uvx"
     args    = ["mcp-server-git"]
+    # env values support ${ENV_VAR} syntax for secrets kept in .env
+    env     = { GITHUB_TOKEN = "${GITHUB_TOKEN}" }
 
 Then in LoomSession.start(), ``_load_mcp_servers()`` is called
 automatically to connect and register tools from each configured server.
@@ -44,6 +46,8 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
+import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -79,9 +83,27 @@ class MCPServerConfig:
     trust_level: str = "safe"   # safe | guarded — maps to Loom TrustLevel
 
 
+_ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
+
+def _expand_env(value: str) -> str:
+    """
+    Expand ${VAR} placeholders in *value* with the current process environment.
+    Unset variables are replaced with the empty string.
+    """
+    def _replace(m: re.Match) -> str:
+        return os.environ.get(m.group(1), "")
+    return _ENV_VAR_PATTERN.sub(_replace, value)
+
+
 def load_mcp_server_configs(config: dict) -> list[MCPServerConfig]:
     """
     Parse ``[[mcp.servers]]`` entries from the loaded loom.toml dict.
+
+    Environment-variable placeholders (``${VAR}``) in ``env`` values are
+    expanded from the current process environment at load time, so secrets
+    stored in ``.env`` (and loaded into the environment before Loom starts)
+    are never written to ``loom.toml`` in plain text.
 
     Returns an empty list if no MCP servers are configured.
     """
@@ -89,11 +111,17 @@ def load_mcp_server_configs(config: dict) -> list[MCPServerConfig]:
     result: list[MCPServerConfig] = []
     for item in raw:
         try:
+            raw_env: dict[str, str] = dict(item.get("env", {}))
+            # Expand ${VAR} in every env value (supports nested ${VAR} in
+            # rare cases; single-pass substitution handles the common case).
+            expanded_env: dict[str, str] = {
+                k: _expand_env(v) for k, v in raw_env.items()
+            }
             result.append(MCPServerConfig(
                 name=item.get("name", "unknown"),
                 command=item.get("command", ""),
                 args=list(item.get("args", [])),
-                env=dict(item.get("env", {})),
+                env=expanded_env,
                 trust_level=item.get("trust_level", "safe"),
             ))
         except Exception as exc:

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -24,6 +24,7 @@ import httpx
 from loom.core.harness.middleware import ToolCall, ToolResult
 from loom.core.harness.permissions import ToolCapability, TrustLevel
 from loom.core.harness.scope import ScopeRequirement, ScopeRequest
+from loom.core.security.self_termination_guard import SelfTerminationGuard
 
 import logging
 
@@ -467,6 +468,21 @@ def make_run_bash_tool(workspace: Path, strict_sandbox: bool = False) -> ToolDef
     """
     async def _run_bash(call: ToolCall) -> ToolResult:
         command = call.args.get("command", "")
+
+        # Issue #98: self-termination guard — before ANY other processing
+        _self_term_guard = SelfTerminationGuard()
+        verdict = _self_term_guard.check(command)
+        if verdict.verdict == "block":
+            _log.warning("Self-termination guard blocked: %s", verdict.description)
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False,
+                error=f"[Security] Blocked by self-termination guard: {verdict.description}",
+                failure_type="security_block",
+            )
+        if verdict.verdict == "warn":
+            _log.warning("Self-termination guard warning: %s", verdict.description)
+
         timeout = call.args.get("timeout", 30)
         cwd = str(workspace) if strict_sandbox else None
         try:

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -29,6 +29,7 @@ from loom.core.security.self_termination_guard import SelfTerminationGuard
 import logging
 
 _log = logging.getLogger(__name__)
+_self_term_guard = SelfTerminationGuard()
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -470,7 +471,6 @@ def make_run_bash_tool(workspace: Path, strict_sandbox: bool = False) -> ToolDef
         command = call.args.get("command", "")
 
         # Issue #98: self-termination guard — before ANY other processing
-        _self_term_guard = SelfTerminationGuard()
         verdict = _self_term_guard.check(command)
         if verdict.verdict == "block":
             _log.warning("Self-termination guard blocked: %s", verdict.description)


### PR DESCRIPTION
## 摘要

**Issue #98** — 新增自我終止保護，防止 Agent 執行會摧毀 Loom 自身進程的命令。
**Issue #99** — MCP server 的 API Key 從 loom.toml 硬編碼改為 \`\${ENV_VAR}\` 語法，機密存 .env。

## 變更

### 新增：`loom/core/security/__init__.py`

補齊 package marker，與 `loom/core/` 底下其他 package 一致。

### 新增：`loom/core/security/self_termination_guard.py`

純 Python，零外部依賴：

| 類型 | Pattern | 範例 |
|------|---------|------|
| **Block** | `pkill` / `killall` + Loom 程序名 | `pkill loom`, `killall gateway` |
| **Block** | `kill` + 命令替換 | `kill $(pgrep loom)`, `` kill `pgrep hermes` `` |
| **Block** | detach operator + Loom | `nohup gateway run &`, `disown loom` |
| **Block** | Loom 程序背景化 | `gateway run &`, `hermes &` |
| **Warn** | 持久化機制 | `authorized_keys`, `crontab -e` |

### 修改：`loom/platform/cli/tools.py`

在 `run_bash` 工具中，於 `asyncio.create_subprocess_shell()` **之前**呼叫 guard。Guard 實例移至 module level（stateless，`__slots__ = ()`），避免每次 call 重新建立。

### 修改：`loom/extensibility/mcp_client.py`

新增 `_expand_env()` 函數，展開 `${VAR}` placeholder：

```python
_ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")

def _expand_env(value: str) -> str:
    return _ENV_VAR_PATTERN.sub(lambda m: os.environ.get(m.group(1), ""), value)
```

`load_mcp_server_configs()` 在建構 `MCPServerConfig` 前先展開所有 env value，使 `loom.toml` 可寫 `${MINIMAX_API_KEY}` 而非明文。

## Issues

- Closes #98
- Closes #99