### PR TITLE
feat(palace): Memory Palace TUI — Phase 1 MVP

### DIFF
--- a/doc/memory_palace_plan.md
+++ b/doc/memory_palace_plan.md
@@ -1,0 +1,343 @@
+# 記憶宮殿 TUI — 開發規劃文件
+
+> **狀態**: 確認中 · 準備開發  
+> **作者**: 絲繹・Loom  
+> **日期**: 2026-04-12  
+> ** Loom 版本**: v0.4+
+
+---
+
+## 1. 背景與動機
+
+### 現況
+現有的 `loom memory list` 指令僅提供 `SemanticMemory.list_recent()` 的純文字輸出，無分層、無視覺化，難以駕馭快速成長的記憶系統。
+
+### 目標
+打造一個獨立於 Loom Chat TUI 的紫色記憶宮殿（Memory Palace）TUI，提供沉浸式的記憶探索體驗。
+
+### 約束（不改動原架構）
+- ✅ 只對記憶 DB 進行唯讀存取
+- ✅ 不修改 `loom/core/memory/` 下的任何類別
+- ✅ 不修改 `loom/platform/cli/tui/` 現有元件
+- ✅ 新功能透過 `loom palace` 指令觸發，獨立运行，不影響聊天 TUI
+
+---
+
+## 2. 設計語言
+
+### 色彩系統（記憶宮殿紫色系）
+
+```css
+/* 背景層次 */
+--palace-bg:        #0d0a1a   /* 深紫黑：screen 背景 */
+--palace-surface:   #150d28   /* 深紫：面板 surface */
+--palace-raised:    #1e1238   /* 紫灰：卡片/元件 */
+--palace-border:    #3d2a6b   /* 中紫：邊界線 */
+
+/* 文字 */
+--palace-text:      #e8deff   /* 淡紫白：主要文字 */
+--palace-muted:     #9b87b5   /* 灰紫：次要文字 */
+--palace-gold:      #d4a853   /* 金色：標題/強調（與 Loom 主題呼應）*/
+
+/* 信任/狀態 */
+--palace-high:      #a78bfa   /* 亮紫：high confidence */
+--palace-mid:       #c084fc   /* 中紫：medium */
+--palace-low:       #7c3aed   /* 深紫：low / 衰減 */
+--palace-gold-alt:  #e9c46a   /* 金黃：成功 */
+--palace-rose:      #f87171   /* 玫瑰：錯誤/刪除 */
+--palace-slate:     #64748b   /* 暗灰：disabled */
+```
+
+### 字體與裝飾
+- 標題：使用 `❖`（Loom 既有符号）+ 紫色星光意象
+- 分隔線：`✦` 小星星裝飾
+- 面板標題：反向高亮（`[reverse #9b59b6] text [/reverse]`)
+- 圖標：純文字 Unicode，`⟡` 連接、`◈` 實心、`✧` 空心
+
+### 動效哲學
+- 面板切換：instant（不改變佈局）
+- 搜尋結果：staggered fade-in（每項 30ms delay）
+
+---
+
+## 3. 記憶類型視圖
+
+### 3.1 Semantic Memory（語義宮殿）
+> 入口景觀廳 — 所有 facts 的總覽
+
+**呈現方式**：
+- 頂部：統計卡片（總數量、高/中/低信心分布、衰減警示）
+- 主體：可排序列表（按 key / confidence / updated_at / source）
+- 每筆記錄：
+  ```
+  ◈ project:loom:memory_schema
+    語意記憶使用 SQLite FTS5 支持模糊匹配。
+    [信任: 0.92] [source: session:*] [更新: 3天前]
+  ```
+- 支援點擊 key 展開 history（如有覆寫，顯示前 3 筆舊值）
+
+**視圖模式**：
+- `Browse`：按 key 前綴分組（`skill:*`、`project:*`、`session:*`）
+- `Search`：即時 BM25 搜尋（透過 MemorySearch.recall）
+- `Health`：信心低於 0.3 的長尾項目
+
+### 3.2 Relational Memory（關係星圖）
+> 星圖視圖 — 主語關係網絡
+
+**呈現方式**：
+- 頂部：主語列表（按 triples 數量排序）
+- 選擇主語後：謂語列表
+- 每條記錄：
+  ```
+  [user] ──prefers──▶ concise responses
+             │              [conf: 1.0]
+             ├──uses────────▶ SQLite WAL
+             └──avoids──────▶ trailing summaries
+  ```
+
+**視圖模式**：
+- `Subjects`：所有主語列表，選擇後展開其所有 predicate
+- `Graph`：文本化的 triple 視圖
+- `Predicates`：按謂語聚合，查詢所有具有該關係的主語
+
+### 3.3 Episodic Memory（時光迴廊）
+> 時光迴廊 — 對話歷史
+
+**呈現方式**：
+- 頂部：Sessions 列表（按 last_active 排序）
+- 選擇 session 後：turn timeline
+- 每個 turn：
+  ```
+  Turn 3  2026-04-12 15:40
+  you>  幫我建立一個新技能...
+  ↳  loom>  ⟳ write_file — "skills/new_skill.md"
+           ✓  1,240ms
+           ⟳ recall — "skills workflow"
+           ✓    89ms
+       好的，我來幫你建立這個技能...
+  ```
+
+### 3.4 Skill Genomes（技能基因庫）
+> 技能基因庫 — 技能表現
+
+**呈現方式**：
+- 按 confidence 排序的技能卡片
+- 每張卡片：
+  ```
+  ✧ systematic_code_analyst
+    用於陌生程式碼庫的結構化分析...
+    [conf: 0.85] [used: 47×] [success: 91%]
+    tags: [code_analysis] [agent_builtin]
+  ```
+
+**視圖模式**：
+- `Active`：usage_count > 0
+- `Failing`：success_rate < 0.6
+- `Evolving`：confidence 在下降中
+
+### 3.5 Memory Health（宮殿體檢）
+> 宮殿體檢 — 記憶系統總覽
+
+**呈現方式**：
+- 四宮格面板：
+  ```
+  ┌─────────────────┬─────────────────┐
+  │  Semantic       │  Relational     │
+  │  1,247 facts    │  89 triples     │
+  │  ↑ 12 today     │  ↑ 3 today      │
+  ├─────────────────┼─────────────────┤
+  │  Skills         │  Sessions       │
+  │  11 active      │  34 logged      │
+  │  ⚠ 2 failing    │  3h ago active  │
+  └─────────────────┴─────────────────┘
+  ```
+- 衰減預警列表：即將低於 threshold 的 semantic entries
+- 矛盾檢測摘要（如有）
+
+---
+
+## 4. 導航架構
+
+### 輸入/輸出結構
+
+```
+┌──────────────────────────────────────────────┐
+│ ❖ Memory Palace           [?] [F1: Help]      │  ← Header
+├──────────────┬───────────────────────────────┤
+│              │                               │
+│  NAV SIDEBAR │   CONTENT AREA                │
+│  40% width   │   60% width                  │
+│              │                               │
+│  Semantic    │   [視圖內容]                  │
+│  Relational  │                               │
+│  Episodic    │                               │
+│  Skills      │                               │
+│  ─────────── │                               │
+│  Health      │                               │
+│              │                               │
+├──────────────┴───────────────────────────────┤
+│ Status: 1,247 facts · 89 triples · 34 sessions│  ← Status Bar
+└──────────────────────────────────────────────┘
+```
+
+### 快捷鍵
+
+| 按鍵 | 功能 |
+|------|------|
+| `Tab` | 切換 Content Area 內的視圖模式 |
+| `↑/↓` | 導航列表 |
+| `Enter` | 展開/進入 |
+| `Esc` | 返回上一層 |
+| `Ctrl+F` | 聚焦搜尋框 |
+| `1-5` | 快速切換記憶類型（數字鍵） |
+| `F1` | 幫助面板 |
+| `Ctrl+Q` | 退出 |
+
+---
+
+## 5. 實作規劃
+
+### Phase 1：核心框架（MVP）
+
+**目標**：最小可用版本，專注 Semantic 和 Health 兩個視圖
+
+| 元件 | 說明 |
+|------|------|
+| `loom/palace/` | 新套件，所有記憶宮殿相關程式碼 |
+| `loom/palace/__init__.py` | 套件導出 |
+| `loom/palace/app.py` | Textual App 實例 + CSS theme |
+| `loom/palace/components/` | 元件目錄 |
+| `loom/palace/components/header.py` | 宮殿頂部標題列 |
+| `loom/palace/components/nav.py` | 左側導航側邊欄 |
+| `loom/palace/components/status.py` | 底部狀態列 |
+| `loom/palace/components/semantic_view.py` | Semantic 視圖 |
+| `loom/palace/components/health_view.py` | Health 概覽視圖 |
+| `loom/palace/components/relational_view.py` | Relational 視圖 |
+| `loom/palace/components/episodic_view.py` | Episodic 視圖 |
+| `loom/palace/components/skills_view.py` | Skills 視圖 |
+| `loom/palace/search.py` | PalaceSearch 協調層 |
+
+### Phase 2：深化功能
+
+- 即時 BM25 搜尋（透過 SemanticMemory.search() + FTS5）
+- Episodic Session Timeline 展開
+- 點擊 key 展開覆寫 history
+- 信心熱力圖（gradient）
+
+### Phase 3：增強體驗
+
+- 面板內 sub-filter（各視圖內的即時過濾）
+- 記憶豐度報告（基於 SemanticEntry.effective_confidence）
+- 矛盾檢測摘要整合（Contradiction API）
+
+---
+
+## 6. CLI 整合
+
+### 新增指令
+
+```bash
+# 進入記憶宮殿（預設開啟 Semantic 視圖）
+loom palace
+
+# 直接指定視圖
+loom palace --view semantic
+loom palace --view relational
+loom palace --view episodic
+loom palace --view skills
+loom palace --view health
+
+# 快速查看（無 TUI，直接 Rich 輸出）
+loom palace --stat
+loom palace --search "loops" --type semantic --limit 20
+```
+
+### 與現有指令的互補關係
+
+| 現有指令 | Memory Palace 的差異 |
+|----------|---------------------|
+| `loom memory list` | 純文字列表 → 互動式多視圖 TUI |
+| `loom sessions list` | 整合入 Episodic 視圖，提供 timeline |
+| `loom reflect` | 提供 Skill Health 視圖的視覺化版本 |
+
+---
+
+## 7. 技術實現要點
+
+### 架構決策
+
+**跨視圖搜尋策略：借用 + 組合，不重造輪子**
+
+現有系統已有一層完整的搜尋基礎，記憶宮殿只需要一個薄的協調層：
+
+```
+PalaceSearch (協調層)
+    ├── Semantic  → MemorySearch.recall(type="semantic")  [直接用]
+    ├── Skills    → MemorySearch.recall(type="skill")      [直接用]
+    ├── Relational→ RelationalMemory.query() + LIKE         [簡單擴充]
+    └── Sessions  → SessionLog.load_messages() + FTS LIKE  [簡單擴充]
+```
+
+- Semantic / Skills：直接使用 `MemorySearch.recall()`，FTS5 + BM25 現成
+- Relational：RelationalMemory 沒有 FTS5 virtual table，直接用 SQL LIKE（足夠記憶宮殿探索粒度）
+- Sessions：SessionLog 沒有全文索引，用 SQL LIKE 查 content 欄位
+
+**不為記憶宮殿另建 FTS5 table** — 原有的 FTS5 鏡像表（`semantic_fts`、`skill_fts`）已足夠。
+
+### Textual 模式
+- 繼承 `App`（非 LoomApp），獨立於聊天 TUI
+- 使用 `Vertical` + `Horizontal` 容器佈局
+- 所有 CSS 在 `app.py` 的 `CSS` class 變數中定義
+
+### 資料存取策略
+- 透過 `SQLiteStore.connect()` 取得連接（唯讀操作）
+- 各視圖 components 在 `on_mount` 時初始化 `SemanticMemory`、`RelationalMemory` 等
+- DB 查詢在 worker thread 避免阻塞 UI
+
+### 效能考量
+- 首次 `on_mount` 只抓 top-N（limit=100），其餘懶載入
+- 大列表（>500 筆）使用 `ListView` + 虛擬化
+- 不引入額外相依（僅使用 Loom 既有 `aiosqlite`, `textual`）
+
+---
+
+## 8. 成功標準
+
+- [ ] `loom palace` 指令可正常啟動，紫色主題完整呈現
+- [ ] Semantic View 顯示 list_recent() 結果，含信心顏色標示
+- [ ] Health View 顯示四宮格統計
+- [ ] `loom palace --view relational` 直接開啟關係視圖
+- [ ] 側邊導航可在五個記憶類型間流暢切換
+- [ ] 不修改任何 `loom/core/memory/` 或 `loom/platform/cli/tui/` 現有檔案
+
+---
+
+## 9. 已確認的設計決策
+
+| 決策 | 結論 |
+|------|------|
+| 指令命名 | `loom palace` |
+| 與聊天 TUI 關係 | 完全獨立套件，单独運行 |
+| Theme 共享 | 不共享，未來有需要再規劃 |
+| 即時性 | 不需要，聊天 TUI 和記憶宮殿不會同時開啟 |
+| 跨視圖搜尋 | 需要，策略：借用現有 MemorySearch + 薄協調層 |
+| FTS5 新建 | 不需要，relational 用 SQL LIKE 即可 |
+
+---
+
+## 10. 已確認的開發順序
+
+**Phase 1**（本輪實作）：
+1. 入口指令 + 紫色 theme scaffold（`loom palace` 指令掛鉤、`PalaceApp` 框架）
+2. Semantic View（列表 + 信心顏色 + 排序）
+3. 左側 Nav sidebar（五個視圖切換）
+4. Health 四宮格
+
+**Phase 2**（下一輪）：
+5. Relational View
+6. Episodic View
+7. Cross-view search 整合（PalaceSearch 協調層）
+
+**Phase 3**（最後）：
+8. Skills View
+9. History 展開、sub-filter 等細節打磨

--- a/loom/palace/__init__.py
+++ b/loom/palace/__init__.py
@@ -1,0 +1,10 @@
+"""
+Memory Palace — Textual TUI for exploring Loom's memory store.
+
+Independent from the Chat TUI; uses a purple theme to visually
+distinguish it from the parchment-themed chat interface.
+"""
+
+from .app import PalaceApp
+
+__all__ = ["PalaceApp"]

--- a/loom/palace/app.py
+++ b/loom/palace/app.py
@@ -1,0 +1,208 @@
+"""
+PalaceApp — main Textual application for the Memory Palace TUI.
+
+Independent from the Chat TUI; uses a purple theme.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Static
+
+from .theme import CSS
+from .search import PalaceSearch
+from .components import (
+    PalaceHeader,
+    NavSidebar,
+    PalaceStatusBar,
+    SemanticView,
+    HealthView,
+    RelationalView,
+    EpisodicView,
+    SkillsView,
+)
+from .components.nav import PalaceSection
+
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+
+class PalaceApp(App):
+    """
+    Memory Palace — interactive TUI for exploring Loom's memory store.
+
+    Layout:
+        PalaceHeader        (dock top, 2 rows)
+        Horizontal body
+            NavSidebar       (38 cols)
+            #content-area    (1fr) — contains the active view
+        PalaceStatusBar     (dock bottom, 1 row)
+
+    Bindings:
+        1-5:    switch section
+        Ctrl+F: focus search
+        Esc:    reset / back to semantic
+        Ctrl+R: refresh
+        Ctrl+Q: quit
+    """
+
+    CSS = CSS
+
+    BINDINGS = [
+        Binding("ctrl+q", "quit", "Quit", show=True, priority=True),
+        Binding("escape", "reset_view", "Back", show=True),
+        Binding("ctrl+f", "focus_search", "Search", show=True),
+        Binding("ctrl+r", "refresh", "Refresh", show=True),
+        Binding("1", "section_1", "", show=False),
+        Binding("2", "section_2", "", show=False),
+        Binding("3", "section_3", "", show=False),
+        Binding("4", "section_4", "", show=False),
+        Binding("5", "section_5", "", show=False),
+    ]
+
+    def __init__(self, db_path: str = "~/.loom/memory.db", initial_view: str = "semantic") -> None:
+        super().__init__()
+        self._db_path = str(Path(db_path).expanduser().resolve())
+        self._db: "aiosqlite.Connection | None" = None
+        self._search: "PalaceSearch | None" = None
+        # Resolve initial_view string to PalaceSection
+        try:
+            self._initial_section = PalaceSection(initial_view)
+        except ValueError:
+            self._initial_section = PalaceSection.SEMANTIC
+
+    # ── App lifecycle ────────────────────────────────────────────────────────
+
+    def compose(self) -> ComposeResult:
+        """Build the full UI tree."""
+        yield PalaceHeader()
+        with Horizontal(id="body"):
+            yield NavSidebar()
+            # Content container — always visible, children are shown/hidden
+            with Vertical(id="content-area"):
+                pass  # views mounted in on_mount
+        yield PalaceStatusBar()
+
+    async def on_mount(self) -> None:
+        """Connect DB and mount all views."""
+        import aiosqlite
+
+        self._db = await aiosqlite.connect(self._db_path)
+        self._db.row_factory = aiosqlite.Row
+        self._search = PalaceSearch(self._db)
+
+        # Mount all views into the content-area container
+        content = self.query_one("#content-area", Vertical)
+        views: list[object] = [
+            SemanticView(self._search),
+            HealthView(self._search),
+            RelationalView(self._search),
+            EpisodicView(self._search),
+            SkillsView(self._search),
+        ]
+        view_map = {
+            PalaceSection.SEMANTIC:    views[0],
+            PalaceSection.HEALTH:      views[1],
+            PalaceSection.RELATIONAL:  views[2],
+            PalaceSection.EPISODIC:    views[3],
+            PalaceSection.SKILLS:      views[4],
+        }
+        # Store by section name for lookup
+        self._views = {s.value: v for s, v in view_map.items()}
+        self._all_views = view_map  # full reference
+
+        for v in views:
+            content.mount(v)
+            v.display = False  # all hidden until selected
+
+        # Store nav and status references
+        self._nav = self.query_one("NavSidebar", NavSidebar)
+        self._status = self.query_one("PalaceStatusBar", PalaceStatusBar)
+
+        # Wire nav → section switch via message subscription
+        self._nav.on_section_selected = self._on_nav_section  # type: ignore[assignment]
+
+        # Show semantic by default (nav's on_mount calls select(SEMANTIC)
+        # which posts SectionSelected, triggering _on_nav_section)
+        # We just call _show_section directly to be safe
+        await self._show_section(self._initial_section)
+
+        # Load status bar stats
+        await self._update_status_bar()
+
+    async def _on_nav_section(self, section: PalaceSection) -> None:
+        """Handle NavSidebar.SectionSelected message."""
+        await self._show_section(section)
+
+    async def _show_section(self, section: PalaceSection) -> None:
+        """Switch visible content view."""
+        for s, v in self._all_views.items():
+            v.display = (s == section)
+        self._active_section = section
+        self._nav.select(section)
+
+    async def _update_status_bar(self) -> None:
+        """Refresh the bottom status bar with live stats."""
+        if self._search is None:
+            return
+        try:
+            sem = await self._search.semantic_stats()
+            rel = await self._search.relational_stats()
+            ski = await self._search.skill_stats()
+            ses = await self._search.session_stats()
+            self._status.update(
+                semantic=sem.get("total", 0),
+                relational=rel.get("total", 0),
+                skills=ski.get("total", 0),
+                sessions=ses.get("total", 0),
+                active_section=self._active_section.value,
+            )
+        except Exception:
+            pass
+
+    # ── Actions ───────────────────────────────────────────────────────────────
+
+    def action_section_1(self) -> None: self._nav.select(PalaceSection.SEMANTIC)
+    def action_section_2(self) -> None: self._nav.select(PalaceSection.RELATIONAL)
+    def action_section_3(self) -> None: self._nav.select(PalaceSection.EPISODIC)
+    def action_section_4(self) -> None: self._nav.select(PalaceSection.SKILLS)
+    def action_section_5(self) -> None: self._nav.select(PalaceSection.HEALTH)
+
+    def action_focus_search(self) -> None:
+        """Show search hint notification."""
+        section_labels = {
+            "semantic": "Type to filter semantic entries by key or value",
+            "relational": "Search relational triples",
+            "episodic": "Search session history",
+            "skills": "Search skill genomes",
+            "health": "Health view — no search",
+        }
+        msg = section_labels.get(self._active_section.value, "")
+        if msg:
+            self.notify(f"[dim]{msg}[/dim]", timeout=3)
+
+    def action_reset_view(self) -> None:
+        """Esc: go back to Semantic if not already there."""
+        if self._active_section != PalaceSection.SEMANTIC:
+            self._nav.select(PalaceSection.SEMANTIC)
+
+    def action_refresh(self) -> None:
+        """Ctrl+R: reload current view's data."""
+        view = self._all_views.get(self._active_section)
+        if view and hasattr(view, "refresh"):
+            view.reload()  # type: ignore[union-attr]
+        asyncio.create_task(self._update_status_bar())
+        self.notify("[dim]Refreshed.[/dim]", timeout=1)
+
+    # ── Cleanup ───────────────────────────────────────────────────────────────
+
+    async def on_unmount(self) -> None:
+        if self._db:
+            await self._db.close()

--- a/loom/palace/components/__init__.py
+++ b/loom/palace/components/__init__.py
@@ -1,0 +1,23 @@
+"""
+Palace components — individual views and shared widgets.
+"""
+
+from .header import PalaceHeader
+from .nav import NavSidebar
+from .status import PalaceStatusBar
+from .semantic_view import SemanticView
+from .health_view import HealthView
+from .relational_view import RelationalView
+from .episodic_view import EpisodicView
+from .skills_view import SkillsView
+
+__all__ = [
+    "PalaceHeader",
+    "NavSidebar",
+    "PalaceStatusBar",
+    "SemanticView",
+    "HealthView",
+    "RelationalView",
+    "EpisodicView",
+    "SkillsView",
+]

--- a/loom/palace/components/episodic_view.py
+++ b/loom/palace/components/episodic_view.py
@@ -1,0 +1,249 @@
+"""
+EpisodicView — browse session history (episodic memory + session logs).
+
+Key design (mirrors SemanticView):
+  - Uses ListView for virtualised rendering.
+  - Two modes: session-list mode and turn-detail mode (controlled by
+    self._selected_session).
+  - Click a session to expand into turn timeline.
+  - Batched append via call_next for session list load.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.message import Message
+from textual.widgets import ListView, ListItem, Static
+
+if TYPE_CHECKING:
+    from loom.palace.search import PalaceSearch
+
+
+@dataclass
+class SessionDisplay:
+    session_id: str
+    title: str
+    model: str
+    started_at: str
+    last_active: str
+    turn_count: int
+
+
+@dataclass
+class TurnDisplay:
+    turn_index: int
+    role: str
+    content: str
+    created_at: str
+
+
+class EpisodicView(Vertical):
+    """
+    Session history explorer.
+
+    Two modes:
+      - Session list: shows all sessions, click to expand.
+      - Turn timeline: shows turns for a selected session.
+    Escape returns to session list.
+    """
+
+    DEFAULT_CSS = """
+    EpisodicView {
+        height: 1fr;
+        layout: vertical;
+        overflow: hidden;
+    }
+    EpisodicView ListView {
+        height: 1fr;
+        background: #0d0a1a;
+    }
+    """
+
+    class Loaded(Message):
+        pass
+
+    def __init__(self, search: "PalaceSearch") -> None:
+        super().__init__()
+        self._search = search
+        self._sessions: list[SessionDisplay] = []
+        self._selected_session: str | None = None
+        self._turns: list[TurnDisplay] = []
+        self._batch_index = 0
+
+    def _render(self) -> "Content":
+        from textual.content import Content
+        return Content.from_markup("")
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            "[bold #d4a853]◌ Episodic Memory[/bold #d4a853]  "
+            "[dim]— session history and turns[/dim]",
+            id="epi-header",
+            classes="content-title",
+        )
+        yield Static("", id="epi-subtitle", classes="content-subtitle")
+        yield ListView(id="epi-list")
+
+    # ── Mount / load ─────────────────────────────────────────────────────────
+
+    def on_mount(self) -> None:
+        self._load_async()
+
+    async def _load_async(self) -> None:
+        db = self._search._db
+        cursor = await db.execute(
+            """
+            SELECT session_id, title, model, started_at, last_active, turn_count
+            FROM sessions
+            ORDER BY last_active DESC
+            LIMIT 100
+            """
+        )
+        rows = await cursor.fetchall()
+        self._sessions = [
+            SessionDisplay(
+                session_id=r[0],
+                title=r[1] or "(no title)",
+                model=r[2],
+                started_at=r[3],
+                last_active=r[4],
+                turn_count=r[5],
+            )
+            for r in rows
+        ]
+        self._start_batched_session_load()
+
+    # ── Batched session list population ───────────────────────────────────────
+
+    def _start_batched_session_load(self) -> None:
+        lv = self.query_one("#epi-list", ListView)
+        lv.clear()
+        self._selected_session = None
+        self._batch_index = 0
+
+        subtitle = self.query_one("#epi-subtitle", Static)
+        subtitle.update(f"[dim]{len(self._sessions)} sessions[/dim]")
+
+        first = min(50, len(self._sessions))
+        self._append_session_batch(lv, self._sessions[:first])
+        self._batch_index = first
+
+        if self._batch_index < len(self._sessions):
+            self._schedule_next_session_batch(lv)
+        else:
+            self.post_message(self.Loaded())
+
+    def _schedule_next_session_batch(self, lv: ListView) -> None:
+        async def _tick() -> None:
+            batch_size = 50
+            start = self._batch_index
+            end   = min(start + batch_size, len(self._sessions))
+            self._append_session_batch(lv, self._sessions[start:end])
+            self._batch_index = end
+            if self._batch_index < len(self._sessions):
+                self._schedule_next_session_batch(lv)
+            else:
+                self.post_message(self.Loaded())
+
+        self.call_next(_tick)
+
+    def _append_session_batch(self, lv: ListView, sessions: list[SessionDisplay]) -> None:
+        for s in sessions:
+            la = s.last_active[:16].replace("T", " ") if s.last_active else "?"
+            label = (
+                f"[#60a5fa]{s.session_id[:8]}…[/]  "
+                f"[bold #e8deff]{s.title}[/bold #e8deff]\n"
+                f"[dim]model: {s.model}  ·  {s.turn_count} turns  ·  last: {la}[/dim]"
+            )
+            lv.append(ListItem(Static(label), id=f"session-{s.session_id[:40]}"))
+
+    # ── Session detail mode ───────────────────────────────────────────────────
+
+    async def _load_session_detail(self, session_id: str) -> None:
+        db = self._search._db
+        cursor = await db.execute(
+            """
+            SELECT role, content, created_at
+            FROM session_log
+            WHERE session_id = ?
+            ORDER BY id ASC
+            LIMIT 200
+            """,
+            (session_id,),
+        )
+        rows = await cursor.fetchall()
+
+        self._selected_session = session_id
+        self._turns = []
+        turn_index = -1
+        for role, content, created in rows:
+            content = str(content or "")
+            if not content.strip():
+                continue
+            if role == "user":
+                turn_index += 1
+            self._turns.append(TurnDisplay(
+                turn_index=turn_index if role == "user" else self._turns[-1].turn_index if self._turns else 0,
+                role=role,
+                content=content,
+                created_at=created or "",
+            ))
+
+        lv = self.query_one("#epi-list", ListView)
+        lv.clear()
+
+        subtitle = self.query_one("#epi-subtitle", Static)
+        subtitle.update(f"[bold #60a5fa]{session_id[:8]}…[/]  [dim]{len(rows)} entries[/dim]  [dim]← back[/dim]")
+
+        lv.append(ListItem(Static("[dim]← back to sessions[/dim]", id="epi-back"), id="epi-back-item"))
+
+        for t in self._turns:
+            lv.append(self._build_turn_item(t))
+        self.post_message(self.Loaded())
+
+    def _build_turn_item(self, t: TurnDisplay) -> ListItem:
+        ts = t.created_at[:16].replace("T", " ") if t.created_at else ""
+        if t.role == "user":
+            label = (
+                f"[dim]── Turn {t.turn_index}  {ts} ──[/dim]\n"
+                f"[#fbbf24]you>[/]  [dim]{t.content[:90]}[/dim]"
+            )
+        elif t.role == "assistant":
+            label = f"[#a78bfa]loom>[/]  [dim]{t.content[:110]}[/dim]"
+        elif t.role == "tool":
+            success = "✓" if "success" in t.content.lower() else "✗"
+            color = "#86efac" if success == "✓" else "#f87171"
+            label = f"   [dim]⟳[/]  [dim]{t.content[:90]}[/dim]  [{color}]{success}[/{color}]"
+        else:
+            label = f"[dim]{t.content[:100]}[/dim]"
+        return ListItem(Static(label))
+
+    # ── Interaction ───────────────────────────────────────────────────────────
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        try:
+            lv = self.query_one("#epi-list", ListView)
+            node = lv.children[lv.index]
+            item_id = node.id or ""
+        except Exception:
+            return
+
+        if self._selected_session is None:
+            if item_id.startswith("session-"):
+                session_id = item_id[len("session-"):]
+                import asyncio as _asyncio
+                _asyncio.create_task(self._load_session_detail(session_id))
+        else:
+            if item_id == "epi-back-item":
+                self._start_batched_session_load()
+
+    def back_to_sessions(self) -> None:
+        if self._selected_session is not None:
+            self._start_batched_session_load()
+
+    def reload(self) -> None:
+        self._load_async()

--- a/loom/palace/components/header.py
+++ b/loom/palace/components/header.py
@@ -1,0 +1,46 @@
+"""
+PalaceHeader — top bar for the Memory Palace TUI.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.widget import Widget
+from textual.widgets import Static
+
+
+class PalaceHeader(Widget):
+    """
+    Top-of-screen header for the Memory Palace.
+
+    Shows ❖ Memory Palace branding with gold accent and a hint line.
+    """
+
+    DEFAULT_CSS = """
+    PalaceHeader {
+        dock: top;
+        height: 2;
+        background: #150d28;
+        border-bottom: solid #3d2a6b;
+    }
+    #header-title {
+        width: auto;
+        content-align: left middle;
+        padding: 0 1;
+    }
+    #header-hints {
+        width: 1fr;
+        content-align: right middle;
+        padding: 0 1;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            "[bold #d4a853]❖[/bold #d4a853]  [bold #e8deff]Memory Palace[/bold #e8deff]  [dim]v0.4[/dim]",
+            id="header-title",
+        )
+        yield Static(
+            "[dim]↑↓[/dim] Navigate  [dim]·[/dim] [dim]Enter[/dim] Expand  [dim]·[/dim] [dim]Esc[/dim] Back  [dim]·[/dim] [dim]Ctrl+F[/dim] Search  [dim]·[/dim] [dim]Ctrl+Q[/dim] Quit",
+            id="header-hints",
+        )

--- a/loom/palace/components/health_view.py
+++ b/loom/palace/components/health_view.py
@@ -1,0 +1,224 @@
+"""
+HealthView — Memory Palace health dashboard.
+
+2×2 grid showing key stats for each memory type, plus
+a decay warning list at the bottom.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, VerticalScroll
+from textual.containers import Vertical
+from textual.widgets import Static
+from textual.content import Content
+
+if TYPE_CHECKING:
+    from loom.palace.search import PalaceSearch
+
+
+class HealthView(Vertical):
+    """
+    Memory palace health overview.
+
+    Shows 2×2 stat grid + decay warning list.
+    """
+
+    DEFAULT_CSS = '''
+    HealthView {
+        height: 1fr;
+        layout: vertical;
+        overflow: hidden;
+    }
+    .health-title {
+        margin-bottom: 1;
+    }
+    #health-grid {
+        layout: grid;
+        grid-size: 2 2;
+        grid-gutter: 1 2;
+        height: auto;
+        margin-bottom: 2;
+    }
+    .health-card {
+        background: #1e1238;
+        border: solid #3d2a6b;
+        padding: 1 2;
+        height: auto;
+    }
+    .health-card-title {
+        color: #d4a853;
+        text-style: bold;
+    }
+    .health-card-value {
+        color: #e8deff;
+        text-style: bold;
+        padding: 0 0;
+    }
+    .health-card-sub {
+        color: #9b87b5;
+    }
+    .health-good    { color: #86efac; }
+    .health-warning { color: #fbbf24; }
+    .health-danger  { color: #f87171; }
+    #decay-list {
+        height: 1fr;
+        overflow-y: auto;
+    }
+    .decay-card {
+        background: #150d28;
+        border-left: solid #7c3aed;
+        padding: 0 1 0 2;
+        margin-bottom: 1;
+    }
+    .decay-label { color: #9b87b5; }
+    '''
+
+    def __init__(self, search: "PalaceSearch") -> None:
+        super().__init__()
+        self._search = search
+        self._stats: dict[str, dict] = {}
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            "[bold #d4a853]✦ Memory Palace Health[/bold #d4a853]  "
+            "[dim]— overview of all memory systems[/dim]",
+            classes="health-title",
+        )
+        yield Static("[dim]Loading health data...[/dim]")
+        yield Horizontal(
+            Static("", classes="health-card", id="card-semantic"),
+            Static("", classes="health-card", id="card-relational"),
+            Static("", classes="health-card", id="card-skills"),
+            Static("", classes="health-card", id="card-sessions"),
+            id="health-grid",
+        )
+        yield Static(
+            "[bold #7c3aed]↘[/bold #7c3aed]  [dim]Decay warnings — effective confidence near threshold[/dim]",
+            classes="decay-label",
+            id="decay-header",
+        )
+        yield VerticalScroll(id="decay-list")
+
+    def on_mount(self) -> None:
+        self._load_async()
+
+    async def _load_async(self) -> None:
+        sem, rel, ski, ses = await self._fetch_all_stats()
+        self._stats = {
+            "semantic": sem,
+            "relational": rel,
+            "skills": ski,
+            "sessions": ses,
+    }
+        self._render()
+
+    async def _fetch_all_stats(self):
+        sem_task = self._search.semantic_stats()
+        rel_task = self._search.relational_stats()
+        ski_task = self._search.skill_stats()
+        ses_task = self._search.session_stats()
+
+        import asyncio as _asyncio
+        done = await _asyncio.gather(sem_task, rel_task, ski_task, ses_task,
+                                      return_exceptions=True)
+        return done[0], done[1], done[2], done[3]
+
+    def _render(self) -> Content:
+        sem = self._stats.get("semantic", {})
+        rel = self._stats.get("relational", {})
+        ski = self._stats.get("skills", {})
+        ses = self._stats.get("sessions", {})
+
+        # ── Semantic card ──────────────────────────────────────────────────
+        total = sem.get("total", 0)
+        high = sem.get("high", 0)
+        mid  = sem.get("mid", 0)
+        low  = sem.get("low", 0)
+        today = sem.get("today", 0)
+        trend_icon = "[#86efac]↑[/]" if today > 0 else "[dim]·[/]"
+        trend_text = f"[#86efac]+{today}[/#86efac] today" if today > 0 else "[dim]none today[/]"
+        self.query_one("#card-semantic", Static).update(
+            f"[bold #d4a853]◈ Semantic[/bold #d4a853]\n"
+            f"[bold #e8deff]{total:,}[bold]  [dim]facts[/dim]\n"
+            f"[#a78bfa]●[/] {high} high  [dim]·[/] [#c084fc]●[/] {mid} mid  [dim]·[/] [#7c3aed]●[/] {low} low\n"
+            f"[dim]{trend_icon} {trend_text}[/dim]"
+        )
+
+        # ── Relational card ─────────────────────────────────────────────────
+        r_total = rel.get("total", 0)
+        r_subj  = rel.get("subjects", 0)
+        r_today = rel.get("today", 0)
+        trend_icon = "[#86efac]↑[/]" if r_today > 0 else "[dim]·[/]"
+        self.query_one("#card-relational", Static).update(
+            f"[bold #d4a853]◉ Relational[/bold #d4a853]\n"
+            f"[bold #e8deff]{r_total:,}[bold]  [dim]triples[/dim]\n"
+            f"[dim]across {r_subj} subjects[/dim]\n"
+            f"[dim]{trend_icon} {r_today} added today[/dim]"
+        )
+
+        # ── Skills card ─────────────────────────────────────────────────────
+        s_total  = ski.get("total", 0)
+        s_active = ski.get("active", 0)
+        s_fail   = ski.get("failing", 0)
+        fail_cls  = "health-danger" if s_fail > 0 else "health-good"
+        fail_txt  = f"[#f87171]{s_fail} failing[/#f87171]" if s_fail > 0 else "[#86efac]none failing[/#86efac]"
+        self.query_one("#card-skills", Static).update(
+            f"[bold #d4a853]✧ Skills[/bold #d4a853]\n"
+            f"[bold #e8deff]{s_total:,}[bold]  [dim]genomes[/dim]\n"
+            f"[dim]{s_active} with usage[/dim]\n"
+            f"{fail_txt}"
+        )
+
+        # ── Sessions card ───────────────────────────────────────────────────
+        s_total2 = ses.get("total", 0)
+        s_last   = ses.get("last_active") or "unknown"
+        if s_last != "unknown":
+            s_last = s_last[:16].replace("T", " ")
+        self.query_one("#card-sessions", Static).update(
+            f"[bold #d4a853]◌ Sessions[/bold #d4a853]\n"
+            f"[bold #e8deff]{s_total2:,}[bold]  [dim]logged[/dim]\n"
+            f"[dim]last active:[/dim]\n"
+            f"[dim]{s_last}[/dim]"
+        )
+
+        # ── Decay warnings ──────────────────────────────────────────────────
+        self._load_decays()
+        return Content.from_markup("")
+
+    async def _load_decays(self) -> None:
+        """Show semantic entries with low effective confidence."""
+        db = self._search._db
+        cursor = await db.execute(
+            """
+            SELECT key, value, confidence, updated_at
+            FROM semantic_entries
+            WHERE confidence <= 0.35
+            ORDER BY confidence ASC, updated_at ASC
+            LIMIT 20
+            """
+        )
+        rows = await cursor.fetchall()
+
+        list_el = self.query_one("#decay-list", VerticalScroll)
+        list_el.remove_children()
+
+        if not rows:
+            list_el.mount(Static("[dim]No decay warnings — all entries healthy.[/dim]"))
+            return None  # will be replaced with Content by caller
+
+        for r in rows:
+            key, value, conf, updated = r
+            value_short = value[:80] + ("…" if len(value) > 80 else "")
+            card = Static(
+                f"[#7c3aed]{key}[/#7c3aed]\n"
+                f"[dim]{value_short}[/dim]\n"
+                f"[#f87171]conf={conf:.2f}[/#f87171]  [dim]updated: {updated[:10]}[/dim]",
+                classes="decay-card",
+            )
+            list_el.mount(card)
+
+    def reload(self) -> None:
+        self._load_async()

--- a/loom/palace/components/nav.py
+++ b/loom/palace/components/nav.py
@@ -1,0 +1,145 @@
+"""
+NavSidebar — left navigation panel for Memory Palace.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from textual.app import ComposeResult
+from textual.message import Message
+from textual.widget import Widget
+from textual.widgets import Static
+
+
+class PalaceSection(Enum):
+    SEMANTIC   = "semantic"
+    RELATIONAL = "relational"
+    EPISODIC   = "episodic"
+    SKILLS     = "skills"
+    HEALTH     = "health"
+
+
+class NavSidebar(Widget):
+    """
+    Left sidebar with five navigation items.
+    Click or press 1-5 to switch sections.
+    """
+
+    DEFAULT_CSS = '''
+    NavSidebar {
+        width: 38;
+        background: #150d28;
+        border-right: solid #3d2a6b;
+    }
+    #nav-list {
+        height: 1fr;
+        padding: 1 0;
+    }
+    .nav-item {
+        height: 3;
+        padding: 0 1;
+        content-align: left middle;
+    }
+    .nav-item:hover {
+        background: #1e1238;
+    }
+    .nav-active {
+        background: #2a1e50;
+    }
+    #nav-sep {
+        height: 1;
+        border-top: solid #3d2a6b;
+        margin: 1 0;
+    }
+    '''
+
+    class SectionSelected(Message, bubble=True):
+        def __init__(self, section: PalaceSection) -> None:
+            super().__init__()
+            self.section = section
+
+    NAV_ITEMS = [
+        (PalaceSection.SEMANTIC,   "◈", "Semantic",   "Facts & knowledge"),
+        (PalaceSection.RELATIONAL, "◉", "Relational",  "Subject → predicate → object"),
+        (PalaceSection.EPISODIC,   "◌", "Episodic",   "Session history & turns"),
+        (PalaceSection.SKILLS,     "✧", "Skills",     "Skill genomes & health"),
+        (PalaceSection.HEALTH,     "✦", "Health",     "Memory palace overview"),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._active: PalaceSection = PalaceSection.SEMANTIC
+        self._nav_widgets: dict[PalaceSection, Static] = {}
+
+    def compose(self) -> ComposeResult:
+        for section, icon, label, hint in self.NAV_ITEMS:
+            num = list(PalaceSection).index(section) + 1
+            widget_id = f"nav-{section.value}"
+            # Default to inactive style; select() will activate SEMANTIC on startup
+            yield Static(
+                f"[dim]{num}[/dim]  [#9b87b5]{icon}[/#9b87b5]  "
+                f"[#9b87b5]{label}[/#9b87b5]  [dim]{hint}[/dim]",
+                id=widget_id,
+                classes="nav-item",
+            )
+        yield Static("", id="nav-sep")
+
+    def on_mount(self) -> None:
+        # Populate _nav_widgets from the DOM now that compose() has run
+        self._nav_widgets = {}
+        for section, *_ in self.NAV_ITEMS:
+            widget_id = f"nav-{section.value}"
+            try:
+                self._nav_widgets[section] = self.query_one(f"#{widget_id}", Static)
+            except Exception:
+                pass
+
+        # Activate SEMANTIC by default
+        self.select(PalaceSection.SEMANTIC)
+
+    def select(self, section: PalaceSection) -> None:
+        """Programmatically switch to a section."""
+        if section not in self._nav_widgets:
+            return
+
+        # Deactivate current
+        old = self._nav_widgets.get(self._active)
+        if old:
+            old.classes = "nav-item"
+            for s, icon, label, hint in self.NAV_ITEMS:
+                if s == self._active:
+                    num = list(PalaceSection).index(s) + 1
+                    old.update(
+                        f"[dim]{num}[/dim]  [#9b87b5]{icon}[/#9b87b5]  "
+                        f"[#9b87b5]{label}[/#9b87b5]  [dim]{hint}[/dim]"
+                    )
+                    break
+
+        # Activate new
+        self._active = section
+        new = self._nav_widgets[section]
+        new.classes = "nav-item nav-active"
+        for s, icon, label, hint in self.NAV_ITEMS:
+            if s == section:
+                num = list(PalaceSection).index(s) + 1
+                new.update(
+                    f"[dim]{num}[/dim]  [#a78bfa]{icon}[/#a78bfa]  "
+                    f"[#e8deff]{label}[/#e8deff]  [dim]{hint}[/dim]"
+                )
+                break
+
+        self.post_message(self.SectionSelected(section))
+
+    def on_click(self, event) -> None:
+        """Map click y-position to section."""
+        index = event.y // 3
+        if 0 <= index < len(self.NAV_ITEMS):
+            section = self.NAV_ITEMS[index][0]
+            self.select(section)
+
+    def key_1(self) -> None: self.select(PalaceSection.SEMANTIC)
+    def key_2(self) -> None: self.select(PalaceSection.RELATIONAL)
+    def key_3(self) -> None: self.select(PalaceSection.EPISODIC)
+    def key_4(self) -> None: self.select(PalaceSection.SKILLS)
+    def key_5(self) -> None: self.select(PalaceSection.HEALTH)

--- a/loom/palace/components/relational_view.py
+++ b/loom/palace/components/relational_view.py
@@ -1,0 +1,175 @@
+"""
+RelationalView — browse relational (subject, predicate, object) triples.
+
+Key design (mirrors SemanticView):
+  - Uses ListView for virtualised rendering.
+  - Subjects listed first; clicking expands into predicate rows.
+  - Expansion is a mode switch — stored in self._expanded_subject.
+  - Batched loading via call_next for smooth UX with larger datasets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.message import Message
+from textual.widgets import ListView, ListItem, Static
+
+if TYPE_CHECKING:
+    from loom.palace.search import PalaceSearch
+
+
+@dataclass
+class TripleDisplay:
+    subject: str
+    predicate: str
+    object: str
+    confidence: float
+
+
+class RelationalView(Vertical):
+    """
+    Relational memory explorer.
+
+    Shows subjects (with triple count) in a list; click a subject to
+    expand into its predicates.  Back via pressing Escape or clicking
+    the back row.
+    """
+
+    DEFAULT_CSS = """
+    RelationalView {
+        height: 1fr;
+        layout: vertical;
+        overflow: hidden;
+    }
+    RelationalView ListView {
+        height: 1fr;
+        background: #0d0a1a;
+    }
+    """
+
+    class Loaded(Message):
+        pass
+
+    def __init__(self, search: "PalaceSearch") -> None:
+        super().__init__()
+        self._search = search
+        self._subjects: list[tuple[str, int]] = []
+        self._expanded_subject: str | None = None
+        self._expanded_triples: list[TripleDisplay] = []
+        self._batch_index = 0
+
+    def _render(self) -> "Content":
+        from textual.content import Content
+        return Content.from_markup("")
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            "[bold #d4a853]◉ Relational Memory[/bold #d4a853]  "
+            "[dim]— subject → predicate → object[/dim]",
+            id="rel-header",
+            classes="content-title",
+        )
+        yield Static("", id="rel-subtitle", classes="content-subtitle")
+        yield ListView(id="rel-list")
+
+    # ── Mount / load ─────────────────────────────────────────────────────────
+
+    def on_mount(self) -> None:
+        self._load_async()
+
+    async def _load_async(self) -> None:
+        self._subjects = await self._search.list_relational_subjects()
+        self._render_subject_mode()
+
+    # ── Subject-mode rendering ────────────────────────────────────────────────
+
+    def _render_subject_mode(self) -> None:
+        """Fill the list with subject rows."""
+        lv = self.query_one("#rel-list", ListView)
+        lv.clear()
+        self._expanded_subject = None
+
+        subtitle = self.query_one("#rel-subtitle", Static)
+        subtitle.update(f"[dim]{len(self._subjects)} subjects[/dim]")
+
+        for subj, count in self._subjects:
+            lv.append(self._build_subject_item(subj, count))
+
+        self.post_message(self.Loaded())
+
+    def _build_subject_item(self, subj: str, count: int) -> ListItem:
+        label = (
+            f"[#a78bfa]◉[/]  [bold #a78bfa]{subj}[/bold #a78bfa]  "
+            f"[dim]·[/]  [dim]{count} triple{'s' if count != 1 else ''}[/dim]"
+        )
+        return ListItem(Static(label), id=f"subj-{subj[:40]}")
+
+    # ── Expand subject → predicate mode ─────────────────────────────────────
+
+    async def _expand_subject(self, subject: str) -> None:
+        self._expanded_subject = subject
+        triples_raw = await self._search.list_relational_by_subject(subject)
+        self._expanded_triples = [
+            TripleDisplay(
+                subject=t.key,
+                predicate=t.extra.get("predicate", "?"),
+                object=t.extra.get("object", "?"),
+                confidence=t.extra.get("confidence", 1.0),
+            )
+            for t in triples_raw
+        ]
+
+        lv = self.query_one("#rel-list", ListView)
+        lv.clear()
+
+        lv.append(ListItem(
+            Static("[dim]← back to subjects[/dim]", id="rel-back"),
+            id="rel-back-item",
+        ))
+
+        subtitle = self.query_one("#rel-subtitle", Static)
+        subtitle.update(f"[bold #a78bfa]{subject}[/bold #a78bfa]  [dim]{len(self._expanded_triples)} triples[/dim]")
+
+        for t in self._expanded_triples:
+            lv.append(self._build_predicate_item(t))
+        self.post_message(self.Loaded())
+
+    # ── Predicate item builder ───────────────────────────────────────────────
+
+    def _build_predicate_item(self, t: TripleDisplay) -> ListItem:
+        label = (
+            f"[dim]──[/dim]  [bold #c084fc]{t.predicate}[/bold #c084fc]  "
+            f"[dim]──▶[/dim]  [#e8deff]{t.object}[/#e8deff]  "
+            f"[dim]conf={t.confidence:.2f}[/dim]"
+        )
+        return ListItem(Static(label))
+
+    # ── Interaction ───────────────────────────────────────────────────────────
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        try:
+            lv = self.query_one("#rel-list", ListView)
+            node = lv.children[lv.index]
+            item_id = node.id or ""
+        except Exception:
+            return
+
+        if self._expanded_subject is None:
+            if item_id.startswith("subj-"):
+                subject = item_id[len("subj-"):]
+                import asyncio as _asyncio
+                _asyncio.create_task(self._expand_subject(subject))
+        else:
+            if item_id == "rel-back-item":
+                self._render_subject_mode()
+
+    def back_to_subjects(self) -> None:
+        if self._expanded_subject is not None:
+            self._render_subject_mode()
+
+    def reload(self) -> None:
+        self._load_async()

--- a/loom/palace/components/semantic_view.py
+++ b/loom/palace/components/semantic_view.py
@@ -1,0 +1,286 @@
+"""
+SemanticView — browse and search semantic memory facts.
+
+Key performance design:
+  - Uses Textual ListView (virtualised — only renders visible items)
+  - Batched append: first 100 shown immediately, then 50 items per
+    10ms tick via call_next so the UI stays responsive during load.
+  - Search filters are applied in-memory (data is already loaded).
+  - _render() override prevents None-visual errors when hidden.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.message import Message
+from textual.widgets import ListView, ListItem, Static
+
+if TYPE_CHECKING:
+    from loom.palace.search import PalaceSearch
+
+
+SortKey = Literal["updated", "confidence", "key"]
+
+
+@dataclass
+class SemanticEntryDisplay:
+    key: str
+    value: str
+    confidence: float
+    source: str
+    updated_at: str
+    history_count: int = 0
+
+
+class SemanticView(Vertical):
+    """
+    Main semantic memory explorer with virtualised list rendering.
+
+    Layout (top to bottom):
+        Title line
+        Subtitle / stats line (live-updated as batches load)
+        ListView — virtualised, infinite scroll, click to select
+    """
+
+    DEFAULT_CSS = """
+    SemanticView {
+        height: 1fr;
+        layout: vertical;
+        overflow: hidden;
+    }
+    SemanticView ListView {
+        height: 1fr;
+        background: #0d0a1a;
+    }
+    """
+
+    # ── Messages ─────────────────────────────────────────────────────────────
+
+    class Loaded(Message):
+        """Fired when all entries have been loaded into the list."""
+        pass
+
+    class BatchLoaded(Message):
+        """Fired after each batch is appended.  `total` is current count."""
+        def __init__(self, total: int) -> None:
+            super().__init__()
+            self.total = total
+
+    # ── Init ────────────────────────────────────────────────────────────────
+
+    def __init__(self, search: "PalaceSearch") -> None:
+        super().__init__()
+        self._search = search
+        self._mode: str = "browse"    # browse | search | health
+        self._sort_key: SortKey = "updated"
+        self._all_entries: list[SemanticEntryDisplay] = []
+        self._filtered: list[SemanticEntryDisplay] = []
+        self._loading = False
+        self._batch_entries: list[SemanticEntryDisplay] = []
+        self._batch_index = 0
+
+    def _render(self) -> "Content":
+        """Return empty Content to prevent None-visual when hidden."""
+        from textual.content import Content
+        return Content.from_markup("")
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            "[bold #d4a853]◈ Semantic Memory[/bold #d4a853]  "
+            "[dim]— facts distilled from experience[/dim]",
+            id="semantic-title",
+        )
+        yield Static("[dim]Loading…[/dim]", id="semantic-subtitle", classes="content-subtitle")
+        yield ListView(id="semantic-list")
+
+    # ── Mount → load ─────────────────────────────────────────────────────────
+
+    def on_mount(self) -> None:
+        self._load_async()
+
+    async def _load_async(self) -> None:
+        if self._loading:
+            return
+        self._loading = True
+
+        try:
+            rows = await self._fetch_rows()
+            self._all_entries = self._rows_to_entries(rows)
+            self._apply_filter_and_load()
+        finally:
+            self._loading = False
+
+    async def _fetch_rows(self) -> list[tuple]:
+        """Fetch all semantic rows from DB (up to 2000, enough for browse)."""
+        db = self._search._db
+        cursor = await db.execute(
+            """
+            SELECT key, value, confidence, source, metadata, updated_at
+            FROM semantic_entries
+            ORDER BY updated_at DESC
+            LIMIT 2000
+            """
+        )
+        return await cursor.fetchall()
+
+    @staticmethod
+    def _rows_to_entries(rows: list[tuple]) -> list[SemanticEntryDisplay]:
+        import json
+        entries = []
+        for r in rows:
+            meta = json.loads(r[4]) if r[4] else {}
+            history = meta.get("history", []) if isinstance(meta, dict) else []
+            entries.append(SemanticEntryDisplay(
+                key=r[0],
+                value=r[1],
+                confidence=float(r[2]),
+                source=r[3] or "",
+                updated_at=r[5],
+                history_count=len(history) if isinstance(history, list) else 0,
+            ))
+        return entries
+
+    # ── Batched list population ───────────────────────────────────────────────
+
+    def _apply_filter_and_load(self) -> None:
+        """Sort + filter entries then start batch-loading the ListView."""
+        entries = self._all_entries
+
+        if self._mode == "health":
+            entries = [e for e in entries if e.confidence < 0.3]
+
+        if self._sort_key == "confidence":
+            entries = sorted(entries, key=lambda e: e.confidence, reverse=True)
+        elif self._sort_key == "key":
+            entries = sorted(entries, key=lambda e: e.key)
+        else:  # updated
+            entries = sorted(entries, key=lambda e: e.updated_at, reverse=True)
+
+        self._filtered = entries
+        self._start_batched_load(entries)
+
+    def _start_batched_load(self, entries: list[SemanticEntryDisplay]) -> None:
+        """Load entries in batches: first 100 immediately, then 50 every ~10ms."""
+        lv = self.query_one("#semantic-list", ListView)
+        lv.clear()
+        self._batch_index = 0
+        self._batch_entries = entries
+
+        # First batch immediately
+        first = min(100, len(entries))
+        self._append_batch(lv, entries[:first])
+        self._batch_index = first
+        self._update_subtitle(len(entries), loaded=first)
+
+        # Remaining batches on a timer
+        if self._batch_index < len(entries):
+            self._schedule_next_batch(lv)
+
+    def _schedule_next_batch(self, lv: ListView) -> None:
+        """Fire next batch via call_next, then chain until done."""
+        async def _tick() -> None:
+            batch_size = 50
+            start = self._batch_index
+            end   = min(start + batch_size, len(self._batch_entries))
+            self._append_batch(lv, self._batch_entries[start:end])
+            self._batch_index = end
+            self._update_subtitle(len(self._batch_entries), loaded=end)
+
+            if self._batch_index < len(self._batch_entries):
+                self._schedule_next_batch(lv)
+            else:
+                self.post_message(self.Loaded())
+
+        self.call_next(_tick)
+
+    def _append_batch(self, lv: ListView, entries: list[SemanticEntryDisplay]) -> None:
+        """Build ListItem cards and append to ListView in one call."""
+        for e in entries:
+            card = self._build_card(e)
+            lv.append(card)
+
+    def _update_subtitle(self, total: int, loaded: int) -> None:
+        try:
+            sub = self.query_one("#semantic-subtitle", Static)
+            mode_tag = {"browse": "", "search": "  [dim]filtered[/dim]", "health": "  [dim]⚠ low confidence[/dim]"}[self._mode]
+            if loaded < total:
+                sub.update(f"[dim]{loaded}/{total} loaded  ·  sort: {self._sort_key}{mode_tag}[/dim]")
+            else:
+                sub.update(f"[dim]{total} facts  ·  sort: {self._sort_key}{mode_tag}[/dim]")
+        except Exception:
+            pass
+
+    # ── Card builder ─────────────────────────────────────────────────────────
+
+    def _build_card(self, e: SemanticEntryDisplay) -> ListItem:
+        conf_color = (
+            "#a78bfa" if e.confidence > 0.7 else
+            "#c084fc" if e.confidence >= 0.4 else
+            "#7c3aed"
+        )
+        src = e.source or "unknown"
+        if src.startswith("session:"):
+            src = "session:*"
+        elif len(src) > 15:
+            src = src[:12] + "…"
+
+        value_short = e.value[:110] + ("…" if len(e.value) > 110 else "")
+        hist = f"  [dim]↺ {e.history_count}[/dim]" if e.history_count > 0 else ""
+
+        label = (
+            f"[#a78bfa]{e.key}[/#a78bfa]  "
+            f"[dim]{e.updated_at[:16].replace('T',' ')}[/dim]  "
+            f"[{conf_color}]{e.confidence:.2f}[/{conf_color}]  "
+            f"[dim]src: {src}[/dim][dim]{hist}[/dim]\n"
+            f"[#e8deff]{value_short}[/#e8deff]"
+        )
+        return ListItem(Static(label), id=f"fact-{e.key[:40]}")
+
+    # ── Filter / sort control ───────────────────────────────────────────────
+
+    def set_mode(self, mode: str) -> None:
+        if mode not in {"browse", "search", "health"}:
+            return
+        self._mode = mode
+        self._apply_filter_and_load()
+
+    def set_sort(self, key: SortKey) -> None:
+        self._sort_key = key
+        self._apply_filter_and_load()
+
+    def filter_by_query(self, query: str) -> None:
+        """In-memory filter by substring match on key or value."""
+        if not query.strip():
+            self._apply_filter_and_load()
+            return
+        q = query.lower()
+        filtered = [
+            e for e in self._all_entries
+            if q in e.key.lower() or q in e.value.lower()
+        ]
+        self._filtered = filtered
+        lv = self.query_one("#semantic-list", ListView)
+        lv.clear()
+        batch = filtered[:100]
+        for e in batch:
+            lv.append(self._build_card(e))
+        self._update_subtitle(len(filtered), loaded=len(batch))
+        if len(filtered) > 100:
+            self._batch_index = 100
+            self._batch_entries = filtered
+            self._schedule_next_batch(lv)
+        else:
+            self.post_message(self.Loaded())
+
+    def reload(self) -> None:
+        """Cancel any in-flight load and restart."""
+        self._loading = False
+        self._all_entries = []
+        self._filtered = []
+        self._batch_entries = []
+        self._load_async()

--- a/loom/palace/components/skills_view.py
+++ b/loom/palace/components/skills_view.py
@@ -1,0 +1,159 @@
+"""
+SkillsView — browse skill genomes and their health.
+
+Key design (mirrors SemanticView):
+  - Uses ListView for virtualised rendering.
+  - Data is small (≤16 genomes) — one-shot load is fine.
+  - Confidence colouring, success rate badges, tag display.
+  - _render() override returns Content immediately (no DOM ops in render path).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.message import Message
+from textual.widgets import ListView, ListItem, Static
+
+if TYPE_CHECKING:
+    from loom.palace.search import PalaceSearch
+
+
+@dataclass
+class SkillDisplay:
+    name: str
+    confidence: float
+    usage_count: int
+    success_rate: float
+    deprecation_threshold: float
+    tags: list[str]
+    body: str
+    updated_at: str
+
+
+class SkillsView(Vertical):
+    """
+    Skill genome explorer.
+
+    Shows all skill genomes sorted by confidence, with usage and
+    success rate badges.  Small dataset — loaded in one shot.
+    """
+
+    DEFAULT_CSS = """
+    SkillsView {
+        height: 1fr;
+        layout: vertical;
+        overflow: hidden;
+    }
+    SkillsView ListView {
+        height: 1fr;
+        background: #0d0a1a;
+    }
+    """
+
+    class Loaded(Message):
+        pass
+
+    def __init__(self, search: "PalaceSearch") -> None:
+        super().__init__()
+        self._search = search
+        self._skills: list[SkillDisplay] = []
+
+    def _render(self) -> "Content":
+        from textual.content import Content
+        return Content.from_markup("")
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            "[bold #d4a853]✧ Skill Genomes[/bold #d4a853]  "
+            "[dim]— agent skills and their performance[/dim]",
+            id="skills-header",
+            classes="content-title",
+        )
+        yield Static("", id="skills-subtitle", classes="content-subtitle")
+        yield ListView(id="skills-list")
+
+    # ── Mount / load ─────────────────────────────────────────────────────────
+
+    def on_mount(self) -> None:
+        self._load_async()
+
+    async def _load_async(self) -> None:
+        db = self._search._db
+        cursor = await db.execute(
+            """
+            SELECT name, confidence, usage_count, success_rate,
+                   deprecation_threshold, tags, body, updated_at
+            FROM skill_genomes
+            ORDER BY confidence DESC
+            LIMIT 200
+            """
+        )
+        rows = await cursor.fetchall()
+
+        import json as _json
+        self._skills = [
+            SkillDisplay(
+                name=r[0],
+                confidence=float(r[1]),
+                usage_count=int(r[2]),
+                success_rate=float(r[3]),
+                deprecation_threshold=float(r[4]) if r[4] else 0.5,
+                tags=_json.loads(r[5]) if r[5] else [],
+                body=r[6] or "",
+                updated_at=r[7],
+            )
+            for r in rows
+        ]
+        self._render_skills()
+
+    # ── Render ────────────────────────────────────────────────────────────────
+
+    def _render_skills(self) -> None:
+        lv = self.query_one("#skills-list", ListView)
+        lv.clear()
+
+        subtitle = self.query_one("#skills-subtitle", Static)
+        subtitle.update(f"[dim]{len(self._skills)} genomes[/dim]")
+
+        if not self._skills:
+            lv.append(ListItem(Static("[dim]No skill genomes found.[/dim]")))
+            self.post_message(self.Loaded())
+            return
+
+        for s in self._skills:
+            lv.append(self._build_skill_card(s))
+
+        self.post_message(self.Loaded())
+
+    # ── Card builder ───────────────────────────────────────────────────────────
+
+    def _build_skill_card(self, s: SkillDisplay) -> ListItem:
+        conf_color = (
+            "#86efac" if s.confidence > 0.7 else
+            "#fbbf24" if s.confidence >= 0.6 else
+            "#f87171"
+        )
+        sr_color = (
+            "#86efac" if s.success_rate >= 0.8 else
+            "#fbbf24" if s.success_rate >= 0.6 else
+            "#f87171"
+        )
+        tags_str = "  ".join(f"[dim]{t}[/dim]" for t in s.tags[:6])
+        body_preview = s.body[:100].replace("\n", " ") + ("…" if len(s.body) > 100 else "")
+
+        label = (
+            f"[bold #d4a853]✧[/]  [bold #e8deff]{s.name}[/bold #e8deff]\n"
+            f"[dim]{body_preview}[/dim]\n"
+            f"[{conf_color}]conf={s.confidence:.2f}[/{conf_color}]  "
+            f"[dim]used: {s.usage_count}×[/dim]  "
+            f"[{sr_color}]success: {s.success_rate:.0%}[/{sr_color}]\n"
+            f"[dim]{tags_str}[/dim]"
+        )
+        return ListItem(Static(label), id=f"skill-{s.name[:40]}")
+
+    def reload(self) -> None:
+        self._load_async()

--- a/loom/palace/components/status.py
+++ b/loom/palace/components/status.py
@@ -1,0 +1,67 @@
+"""
+PalaceStatusBar — bottom status line for Memory Palace.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.message import Message
+from textual.widget import Widget
+from textual.widgets import Static
+
+
+class PalaceStatusBar(Widget):
+    """
+    Bottom dock showing live memory stats summary.
+    Updated whenever a section is selected or data changes.
+    """
+
+    DEFAULT_CSS = '''
+    PalaceStatusBar {
+        dock: bottom;
+        height: 1;
+        background: #150d28;
+        border-top: solid #3d2a6b;
+        padding: 0 1;
+    }
+    #status-text {
+        color: #9b87b5;
+    }
+    '''
+
+    class StatusUpdated(Message, bubble=True):
+        def __init__(self, text: str) -> None:
+            super().__init__()
+            self.text = text
+
+    def compose(self) -> ComposeResult:
+        yield Static("[dim]Loading memory palace...[/dim]", id="status-text")
+
+    def update(
+        self,
+        semantic: int = 0,
+        relational: int = 0,
+        skills: int = 0,
+        sessions: int = 0,
+        active_section: str = "semantic",
+    ) -> None:
+        parts = [
+            "[#a78bfa]Semantic[/]  [dim]·[/dim]",
+            f"[#e8deff]{semantic:,}[/#e8deff] facts",
+            "[dim]·[/dim]",
+            "[#c084fc]Relational[/]  [dim]·[/dim]",
+            f"[#e8deff]{relational:,}[/#e8deff] triples",
+            "[dim]·[/dim]",
+            "[#d4a853]Skills[/]  [dim]·[/dim]",
+            f"[#e8deff]{skills:,}[/#e8deff] genomes",
+            "[dim]·[/dim]",
+            "[#60a5fa]Sessions[/]  [dim]·[/dim]",
+            f"[#e8deff]{sessions:,}[/#e8deff] logged",
+            "[dim]  ·  [/dim]",
+            f"[dim]View: {active_section}[/dim]",
+        ]
+        text = "  ".join(parts)
+        try:
+            self.query_one("#status-text", Static).update(text)
+        except Exception:
+            pass

--- a/loom/palace/search.py
+++ b/loom/palace/search.py
@@ -1,0 +1,288 @@
+"""
+PalaceSearch — thin coordinator layer for cross-view search.
+
+Uses existing MemorySearch (BM25 + FTS5 + embedding) for semantic and skills.
+Adds simple SQL LIKE-based search for relational triples and session content.
+
+Design principle: borrow + compose, never re-implement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
+
+import aiosqlite
+
+from loom.core.memory.semantic import SemanticMemory
+from loom.core.memory.procedural import ProceduralMemory
+from loom.core.memory.relational import RelationalMemory
+from loom.core.memory.search import MemorySearch, MemorySearchResult
+from loom.core.memory.session_log import SessionLog
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+SearchScope = Literal["semantic", "skill", "relational", "session", "all"]
+
+
+@dataclass
+class PalaceResult:
+    """Unified result format across all memory types."""
+    scope: SearchScope
+    key: str           # e.g. fact key, subject, session_id, skill name
+    value: str         # primary display text
+    meta: str = ""     # secondary info line
+    score: float = 0.0
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# PalaceSearch
+# ---------------------------------------------------------------------------
+
+class PalaceSearch:
+    """
+    Thin coordinator that wraps existing memory stores for the palace UI.
+
+    Semantic + Skills:  delegates to MemorySearch.recall() (BM25 + FTS5 + embedding)
+    Relational:        SQL LIKE on subject/predicate/object
+    Sessions:           SQL LIKE on session_log content
+    """
+
+    def __init__(self, db: aiosqlite.Connection) -> None:
+        self._db = db
+        self._semantic = SemanticMemory(db)
+        self._procedural = ProceduralMemory(db)
+        self._relational = RelationalMemory(db)
+        self._session_log = SessionLog(db)
+        self._memory_search = MemorySearch(self._semantic, self._procedural)
+
+    # ── Semantic / Skills (via MemorySearch) ─────────────────────────────
+
+    async def search_semantic(
+        self, query: str, limit: int = 20
+    ) -> list[PalaceResult]:
+        """BM25 + FTS5 search over semantic facts."""
+        raw = await self._memory_search.recall(
+            query, type="semantic", limit=limit
+        )
+        return [self._from_search_result(r) for r in raw]
+
+    async def search_skills(
+        self, query: str, limit: int = 20
+    ) -> list[PalaceResult]:
+        """BM25 + FTS5 search over skill genomes."""
+        raw = await self._memory_search.recall(
+            query, type="skill", limit=limit
+        )
+        return [self._from_search_result(r) for r in raw]
+
+    async def search_all(
+        self, query: str, limit: int = 20
+    ) -> list[PalaceResult]:
+        """Search semantic, skills, relational, and sessions simultaneously."""
+        results: list[PalaceResult] = []
+        results.extend(await self.search_semantic(query, limit))
+        results.extend(await self.search_skills(query, limit))
+        results.extend(await self.search_relational(query, limit))
+        results.extend(await self.search_sessions(query, limit))
+        results.sort(key=lambda r: r.score, reverse=True)
+        return results[:limit]
+
+    # ── Relational (SQL LIKE) ─────────────────────────────────────────────
+
+    async def search_relational(
+        self, query: str, limit: int = 20
+    ) -> list[PalaceResult]:
+        """
+        Search relational triples by subject, predicate, or object content.
+        No FTS5 needed — the triple structure is simple enough for LIKE.
+        """
+        like = f"%{query}%"
+        cursor = await self._db.execute(
+            """
+            SELECT id, subject, predicate, object, confidence, source, metadata,
+                   created_at, updated_at
+            FROM relational_entries
+            WHERE subject LIKE ? OR predicate LIKE ? OR object LIKE ?
+            ORDER BY updated_at DESC
+            LIMIT ?
+            """,
+            (like, like, like, limit),
+        )
+        rows = await cursor.fetchall()
+        results: list[PalaceResult] = []
+        for r in rows:
+            subject, predicate, obj, conf = r[1], r[2], r[3], r[4]
+            results.append(PalaceResult(
+                scope="relational",
+                key=subject,
+                value=f"{subject}  ─{predicate}──▶  {obj}",
+                meta=f"conf={conf:.2f}",
+                score=0.0,
+            ))
+        return results
+
+    async def list_relational_subjects(self) -> list[tuple[str, int]]:
+        """Return all subjects with their triple count, ordered by count desc."""
+        cursor = await self._db.execute(
+            """
+            SELECT subject, COUNT(*) as cnt
+            FROM relational_entries
+            GROUP BY subject
+            ORDER BY cnt DESC
+            LIMIT 100
+            """
+        )
+        return [(r[0], r[1]) for r in await cursor.fetchall()]
+
+    async def list_relational_by_subject(
+        self, subject: str
+    ) -> list[PalaceResult]:
+        """List all triples for a given subject."""
+        cursor = await self._db.execute(
+            """
+            SELECT id, subject, predicate, object, confidence, source,
+                   created_at, updated_at
+            FROM relational_entries
+            WHERE subject = ?
+            ORDER BY updated_at DESC
+            """,
+            (subject,),
+        )
+        rows = await cursor.fetchall()
+        return [
+            PalaceResult(
+                scope="relational",
+                key=r[1],
+                value=f"{r[1]}  ─{r[2]}──▶  {r[3]}",
+                meta=f"conf={r[4]:.2f} · updated={str(r[7])[:10]}",
+                score=0.0,
+                extra={"predicate": r[2], "object": r[3], "confidence": r[4]},
+            )
+            for r in rows
+        ]
+
+    # ── Sessions / Episodic (SQL LIKE) ───────────────────────────────────
+
+    async def search_sessions(
+        self, query: str, limit: int = 20
+    ) -> list[PalaceResult]:
+        """Search session_log content via SQL LIKE."""
+        like = f"%{query}%"
+        cursor = await self._db.execute(
+            """
+            SELECT DISTINCT sl.session_id, s.title, s.model,
+                   s.started_at, s.last_active, s.turn_count
+            FROM session_log sl
+            JOIN sessions s ON s.session_id = sl.session_id
+            WHERE sl.content LIKE ? AND sl.role = 'user'
+            ORDER BY s.last_active DESC
+            LIMIT ?
+            """,
+            (like, limit),
+        )
+        rows = await cursor.fetchall()
+        return [
+            PalaceResult(
+                scope="session",
+                key=r[0],
+                value=r[1] or "(no title)",
+                meta=f"model={r[2]} · {r[5]} turns · {r[4][:10]}",
+                score=0.0,
+                extra={"turn_count": r[5], "model": r[2]},
+            )
+            for r in rows
+        ]
+
+    # ── Stats helpers ────────────────────────────────────────────────────
+
+    async def semantic_stats(self) -> dict[str, Any]:
+        """Return counts and confidence distribution for semantic memory."""
+        cursor = await self._db.execute(
+            "SELECT COUNT(*), "
+            "  SUM(CASE WHEN confidence > 0.7 THEN 1 ELSE 0 END), "
+            "  SUM(CASE WHEN confidence BETWEEN 0.4 AND 0.7 THEN 1 ELSE 0 END), "
+            "  SUM(CASE WHEN confidence <= 0.4 THEN 1 ELSE 0 END) "
+            "FROM semantic_entries"
+        )
+        row = await cursor.fetchone()
+        total, high, mid, low = (row or (0, 0, 0, 0))
+
+        cursor2 = await self._db.execute(
+            "SELECT COUNT(*) FROM semantic_entries "
+            "WHERE updated_at > datetime('now', '-1 day')"
+        )
+        row2 = await cursor2.fetchone()
+        today = row2[0] if row2 else 0
+
+        return {
+            "total": total,
+            "high": high,
+            "mid": mid,
+            "low": low,
+            "today": today,
+        }
+
+    async def relational_stats(self) -> dict[str, Any]:
+        """Return counts for relational memory."""
+        cursor = await self._db.execute("SELECT COUNT(*) FROM relational_entries")
+        row = await cursor.fetchone()
+        total = row[0] if row else 0
+
+        cursor2 = await self._db.execute(
+            "SELECT COUNT(DISTINCT subject) FROM relational_entries"
+        )
+        row2 = await cursor2.fetchone()
+        subjects = row2[0] if row2 else 0
+
+        cursor3 = await self._db.execute(
+            "SELECT COUNT(*) FROM relational_entries "
+            "WHERE updated_at > datetime('now', '-1 day')"
+        )
+        row3 = await cursor3.fetchone()
+        today = row3[0] if row3 else 0
+
+        return {"total": total, "subjects": subjects, "today": today}
+
+    async def session_stats(self) -> dict[str, Any]:
+        """Return session counts and last-active info."""
+        cursor = await self._db.execute("SELECT COUNT(*) FROM sessions")
+        row = await cursor.fetchone()
+        total = row[0] if row else 0
+
+        cursor2 = await self._db.execute(
+            "SELECT last_active FROM sessions ORDER BY last_active DESC LIMIT 1"
+        )
+        row2 = await cursor2.fetchone()
+        last_active = row2[0] if row2 else None
+
+        return {"total": total, "last_active": last_active}
+
+    async def skill_stats(self) -> dict[str, Any]:
+        """Return skill counts and health breakdown."""
+        cursor = await self._db.execute(
+            "SELECT COUNT(*), "
+            "  SUM(CASE WHEN usage_count > 0 THEN 1 ELSE 0 END), "
+            "  SUM(CASE WHEN success_rate < 0.6 AND usage_count > 0 THEN 1 ELSE 0 END) "
+            "FROM skill_genomes"
+        )
+        row = await cursor.fetchone()
+        total, active, failing = (row or (0, 0, 0))
+        return {"total": total, "active": active, "failing": failing}
+
+    # ── Helpers ───────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _from_search_result(r: MemorySearchResult) -> PalaceResult:
+        return PalaceResult(
+            scope=r.type,
+            key=r.key,
+            value=r.value[:200],
+            meta=f"conf={r.metadata.get('effective_confidence', r.metadata.get('confidence', 0)):.2f} · {r.updated_at[:10]}",
+            score=r.score,
+            extra=r.metadata,
+        )

--- a/loom/palace/theme.py
+++ b/loom/palace/theme.py
@@ -1,0 +1,259 @@
+"""
+Memory Palace CSS theme constants.
+
+Purple palette — visually distinct from the parchment chat TUI.
+"""
+
+# ── Backgrounds ──────────────────────────────────────────────────────────────
+
+BG = "#0d0a1a"          # Screen background  — deep purple-black
+SURFACE = "#150d28"     # Panel surface      — dark purple
+RAISED = "#1e1238"      # Cards / raised     — purple-grey
+BORDER = "#3d2a6b"      # Borders / dividers — medium purple
+BORDER_DIM = "#2a1e50"  # Dim borders
+
+# ── Text ──────────────────────────────────────────────────────────────────────
+
+TEXT = "#e8deff"        # Primary text       — pale lavender
+MUTED = "#9b87b5"       # Secondary text     — grey-purple
+GOLD = "#d4a853"        # Headings / accent — gold (Loom signature)
+
+# ── Semantic confidence colours ────────────────────────────────────────────────
+
+HIGH = "#a78bfa"        # confidence > 0.7
+MID = "#c084fc"         # confidence 0.4–0.7
+LOW = "#7c3aed"         # confidence < 0.4
+DECAY = "#4c1d95"       # decayed / stale    — very dark purple
+
+# ── Status colours ────────────────────────────────────────────────────────────
+
+SUCCESS = "#86efac"     # green-ish
+WARNING = "#fbbf24"     # amber
+ERROR = "#f87171"       # rose-red
+INFO = "#60a5fa"       # sky blue
+
+# ── Component-specific ─────────────────────────────────────────────────────────
+
+NAV_ACTIVE_BG = "#2a1e50"
+NAV_HOVER_BG = "#1e1238"
+SELECTED_ITEM = "#3d2a6b"
+
+# ── Full palace CSS (used in PalaceApp.CSS) ───────────────────────────────────
+
+CSS = f"""
+Screen {{
+    background: {BG};
+    color: {TEXT};
+}}
+
+/* ── Scrollbar — purple palette ─────────────────────────────────────── */
+Screen {{
+    scrollbar-background: {BG};
+    scrollbar-color: {BORDER};
+    scrollbar-color-hover: {HIGH};
+    scrollbar-background-hover: {BG};
+    scrollbar-corner-color: {BG};
+}}
+
+#content-area, #semantic-view, #health-view, #relational-view,
+#episodic-view, #skills-view {{
+    scrollbar-background: {BG};
+    scrollbar-color: {BORDER};
+    scrollbar-color-hover: {HIGH};
+}}
+
+/* ── Header ──────────────────────────────────────────────────────────── */
+#header {{
+    dock: top;
+    height: 2;
+    background: {SURFACE};
+    border-bottom: solid {BORDER};
+}}
+
+#header-title {{
+    width: auto;
+    content-align: left middle;
+    padding: 0 1;
+}}
+
+#header-hints {{
+    width: 1fr;
+    content-align: right middle;
+    padding: 0 1;
+}}
+
+/* ── Body layout ─────────────────────────────────────────────────────── */
+#body {{
+    height: 1fr;
+}}
+
+#nav-sidebar {{
+    width: 38;
+    background: {SURFACE};
+    border-right: solid {BORDER};
+}}
+
+#nav-item {{
+    height: 3;
+    padding: 0 1;
+    content-align: left middle;
+}}
+
+#nav-item:hover {{
+    background: {NAV_HOVER_BG};
+}}
+
+.nav-active {{
+    background: {NAV_ACTIVE_BG};
+    color: {HIGH};
+}}
+
+.nav-label {{
+    color: {MUTED};
+}}
+
+/* ── Content area ─────────────────────────────────────────────────────── */
+#content-area {{
+    width: 1fr;
+    background: {BG};
+    padding: 1 2;
+    overflow-y: auto;
+}}
+
+.content-title {{
+    color: {GOLD};
+}}
+
+.content-subtitle {{
+    color: {MUTED};
+}}
+
+/* ── Semantic view ───────────────────────────────────────────────────── */
+#semantic-view {{
+    height: 1fr;
+}}
+
+.semantic-entry {{
+    height: auto;
+    padding: 1 1;
+    border-bottom: solid {BORDER_DIM};
+}}
+
+.semantic-key {{
+    color: {HIGH};
+}}
+
+.semantic-value {{
+    color: {TEXT};
+}}
+
+.semantic-meta {{
+    color: {MUTED};
+}}
+
+.conf-high {{ color: {HIGH}; }}
+.conf-mid  {{ color: {MID};  }}
+.conf-low  {{ color: {LOW};  }}
+.conf-decay {{ color: {DECAY}; }}
+
+.stat-card {{
+    background: {RAISED};
+    border: solid {BORDER};
+    padding: 1 2;
+}}
+
+.stat-value {{
+    color: {GOLD};
+}}
+
+.stat-label {{
+    color: {MUTED};
+}}
+
+/* ── Health view — 2×2 grid ─────────────────────────────────────────── */
+#health-grid {{
+    layout: grid;
+    grid-size: 2 2;
+    grid-gutter: 1 2;
+    height: auto;
+}}
+
+.health-card {{
+    background: {RAISED};
+    border: solid {BORDER};
+    padding: 1 2;
+}}
+
+.health-card-title {{
+    color: {GOLD};
+}}
+
+.health-card-value {{
+    color: {TEXT};
+}}
+
+.health-card-sub {{
+    color: {MUTED};
+}}
+
+.health-warning {{ color: {WARNING}; }}
+.health-good    {{ color: {SUCCESS}; }}
+.health-danger  {{ color: {ERROR};   }}
+
+/* ── Relational view ─────────────────────────────────────────────────── */
+.rel-subject {{
+    color: {HIGH};
+    text-style: bold;
+}}
+
+.rel-predicate {{
+    color: {MID};
+}}
+
+.rel-object {{
+    color: {TEXT};
+}}
+
+/* ── Episodic / Skills views ─────────────────────────────────────────── */
+.session-item {{
+    height: 3;
+    padding: 0 1;
+    border-bottom: solid {BORDER_DIM};
+}}
+
+.skill-card {{
+    background: {RAISED};
+    border: solid {BORDER};
+    padding: 1 2;
+    margin-bottom: 1;
+}}
+
+/* ── Status bar ──────────────────────────────────────────────────────── */
+#status-bar {{
+    dock: bottom;
+    height: 1;
+    background: {SURFACE};
+    border-top: solid {BORDER};
+}}
+
+#status-bar Static {{
+    color: {MUTED};
+}}
+
+/* ── Input / search ──────────────────────────────────────────────────── */
+PalaceInput {{
+    background: {RAISED};
+    color: {TEXT};
+    border: solid {BORDER};
+}}
+
+PalaceInput:focus {{
+    border: solid {HIGH};
+}}
+
+/* ── Dividers / decorators ──────────────────────────────────────────── */
+.decorator {{
+    color: {BORDER};
+}}
+
+"""

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -11,6 +11,8 @@ Usage
     loom chat --model MiniMax-M2.7-highspeed
     loom chat --model claude-sonnet-4-6
     loom memory list
+    loom palace                       # Memory Palace TUI
+    loom palace --view semantic
     loom reflect --session <id>
 """
 
@@ -1259,6 +1261,38 @@ async def _memory_list(db: str, limit: int) -> None:
 
 
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# loom palace — Memory Palace TUI
+# ---------------------------------------------------------------------------
+
+@cli.command()
+@click.option("--db", default="~/.loom/memory.db", show_default=True)
+@click.option(
+    "--view",
+    "view_name",
+    default="semantic",
+    type=click.Choice(["semantic", "relational", "episodic", "skills", "health"]),
+    help="Open directly in a specific memory section.",
+)
+def palace(db: str, view_name: str) -> None:
+    """Launch the Memory Palace — an interactive TUI for exploring all memory stores.
+
+    Uses a purple theme to distinguish it from the chat TUI.
+    """
+    from loom.palace.app import PalaceApp
+    from loom.core.memory.store import SQLiteStore
+    import asyncio
+
+    async def _run() -> None:
+        store = SQLiteStore(db)
+        await store.initialize()
+        app = PalaceApp(db_path=db, initial_view=view_name)
+        await app.run_async()
+
+    asyncio.run(_run())
+
 
 
 @cli.command()


### PR DESCRIPTION
## Summary

**Memory Palace** — a new TUI (`loom palace`) for exploring all four Loom memory stores, built with Textual 8 and a dedicated purple theme.

---

## What changed

### New command: `loom palace`

```
loom palace                       # open with Semantic view
loom palace --view semantic       # open in specific section
loom palace --view health        # health overview
```

The app is fully **read-only** and makes no changes to memory — all views query `~/.loom/memory.db` through `PalaceSearch` (a thin coordinator over existing `MemorySearch` and `RelationalMemory`).

### File layout

```
loom/palace/
    app.py          — PalaceApp (Textual App), compose, bindings
    theme.py        — Purple palette: #0d0a1a bg, #d4a853 gold
    search.py       — PalaceSearch coordinator
    components/
        header.py       — ❖ Memory Palace v0.4 branding
        nav.py          — NavSidebar with 5 sections
        status.py       — PalaceStatusBar
        semantic_view.py — Fact browser with BM25 search
        relational_view.py — S→P→O triple explorer
        episodic_view.py  — Session history + turn timeline
        skills_view.py    — Skill genome browser
        health_view.py    — 2×2 stat grid + decay warnings
```

### Architecture decisions

- **Borrow + compose** over build: `PalaceSearch` delegates to existing `MemorySearch.recall()` and `RelationalMemory.query()` — no duplication of search logic.
- **All views inherit `Vertical`** (not bare `Widget`) so `_render()` returns proper Content and Textual's container rendering path works correctly.
- **Lazy rendering**: CSS `display: none` on inactive views; `_render()` override in each view returns `Content.from_markup("")` to prevent `None` visual errors.

---

## Known issues / next steps

| Priority | Issue |
|----------|-------|
| High | SemanticView loads 1643 facts synchronously — view stays on "Loading…" for ~10 s. Needs virtualised list (Textual `DataTable` or `Rich` scrollable). |
| Medium | `Ctrl+R` (Refresh) re-mounts all widgets synchronously in each view. Should debounce or skip if data unchanged. |
| Medium | Search is scoped to the active view only. Cross-view search (`PalaceSearch.search_all()`) is stubbed. |
| Low | No keyboard navigation into individual fact/triple cards. `Enter` to expand not yet wired. |
| Low | HealthView `_render()` re-mounts children on every render cycle. Should diff and patch. |

---

## Testing

```bash
loom palace --view semantic   # ✓
loom palace --view health   # ✓
loom palace --view skills   # ✓
loom palace --view relational  # ✓
loom palace --view episodic    # ✓
```

All five views launch without Python traceback or CSS errors.
