### PR TITLE
feat(ui): ExecutionEnvelope UI renovation (#106, #107, #110)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ skills/news-aggregator/
 skills/systematic_code_analyst/
 skills/security_assessment/
 doc/silky_draw_reference.md
+skills/silky_minimax_draw
 
 # Personal config (use loom.toml.example as template)
 loom.toml

--- a/loom/core/events.py
+++ b/loom/core/events.py
@@ -129,10 +129,78 @@ class ThinkCollapsed:
     full: str
 
 
+# ---------------------------------------------------------------------------
+# Issue #106: ExecutionEnvelope ViewModel & stream events
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ExecutionNodeView:
+    """Single action node view for UI consumption.
+
+    Maps 1:1 to an ``ActionRecord`` but carries only the fields the
+    presentation layer needs — no mutable state, no references to
+    middleware internals.
+    """
+    node_id: str           # ActionRecord.id
+    call_id: str           # ToolCall.id
+    action_id: str | None  # same as node_id (for API clarity)
+    tool_name: str
+    level: int             # parallel level (0 = all current dispatch)
+    state: str             # ActionState.value
+    trust_level: str       # SAFE / GUARDED / CRITICAL
+    capabilities: list[str] = field(default_factory=list)
+    args_preview: str = ""
+    duration_ms: float = 0.0
+    error_snippet: str = ""
+    depends_on: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ExecutionEnvelopeView:
+    """Aggregate view for one tool-use batch — the primary UI unit.
+
+    Built by ``LoomSession._build_envelope_view()`` (projection layer)
+    and yielded as part of ``EnvelopeStarted / Updated / Completed``
+    stream events.  TUI and Discord both consume this same structure.
+    """
+    envelope_id: str       # human-readable, e.g. "e1", "e2"
+    session_id: str
+    turn_index: int
+    status: str            # "running" / "completed" / "failed"
+    node_count: int
+    parallel_groups: int   # number of distinct levels
+    elapsed_ms: float = 0.0
+    levels: list[list[str]] = field(default_factory=list)
+    nodes: list[ExecutionNodeView] = field(default_factory=list)
+
+
+@dataclass
+class EnvelopeStarted:
+    """A new tool-use batch (envelope) has been created and dispatch begins."""
+    envelope: ExecutionEnvelopeView
+
+
+@dataclass
+class EnvelopeUpdated:
+    """A node inside the current envelope changed state (e.g. tool finished)."""
+    envelope: ExecutionEnvelopeView
+
+
+@dataclass
+class EnvelopeCompleted:
+    """All nodes in the envelope have reached terminal states."""
+    envelope: ExecutionEnvelopeView
+
+
 __all__ = [
     "ActionRolledBack",
     "ActionStateChange",
     "CompressDone",
+    "EnvelopeCompleted",
+    "EnvelopeStarted",
+    "EnvelopeUpdated",
+    "ExecutionEnvelopeView",
+    "ExecutionNodeView",
     "TextChunk",
     "ThinkCollapsed",
     "ToolBegin",

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -62,7 +62,7 @@ from loom.core.events import (
     TurnDropped,
     TurnPaused,
 )
-from loom.core.harness.lifecycle import ActionRecord, ExecutionEnvelope
+from loom.core.harness.lifecycle import ActionRecord, ExecutionEnvelope, LIFECYCLE_CTX_KEY
 from loom.core.harness.middleware import (
     BlastRadiusMiddleware,
     LifecycleGateMiddleware,
@@ -1680,7 +1680,14 @@ class LoomSession:
             abort_signal=self._abort.signal,
             origin=self._current_origin,
         )
-        return await self._pipeline.execute(call, tool_def.executor)
+        result = await self._pipeline.execute(call, tool_def.executor)
+
+        # Issue #106: link ActionRecord from LifecycleMiddleware to the envelope
+        ctx = call.metadata.get(LIFECYCLE_CTX_KEY)
+        if ctx is not None and self._current_envelope is not None:
+            self._current_envelope.add(ctx.record)
+
+        return result
 
     async def _on_trace(self, call: ToolCall, result: ToolResult) -> None:
         summary = (

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -49,6 +49,11 @@ from loom.core.events import (
     ActionRolledBack,
     ActionStateChange,
     CompressDone,
+    EnvelopeCompleted,
+    EnvelopeStarted,
+    EnvelopeUpdated,
+    ExecutionEnvelopeView,
+    ExecutionNodeView,
     TextChunk,
     ThinkCollapsed,
     ToolBegin,
@@ -484,6 +489,10 @@ class LoomSession:
         self._current_envelope: ExecutionEnvelope | None = None
         self._lifecycle_events: asyncio.Queue = asyncio.Queue()
 
+        # Issue #106: Envelope-centric UI — incremental counter & history
+        self._envelope_counter: int = 0
+        self._recent_envelopes: list[ExecutionEnvelopeView] = []
+
         # Issue #28: Predictive memory pre-fetcher — default off (opt-in)
         self._prefetch_enabled: bool = (
             config.get("session", {}).get("prefetch_enabled", False)
@@ -851,6 +860,7 @@ class LoomSession:
     ) -> AsyncIterator[
         TextChunk | ToolBegin | ToolEnd | TurnPaused | TurnDone | TurnDropped
         | ActionStateChange | ActionRolledBack
+        | EnvelopeStarted | EnvelopeUpdated | EnvelopeCompleted
     ]:
         """
         Run one complete agent turn and yield typed UI events.
@@ -1117,6 +1127,18 @@ class LoomSession:
                     response.tool_uses
                 )
 
+                # ── Issue #106: Create envelope for this tool batch ────────
+                self._envelope_counter += 1
+                envelope = ExecutionEnvelope(
+                    session_id=self.session_id,
+                    turn_index=self._turn_index,
+                )
+                self._current_envelope = envelope
+                _batch_t0 = time.monotonic()
+
+                # Yield EnvelopeStarted *before* ToolBegin events
+                yield EnvelopeStarted(envelope=self._build_envelope_view(_batch_t0))
+
                 if parallel:
                     # Announce all tools, then run concurrently
                     for tu in response.tool_uses:
@@ -1135,6 +1157,8 @@ class LoomSession:
                         # Drain lifecycle events queued during dispatch
                         while not self._lifecycle_events.empty():
                             yield self._lifecycle_events.get_nowait()
+                        # Issue #106: Yield envelope update after each tool completes
+                        yield EnvelopeUpdated(envelope=self._build_envelope_view(_batch_t0))
                         self.messages.append(
                             self.router.format_tool_result(
                                 self.model, tu.id, tool_output, result.success,
@@ -1176,6 +1200,8 @@ class LoomSession:
                         # Drain lifecycle events queued during dispatch
                         while not self._lifecycle_events.empty():
                             yield self._lifecycle_events.get_nowait()
+                        # Issue #106: Yield envelope update after each tool completes
+                        yield EnvelopeUpdated(envelope=self._build_envelope_view(_batch_t0))
                         self.messages.append(
                             self.router.format_tool_result(
                                 self.model, tu.id, tool_output, result.success,
@@ -1185,6 +1211,16 @@ class LoomSession:
                             "tool", tool_output[:500],
                             {"tool_call_id": tu.id, "tool_name": tu.name},
                         ))
+
+                # ── Issue #106: Envelope completed ─────────────────────────
+                if self._current_envelope is not None:
+                    self._current_envelope.complete()
+                _completed_view = self._build_envelope_view(_batch_t0)
+                yield EnvelopeCompleted(envelope=_completed_view)
+                # Keep last 10 envelopes for TUI history display
+                self._recent_envelopes.append(_completed_view)
+                if len(self._recent_envelopes) > 10:
+                    self._recent_envelopes = self._recent_envelopes[-10:]
 
                 # Check budget after tool results are appended — the next LLM
                 # call in this loop will include them and may push over the limit.
@@ -1765,6 +1801,83 @@ class LoomSession:
                     message=str(rb_msg)[:200],
                 )
             )
+
+    # ------------------------------------------------------------------
+    # Issue #106: Envelope projection — build read-only view for UI
+    # ------------------------------------------------------------------
+
+    def _build_envelope_view(self, batch_t0: float = 0.0) -> ExecutionEnvelopeView:
+        """Build a read-only ``ExecutionEnvelopeView`` from the live envelope.
+
+        This is the projection layer described in doc/43 — it only does
+        view shaping, never mutates middleware state.
+        """
+        env = self._current_envelope
+        if env is None:
+            return ExecutionEnvelopeView(
+                envelope_id=f"e{self._envelope_counter}",
+                session_id=self.session_id,
+                turn_index=self._turn_index,
+                status="running",
+                node_count=0,
+                parallel_groups=0,
+            )
+
+        nodes: list[ExecutionNodeView] = []
+        for record in env.records:
+            call = record.call
+            tdef = None
+            if record.tool_name != "(unknown)":
+                tdef = self.registry.get(record.tool_name)
+
+            # Build args preview from first string argument
+            args_preview = ""
+            if call and call.args:
+                first_val = next(iter(call.args.values()), "")
+                if isinstance(first_val, str):
+                    args_preview = first_val.replace("\n", "↵")[:60]
+
+            nodes.append(ExecutionNodeView(
+                node_id=record.id,
+                call_id=call.id if call else "",
+                action_id=record.id,
+                tool_name=record.tool_name,
+                level=0,  # all current parallel dispatch = single level
+                state=record.state.value,
+                trust_level=tdef.trust_level.plain if tdef else "SAFE",
+                capabilities=[c.name for c in tdef.capabilities] if tdef else [],
+                args_preview=args_preview,
+                duration_ms=record.elapsed_ms,
+                error_snippet=(
+                    (record.result.error or "")[:80]
+                    if record.result and not record.result.success
+                    else ""
+                ),
+            ))
+
+        # Compute aggregate status
+        all_done = env.all_terminal
+        has_failure = any(r.is_failure for r in env.records)
+        if all_done and has_failure:
+            status = "failed"
+        elif all_done:
+            status = "completed"
+        else:
+            status = "running"
+
+        elapsed_ms = (time.monotonic() - batch_t0) * 1000 if batch_t0 else 0.0
+
+        return ExecutionEnvelopeView(
+            envelope_id=f"e{self._envelope_counter}",
+            session_id=self.session_id,
+            turn_index=self._turn_index,
+            status=status,
+            node_count=len(env.records),
+            parallel_groups=1,
+            elapsed_ms=elapsed_ms,
+            levels=[[n.node_id for n in nodes]],
+            nodes=nodes,
+        )
 
     @staticmethod
     def _format_scope_panel(call: ToolCall) -> str:

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -481,6 +481,9 @@ class LoomChatApp:
             ThinkCollapsed as TuiThinkCollapsed,
             ActionStateChange as TuiActionStateChange,
             ActionRolledBack as TuiActionRolledBack,
+            EnvelopeStarted as TuiEnvelopeStarted,
+            EnvelopeUpdated as TuiEnvelopeUpdated,
+            EnvelopeCompleted as TuiEnvelopeCompleted,
         )
         from loom.platform.cli.ui import (
             TextChunk,
@@ -491,6 +494,11 @@ class LoomChatApp:
             TurnPaused,
             ActionStateChange,
             ActionRolledBack,
+        )
+        from loom.core.events import (
+            EnvelopeStarted,
+            EnvelopeUpdated,
+            EnvelopeCompleted,
         )
 
         class _App(LoomApp):
@@ -729,6 +737,18 @@ class LoomChatApp:
                                     rollback_success=ev.rollback_success,
                                     message=ev.message,
                                 )
+                            )
+                        elif isinstance(ev, EnvelopeStarted):
+                            await self.dispatch_stream_event(
+                                TuiEnvelopeStarted(envelope=ev.envelope)
+                            )
+                        elif isinstance(ev, EnvelopeUpdated):
+                            await self.dispatch_stream_event(
+                                TuiEnvelopeUpdated(envelope=ev.envelope)
+                            )
+                        elif isinstance(ev, EnvelopeCompleted):
+                            await self.dispatch_stream_event(
+                                TuiEnvelopeCompleted(envelope=ev.envelope)
                             )
                 except asyncio.CancelledError:
                     pass

--- a/loom/platform/cli/tui/__init__.py
+++ b/loom/platform/cli/tui/__init__.py
@@ -29,6 +29,7 @@ from .components import (
     ArtifactsPanel,
     SwarmDashboard,
     ActivityEntry,
+    ExecutionDashboard,
     BudgetPanel,
     WorkspacePanel,
     WorkspaceTab,
@@ -42,6 +43,9 @@ from .events import (
     TurnDone,
     ClearScreen,
     BudgetUpdate,
+    EnvelopeStarted,
+    EnvelopeUpdated,
+    EnvelopeCompleted,
 )
 
 __all__ = [
@@ -59,6 +63,7 @@ __all__ = [
     "ArtifactsPanel",
     "SwarmDashboard",
     "ActivityEntry",
+    "ExecutionDashboard",
     "BudgetPanel",
     "WorkspacePanel",
     "WorkspaceTab",
@@ -70,4 +75,7 @@ __all__ = [
     "TurnDone",
     "ClearScreen",
     "BudgetUpdate",
+    "EnvelopeStarted",
+    "EnvelopeUpdated",
+    "EnvelopeCompleted",
 ]

--- a/loom/platform/cli/tui/app.py
+++ b/loom/platform/cli/tui/app.py
@@ -52,6 +52,9 @@ from .events import (
     BudgetUpdate,
     ActionStateChange,
     ActionRolledBack,
+    EnvelopeStarted,
+    EnvelopeUpdated,
+    EnvelopeCompleted,
 )
 
 if TYPE_CHECKING:
@@ -65,7 +68,7 @@ class LoomCommandProvider(Provider):
         commands = [
             ("Toggle Workspace Sidebar", app.action_toggle_sidebar, "Hide/show the right sidebar"),
             ("Switch to Artifacts Tab", lambda: self._focus_tab(WorkspaceTab.ARTIFACTS), "View created artifacts"),
-            ("Switch to Swarm Dashboard", lambda: self._focus_tab(WorkspaceTab.SWARM), "View active agents and history"),
+            ("Switch to Execution Dashboard", lambda: self._focus_tab(WorkspaceTab.EXECUTION), "View envelope execution status"),
             ("Switch to Budget Tab", lambda: self._focus_tab(WorkspaceTab.BUDGET), "View context token usage"),
             ("Clear Conversation", app.action_clear_screen, "Clear the chat history"),
 
@@ -315,7 +318,7 @@ class LoomApp(App):
         workspace.toggle_tab()
         labels = {
             WorkspaceTab.ARTIFACTS: "Artifacts",
-            WorkspaceTab.SWARM:     "Swarm",
+            WorkspaceTab.EXECUTION: "Execution",
             WorkspaceTab.BUDGET:    "Budget",
         }
         self.notify(f"Workspace: {labels[workspace.active_tab]}", timeout=1)
@@ -344,6 +347,12 @@ class LoomApp(App):
             self._on_action_state_change(event)
         elif isinstance(event, ActionRolledBack):
             self._on_action_rolled_back(event)
+        elif isinstance(event, EnvelopeStarted):
+            self._on_envelope_started(event)
+        elif isinstance(event, EnvelopeUpdated):
+            self._on_envelope_updated(event)
+        elif isinstance(event, EnvelopeCompleted):
+            self._on_envelope_completed(event)
 
     async def _on_turn_start(self, event: TurnStart) -> None:
         msg_list = self.query_one("#message-list", MessageList)
@@ -424,6 +433,20 @@ class LoomApp(App):
             f"\n  ↩ {icon} {event.tool_name} rolled back"
             + (f" — {event.message}" if event.message else "")
         )
+
+    # ── Envelope event handlers (Issue #106/#107) ────────────────────────────
+
+    def _on_envelope_started(self, event: EnvelopeStarted) -> None:
+        workspace = self.query_one("#workspace-panel", WorkspacePanel)
+        workspace.on_envelope_started(event.envelope)
+
+    def _on_envelope_updated(self, event: EnvelopeUpdated) -> None:
+        workspace = self.query_one("#workspace-panel", WorkspacePanel)
+        workspace.on_envelope_updated(event.envelope)
+
+    def _on_envelope_completed(self, event: EnvelopeCompleted) -> None:
+        workspace = self.query_one("#workspace-panel", WorkspacePanel)
+        workspace.on_envelope_completed(event.envelope)
 
     async def _on_turn_paused(self, event: TurnPaused) -> None:
         from .components.interactive_widgets import InlinePauseWidget

--- a/loom/platform/cli/tui/components/__init__.py
+++ b/loom/platform/cli/tui/components/__init__.py
@@ -13,6 +13,7 @@ from .observability_panel import ObservabilityPanel
 from .artifact_card import Artifact, ArtifactCard, ArtifactState
 from .artifacts_panel import ArtifactsPanel
 from .swarm_dashboard import SwarmDashboard, ActivityEntry
+from .execution_dashboard import ExecutionDashboard
 from .budget_panel import BudgetPanel
 from .workspace_panel import WorkspacePanel, WorkspaceTab
 from .interactive_widgets import InlineConfirmWidget, InlinePauseWidget
@@ -34,6 +35,7 @@ __all__ = [
     "ArtifactsPanel",
     "SwarmDashboard",
     "ActivityEntry",
+    "ExecutionDashboard",
     "BudgetPanel",
     "WorkspacePanel",
     "WorkspaceTab",

--- a/loom/platform/cli/tui/components/execution_dashboard.py
+++ b/loom/platform/cli/tui/components/execution_dashboard.py
@@ -161,10 +161,10 @@ class ExecutionDashboard(VerticalScroll):
         recent_w.update(self._render_recent())
 
     def _render_header(self, view: "ExecutionEnvelopeView") -> str:
-        """Render the envelope header block."""
+        """Render the envelope header — plain text, no box drawing."""
         elapsed = self._fmt_dur(view.elapsed_ms)
 
-        # Status colour
+        # Status icon
         if view.status == "completed":
             status_icon = "[#7a9e78]✓[/#7a9e78]"
         elif view.status == "failed":
@@ -182,9 +182,9 @@ class ExecutionDashboard(VerticalScroll):
         )
 
         lines = [
-            f"╭─ {status_icon} Envelope [bold]{view.envelope_id}[/bold]"
+            f"{status_icon} Exec Env [bold]{view.envelope_id}[/bold]"
             f" · {view.node_count} node{'s' if view.node_count != 1 else ''}"
-            f" · {elapsed} ─╮",
+            f" · {elapsed}",
         ]
 
         # Status counters — only show non-zero
@@ -198,9 +198,8 @@ class ExecutionDashboard(VerticalScroll):
         if failed:
             counters.append(f"[#b87060]failed: {failed}[/#b87060]")
         if counters:
-            lines.append(f"│ {'  '.join(counters)}")
+            lines.append(f"  {'  '.join(counters)}")
 
-        lines.append(f"╰{'─' * 40}╯")
         return "\n".join(lines)
 
     def _render_levels(self, view: "ExecutionEnvelopeView") -> str:

--- a/loom/platform/cli/tui/components/execution_dashboard.py
+++ b/loom/platform/cli/tui/components/execution_dashboard.py
@@ -1,0 +1,272 @@
+"""
+ExecutionDashboard — envelope-centric execution view.
+
+Replaces SwarmDashboard (Issue #107, TUI Phase A).
+Shows the current envelope's header, level-based node list,
+and a summary of recently completed envelopes.
+
+TODO: SwarmDashboard (swarm_dashboard.py) is preserved for backward
+compatibility.  Remove it once this component is confirmed stable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from rich.markup import escape as markup_escape
+from textual.app import ComposeResult
+from textual.containers import VerticalScroll
+from textual.widgets import Static
+
+if TYPE_CHECKING:
+    from loom.core.events import ExecutionEnvelopeView, ExecutionNodeView
+
+
+# ── Node state → icon mapping (Parchment palette) ────────────────────────
+_STATE_ICONS: dict[str, tuple[str, str]] = {
+    # state → (icon, rich colour tag)
+    "declared":      ("·",  "dim"),
+    "authorized":    ("·",  "dim"),
+    "prepared":      ("·",  "dim"),
+    "executing":     ("⟳", "#c8a464"),
+    "observed":      ("✓", "#7a9e78"),
+    "validated":     ("✓", "#7a9e78"),
+    "committed":     ("✓", "#7a9e78"),
+    "memorialized":  ("✓", "#7a9e78"),
+    "denied":        ("⊘", "#b87060"),
+    "aborted":       ("⊘", "#b87060"),
+    "timed_out":     ("✗", "#b87060"),
+    "reverting":     ("↩", "#c8924a"),
+    "reverted":      ("↩", "#c8924a"),
+}
+
+
+@dataclass
+class _EnvelopeHistory:
+    """Lightweight record for the RECENT section."""
+    envelope_id: str
+    node_count: int
+    fail_count: int
+    elapsed_ms: float
+
+
+class ExecutionDashboard(VerticalScroll):
+    """Envelope-aware execution dashboard.
+
+    Sections:
+    1. Envelope Header — id, node count, group count, elapsed, status counters
+    2. Level List — per-level node rows with state icons
+    3. Recent Envelopes — last 5 completed envelopes summary
+    """
+
+    DEFAULT_CSS = """
+    ExecutionDashboard {
+        overflow-y: auto;
+        height: 1fr;
+    }
+    #exec-header {
+        height: auto;
+        padding-bottom: 0;
+        margin-bottom: 0;
+    }
+    #exec-levels {
+        height: auto;
+        padding-bottom: 0;
+        margin-bottom: 1;
+    }
+    #exec-recent {
+        height: auto;
+    }
+    """
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._current_view: ExecutionEnvelopeView | None = None
+        self._history: list[_EnvelopeHistory] = []
+
+    def compose(self) -> ComposeResult:
+        yield Static("", id="exec-header")
+        yield Static("", id="exec-levels")
+        yield Static("[dim]No envelopes yet.[/dim]", id="exec-recent")
+
+    # ── Public API (called from WorkspacePanel → App) ───────────────────
+
+    def on_envelope_started(self, view: "ExecutionEnvelopeView") -> None:
+        """A new tool batch envelope was created."""
+        self._current_view = view
+        self._render()
+
+    def on_envelope_updated(self, view: "ExecutionEnvelopeView") -> None:
+        """A node finished inside the current envelope."""
+        self._current_view = view
+        self._render()
+
+    def on_envelope_completed(self, view: "ExecutionEnvelopeView") -> None:
+        """All nodes in the envelope reached terminal states."""
+        self._current_view = view
+
+        # Archive into history
+        fail_count = sum(
+            1 for n in view.nodes
+            if n.state in ("denied", "aborted", "timed_out", "reverted")
+        )
+        self._history.append(_EnvelopeHistory(
+            envelope_id=view.envelope_id,
+            node_count=view.node_count,
+            fail_count=fail_count,
+            elapsed_ms=view.elapsed_ms,
+        ))
+        # Keep only last 5
+        if len(self._history) > 5:
+            self._history = self._history[-5:]
+
+        self._render()
+        # Clear current view after rendering so the completed state is visible
+        # until the next envelope starts.
+
+    def clear(self) -> None:
+        """Reset dashboard state."""
+        self._current_view = None
+        self._history = []
+        self._render()
+
+    # ── Internal rendering ───────────────────────────────────────────────
+
+    def _render(self) -> None:
+        from textual.css.query import NoMatches
+        try:
+            header_w = self.query_one("#exec-header", Static)
+            levels_w = self.query_one("#exec-levels", Static)
+            recent_w = self.query_one("#exec-recent", Static)
+        except NoMatches:
+            return
+
+        view = self._current_view
+        if view is None and not self._history:
+            header_w.update("")
+            levels_w.update("")
+            recent_w.update("[dim]No envelopes yet.[/dim]")
+            return
+
+        # ── Header ─────────────────────────────────────────────────
+        if view is not None:
+            header_w.update(self._render_header(view))
+            levels_w.update(self._render_levels(view))
+        else:
+            header_w.update("")
+            levels_w.update("")
+
+        # ── Recent history ─────────────────────────────────────────
+        recent_w.update(self._render_recent())
+
+    def _render_header(self, view: "ExecutionEnvelopeView") -> str:
+        """Render the envelope header block."""
+        elapsed = self._fmt_dur(view.elapsed_ms)
+
+        # Status colour
+        if view.status == "completed":
+            status_icon = "[#7a9e78]✓[/#7a9e78]"
+        elif view.status == "failed":
+            status_icon = "[#b87060]✗[/#b87060]"
+        else:
+            status_icon = "[#c8a464]⟳[/#c8a464]"
+
+        # Count nodes by category
+        running = sum(1 for n in view.nodes if n.state == "executing")
+        blocked = sum(1 for n in view.nodes if n.state in ("denied", "aborted"))
+        failed = sum(1 for n in view.nodes if n.state in ("timed_out", "reverted"))
+        done = sum(
+            1 for n in view.nodes
+            if n.state in ("observed", "validated", "committed", "memorialized")
+        )
+
+        lines = [
+            f"╭─ {status_icon} Envelope [bold]{view.envelope_id}[/bold]"
+            f" · {view.node_count} node{'s' if view.node_count != 1 else ''}"
+            f" · {elapsed} ─╮",
+        ]
+
+        # Status counters — only show non-zero
+        counters = []
+        if done:
+            counters.append(f"[#7a9e78]done: {done}[/#7a9e78]")
+        if running:
+            counters.append(f"[#c8a464]running: {running}[/#c8a464]")
+        if blocked:
+            counters.append(f"[#b87060]blocked: {blocked}[/#b87060]")
+        if failed:
+            counters.append(f"[#b87060]failed: {failed}[/#b87060]")
+        if counters:
+            lines.append(f"│ {'  '.join(counters)}")
+
+        lines.append(f"╰{'─' * 40}╯")
+        return "\n".join(lines)
+
+    def _render_levels(self, view: "ExecutionEnvelopeView") -> str:
+        """Render per-level node rows with state icons."""
+        if not view.nodes:
+            return ""
+
+        lines: list[str] = []
+        # Build lookup by node_id
+        node_map = {n.node_id: n for n in view.nodes}
+
+        for level_idx, level_ids in enumerate(view.levels):
+            for node_id in level_ids:
+                node: ExecutionNodeView | None = node_map.get(node_id)
+                if node is None:
+                    continue
+                icon, colour = _STATE_ICONS.get(node.state, ("?", "dim"))
+                name = markup_escape(node.tool_name)
+                name_col = f"{name:<14}"
+
+                # Duration or placeholder
+                if node.state == "executing":
+                    dur = "[dim]…[/dim]"
+                elif node.duration_ms > 0:
+                    dur = f"[dim]{self._fmt_dur(node.duration_ms)}[/dim]"
+                else:
+                    dur = "[dim]waiting[/dim]"
+
+                # Trust badge
+                trust = ""
+                if node.trust_level in ("GUARDED", "CRITICAL"):
+                    trust_color = "#c8924a" if node.trust_level == "GUARDED" else "#b87060"
+                    trust = f" [{trust_color}]{node.trust_level[0]}[/{trust_color}]"
+
+                # Error snippet (if failed)
+                error = ""
+                if node.error_snippet:
+                    err_safe = markup_escape(node.error_snippet[:40])
+                    error = f"\n  [dim]└ {err_safe}[/dim]"
+
+                lines.append(
+                    f"[{colour}]{icon}[/{colour}] [dim]{name_col}[/dim]{trust} {dur}{error}"
+                )
+
+        return "\n".join(lines)
+
+    def _render_recent(self) -> str:
+        """Render the RECENT section with completed envelope summaries."""
+        if not self._history:
+            return "[dim]No completed envelopes.[/dim]"
+
+        lines: list[str] = []
+        lines.append(f"[dim]── RECENT ({len(self._history)}) ──────────────────[/dim]")
+
+        for h in reversed(self._history):
+            elapsed = self._fmt_dur(h.elapsed_ms)
+            if h.fail_count > 0:
+                status = f"[#b87060]✗[/#b87060]"
+                detail = f"{h.node_count} actions · {h.fail_count} failed · {elapsed}"
+            else:
+                status = f"[#7a9e78]✓[/#7a9e78]"
+                detail = f"{h.node_count} actions · {elapsed}"
+            lines.append(f"{status} [dim]{h.envelope_id}  {detail}[/dim]")
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def _fmt_dur(ms: float) -> str:
+        return f"{ms / 1000:.1f}s" if ms >= 1000 else f"{ms:.0f}ms"

--- a/loom/platform/cli/tui/components/execution_dashboard.py
+++ b/loom/platform/cli/tui/components/execution_dashboard.py
@@ -95,12 +95,12 @@ class ExecutionDashboard(VerticalScroll):
     def on_envelope_started(self, view: "ExecutionEnvelopeView") -> None:
         """A new tool batch envelope was created."""
         self._current_view = view
-        self._render()
+        self._refresh_display()
 
     def on_envelope_updated(self, view: "ExecutionEnvelopeView") -> None:
         """A node finished inside the current envelope."""
         self._current_view = view
-        self._render()
+        self._refresh_display()
 
     def on_envelope_completed(self, view: "ExecutionEnvelopeView") -> None:
         """All nodes in the envelope reached terminal states."""
@@ -121,7 +121,7 @@ class ExecutionDashboard(VerticalScroll):
         if len(self._history) > 5:
             self._history = self._history[-5:]
 
-        self._render()
+        self._refresh_display()
         # Clear current view after rendering so the completed state is visible
         # until the next envelope starts.
 
@@ -129,11 +129,11 @@ class ExecutionDashboard(VerticalScroll):
         """Reset dashboard state."""
         self._current_view = None
         self._history = []
-        self._render()
+        self._refresh_display()
 
     # ── Internal rendering ───────────────────────────────────────────────
 
-    def _render(self) -> None:
+    def _refresh_display(self) -> None:
         from textual.css.query import NoMatches
         try:
             header_w = self.query_one("#exec-header", Static)

--- a/loom/platform/cli/tui/components/workspace_panel.py
+++ b/loom/platform/cli/tui/components/workspace_panel.py
@@ -17,13 +17,14 @@ from textual.widgets import Static
 
 from .artifact_card import ArtifactState
 from .artifacts_panel import ArtifactsPanel
-from .swarm_dashboard import SwarmDashboard, ActivityEntry
+from .swarm_dashboard import SwarmDashboard, ActivityEntry  # backward compat
+from .execution_dashboard import ExecutionDashboard
 from .budget_panel import BudgetPanel
 
 
 class WorkspaceTab(Enum):
     ARTIFACTS = "artifacts"
-    SWARM = "swarm"
+    EXECUTION = "execution"
     BUDGET = "budget"
 
 
@@ -56,7 +57,7 @@ class WorkspacePanel(Widget):
         scrollbar-color-hover: #c8a464;
         scrollbar-background: #1c1814;
     }
-    #swarm-panel {
+    #execution-panel {
         height: 1fr;
         overflow-y: auto;
         scrollbar-color: #4a4038;
@@ -82,19 +83,19 @@ class WorkspacePanel(Widget):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self._artifacts_panel: ArtifactsPanel | None = None
-        self._swarm_panel: SwarmDashboard | None = None
+        self._execution_panel: ExecutionDashboard | None = None
         self._budget_panel: BudgetPanel | None = None
 
     def compose(self) -> ComposeResult:
         yield Static("", id="workspace-header")
         yield Static("", id="workspace-divider")
         yield ArtifactsPanel(id="artifacts-panel")
-        yield SwarmDashboard(id="swarm-panel")
+        yield ExecutionDashboard(id="execution-panel")
         yield BudgetPanel(id="budget-panel")
 
     def on_mount(self) -> None:
         self._artifacts_panel = self.query_one("#artifacts-panel", ArtifactsPanel)
-        self._swarm_panel = self.query_one("#swarm-panel", SwarmDashboard)
+        self._execution_panel = self.query_one("#execution-panel", ExecutionDashboard)
         self._budget_panel = self.query_one("#budget-panel", BudgetPanel)
         self._update_visibility()
         self._render_header()
@@ -109,8 +110,8 @@ class WorkspacePanel(Widget):
         self.active_tab = tab
 
     def toggle_tab(self) -> None:
-        """Cycle Artifacts → Swarm → Budget → Artifacts."""
-        order = [WorkspaceTab.ARTIFACTS, WorkspaceTab.SWARM, WorkspaceTab.BUDGET]
+        """Cycle Artifacts → Execution → Budget → Artifacts."""
+        order = [WorkspaceTab.ARTIFACTS, WorkspaceTab.EXECUTION, WorkspaceTab.BUDGET]
         idx = order.index(self.active_tab)
         self.active_tab = order[(idx + 1) % len(order)]
 
@@ -131,7 +132,7 @@ class WorkspacePanel(Widget):
         if x < 14:
             self.active_tab = WorkspaceTab.ARTIFACTS
         elif x < 20:
-            self.active_tab = WorkspaceTab.SWARM
+            self.active_tab = WorkspaceTab.EXECUTION
         else:
             self.active_tab = WorkspaceTab.BUDGET
 
@@ -148,9 +149,22 @@ class WorkspacePanel(Widget):
             self._artifacts_panel.add_artifact(path, state, diff_lines, preview)
 
     def append_activity(self, entry: ActivityEntry) -> None:
-        """Add a completed tool call to the Swarm Dashboard."""
-        if self._swarm_panel:
-            self._swarm_panel.append_entry(entry)
+        """Add a completed tool call to the Activity log (backward compat)."""
+        pass  # Activity feed now driven by envelope events via ExecutionDashboard
+
+    # ── Envelope delegates (Issue #106/#107) ─────────────────────────────────
+
+    def on_envelope_started(self, view) -> None:
+        if self._execution_panel:
+            self._execution_panel.on_envelope_started(view)
+
+    def on_envelope_updated(self, view) -> None:
+        if self._execution_panel:
+            self._execution_panel.on_envelope_updated(view)
+
+    def on_envelope_completed(self, view) -> None:
+        if self._execution_panel:
+            self._execution_panel.on_envelope_completed(view)
 
     def update_budget(
         self,
@@ -170,8 +184,8 @@ class WorkspacePanel(Widget):
     def _update_visibility(self) -> None:
         if self._artifacts_panel:
             self._artifacts_panel.display = self.active_tab == WorkspaceTab.ARTIFACTS
-        if self._swarm_panel:
-            self._swarm_panel.display = self.active_tab == WorkspaceTab.SWARM
+        if self._execution_panel:
+            self._execution_panel.display = self.active_tab == WorkspaceTab.EXECUTION
         if self._budget_panel:
             self._budget_panel.display = self.active_tab == WorkspaceTab.BUDGET
 
@@ -189,7 +203,7 @@ class WorkspacePanel(Widget):
 
         header.update(
             f"{_tab('Art', WorkspaceTab.ARTIFACTS)} "
-            f"{_tab('Swa', WorkspaceTab.SWARM)} "
+            f"{_tab('Exe', WorkspaceTab.EXECUTION)} "
             f"{_tab('Bgt', WorkspaceTab.BUDGET)} "
             f" [dim]F2[/dim]"
         )

--- a/loom/platform/cli/tui/events.py
+++ b/loom/platform/cli/tui/events.py
@@ -133,3 +133,25 @@ class ThinkCollapsed(StreamEvent):
 
     summary: str   # first ~120 chars, one line
     full: str      # complete think content
+
+
+# ---------------------------------------------------------------------------
+# Issue #106: Envelope stream events (TUI wrappers)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class EnvelopeStarted(StreamEvent):
+    """A new tool-use batch (envelope) has been created."""
+    envelope: Any  # ExecutionEnvelopeView (avoid circular import)
+
+
+@dataclass
+class EnvelopeUpdated(StreamEvent):
+    """A node inside the current envelope changed state."""
+    envelope: Any  # ExecutionEnvelopeView
+
+
+@dataclass
+class EnvelopeCompleted(StreamEvent):
+    """All nodes in the envelope have reached terminal states."""
+    envelope: Any  # ExecutionEnvelopeView

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -69,6 +69,10 @@ except ImportError as exc:  # pragma: no cover
     ) from exc
 
 from loom.core.harness.scope import ConfirmDecision
+from loom.core.events import (
+    EnvelopeStarted, EnvelopeUpdated, EnvelopeCompleted,
+    ExecutionEnvelopeView,
+)
 from loom.platform.cli.ui import (
     ActionRolledBack, ActionStateChange,
     CompressDone, TextChunk, ThinkCollapsed, ToolBegin, ToolEnd,
@@ -140,6 +144,46 @@ class _ConfirmView(View):
 
 _MAX_CHARS     = 2000  # Discord per-message limit
 _THREAD_ARCHIVE_MINUTES = 1440  # 24h auto-archive for threads
+
+# ── Envelope display helpers (Issue #110) ────────────────────────────────
+
+_ENVELOPE_STATE_ICONS: dict[str, str] = {
+    "declared": "·", "authorized": "·", "prepared": "·",
+    "executing": "⟳", "observed": "✓", "validated": "✓",
+    "committed": "✓", "memorialized": "✓",
+    "denied": "⊘", "aborted": "⊘", "timed_out": "✗",
+    "reverting": "↩", "reverted": "↩",
+}
+
+
+def _format_envelope_status(view: ExecutionEnvelopeView) -> str:
+    """Format an envelope view into a compact Discord status block."""
+    lines: list[str] = []
+    # Header
+    header = f"-# Envelope {view.envelope_id} · {view.node_count} actions"
+    if view.parallel_groups > 1:
+        header += f" · {view.parallel_groups} parallel groups"
+    if view.status == "failed":
+        header += " · **failed**"
+    elif view.status == "completed":
+        header += f" · completed {view.elapsed_ms / 1000:.1f}s"
+    lines.append(header)
+
+    # Level list with state icons
+    for level_idx, level_nodes in enumerate(view.levels):
+        level_parts: list[str] = []
+        for node_id in level_nodes:
+            node = next((n for n in view.nodes if n.node_id == node_id), None)
+            if node:
+                icon = _ENVELOPE_STATE_ICONS.get(node.state, "?")
+                name = node.tool_name
+                extra = ""
+                if node.error_snippet:
+                    extra = f" ({node.error_snippet[:40]})"
+                level_parts.append(f"{icon} {name}{extra}")
+        lines.append(f"-# L{level_idx}  {'  '.join(level_parts)}")
+
+    return "\n".join(lines)
 
 
 class LoomDiscordBot:
@@ -620,6 +664,10 @@ class LoomDiscordBot:
         tool_buf = ""       # accumulates tool activity lines (edited into status_msg)
         narration_buf = ""  # accumulates LLM text; flushed as send-once before each tool
         _pending_think = ""  # dim think summary, flushed into tool_buf before next tool
+        _envelope_active = False    # True once we receive envelope events (suppresses old ToolBegin/End display)
+        _last_envelope_view: ExecutionEnvelopeView | None = None
+        _last_envelope_edit: float = 0.0  # monotonic timestamp of last envelope edit (debounce)
+        _ENVELOPE_DEBOUNCE_S = 0.5
 
         # ── Run turn with typing indicator ────────────────────────────────
         async with message.channel.typing():
@@ -633,6 +681,44 @@ class LoomDiscordBot:
                         # so reasoning context is visible inline in the activity log.
                         _pending_think = f"-# 💭 {event.summary}"
 
+                    elif isinstance(event, EnvelopeStarted):
+                        _envelope_active = True
+                        _last_envelope_view = event.envelope
+                        # Flush narration before envelope
+                        narration = narration_buf.strip()
+                        narration_buf = ""
+                        if len(narration) >= 10:
+                            await message.channel.send(f"⬥ {narration}")
+                        # Flush pending think
+                        if _pending_think:
+                            tool_buf = _pending_think + "\n"
+                            _pending_think = ""
+                        else:
+                            tool_buf = ""
+                        tool_buf += _format_envelope_status(event.envelope)
+                        await _safe_edit(status_msg, tool_buf.lstrip())
+                        _last_envelope_edit = time.monotonic()
+
+                    elif isinstance(event, EnvelopeUpdated):
+                        _last_envelope_view = event.envelope
+                        now = time.monotonic()
+                        if now - _last_envelope_edit >= _ENVELOPE_DEBOUNCE_S:
+                            # Rebuild tool_buf from envelope status
+                            prefix = ""
+                            if _pending_think:
+                                prefix = _pending_think + "\n"
+                                _pending_think = ""
+                            tool_buf = prefix + _format_envelope_status(event.envelope)
+                            await _safe_edit(status_msg, tool_buf.lstrip())
+                            _last_envelope_edit = now
+
+                    elif isinstance(event, EnvelopeCompleted):
+                        _last_envelope_view = event.envelope
+                        _envelope_active = False
+                        tool_buf = _format_envelope_status(event.envelope)
+                        await _safe_edit(status_msg, tool_buf.lstrip())
+                        _last_envelope_edit = time.monotonic()
+
                     elif isinstance(event, ToolBegin):
                         # Flush narration before tool activity (send-once, ⬥ prefix).
                         narration = narration_buf.strip()
@@ -640,37 +726,39 @@ class LoomDiscordBot:
                         if len(narration) >= 10:
                             await message.channel.send(f"⬥ {narration}")
 
-                        # Flush pending think summary before this tool batch.
-                        if _pending_think:
-                            tool_buf += ("\n" if tool_buf else "") + _pending_think
-                            _pending_think = ""
+                        if not _envelope_active:
+                            # Flush pending think summary before this tool batch.
+                            if _pending_think:
+                                tool_buf += ("\n" if tool_buf else "") + _pending_think
+                                _pending_think = ""
 
-                        # Build tool line with kimaki-style symbol:
-                        #   ◼︎ for file writes, ┣ for everything else.
-                        if event.args:
-                            first_val = next(iter(event.args.values()), "")
-                            primary = str(first_val).replace("\n", "↵")[:120]
-                            args_str = f'"{primary}"' if primary else ""
-                        else:
-                            args_str = ""
-                        symbol = "◼︎" if event.name in ("write_file",) else "┣"
-                        tool_line = (
-                            f"\n{symbol} {event.name}"
-                            + (f" — {args_str}" if args_str else "")
-                        )
-                        tool_buf += tool_line
-                        await _safe_edit(status_msg, tool_buf.lstrip())
+                            # Build tool line with kimaki-style symbol:
+                            #   ◼︎ for file writes, ┣ for everything else.
+                            if event.args:
+                                first_val = next(iter(event.args.values()), "")
+                                primary = str(first_val).replace("\n", "↵")[:120]
+                                args_str = f'"{primary}"' if primary else ""
+                            else:
+                                args_str = ""
+                            symbol = "◼︎" if event.name in ("write_file",) else "┣"
+                            tool_line = (
+                                f"\n{symbol} {event.name}"
+                                + (f" — {args_str}" if args_str else "")
+                            )
+                            tool_buf += tool_line
+                            await _safe_edit(status_msg, tool_buf.lstrip())
 
                     elif isinstance(event, ToolEnd):
-                        if event.success:
-                            tool_buf += f" ✓ {event.duration_ms:.0f}ms"
-                        else:
-                            err = (
-                                event.output[:80].replace("\n", " ")
-                                if event.output else "failed"
-                            )
-                            tool_buf += f" ✗ {err}"
-                        await _safe_edit(status_msg, tool_buf.lstrip())
+                        if not _envelope_active:
+                            if event.success:
+                                tool_buf += f" ✓ {event.duration_ms:.0f}ms"
+                            else:
+                                err = (
+                                    event.output[:80].replace("\n", " ")
+                                    if event.output else "failed"
+                                )
+                                tool_buf += f" ✗ {err}"
+                            await _safe_edit(status_msg, tool_buf.lstrip())
 
                     elif isinstance(event, TurnPaused):
                         pause_body = (
@@ -737,8 +825,24 @@ class LoomDiscordBot:
                             tool_buf += f" — {event.message[:80]}"
                         await _safe_edit(status_msg, tool_buf.lstrip())
 
-                    elif isinstance(event, (ActionStateChange, TurnDone)):
-                        pass  # ActionStateChange: too granular for Discord display
+                    elif isinstance(event, ActionStateChange):
+                        pass  # too granular for Discord display
+
+                    elif isinstance(event, TurnDone):
+                        # Compact envelope summary after the turn
+                        if _last_envelope_view:
+                            v = _last_envelope_view
+                            fail_count = sum(
+                                1 for n in v.nodes
+                                if n.state in ("denied", "aborted", "timed_out", "reverted")
+                            )
+                            summary = (
+                                f"-# ✓ {v.node_count} actions · "
+                                f"{v.parallel_groups} parallel · "
+                                f"{fail_count} failed · "
+                                f"{v.elapsed_ms / 1000:.1f}s"
+                            )
+                            await message.channel.send(summary)
 
             except asyncio.CancelledError:
                 # Cleanup any pending confirmation buttons in this thread immediately


### PR DESCRIPTION
## Summary

- **#106 Backend**: `ExecutionEnvelope` 升級為真實執行單位，`stream_turn()` 產出 `EnvelopeStarted/Updated/Completed` events，含完整 ViewModel (`ExecutionEnvelopeView` + `ExecutionNodeView`)，遞增序號 (`e1`, `e2`...)
- **#107 TUI Phase A**: 新增 `ExecutionDashboard` 元件取代 `SwarmDashboard`（WorkspaceTab.SWARM → EXECUTION），顯示 envelope header、level list、近 5 筆歷史摘要
- **#110 Discord Phase A**: `status_msg` 升級為 envelope batch snapshot，500ms debounce 控制 edit 頻率，turn 完成後送出 compact summary 行

## Changes (11 files, +694 / -47)

| File | Change |
|------|--------|
| `loom/core/events.py` | ViewModel dataclasses + 3 stream events |
| `loom/core/session.py` | Envelope 建立、`_build_envelope_view()` projection、yield events、history cache |
| `loom/platform/cli/tui/components/execution_dashboard.py` | **NEW** — envelope-aware execution dashboard |
| `loom/platform/cli/tui/components/workspace_panel.py` | SWARM → EXECUTION，ExecutionDashboard 替換，envelope delegates |
| `loom/platform/cli/tui/app.py` | 3 個 envelope handler + command/label 更新 |
| `loom/platform/cli/tui/events.py` | TUI envelope event wrappers |
| `loom/platform/cli/main.py` | `_run_turn` 中 core → TUI envelope event 轉換 |
| `loom/platform/cli/tui/components/__init__.py` | Export ExecutionDashboard |
| `loom/platform/cli/tui/__init__.py` | Export ExecutionDashboard + envelope events |
| `loom/platform/discord/bot.py` | `_format_envelope_status()`、envelope event handling、debounce、compact summary |

## Backward Compatibility

- `ToolBegin/ToolEnd` 路徑完全保留，舊消費者不受影響
- `swarm_dashboard.py` 暫時保留（不再作為預設元件），穩定後再移除
- `SwarmDashboard` / `ActivityEntry` 仍從 `components/__init__.py` export

## Design Decisions

1. **`swarm_dashboard.py` 保留** — 確認穩定後再移除，降低 regression 風險
2. **Envelope ID 用遞增序號** (`e1`, `e2`...) — 比 UUID 前 8 碼更有可讀性
3. **Discord edit 用 500ms debounce** — `EnvelopeUpdated` 高頻觸發時跳過中間 edit，避免 rate limit
4. **Parallel levels 目前均為 L0** — `level` 欄位預留給未來多層 DAG 支援

## Test plan

- [x] `pytest tests/ -x -q` — 706 passed, 0 regressions（1 個 pre-existing MCP test failure 不相關）
- [x] 所有修改檔案 syntax check 通過
- [ ] `loom chat --tui` → 觸發工具呼叫 → 確認 Execution tab 顯示 envelope header + level list + 歷史
- [ ] `loom discord start` → 觸發工具呼叫 → 確認 status_msg 為 envelope snapshot + compact summary
- [ ] F2 cycle 確認 Art → Exe → Bgt 順序正確
- [ ] 多工具並行 batch → 確認所有 nodes 正確顯示在同一 envelope

Closes #106, closes #107, closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)