### PR TITLE
feat(ux): TUI/Discord confirm prompt — y/s/a/N scope lease parity (#104)

### DIFF
--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -904,27 +904,28 @@ async def _chat_tui(model: str, db: str, resume_session_id: str | None = None) -
         app = LoomChatApp.create(session)
 
         # Replace BlastRadiusMiddleware's confirm_fn with a TUI-aware version that
-        # shows a ModalScreen dialog — no terminal suspension needed.
+        # shows an inline widget dialog — no terminal suspension needed.
         from loom.core.harness.middleware import BlastRadiusMiddleware
+        from loom.core.harness.scope import ConfirmDecision
         from loom.platform.cli.tui.components.interactive_widgets import InlineConfirmWidget
         import asyncio
 
-        async def _tui_confirm(call: "ToolCall") -> bool:
+        async def _tui_confirm(call: "ToolCall") -> "ConfirmDecision":
             args_preview = "  ".join(
                 f"{k}={str(v)[:40]}" for k, v in call.args.items()
             )[:120]
-            
+
             msg_list = app.query_one("#message-list")
-            future = asyncio.Future()
+            future: asyncio.Future[ConfirmDecision] = asyncio.Future()
             widget = InlineConfirmWidget(
                 tool_name=call.tool_name,
                 trust_label=call.trust_level.plain,
                 args_preview=args_preview,
-                future=future
+                future=future,
             )
             msg_list.mount(widget)
             msg_list.scroll_end(animate=False)
-            
+
             return await future
 
         for mw in session._pipeline._middlewares:

--- a/loom/platform/cli/tui/components/interactive_widgets.py
+++ b/loom/platform/cli/tui/components/interactive_widgets.py
@@ -11,6 +11,9 @@ from textual.containers import Horizontal
 from textual.widgets import Button, Static, Input
 from textual.widget import Widget
 
+from loom.core.harness.scope import ConfirmDecision
+
+
 class InlineConfirmWidget(Widget):
     DEFAULT_CSS = """
     InlineConfirmWidget {
@@ -19,19 +22,28 @@ class InlineConfirmWidget(Widget):
         margin: 1 0;
         background: #242018;
         border-left: thick #c8924a;
-        layout: horizontal;
-        align: left middle;
+        layout: vertical;
     }
     InlineConfirmWidget.critical { border-left: thick #b87060; }
-    .confirm-content { margin-right: 2; width: 1fr; }
-    .confirm-buttons { height: auto; width: auto; align: right middle; }
-    .btn-allow { background: #7a9e78; color: #1c1814; border: none; min-width: 10; margin-right: 1; min-height: 1; padding: 0 1; }
-    .btn-allow:hover { background: #9abf98; }
-    .btn-deny { background: #b87060; color: #1c1814; border: none; min-width: 10; min-height: 1; padding: 0 1; }
-    .btn-deny:hover { background: #d09080; }
+    .confirm-content { margin-bottom: 1; width: 1fr; }
+    .confirm-buttons { height: auto; width: auto; align: left middle; }
+    .btn-allow  { background: #7a9e78; color: #1c1814; border: none; min-width: 12; margin-right: 1; min-height: 1; padding: 0 1; }
+    .btn-allow:hover  { background: #9abf98; }
+    .btn-lease  { background: #6a7a9e; color: #e0d8c0; border: none; min-width: 12; margin-right: 1; min-height: 1; padding: 0 1; }
+    .btn-lease:hover  { background: #8a9abe; }
+    .btn-auto   { background: #7a6a9e; color: #e0d8c0; border: none; min-width: 12; margin-right: 1; min-height: 1; padding: 0 1; }
+    .btn-auto:hover   { background: #9a8abe; }
+    .btn-deny   { background: #b87060; color: #1c1814; border: none; min-width: 12; min-height: 1; padding: 0 1; }
+    .btn-deny:hover   { background: #d09080; }
     """
 
-    def __init__(self, tool_name: str, trust_label: str, args_preview: str, future: asyncio.Future[bool]) -> None:
+    def __init__(
+        self,
+        tool_name: str,
+        trust_label: str,
+        args_preview: str,
+        future: "asyncio.Future[ConfirmDecision]",
+    ) -> None:
         super().__init__()
         self._tool_name = tool_name
         self._trust_label = trust_label
@@ -40,25 +52,37 @@ class InlineConfirmWidget(Widget):
         self._resolved = False
 
     def compose(self) -> ComposeResult:
-        if self._trust_label == "CRITICAL": self.add_class("critical")
+        if self._trust_label == "CRITICAL":
+            self.add_class("critical")
         colour = "#b87060" if self._trust_label == "CRITICAL" else "#c8924a"
-        if self._trust_label == "SAFE": colour = "#7a9e78"
+        if self._trust_label == "SAFE":
+            colour = "#7a9e78"
 
-        yield Static(f"[bold {colour}]Action Required ({self._trust_label})[/]\n"
-                     f"[bold]{escape(self._tool_name)}[/] [dim]{escape(self._args_preview)}[/dim]", 
-                     classes="confirm-content")
+        yield Static(
+            f"[bold {colour}]Action Required ({self._trust_label})[/]\n"
+            f"[bold]{escape(self._tool_name)}[/] [dim]{escape(self._args_preview)}[/dim]\n"
+            f"[dim]y=approve once  s=scope lease (30 min)  a=auto-approve  N=deny[/dim]",
+            classes="confirm-content",
+        )
         with Horizontal(classes="confirm-buttons"):
-            yield Button("✓ Allow", id="btn-allow", classes="btn-allow")
-            yield Button("✗ Deny", id="btn-deny", classes="btn-deny")
+            yield Button("✓ Allow [y]", id="btn-allow", classes="btn-allow")
+            yield Button("⏱ Lease [s]", id="btn-lease", classes="btn-lease")
+            yield Button("⚡ Auto  [a]", id="btn-auto", classes="btn-auto")
+            yield Button("✗ Deny  [N]", id="btn-deny", classes="btn-deny")
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        if self._resolved: return
+        if self._resolved:
+            return
         self._resolved = True
-        is_allow = event.button.id == "btn-allow"
-        
+        decision_map = {
+            "btn-allow": ConfirmDecision.ONCE,
+            "btn-lease": ConfirmDecision.SCOPE,
+            "btn-auto":  ConfirmDecision.AUTO,
+            "btn-deny":  ConfirmDecision.DENY,
+        }
+        decision = decision_map.get(event.button.id, ConfirmDecision.DENY)
         if not self._future.done():
-            self._future.set_result(is_allow)
-        
+            self._future.set_result(decision)
         self.remove()
 
 class InlinePauseWidget(Widget):

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -44,8 +44,10 @@ Streaming strategy
 
 Confirm flow
 ------------
-BlastRadiusMiddleware.confirm_fn is patched to send an Allow / Deny button
-message in the thread and await the button interaction (60s timeout → deny).
+BlastRadiusMiddleware.confirm_fn is patched to send a four-button message
+(Allow / Lease / Auto / Deny) in the thread and await the button interaction
+(60s timeout → deny).  Lease and Auto decisions post a follow-up message
+showing the TTL or grant scope.
 """
 
 from __future__ import annotations
@@ -66,6 +68,7 @@ except ImportError as exc:  # pragma: no cover
         "Install with:  pip install 'loom[discord]'"
     ) from exc
 
+from loom.core.harness.scope import ConfirmDecision
 from loom.platform.cli.ui import (
     ActionRolledBack, ActionStateChange,
     CompressDone, TextChunk, ThinkCollapsed, ToolBegin, ToolEnd,
@@ -79,40 +82,56 @@ if TYPE_CHECKING:
 
 
 # ---------------------------------------------------------------------------
-# Confirm view (Allow / Deny buttons)
+# Confirm view (y / s / a / N buttons)
 # ---------------------------------------------------------------------------
 
 class _ConfirmView(View):
-    """Discord UI view with Allow / Deny buttons for tool confirmation."""
+    """Discord UI view with Allow / Lease / Auto / Deny buttons for tool confirmation."""
 
     def __init__(self, timeout: float = 60.0) -> None:
         super().__init__(timeout=timeout)
-        self._approved: bool | None = None
+        self._decision: ConfirmDecision | None = None
         self._done = asyncio.Event()
 
-    @discord.ui.button(label="Allow", style=ButtonStyle.green, emoji="✅")
+    @discord.ui.button(label="Allow (y)", style=ButtonStyle.green, emoji="✅")
     async def allow_button(self, interaction: Interaction, button: Button) -> None:
-        self._approved = True
+        self._decision = ConfirmDecision.ONCE
         self._done.set()
         await interaction.response.edit_message(
             content="✅ **Allowed** — executing tool…", view=None
         )
 
-    @discord.ui.button(label="Deny", style=ButtonStyle.red, emoji="❌")
+    @discord.ui.button(label="Lease (s)", style=ButtonStyle.blurple, emoji="⏱️")
+    async def lease_button(self, interaction: Interaction, button: Button) -> None:
+        self._decision = ConfirmDecision.SCOPE
+        self._done.set()
+        await interaction.response.edit_message(
+            content="⏱️ **Lease granted** — executing tool…", view=None
+        )
+
+    @discord.ui.button(label="Auto (a)", style=ButtonStyle.grey, emoji="⚡")
+    async def auto_button(self, interaction: Interaction, button: Button) -> None:
+        self._decision = ConfirmDecision.AUTO
+        self._done.set()
+        await interaction.response.edit_message(
+            content="⚡ **Auto-approve granted** — executing tool…", view=None
+        )
+
+    @discord.ui.button(label="Deny (N)", style=ButtonStyle.red, emoji="❌")
     async def deny_button(self, interaction: Interaction, button: Button) -> None:
-        self._approved = False
+        self._decision = ConfirmDecision.DENY
         self._done.set()
         await interaction.response.edit_message(
             content="❌ **Denied** — tool call blocked.", view=None
         )
 
     async def on_timeout(self) -> None:
-        self._approved = False
+        self._decision = ConfirmDecision.DENY
         self._done.set()
 
-    async def wait_decision(self) -> bool:
+    async def wait_decision(self) -> ConfirmDecision:
         await self._done.wait()
-        return bool(self._approved)
+        return self._decision if self._decision is not None else ConfirmDecision.DENY
 
 
 # ---------------------------------------------------------------------------
@@ -788,11 +807,12 @@ class LoomDiscordBot:
 
     def _make_confirm_fn(self, thread_id: int):
         client = self._client
+        _LEASE_TTL_MIN = 30  # matches BlastRadiusMiddleware._SCOPE_LEASE_TTL
 
-        async def _confirm(call: "ToolCall") -> bool:
+        async def _confirm(call: "ToolCall") -> ConfirmDecision:
             channel = client.get_channel(thread_id)
             if channel is None:
-                return False
+                return ConfirmDecision.DENY
 
             args_preview = "  ".join(
                 f"{k}={str(v)[:40]}" for k, v in call.args.items()
@@ -810,10 +830,22 @@ class LoomDiscordBot:
             )
             self._active_confirmations[thread_id] = msg
             try:
-                res = await view.wait_decision()
-                return res
+                decision = await view.wait_decision()
             finally:
                 self._active_confirmations.pop(thread_id, None)
+
+            if decision == ConfirmDecision.SCOPE:
+                await channel.send(
+                    f"⏱️ **Scope lease granted** for `{call.tool_name}` — "
+                    f"auto-approved for this scope for the next **{_LEASE_TTL_MIN} minutes**."
+                )
+            elif decision == ConfirmDecision.AUTO:
+                await channel.send(
+                    f"⚡ **Permanent auto-approve granted** for `{call.tool_name}` — "
+                    f"all future calls of this tool class will be approved automatically."
+                )
+
+            return decision
 
         return _confirm
 

--- a/tests/test_confirm_parity.py
+++ b/tests/test_confirm_parity.py
@@ -1,0 +1,318 @@
+"""
+Tests for Issue #104 — TUI/Discord confirm prompt y/s/a/N parity.
+
+Coverage:
+  1. InlineConfirmWidget: each button maps to the correct ConfirmDecision
+  2. InlineConfirmWidget: second press is ignored (idempotent)
+  3. InlineConfirmWidget: remove() called after resolve
+  4. _ConfirmView: each button handler sets the correct decision
+  5. _ConfirmView: wait_decision() resolves to the set decision
+  6. _ConfirmView: on_timeout() falls back to DENY
+  7. _make_confirm_fn: channel=None → DENY without any send
+  8. _make_confirm_fn: SCOPE decision posts TTL follow-up message
+  9. _make_confirm_fn: AUTO decision posts permanent-grant follow-up
+ 10. _make_confirm_fn: ONCE decision posts no follow-up
+ 11. _make_confirm_fn: DENY decision posts no follow-up
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from loom.core.harness.scope import ConfirmDecision
+
+
+# ---------------------------------------------------------------------------
+# Discord stub
+# Discord.py is an optional dependency.  Register a minimal stub in
+# sys.modules *before* importing bot.py so the module-level try/import
+# block succeeds without the real library installed.
+# ---------------------------------------------------------------------------
+
+class _StubView:
+    """Minimal discord.ui.View replacement — accepts any keyword args."""
+    def __init__(self, **kwargs):
+        pass
+
+
+def _noop_button(**kwargs):
+    """Stand-in for @discord.ui.button — passes the decorated function through unchanged."""
+    return lambda fn: fn
+
+
+_discord_stub = MagicMock()
+_discord_stub.ui.View = _StubView
+_discord_stub.ui.button = _noop_button
+_discord_stub.ButtonStyle.green = "green"
+_discord_stub.ButtonStyle.red = "red"
+_discord_stub.ButtonStyle.blurple = "blurple"
+_discord_stub.ButtonStyle.grey = "grey"
+
+sys.modules.setdefault("discord", _discord_stub)
+sys.modules.setdefault("discord.ui", _discord_stub.ui)
+
+# PIL is an optional TUI dependency (image_widget.py); stub it so the
+# components package __init__.py can be fully imported in test context.
+sys.modules.setdefault("PIL", MagicMock())
+sys.modules.setdefault("PIL.Image", MagicMock())
+
+# Import after stub registration
+from loom.platform.discord.bot import _ConfirmView, LoomDiscordBot  # noqa: E402
+from loom.core.harness.middleware import ToolCall  # noqa: E402
+from loom.core.harness.permissions import TrustLevel  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_widget(future: "asyncio.Future[ConfirmDecision]"):
+    """Construct an InlineConfirmWidget bypassing Textual's __init__."""
+    from loom.platform.cli.tui.components.interactive_widgets import InlineConfirmWidget
+    widget = object.__new__(InlineConfirmWidget)
+    widget._tool_name = "write_file"
+    widget._trust_label = "GUARDED"
+    widget._args_preview = "path=/tmp/x"
+    widget._future = future
+    widget._resolved = False
+    return widget
+
+
+def _press(widget, button_id: str) -> None:
+    """Simulate a button press on the widget, patching remove() to avoid Textual context."""
+    event = MagicMock()
+    event.button.id = button_id
+    with patch.object(widget, "remove"):
+        widget.on_button_pressed(event)
+
+
+def _make_call() -> ToolCall:
+    return ToolCall(
+        tool_name="write_file",
+        args={"path": "/tmp/x", "content": "hello"},
+        trust_level=TrustLevel.GUARDED,
+        session_id="test",
+    )
+
+
+def _make_bot_stub(channel=None) -> LoomDiscordBot:
+    """Create a LoomDiscordBot instance without calling __init__."""
+    bot = object.__new__(LoomDiscordBot)
+    bot._active_confirmations = {}
+    mock_client = MagicMock()
+    mock_client.get_channel.return_value = channel
+    bot._client = mock_client
+    return bot
+
+
+# =====================================================================
+# 1–3: TUI — InlineConfirmWidget
+# =====================================================================
+
+class TestInlineConfirmWidget:
+
+    def test_allow_resolves_once(self):
+        loop = asyncio.new_event_loop()
+        future: asyncio.Future[ConfirmDecision] = loop.create_future()
+        widget = _make_widget(future)
+        _press(widget, "btn-allow")
+        assert future.result() == ConfirmDecision.ONCE
+        loop.close()
+
+    def test_lease_resolves_scope(self):
+        loop = asyncio.new_event_loop()
+        future: asyncio.Future[ConfirmDecision] = loop.create_future()
+        widget = _make_widget(future)
+        _press(widget, "btn-lease")
+        assert future.result() == ConfirmDecision.SCOPE
+        loop.close()
+
+    def test_auto_resolves_auto(self):
+        loop = asyncio.new_event_loop()
+        future: asyncio.Future[ConfirmDecision] = loop.create_future()
+        widget = _make_widget(future)
+        _press(widget, "btn-auto")
+        assert future.result() == ConfirmDecision.AUTO
+        loop.close()
+
+    def test_deny_resolves_deny(self):
+        loop = asyncio.new_event_loop()
+        future: asyncio.Future[ConfirmDecision] = loop.create_future()
+        widget = _make_widget(future)
+        _press(widget, "btn-deny")
+        assert future.result() == ConfirmDecision.DENY
+        loop.close()
+
+    def test_unknown_button_falls_back_to_deny(self):
+        loop = asyncio.new_event_loop()
+        future: asyncio.Future[ConfirmDecision] = loop.create_future()
+        widget = _make_widget(future)
+        _press(widget, "btn-something-unexpected")
+        assert future.result() == ConfirmDecision.DENY
+        loop.close()
+
+    def test_second_press_ignored(self):
+        """Pressing a second button must not overwrite the first decision."""
+        loop = asyncio.new_event_loop()
+        future: asyncio.Future[ConfirmDecision] = loop.create_future()
+        widget = _make_widget(future)
+        _press(widget, "btn-allow")
+        _press(widget, "btn-deny")  # should be ignored
+        assert future.result() == ConfirmDecision.ONCE
+        loop.close()
+
+    def test_remove_called_once_on_press(self):
+        loop = asyncio.new_event_loop()
+        future: asyncio.Future[ConfirmDecision] = loop.create_future()
+        widget = _make_widget(future)
+        remove_mock = MagicMock()
+        with patch.object(widget, "remove", remove_mock):
+            event = MagicMock()
+            event.button.id = "btn-allow"
+            widget.on_button_pressed(event)
+        remove_mock.assert_called_once()
+        loop.close()
+
+
+# =====================================================================
+# 4–6: Discord — _ConfirmView
+# =====================================================================
+
+class TestConfirmView:
+
+    async def test_allow_button_returns_once(self):
+        view = _ConfirmView(timeout=60.0)
+        interaction = AsyncMock()
+        await view.allow_button(interaction, MagicMock())
+        decision = await view.wait_decision()
+        assert decision == ConfirmDecision.ONCE
+
+    async def test_lease_button_returns_scope(self):
+        view = _ConfirmView(timeout=60.0)
+        interaction = AsyncMock()
+        await view.lease_button(interaction, MagicMock())
+        decision = await view.wait_decision()
+        assert decision == ConfirmDecision.SCOPE
+
+    async def test_auto_button_returns_auto(self):
+        view = _ConfirmView(timeout=60.0)
+        interaction = AsyncMock()
+        await view.auto_button(interaction, MagicMock())
+        decision = await view.wait_decision()
+        assert decision == ConfirmDecision.AUTO
+
+    async def test_deny_button_returns_deny(self):
+        view = _ConfirmView(timeout=60.0)
+        interaction = AsyncMock()
+        await view.deny_button(interaction, MagicMock())
+        decision = await view.wait_decision()
+        assert decision == ConfirmDecision.DENY
+
+    async def test_timeout_falls_back_to_deny(self):
+        view = _ConfirmView(timeout=60.0)
+        await view.on_timeout()
+        decision = await view.wait_decision()
+        assert decision == ConfirmDecision.DENY
+
+    async def test_wait_decision_without_set_falls_back_to_deny(self):
+        """If _decision is never set (edge case), wait_decision returns DENY."""
+        view = _ConfirmView(timeout=60.0)
+        # Manually signal done without setting _decision
+        view._done.set()
+        decision = await view.wait_decision()
+        assert decision == ConfirmDecision.DENY
+
+
+# =====================================================================
+# 7–11: Discord — _make_confirm_fn
+# =====================================================================
+
+class TestMakeConfirmFn:
+
+    async def test_channel_none_returns_deny_no_send(self):
+        bot = _make_bot_stub(channel=None)
+        confirm_fn = bot._make_confirm_fn(thread_id=42)
+        result = await confirm_fn(_make_call())
+        assert result == ConfirmDecision.DENY
+        bot._client.get_channel.assert_called_once_with(42)
+
+    async def test_once_decision_no_followup(self):
+        channel = AsyncMock()
+        bot = _make_bot_stub(channel=channel)
+        confirm_fn = bot._make_confirm_fn(thread_id=1)
+
+        with patch(
+            "loom.platform.discord.bot._ConfirmView.wait_decision",
+            new=AsyncMock(return_value=ConfirmDecision.ONCE),
+        ):
+            result = await confirm_fn(_make_call())
+
+        assert result == ConfirmDecision.ONCE
+        # Only one send: the prompt — no follow-up
+        assert channel.send.call_count == 1
+
+    async def test_deny_decision_no_followup(self):
+        channel = AsyncMock()
+        bot = _make_bot_stub(channel=channel)
+        confirm_fn = bot._make_confirm_fn(thread_id=1)
+
+        with patch(
+            "loom.platform.discord.bot._ConfirmView.wait_decision",
+            new=AsyncMock(return_value=ConfirmDecision.DENY),
+        ):
+            result = await confirm_fn(_make_call())
+
+        assert result == ConfirmDecision.DENY
+        assert channel.send.call_count == 1
+
+    async def test_scope_decision_posts_ttl_followup(self):
+        channel = AsyncMock()
+        bot = _make_bot_stub(channel=channel)
+        confirm_fn = bot._make_confirm_fn(thread_id=1)
+
+        with patch(
+            "loom.platform.discord.bot._ConfirmView.wait_decision",
+            new=AsyncMock(return_value=ConfirmDecision.SCOPE),
+        ):
+            result = await confirm_fn(_make_call())
+
+        assert result == ConfirmDecision.SCOPE
+        # Prompt + follow-up = 2 sends
+        assert channel.send.call_count == 2
+        followup_text: str = channel.send.call_args_list[1][0][0]
+        assert "30 minutes" in followup_text
+        assert "write_file" in followup_text
+
+    async def test_auto_decision_posts_permanent_grant_followup(self):
+        channel = AsyncMock()
+        bot = _make_bot_stub(channel=channel)
+        confirm_fn = bot._make_confirm_fn(thread_id=1)
+
+        with patch(
+            "loom.platform.discord.bot._ConfirmView.wait_decision",
+            new=AsyncMock(return_value=ConfirmDecision.AUTO),
+        ):
+            result = await confirm_fn(_make_call())
+
+        assert result == ConfirmDecision.AUTO
+        assert channel.send.call_count == 2
+        followup_text: str = channel.send.call_args_list[1][0][0]
+        assert "auto" in followup_text.lower() or "permanent" in followup_text.lower()
+        assert "write_file" in followup_text
+
+    async def test_active_confirmations_cleared_after_decision(self):
+        """_active_confirmations entry must be removed even if an exception occurs."""
+        channel = AsyncMock()
+        bot = _make_bot_stub(channel=channel)
+        confirm_fn = bot._make_confirm_fn(thread_id=99)
+
+        with patch(
+            "loom.platform.discord.bot._ConfirmView.wait_decision",
+            new=AsyncMock(return_value=ConfirmDecision.ONCE),
+        ):
+            await confirm_fn(_make_call())
+
+        assert 99 not in bot._active_confirmations


### PR DESCRIPTION
## Summary

Closes #104. Extends the tool confirmation dialog on **TUI** and **Discord** to match the CLI's four-option `y/s/a/N` prompt introduced in #88 / #102.

- **TUI** (`InlineConfirmWidget`): adds ⏱ Lease and ⚡ Auto buttons; widget layout changed to `vertical` to fit four buttons + hint text; `future` type updated to `asyncio.Future[ConfirmDecision]`
- **Discord** (`_ConfirmView`): adds Lease (blurple) and Auto (grey) buttons; `wait_decision()` now returns `ConfirmDecision`; `_make_confirm_fn` posts a follow-up message on SCOPE/AUTO decisions showing TTL or permanent grant info
- **No middleware changes** — `_normalize_decision()` already handles `bool | ConfirmDecision`

## Changed files

| File | Change |
|------|--------|
| `loom/platform/cli/tui/components/interactive_widgets.py` | 4-button widget, `ConfirmDecision` future |
| `loom/platform/cli/main.py` | `_tui_confirm` returns `ConfirmDecision` |
| `loom/platform/discord/bot.py` | `_ConfirmView` + `_make_confirm_fn` upgrade |

## Test plan

- [ ] **TUI**: trigger a GUARDED tool call in `loom chat --tui` — confirm the inline widget shows four buttons with hint text; verify each button resolves correctly (ONCE / SCOPE / AUTO / DENY)
- [ ] **TUI lease**: click ⏱ Lease — confirm subsequent calls to the same scope are auto-approved for 30 min without re-prompting
- [ ] **TUI auto**: click ⚡ Auto — confirm all future calls of that tool class skip confirmation
- [ ] **Discord**: trigger a GUARDED call in a Discord thread — confirm the message shows four buttons (Allow / Lease / Auto / Deny)
- [ ] **Discord lease**: click Lease — confirm follow-up message shows "30 minutes" TTL
- [ ] **Discord auto**: click Auto — confirm follow-up message describes permanent grant
- [ ] **Discord timeout**: wait 60s — confirm decision falls back to DENY
- [ ] **Unit tests**: `pytest tests/` passes (excluding pre-existing `test_session.py::test_start_loads_mcp_servers_into_session` failure unrelated to this PR)

## Notes for reviewers

- `_LEASE_TTL_MIN = 30` in `_make_confirm_fn` is intentionally a local constant mirroring `BlastRadiusMiddleware._SCOPE_LEASE_TTL = 30 * 60` — kept close to the display logic rather than importing a private class constant
- Discord `ButtonStyle.blurple` maps to Discord's brand blue, chosen to visually distinguish "temporary grant" from "permanent" (grey) and "allow once" (green)
- The existing `bool`-returning path via `_normalize_decision()` remains fully intact; no regression for any caller that still passes `True`/`False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)