### PR TITLE
feat(tui): ExecutionDashboard Phase B + Confirm Graph integration (#108, #109)

### DIFF
--- a/loom/core/events.py
+++ b/loom/core/events.py
@@ -153,6 +153,13 @@ class ExecutionNodeView:
     duration_ms: float = 0.0
     error_snippet: str = ""
     depends_on: list[str] = field(default_factory=list)
+    # ── Detail fields (Issue #108) ──────────────────────────────────
+    full_args: dict[str, Any] = field(default_factory=dict)
+    state_history: list[dict[str, Any]] = field(default_factory=list)
+    auth_decision: str = ""      # "once" / "scope" / "auto" / "deny" / ""
+    auth_expires: float = 0.0    # time.time() expiry; 0 = permanent/N/A
+    auth_selector: str = ""      # scope selector (e.g. "/workspace/doc/")
+    output_preview: str = ""     # first ~200 chars of tool output
 
 
 @dataclass
@@ -192,6 +199,13 @@ class EnvelopeCompleted:
     envelope: ExecutionEnvelopeView
 
 
+@dataclass
+class GrantsSnapshot:
+    """Current state of active scope grants for UI display (#108)."""
+    active_count: int
+    next_expiry_secs: float = 0.0  # seconds until nearest expiry; 0 = none
+
+
 __all__ = [
     "ActionRolledBack",
     "ActionStateChange",
@@ -201,6 +215,7 @@ __all__ = [
     "EnvelopeUpdated",
     "ExecutionEnvelopeView",
     "ExecutionNodeView",
+    "GrantsSnapshot",
     "TextChunk",
     "ThinkCollapsed",
     "ToolBegin",

--- a/loom/core/harness/lifecycle.py
+++ b/loom/core/harness/lifecycle.py
@@ -40,6 +40,10 @@ class ActionState(Enum):
         DECLARED → AUTHORIZED → PREPARED → EXECUTING → OBSERVED →
         VALIDATED → COMMITTED → MEMORIALIZED
 
+    Confirm path (GUARDED / CRITICAL tools):
+        DECLARED → AWAITING_CONFIRM → AUTHORIZED → PREPARED → ...
+        DECLARED → AWAITING_CONFIRM → DENIED  (user denied)
+
     Rollback path:
         VALIDATED (fail) → REVERTING → REVERTED → MEMORIALIZED
 
@@ -50,6 +54,7 @@ class ActionState(Enum):
     """
     # --- Normal lifecycle ---
     DECLARED      = "declared"       # ToolCall created from LLM output
+    AWAITING_CONFIRM = "awaiting_confirm"  # Waiting for human confirmation
     AUTHORIZED    = "authorized"     # Passed blast-radius / permission check
     PREPARED      = "prepared"       # Preconditions verified
     EXECUTING     = "executing"      # Tool executor invoked (in flight)
@@ -92,7 +97,8 @@ _FAILURE_STATES = {
 
 # Valid state transitions — key can transition to any value in the set.
 _VALID_TRANSITIONS: dict[ActionState, set[ActionState]] = {
-    ActionState.DECLARED:     {ActionState.AUTHORIZED, ActionState.DENIED},
+    ActionState.DECLARED:     {ActionState.AUTHORIZED, ActionState.AWAITING_CONFIRM, ActionState.DENIED},
+    ActionState.AWAITING_CONFIRM: {ActionState.AUTHORIZED, ActionState.DENIED},
     ActionState.AUTHORIZED:   {ActionState.PREPARED, ActionState.ABORTED},
     ActionState.PREPARED:     {ActionState.EXECUTING, ActionState.ABORTED},
     ActionState.EXECUTING:    {ActionState.OBSERVED, ActionState.TIMED_OUT, ActionState.ABORTED},

--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -870,6 +870,32 @@ class LifecycleMiddleware(Middleware):
         self._LifecycleContext = LifecycleContext
         self._CTX_KEY = LIFECYCLE_CTX_KEY
 
+    @staticmethod
+    async def _advance_to(
+        ctx: "LifecycleContext",
+        target: "ActionState",
+        auth_reason: str = "passed blast radius",
+    ) -> None:
+        """Advance record through pre-execution states up to *target*.
+
+        Handles DECLARED, AWAITING_CONFIRM, AUTHORIZED, PREPARED, EXECUTING
+        in order, stopping when *target* is reached or surpassed.
+        Extracted to avoid DRY violations across fallback paths (#108 review).
+        """
+        from .lifecycle import ActionState as AS
+        _chain = [
+            (AS.DECLARED,          AS.AUTHORIZED, auth_reason),
+            (AS.AWAITING_CONFIRM,  AS.AUTHORIZED, auth_reason),
+            (AS.AUTHORIZED,        AS.PREPARED,   None),
+            (AS.PREPARED,          AS.EXECUTING,  None),
+            (AS.EXECUTING,         AS.OBSERVED,   None),
+        ]
+        for from_state, to_state, reason in _chain:
+            if ctx.record.state == from_state:
+                await ctx.transition(to_state, reason=reason)
+            if ctx.record.state == target:
+                break
+
     async def process(self, call: ToolCall, next: ToolHandler) -> ToolResult:
         ActionRecord = self._ActionRecord
         ActionIntent = self._ActionIntent
@@ -930,10 +956,7 @@ class LifecycleMiddleware(Middleware):
         if not result.success and result.failure_type == "validation_error":
             # Schema validation failed AFTER authorization passed
             auth_reason = ctx.authorization_reason or "passed blast radius"
-            if record.state == ActionState.AWAITING_CONFIRM:
-                await ctx.transition(ActionState.AUTHORIZED, reason=auth_reason)
-            elif record.state == ActionState.DECLARED:
-                await ctx.transition(ActionState.AUTHORIZED, reason=auth_reason)
+            await self._advance_to(ctx, ActionState.AUTHORIZED, auth_reason)
             await ctx.transition(ActionState.ABORTED, reason=result.error)
             record.result = result
             await ctx.memorialize("validation_error")
@@ -950,14 +973,7 @@ class LifecycleMiddleware(Middleware):
                 return result
             # Fallback: force through remaining states
             if not record.state.is_terminal:
-                if record.state == ActionState.DECLARED:
-                    await ctx.transition(ActionState.AUTHORIZED, reason="passed blast radius")
-                if record.state == ActionState.AWAITING_CONFIRM:
-                    await ctx.transition(ActionState.AUTHORIZED, reason="passed blast radius")
-                if record.state == ActionState.AUTHORIZED:
-                    await ctx.transition(ActionState.PREPARED)
-                if record.state == ActionState.PREPARED:
-                    await ctx.transition(ActionState.EXECUTING)
+                await self._advance_to(ctx, ActionState.EXECUTING)
                 await ctx.transition(ActionState.TIMED_OUT, reason=result.error)
                 record.result = result
                 await ctx.memorialize("timed_out")
@@ -973,18 +989,8 @@ class LifecycleMiddleware(Middleware):
                 "pipeline may be misconfigured; stamping states retroactively",
                 call.tool_name, record.state.value,
             )
-            if record.state == ActionState.DECLARED:
-                auth_reason = ctx.authorization_reason or "passed blast radius"
-                await ctx.transition(ActionState.AUTHORIZED, reason=auth_reason)
-            if record.state == ActionState.AWAITING_CONFIRM:
-                auth_reason = ctx.authorization_reason or "passed blast radius"
-                await ctx.transition(ActionState.AUTHORIZED, reason=auth_reason)
-            if record.state == ActionState.AUTHORIZED:
-                await ctx.transition(ActionState.PREPARED)
-            if record.state == ActionState.PREPARED:
-                await ctx.transition(ActionState.EXECUTING)
-            if record.state == ActionState.EXECUTING:
-                await ctx.transition(ActionState.OBSERVED)
+            auth_reason = ctx.authorization_reason or "passed blast radius"
+            await self._advance_to(ctx, ActionState.OBSERVED, auth_reason)
             record.result = result
 
         # ── Post-validation (if post_validator defined) ───────────────

--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -335,6 +335,13 @@ class BlastRadiusMiddleware(Middleware):
             ctx.authorization_result = result
             ctx.authorization_reason = reason
 
+    async def _enter_awaiting_confirm(self, call: ToolCall) -> None:
+        """Transition ActionRecord to AWAITING_CONFIRM before prompting user (#109)."""
+        from .lifecycle import LIFECYCLE_CTX_KEY, ActionState
+        ctx = call.metadata.get(LIFECYCLE_CTX_KEY)
+        if ctx is not None and ctx.record.state == ActionState.DECLARED:
+            await ctx.transition(ActionState.AWAITING_CONFIRM, reason="awaiting user confirmation")
+
     def _write_scope_metadata(
         self, call: ToolCall, scope_request: Any,
         diff: Any | None, verdict: Any,
@@ -441,6 +448,7 @@ class BlastRadiusMiddleware(Middleware):
         if self._is_unattended(call):
             return self._deny_unattended(call, verdict.value)
 
+        await self._enter_awaiting_confirm(call)
         raw = await self._confirm(call)
         decision = self._normalize_decision(raw)
 
@@ -531,6 +539,7 @@ class BlastRadiusMiddleware(Middleware):
         if self._is_unattended(call):
             return self._deny_unattended(call, "legacy-not-authorized")
 
+        await self._enter_awaiting_confirm(call)
         raw = await self._confirm(call)
         decision = self._normalize_decision(raw)
 
@@ -905,14 +914,14 @@ class LifecycleMiddleware(Middleware):
         # LifecycleGateMiddleware ever ran.
 
         if not result.success and result.failure_type == "permission_denied":
-            if record.state == ActionState.DECLARED:
+            if record.state in (ActionState.DECLARED, ActionState.AWAITING_CONFIRM):
                 await ctx.transition(ActionState.DENIED, reason=result.error)
                 record.result = result
                 await ctx.memorialize("denied")
                 return result
 
         if not result.success and result.failure_type == "tool_not_found":
-            if record.state == ActionState.DECLARED:
+            if record.state in (ActionState.DECLARED, ActionState.AWAITING_CONFIRM):
                 record.result = result
                 await ctx.transition(ActionState.DENIED, reason="tool not found")
                 await ctx.memorialize("tool_not_found")
@@ -921,7 +930,10 @@ class LifecycleMiddleware(Middleware):
         if not result.success and result.failure_type == "validation_error":
             # Schema validation failed AFTER authorization passed
             auth_reason = ctx.authorization_reason or "passed blast radius"
-            await ctx.transition(ActionState.AUTHORIZED, reason=auth_reason)
+            if record.state == ActionState.AWAITING_CONFIRM:
+                await ctx.transition(ActionState.AUTHORIZED, reason=auth_reason)
+            elif record.state == ActionState.DECLARED:
+                await ctx.transition(ActionState.AUTHORIZED, reason=auth_reason)
             await ctx.transition(ActionState.ABORTED, reason=result.error)
             record.result = result
             await ctx.memorialize("validation_error")
@@ -939,6 +951,8 @@ class LifecycleMiddleware(Middleware):
             # Fallback: force through remaining states
             if not record.state.is_terminal:
                 if record.state == ActionState.DECLARED:
+                    await ctx.transition(ActionState.AUTHORIZED, reason="passed blast radius")
+                if record.state == ActionState.AWAITING_CONFIRM:
                     await ctx.transition(ActionState.AUTHORIZED, reason="passed blast radius")
                 if record.state == ActionState.AUTHORIZED:
                     await ctx.transition(ActionState.PREPARED)
@@ -960,6 +974,9 @@ class LifecycleMiddleware(Middleware):
                 call.tool_name, record.state.value,
             )
             if record.state == ActionState.DECLARED:
+                auth_reason = ctx.authorization_reason or "passed blast radius"
+                await ctx.transition(ActionState.AUTHORIZED, reason=auth_reason)
+            if record.state == ActionState.AWAITING_CONFIRM:
                 auth_reason = ctx.authorization_reason or "passed blast radius"
                 await ctx.transition(ActionState.AUTHORIZED, reason=auth_reason)
             if record.state == ActionState.AUTHORIZED:

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -54,6 +54,7 @@ from loom.core.events import (
     EnvelopeUpdated,
     ExecutionEnvelopeView,
     ExecutionNodeView,
+    GrantsSnapshot,
     TextChunk,
     ThinkCollapsed,
     ToolBegin,
@@ -861,6 +862,7 @@ class LoomSession:
         TextChunk | ToolBegin | ToolEnd | TurnPaused | TurnDone | TurnDropped
         | ActionStateChange | ActionRolledBack
         | EnvelopeStarted | EnvelopeUpdated | EnvelopeCompleted
+        | GrantsSnapshot
     ]:
         """
         Run one complete agent turn and yield typed UI events.
@@ -1169,17 +1171,45 @@ class LoomSession:
                             {"tool_call_id": tu.id, "tool_name": tu.name},
                         ))
                 else:
-                    # Sequential: single tool, or needs interactive confirmation
+                    # Sequential: single tool, or needs interactive confirmation.
+                    # Dispatched as a task so we can drain lifecycle events
+                    # (e.g. AWAITING_CONFIRM) while the confirm widget blocks.
                     for tu in response.tool_uses:
                         yield ToolBegin(name=tu.name, args=tu.args, call_id=tu.id)
                         ts = time.monotonic()
+
+                        dispatch_task = asyncio.create_task(
+                            self._dispatch(tu.name, tu.args, tu.id)
+                        )
+                        # Drain lifecycle events while dispatch is in flight.
+                        # This makes ⏳ awaiting_confirm visible in the TUI
+                        # before the user responds to the confirm prompt (#109).
+                        _last_envelope_yield = time.monotonic()
+                        while not dispatch_task.done():
+                            try:
+                                await asyncio.wait_for(
+                                    asyncio.shield(dispatch_task), timeout=0.15,
+                                )
+                            except asyncio.TimeoutError:
+                                pass
+                            except Exception:
+                                break
+                            # Drain any lifecycle events queued during this tick
+                            drained = False
+                            while not self._lifecycle_events.empty():
+                                yield self._lifecycle_events.get_nowait()
+                                drained = True
+                            # Yield an envelope update if state changed
+                            if drained:
+                                yield EnvelopeUpdated(
+                                    envelope=self._build_envelope_view(_batch_t0)
+                                )
+                                _last_envelope_yield = time.monotonic()
+
+                        # Collect the result
                         try:
-                            result = await self._dispatch(tu.name, tu.args, tu.id)
+                            result = dispatch_task.result()
                         except Exception as _dispatch_exc:
-                            # An unexpected exception in dispatch (e.g. TUI confirm crash)
-                            # must still produce a tool result message — otherwise the
-                            # assistant's tool_calls entry becomes orphaned and the next
-                            # API call gets a 2013 "tool id not found" error.
                             result = ToolResult(
                                 call_id=tu.id,
                                 tool_name=tu.name,
@@ -1187,6 +1217,7 @@ class LoomSession:
                                 error=f"Internal dispatch error: {_dispatch_exc}",
                                 failure_type="execution_error",
                             )
+
                         duration_ms = (time.monotonic() - ts) * 1000
                         tool_count += 1
                         tool_output = str(result.output) if result.success else (result.error or "")
@@ -1197,7 +1228,7 @@ class LoomSession:
                             duration_ms=duration_ms,
                             call_id=tu.id,
                         )
-                        # Drain lifecycle events queued during dispatch
+                        # Final drain of lifecycle events after dispatch
                         while not self._lifecycle_events.empty():
                             yield self._lifecycle_events.get_nowait()
                         # Issue #106: Yield envelope update after each tool completes
@@ -1221,6 +1252,9 @@ class LoomSession:
                 self._recent_envelopes.append(_completed_view)
                 if len(self._recent_envelopes) > 10:
                     self._recent_envelopes = self._recent_envelopes[-10:]
+
+                # ── Issue #108: Grants snapshot after each batch ──────────
+                yield self._build_grants_snapshot()
 
                 # Check budget after tool results are appended — the next LLM
                 # call in this loop will include them and may push over the limit.
@@ -1682,10 +1716,12 @@ class LoomSession:
         )
         result = await self._pipeline.execute(call, tool_def.executor)
 
-        # Issue #106: link ActionRecord from LifecycleMiddleware to the envelope
+        # Issue #106: link ActionRecord to the envelope (if not already linked
+        # by _on_state_change during execution — see #109 early-add logic).
         ctx = call.metadata.get(LIFECYCLE_CTX_KEY)
         if ctx is not None and self._current_envelope is not None:
-            self._current_envelope.add(ctx.record)
+            if ctx.record not in self._current_envelope.records:
+                self._current_envelope.add(ctx.record)
 
         return result
 
@@ -1781,7 +1817,16 @@ class LoomSession:
 
         Called by LifecycleMiddleware on each state transition.
         Also enqueues ActionRolledBack when transitioning to 'reverted'.
+
+        Issue #109: early-add the record to the envelope on first state
+        change so _build_envelope_view() can see ⏳ awaiting_confirm
+        while the confirm widget is blocking.
         """
+        # Early-add record to envelope (#109)
+        if self._current_envelope is not None:
+            if record not in self._current_envelope.records:
+                self._current_envelope.add(record)
+
         call_id = record.call.id if record.call else ""
         self._lifecycle_events.put_nowait(
             ActionStateChange(
@@ -1844,6 +1889,33 @@ class LoomSession:
                 if isinstance(first_val, str):
                     args_preview = first_val.replace("\n", "↵")[:60]
 
+            # Detail fields (Issue #108)
+            full_args = dict(call.args) if call and call.args else {}
+            state_history = record.history_dicts()
+            auth_decision = ""
+            auth_expires = 0.0
+            auth_selector = ""
+            if call:
+                auth_decision = call.metadata.get("confirm_decision", "")
+                # Extract scope grant info if available
+                scope_req = call.metadata.get("scope_request")
+                if scope_req is not None:
+                    reqs = getattr(scope_req, "requirements", [])
+                    if reqs:
+                        auth_selector = reqs[0].selector
+                # Check for lease TTL from grants
+                if auth_decision == "scope":
+                    for g in self.perm._effective_grants():
+                        if (hasattr(g, "source") and g.source == "lease"
+                                and g.valid_until > 0):
+                            auth_expires = g.valid_until
+                            break
+
+            output_preview = ""
+            if record.result:
+                raw = record.result.output if record.result.success else (record.result.error or "")
+                output_preview = str(raw)[:200]
+
             nodes.append(ExecutionNodeView(
                 node_id=record.id,
                 call_id=call.id if call else "",
@@ -1860,6 +1932,12 @@ class LoomSession:
                     if record.result and not record.result.success
                     else ""
                 ),
+                full_args=full_args,
+                state_history=state_history,
+                auth_decision=auth_decision,
+                auth_expires=auth_expires,
+                auth_selector=auth_selector,
+                output_preview=output_preview,
             ))
 
         # Compute aggregate status
@@ -1885,6 +1963,22 @@ class LoomSession:
             levels=[[n.node_id for n in nodes]],
             nodes=nodes,
         )
+
+    def _build_grants_snapshot(self) -> GrantsSnapshot:
+        """Build a GrantsSnapshot from current PermissionContext (#108)."""
+        import time as _time
+        grants = self.perm._effective_grants()
+        now = _time.time()
+        active = len(grants)
+        # Find nearest expiry
+        next_expiry_secs = 0.0
+        for g in grants:
+            if g.valid_until > 0:
+                remaining = g.valid_until - now
+                if remaining > 0:
+                    if next_expiry_secs == 0.0 or remaining < next_expiry_secs:
+                        next_expiry_secs = remaining
+        return GrantsSnapshot(active_count=active, next_expiry_secs=next_expiry_secs)
 
     @staticmethod
     def _format_scope_panel(call: ToolCall) -> str:

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1199,12 +1199,15 @@ class LoomSession:
                             while not self._lifecycle_events.empty():
                                 yield self._lifecycle_events.get_nowait()
                                 drained = True
-                            # Yield an envelope update if state changed
-                            if drained:
+                            # Yield envelope update if state changed, or as a
+                            # periodic fallback every ~1s so the TUI stays fresh
+                            # even if no lifecycle events fired (#108 review).
+                            now_mono = time.monotonic()
+                            if drained or (now_mono - _last_envelope_yield) > 1.0:
                                 yield EnvelopeUpdated(
                                     envelope=self._build_envelope_view(_batch_t0)
                                 )
-                                _last_envelope_yield = time.monotonic()
+                                _last_envelope_yield = now_mono
 
                         # Collect the result
                         try:

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -484,6 +484,7 @@ class LoomChatApp:
             EnvelopeStarted as TuiEnvelopeStarted,
             EnvelopeUpdated as TuiEnvelopeUpdated,
             EnvelopeCompleted as TuiEnvelopeCompleted,
+            GrantsUpdate as TuiGrantsUpdate,
         )
         from loom.platform.cli.ui import (
             TextChunk,
@@ -499,6 +500,7 @@ class LoomChatApp:
             EnvelopeStarted,
             EnvelopeUpdated,
             EnvelopeCompleted,
+            GrantsSnapshot,
         )
 
         class _App(LoomApp):
@@ -750,6 +752,13 @@ class LoomChatApp:
                             await self.dispatch_stream_event(
                                 TuiEnvelopeCompleted(envelope=ev.envelope)
                             )
+                        elif isinstance(ev, GrantsSnapshot):
+                            await self.dispatch_stream_event(
+                                TuiGrantsUpdate(
+                                    active_count=ev.active_count,
+                                    next_expiry_secs=ev.next_expiry_secs,
+                                )
+                            )
                 except asyncio.CancelledError:
                     pass
                 except Exception as exc:
@@ -946,6 +955,7 @@ async def _chat_tui(model: str, db: str, resume_session_id: str | None = None) -
                 args_preview=args_preview,
                 future=future,
                 justification=str(justification) if justification else None,
+                call_id=call.id,
             )
             msg_list.mount(widget)
             msg_list.scroll_end(animate=False)

--- a/loom/platform/cli/tui/__init__.py
+++ b/loom/platform/cli/tui/__init__.py
@@ -46,6 +46,7 @@ from .events import (
     EnvelopeStarted,
     EnvelopeUpdated,
     EnvelopeCompleted,
+    GrantsUpdate,
 )
 
 __all__ = [
@@ -78,4 +79,5 @@ __all__ = [
     "EnvelopeStarted",
     "EnvelopeUpdated",
     "EnvelopeCompleted",
+    "GrantsUpdate",
 ]

--- a/loom/platform/cli/tui/app.py
+++ b/loom/platform/cli/tui/app.py
@@ -38,6 +38,7 @@ from .components import (
     WorkspaceTab,
     ArtifactState,
     ActivityEntry,
+    ExecutionDashboard,
 )
 from .components.message_list import Role
 from .events import (
@@ -55,6 +56,7 @@ from .events import (
     EnvelopeStarted,
     EnvelopeUpdated,
     EnvelopeCompleted,
+    GrantsUpdate,
 )
 
 if TYPE_CHECKING:
@@ -353,6 +355,8 @@ class LoomApp(App):
             self._on_envelope_updated(event)
         elif isinstance(event, EnvelopeCompleted):
             self._on_envelope_completed(event)
+        elif isinstance(event, GrantsUpdate):
+            self._on_grants_update(event)
 
     async def _on_turn_start(self, event: TurnStart) -> None:
         msg_list = self.query_one("#message-list", MessageList)
@@ -447,6 +451,10 @@ class LoomApp(App):
     def _on_envelope_completed(self, event: EnvelopeCompleted) -> None:
         workspace = self.query_one("#workspace-panel", WorkspacePanel)
         workspace.on_envelope_completed(event.envelope)
+
+    def _on_grants_update(self, event: GrantsUpdate) -> None:
+        status_bar = self.query_one("#status-bar", StatusBar)
+        status_bar.update_grants(event.active_count, event.next_expiry_secs)
 
     async def _on_turn_paused(self, event: TurnPaused) -> None:
         from .components.interactive_widgets import InlinePauseWidget
@@ -570,3 +578,17 @@ class LoomApp(App):
 
     def on_input_area_submit(self, event: InputArea.Submit) -> None:
         self.post_message(self.UserMessage(event.text))
+
+    def on_execution_dashboard_scroll_to_confirm(
+        self, event: ExecutionDashboard.ScrollToConfirm,
+    ) -> None:
+        """When ⏳ node is activated, scroll MessageList to the matching confirm widget (#109)."""
+        from .components.interactive_widgets import InlineConfirmWidget
+        try:
+            msg_list = self.query_one("#message-list", MessageList)
+        except Exception:
+            return
+        for widget in msg_list.query(InlineConfirmWidget):
+            if getattr(widget, "_call_id", "") == event.call_id:
+                widget.scroll_visible(animate=True)
+                return

--- a/loom/platform/cli/tui/components/execution_dashboard.py
+++ b/loom/platform/cli/tui/components/execution_dashboard.py
@@ -5,18 +5,26 @@ Replaces SwarmDashboard (Issue #107, TUI Phase A).
 Shows the current envelope's header, level-based node list,
 and a summary of recently completed envelopes.
 
+Phase B (#108/#109):
+- Node selection with up/down keys, Enter to expand detail pane
+- ⏳ awaiting_confirm state rendering
+- Node Detail Pane: state history, auth info, args, output
+- Click ⏳ node → scroll MessageList to InlineConfirmWidget
+
 TODO: SwarmDashboard (swarm_dashboard.py) is preserved for backward
 compatibility.  Remove it once this component is confirmed stable.
 """
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from rich.markup import escape as markup_escape
 from textual.app import ComposeResult
 from textual.containers import VerticalScroll
+from textual.message import Message
 from textual.widgets import Static
 
 if TYPE_CHECKING:
@@ -26,19 +34,20 @@ if TYPE_CHECKING:
 # ── Node state → icon mapping (Parchment palette) ────────────────────────
 _STATE_ICONS: dict[str, tuple[str, str]] = {
     # state → (icon, rich colour tag)
-    "declared":      ("·",  "dim"),
-    "authorized":    ("·",  "dim"),
-    "prepared":      ("·",  "dim"),
-    "executing":     ("⟳", "#c8a464"),
-    "observed":      ("✓", "#7a9e78"),
-    "validated":     ("✓", "#7a9e78"),
-    "committed":     ("✓", "#7a9e78"),
-    "memorialized":  ("✓", "#7a9e78"),
-    "denied":        ("⊘", "#b87060"),
-    "aborted":       ("⊘", "#b87060"),
-    "timed_out":     ("✗", "#b87060"),
-    "reverting":     ("↩", "#c8924a"),
-    "reverted":      ("↩", "#c8924a"),
+    "declared":          ("·",  "dim"),
+    "awaiting_confirm":  ("⏳", "#c8924a"),
+    "authorized":        ("·",  "dim"),
+    "prepared":          ("·",  "dim"),
+    "executing":         ("⟳", "#c8a464"),
+    "observed":          ("✓", "#7a9e78"),
+    "validated":         ("✓", "#7a9e78"),
+    "committed":         ("✓", "#7a9e78"),
+    "memorialized":      ("✓", "#7a9e78"),
+    "denied":            ("⊘", "#b87060"),
+    "aborted":           ("⊘", "#b87060"),
+    "timed_out":         ("✗", "#b87060"),
+    "reverting":         ("↩", "#c8924a"),
+    "reverted":          ("↩", "#c8924a"),
 }
 
 
@@ -56,8 +65,9 @@ class ExecutionDashboard(VerticalScroll):
 
     Sections:
     1. Envelope Header — id, node count, group count, elapsed, status counters
-    2. Level List — per-level node rows with state icons
-    3. Recent Envelopes — last 5 completed envelopes summary
+    2. Level List — per-level node rows with state icons (selectable)
+    3. Node Detail — expanded view of selected node
+    4. Recent Envelopes — last 5 completed envelopes summary
     """
 
     DEFAULT_CSS = """
@@ -73,6 +83,11 @@ class ExecutionDashboard(VerticalScroll):
     #exec-levels {
         height: auto;
         padding-bottom: 0;
+        margin-bottom: 0;
+    }
+    #exec-detail {
+        height: auto;
+        padding: 0;
         margin-bottom: 1;
     }
     #exec-recent {
@@ -80,14 +95,25 @@ class ExecutionDashboard(VerticalScroll):
     }
     """
 
+    # ── Bubble messages ─────────────────────────────────────────────────
+
+    class ScrollToConfirm(Message, bubble=True):
+        """Request MessageList to scroll to the InlineConfirmWidget for this call_id."""
+        def __init__(self, call_id: str) -> None:
+            super().__init__()
+            self.call_id = call_id
+
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self._current_view: ExecutionEnvelopeView | None = None
         self._history: list[_EnvelopeHistory] = []
+        self._selected_idx: int = -1  # -1 = no selection
+        self._detail_expanded: bool = False
 
     def compose(self) -> ComposeResult:
         yield Static("", id="exec-header")
         yield Static("", id="exec-levels")
+        yield Static("", id="exec-detail")
         yield Static("[dim]No envelopes yet.[/dim]", id="exec-recent")
 
     # ── Public API (called from WorkspacePanel → App) ───────────────────
@@ -95,6 +121,8 @@ class ExecutionDashboard(VerticalScroll):
     def on_envelope_started(self, view: "ExecutionEnvelopeView") -> None:
         """A new tool batch envelope was created."""
         self._current_view = view
+        self._selected_idx = -1
+        self._detail_expanded = False
         self._refresh_display()
 
     def on_envelope_updated(self, view: "ExecutionEnvelopeView") -> None:
@@ -122,14 +150,62 @@ class ExecutionDashboard(VerticalScroll):
             self._history = self._history[-5:]
 
         self._refresh_display()
-        # Clear current view after rendering so the completed state is visible
-        # until the next envelope starts.
 
     def clear(self) -> None:
         """Reset dashboard state."""
         self._current_view = None
         self._history = []
+        self._selected_idx = -1
+        self._detail_expanded = False
         self._refresh_display()
+
+    # ── Keyboard navigation (#108) ──────────────────────────────────────
+
+    def key_up(self) -> None:
+        """Move selection up in Level List."""
+        if self._current_view is None or not self._current_view.nodes:
+            return
+        if self._selected_idx <= 0:
+            self._selected_idx = 0
+        else:
+            self._selected_idx -= 1
+        self._refresh_display()
+
+    def key_down(self) -> None:
+        """Move selection down in Level List."""
+        if self._current_view is None or not self._current_view.nodes:
+            return
+        max_idx = len(self._current_view.nodes) - 1
+        if self._selected_idx < max_idx:
+            self._selected_idx += 1
+        self._refresh_display()
+
+    def key_enter(self) -> None:
+        """Toggle detail pane for selected node, or scroll to confirm widget."""
+        if self._current_view is None or self._selected_idx < 0:
+            return
+        nodes = self._current_view.nodes
+        if self._selected_idx >= len(nodes):
+            return
+
+        node = nodes[self._selected_idx]
+
+        # ⏳ node → scroll to confirm widget (#109)
+        if node.state == "awaiting_confirm" and node.call_id:
+            self.post_message(self.ScrollToConfirm(call_id=node.call_id))
+            return
+
+        self._detail_expanded = not self._detail_expanded
+        self._refresh_display()
+
+    def key_escape(self) -> None:
+        """Close detail pane or deselect."""
+        if self._detail_expanded:
+            self._detail_expanded = False
+            self._refresh_display()
+        elif self._selected_idx >= 0:
+            self._selected_idx = -1
+            self._refresh_display()
 
     # ── Internal rendering ───────────────────────────────────────────────
 
@@ -138,6 +214,7 @@ class ExecutionDashboard(VerticalScroll):
         try:
             header_w = self.query_one("#exec-header", Static)
             levels_w = self.query_one("#exec-levels", Static)
+            detail_w = self.query_one("#exec-detail", Static)
             recent_w = self.query_one("#exec-recent", Static)
         except NoMatches:
             return
@@ -146,6 +223,7 @@ class ExecutionDashboard(VerticalScroll):
         if view is None and not self._history:
             header_w.update("")
             levels_w.update("")
+            detail_w.update("")
             recent_w.update("[dim]No envelopes yet.[/dim]")
             return
 
@@ -153,9 +231,15 @@ class ExecutionDashboard(VerticalScroll):
         if view is not None:
             header_w.update(self._render_header(view))
             levels_w.update(self._render_levels(view))
+            # ── Detail pane ────────────────────────────────────────
+            if self._detail_expanded and 0 <= self._selected_idx < len(view.nodes):
+                detail_w.update(self._render_detail(view.nodes[self._selected_idx]))
+            else:
+                detail_w.update("")
         else:
             header_w.update("")
             levels_w.update("")
+            detail_w.update("")
 
         # ── Recent history ─────────────────────────────────────────
         recent_w.update(self._render_recent())
@@ -174,6 +258,7 @@ class ExecutionDashboard(VerticalScroll):
 
         # Count nodes by category
         running = sum(1 for n in view.nodes if n.state == "executing")
+        confirming = sum(1 for n in view.nodes if n.state == "awaiting_confirm")
         blocked = sum(1 for n in view.nodes if n.state in ("denied", "aborted"))
         failed = sum(1 for n in view.nodes if n.state in ("timed_out", "reverted"))
         done = sum(
@@ -193,6 +278,8 @@ class ExecutionDashboard(VerticalScroll):
             counters.append(f"[#7a9e78]done: {done}[/#7a9e78]")
         if running:
             counters.append(f"[#c8a464]running: {running}[/#c8a464]")
+        if confirming:
+            counters.append(f"[#c8924a]confirm: {confirming}[/#c8924a]")
         if blocked:
             counters.append(f"[#b87060]blocked: {blocked}[/#b87060]")
         if failed:
@@ -203,13 +290,14 @@ class ExecutionDashboard(VerticalScroll):
         return "\n".join(lines)
 
     def _render_levels(self, view: "ExecutionEnvelopeView") -> str:
-        """Render per-level node rows with state icons."""
+        """Render per-level node rows with state icons. Selected node highlighted."""
         if not view.nodes:
             return ""
 
         lines: list[str] = []
         # Build lookup by node_id
         node_map = {n.node_id: n for n in view.nodes}
+        flat_idx = 0
 
         for level_idx, level_ids in enumerate(view.levels):
             for node_id in level_ids:
@@ -221,7 +309,9 @@ class ExecutionDashboard(VerticalScroll):
                 name_col = f"{name:<14}"
 
                 # Duration or placeholder
-                if node.state == "executing":
+                if node.state == "awaiting_confirm":
+                    dur = "[#c8924a]awaiting confirm…[/#c8924a]"
+                elif node.state == "executing":
                     dur = "[dim]…[/dim]"
                 elif node.duration_ms > 0:
                     dur = f"[dim]{self._fmt_dur(node.duration_ms)}[/dim]"
@@ -240,9 +330,107 @@ class ExecutionDashboard(VerticalScroll):
                     err_safe = markup_escape(node.error_snippet[:40])
                     error = f"\n  [dim]└ {err_safe}[/dim]"
 
-                lines.append(
-                    f"[{colour}]{icon}[/{colour}] [dim]{name_col}[/dim]{trust} {dur}{error}"
-                )
+                # Selection highlight
+                selected = flat_idx == self._selected_idx
+                if selected:
+                    row = (
+                        f"[reverse] [{colour}]{icon}[/{colour}] "
+                        f"{name_col}{trust} {dur} [/reverse]{error}"
+                    )
+                else:
+                    row = (
+                        f"[{colour}]{icon}[/{colour}] "
+                        f"[dim]{name_col}[/dim]{trust} {dur}{error}"
+                    )
+                lines.append(row)
+                flat_idx += 1
+
+        # Navigation hint
+        if view.nodes:
+            lines.append("[dim]↑↓ select · Enter detail · Esc back[/dim]")
+
+        return "\n".join(lines)
+
+    def _render_detail(self, node: "ExecutionNodeView") -> str:
+        """Render expanded Node Detail Pane (#108)."""
+        lines: list[str] = []
+        name = markup_escape(node.tool_name)
+        icon, colour = _STATE_ICONS.get(node.state, ("?", "dim"))
+
+        lines.append(f"[dim]── Detail ──────────────────────────[/dim]")
+        lines.append(f"[bold]{name}[/bold]  [{colour}]{icon} {node.state}[/{colour}]")
+
+        # Trust level + capabilities
+        trust_str = node.trust_level
+        if node.trust_level == "GUARDED":
+            trust_str = f"[#c8924a]{node.trust_level}[/#c8924a]"
+        elif node.trust_level == "CRITICAL":
+            trust_str = f"[#b87060]{node.trust_level}[/#b87060]"
+        else:
+            trust_str = f"[#7a9e78]{node.trust_level}[/#7a9e78]"
+        caps = ", ".join(node.capabilities) if node.capabilities else "none"
+        lines.append(f"  Trust: {trust_str}  Caps: [dim]{caps}[/dim]")
+
+        # Authorization info
+        if node.auth_decision:
+            auth_label = node.auth_decision.upper()
+            if node.auth_decision == "deny":
+                auth_line = f"  Auth: [#b87060]{auth_label}[/#b87060]"
+            elif node.auth_decision == "scope":
+                remaining = ""
+                if node.auth_expires > 0:
+                    secs_left = node.auth_expires - time.time()
+                    if secs_left > 0:
+                        mins = int(secs_left // 60)
+                        secs = int(secs_left % 60)
+                        remaining = f"  [dim](remaining: {mins}m {secs:02d}s)[/dim]"
+                    else:
+                        remaining = "  [#b87060](expired)[/#b87060]"
+                auth_line = f"  Auth: [#6a7a9e]SCOPE (lease)[/#6a7a9e]{remaining}"
+            elif node.auth_decision == "auto":
+                auth_line = f"  Auth: [#7a6a9e]AUTO (permanent)[/#7a6a9e]"
+            else:
+                auth_line = f"  Auth: [#7a9e78]ONCE[/#7a9e78]"
+            lines.append(auth_line)
+            if node.auth_selector:
+                lines.append(f"  Selector: [dim]{markup_escape(node.auth_selector)}[/dim]")
+
+        # Duration
+        if node.duration_ms > 0:
+            lines.append(f"  Duration: {self._fmt_dur(node.duration_ms)}")
+
+        # Full args
+        if node.full_args:
+            lines.append(f"  [dim]Args:[/dim]")
+            for k, v in node.full_args.items():
+                v_str = str(v)
+                if len(v_str) > 80:
+                    v_str = v_str[:77] + "..."
+                lines.append(f"    [dim]{markup_escape(k)}:[/dim] {markup_escape(v_str)}")
+
+        # Output preview
+        if node.output_preview:
+            preview = markup_escape(node.output_preview[:120])
+            lines.append(f"  [dim]Output:[/dim] {preview}")
+
+        # State history timeline
+        if node.state_history:
+            lines.append(f"  [dim]History:[/dim]")
+            for entry in node.state_history:
+                ts = entry.get("ts", "")
+                # Show only HH:MM:SS from ISO timestamp
+                if "T" in ts:
+                    ts = ts.split("T")[1][:8]
+                from_s = entry.get("from", "?")
+                to_s = entry.get("to", "?")
+                reason = entry.get("reason", "")
+                reason_str = f" [dim]({markup_escape(reason[:40])})[/dim]" if reason else ""
+                lines.append(f"    [dim]{ts}[/dim] {from_s} → {to_s}{reason_str}")
+
+        # Error
+        if node.error_snippet:
+            err_safe = markup_escape(node.error_snippet)
+            lines.append(f"  [#b87060]Error: {err_safe}[/#b87060]")
 
         return "\n".join(lines)
 

--- a/loom/platform/cli/tui/components/interactive_widgets.py
+++ b/loom/platform/cli/tui/components/interactive_widgets.py
@@ -44,6 +44,7 @@ class InlineConfirmWidget(Widget):
         args_preview: str,
         future: "asyncio.Future[ConfirmDecision]",
         justification: str | None = None,
+        call_id: str = "",
     ) -> None:
         super().__init__()
         self._tool_name = tool_name
@@ -51,6 +52,7 @@ class InlineConfirmWidget(Widget):
         self._args_preview = args_preview
         self._future = future
         self._justification = justification
+        self._call_id = call_id
         self._resolved = False
 
     def compose(self) -> ComposeResult:

--- a/loom/platform/cli/tui/components/status_bar.py
+++ b/loom/platform/cli/tui/components/status_bar.py
@@ -18,7 +18,7 @@ class StatusBar(Widget):
     Bottom status bar showing context budget and token usage.
 
     Color-coded context bar: green < 60%, yellow 60-85%, red > 85%.
-    Shows trust mode, token counts, elapsed time, tool count.
+    Shows trust mode, token counts, elapsed time, tool count, active grants.
     """
 
     context_fraction: reactive[float] = reactive(0.0)
@@ -26,6 +26,8 @@ class StatusBar(Widget):
     output_tokens: reactive[int] = reactive(0)
     elapsed_ms: reactive[float] = reactive(0.0)
     tool_count: reactive[int] = reactive(0)
+    active_grants: reactive[int] = reactive(0)
+    next_expiry_secs: reactive[float] = reactive(0.0)  # seconds until next expiry; 0 = N/A
 
     def compose(self) -> ComposeResult:
         yield Static("", id="status-content")
@@ -47,6 +49,12 @@ class StatusBar(Widget):
         self.output_tokens = output_tokens
         self.elapsed_ms = elapsed_ms
         self.tool_count = tool_count
+        self._update_display()
+
+    def update_grants(self, active: int, next_expiry_secs: float = 0.0) -> None:
+        """Update active grants indicator (#108)."""
+        self.active_grants = active
+        self.next_expiry_secs = next_expiry_secs
         self._update_display()
 
     def watch_context_fraction(self, fraction: float) -> None:
@@ -93,5 +101,24 @@ class StatusBar(Widget):
         if self.tool_count > 0:
             label = "tool" if self.tool_count == 1 else "tools"
             parts.append(f"[dim]{self.tool_count} {label}[/dim]")
+
+        # Active grants indicator (#108)
+        if self.active_grants > 0:
+            exp = self.next_expiry_secs
+            if exp > 0:
+                mins = int(exp // 60)
+                secs = int(exp % 60)
+                if exp < 300:
+                    # < 5 min → yellow warning
+                    expiry_str = f"[yellow]{mins}m {secs:02d}s[/yellow]"
+                else:
+                    expiry_str = f"[dim]{mins}m[/dim]"
+                grants_str = (
+                    f"[dim]grants:[/dim] {self.active_grants} active"
+                    f" [dim]· next expiry[/dim] {expiry_str}"
+                )
+            else:
+                grants_str = f"[dim]grants:[/dim] {self.active_grants} active"
+            parts.append(grants_str)
 
         content.update("  [dim]|[/dim]  ".join(parts))

--- a/loom/platform/cli/tui/events.py
+++ b/loom/platform/cli/tui/events.py
@@ -155,3 +155,10 @@ class EnvelopeUpdated(StreamEvent):
 class EnvelopeCompleted(StreamEvent):
     """All nodes in the envelope have reached terminal states."""
     envelope: Any  # ExecutionEnvelopeView
+
+
+@dataclass
+class GrantsUpdate(StreamEvent):
+    """Active scope grants changed (#108)."""
+    active_count: int
+    next_expiry_secs: float = 0.0


### PR DESCRIPTION
## Summary

- **#109**: Add `AWAITING_CONFIRM` state to `ActionState` lifecycle, wire `BlastRadiusMiddleware` to transition before confirm prompt, render ⏳ in ExecutionDashboard Level List, click-to-scroll to `InlineConfirmWidget`
- **#108**: Node selection (↑↓/Enter/Esc), Node Detail Pane (trust, auth info, TTL, args, state history), StatusBar grants indicator, `GrantsSnapshot` event pipeline

### Key changes by layer

| Layer | Files | What |
|-------|-------|------|
| Lifecycle | `lifecycle.py` | `AWAITING_CONFIRM` state + transitions |
| Middleware | `middleware.py` | `_enter_awaiting_confirm()` before confirm, `AWAITING_CONFIRM` handling in all fallback paths |
| Session | `session.py` | Dispatch drain loop for real-time ⏳, early-add records to envelope, `_build_grants_snapshot()`, extended `_build_envelope_view()` |
| Core Events | `events.py` | `ExecutionNodeView` detail fields, `GrantsSnapshot` dataclass |
| TUI Dashboard | `execution_dashboard.py` | Node selection, detail pane, ⏳ icon, `ScrollToConfirm` message |
| TUI StatusBar | `status_bar.py` | `update_grants()`, active grants indicator with TTL color |
| TUI Events | `events.py`, `app.py` | `GrantsUpdate` event, `_on_grants_update()` handler, `ScrollToConfirm` handler |
| TUI Widgets | `interactive_widgets.py` | `call_id` param on `InlineConfirmWidget` |
| TUI Main | `main.py` | `GrantsSnapshot → GrantsUpdate` conversion, `call_id` passthrough |

### Known issue

- Grants indicator only appears after a SCOPE/AUTO confirm decision — SAFE tools don't create grants. Needs investigation for whether we should show a "grants: 0" dim state or only display when active. Tracked for follow-up.

## Test plan

- [x] 706 tests pass (1 pre-existing MCP skip)
- [x] All 128 lifecycle/harness tests pass
- [x] TUI: F2 → Execution tab renders envelope nodes
- [x] TUI: ↑↓ node selection with reverse highlight
- [x] TUI: Enter expands Node Detail Pane (trust, args, state history)
- [x] TUI: Esc collapses detail / deselects
- [ ] TUI: ⏳ icon visible during GUARDED tool confirm wait
- [ ] TUI: Enter on ⏳ node scrolls to InlineConfirmWidget
- [ ] TUI: StatusBar grants indicator after SCOPE approve
- [ ] Discord: no regression (GrantsSnapshot silently ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)