### PR TITLE
fix(harness): narrow LegitimacyGuard scope — write_file only, session-trust (#118)

### DIFF
--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -178,35 +178,39 @@ class TraceMiddleware(Middleware):
 
 class LegitimacyGuardMiddleware(Middleware):
     """
-    Read-before-Write guard (Issue #47 Phase 3, refined Issue #118).
+    Read-before-Write guard + Trajectory Anomaly detection
+    (Issue #47 Phase 3, refined Issue #118).
 
-    Scope: ``write_file`` only.  The rule mirrors Claude Code's Read-before-Edit
-    contract — the agent must call ``read_file`` (or a directory probe) on the
-    target path before writing to it.  This prevents hallucinated overwrites.
+    **Layer 1 — Hard guard (strict_guard_tools, currently write_file only)**
 
-    ``run_bash`` and MCP tools are intentionally excluded: exec authorization
-    belongs to ``BlastRadiusMiddleware`` (EXEC capability + exec_auto grants),
-    and MCP generative tools (text_to_image, text_to_audio, …) have no local
-    file path to pre-read.
+    Mirrors Claude Code's Read-before-Edit contract: the agent must call a
+    probe tool (``read_file``, ``list_dir``, etc.) before writing.  This
+    prevents hallucinated overwrites of files the agent has never seen.
 
-    Per-path tracking (Issue #118):
-        ``_read_paths`` records every ``read_file`` path argument this turn.
-        ``write_file(path=X)`` passes if X was read this turn, OR if any probe
-        tool ran (``has_probed`` — covers list_dir, web_search, etc. for new-file
-        creation where there is nothing to pre-read).
+    ``run_bash`` and MCP tools are intentionally excluded from hard-guard:
+    exec authorization belongs to ``BlastRadiusMiddleware``.
 
-    Session-trust (Issue #118):
-        Once a strict-guard tool executes successfully, it is added to
-        ``_session_trusted``.  Future turns skip the probe requirement for that
-        tool — the human already reviewed and approved it in this session.
+    **Layer 2 — Soft guard (Trajectory Anomaly, Issue #118)**
 
-    ``reset_probe()`` resets per-turn state (``has_probed``, ``_read_paths``)
-    but intentionally leaves ``_session_trusted`` intact.
+    When the agent calls a tool with ``EXEC`` capability (e.g. ``run_bash``)
+    and has *not* probed this turn, ``call.metadata["trajectory_anomaly"]``
+    is set to ``True``.  ``BlastRadiusMiddleware._exec_auto_approved()``
+    reads this flag and **downgrades** exec_auto pre-authorization to
+    require human confirmation.  This is a *soft* guard: the call is not
+    blocked, just stripped of its fast-pass.
+
+    **Session-trust (Issue #118)**
+
+    Once a strict-guard tool executes successfully, it is added to
+    ``_session_trusted``.  Future turns skip the probe requirement for
+    that tool — the human already reviewed and approved it.
+
+    ``reset_probe()`` resets per-turn state (``has_probed``) but
+    intentionally leaves ``_session_trusted`` intact.
     """
 
     def __init__(self) -> None:
         self.has_probed: bool = False
-        self._read_paths: set[str] = set()
         self.probe_tools = frozenset({
             "list_dir", "read_file", "search_files", "grep_search",
             "fetch_url_tool", "web_search", "recall_memory", "query_relations"
@@ -223,15 +227,10 @@ class LegitimacyGuardMiddleware(Middleware):
     def reset_probe(self) -> None:
         """Reset per-turn probe state. Does NOT clear session-level trust."""
         self.has_probed = False
-        self._read_paths.clear()
 
     async def process(self, call: ToolCall, next: ToolHandler) -> ToolResult:
         if call.tool_name in self.probe_tools:
             self.has_probed = True
-            if call.tool_name == "read_file":
-                path = call.args.get("path", "")
-                if path:
-                    self._read_paths.add(path)
 
         # TODO(#xx): Phase 4 - Goal Drift / Re-justification budget.
         # Enforce re-justification for guarded actions after N steps without human interaction.
@@ -242,10 +241,11 @@ class LegitimacyGuardMiddleware(Middleware):
         if is_strict and call.tool_name in self._session_trusted:
             return await next(call)
 
+        # --- Layer 1: Hard guard (write_file) ---
         if is_strict and not self.has_probed:
             target = call.args.get("path", "")
             error_msg = (
-                f"LEGITIMACY GUARD: Blocked `write_file`"
+                f"LEGITIMACY GUARD: Blocked `{call.tool_name}`"
                 + (f" → '{target}'" if target else "")
                 + ". You must read the target file (or list its directory) before "
                 "writing. Call read_file or list_dir first to establish context — "
@@ -265,6 +265,13 @@ class LegitimacyGuardMiddleware(Middleware):
                 error=error_msg,
                 failure_type="permission_denied"
             )
+
+        # --- Layer 2: Trajectory Anomaly (soft guard for EXEC tools) ---
+        # When EXEC tools run without any prior probe this turn, flag the call
+        # so BlastRadiusMiddleware can downgrade exec_auto to require confirm.
+        if not is_strict and not self.has_probed:
+            if call.capabilities & ToolCapability.EXEC:
+                call.metadata["trajectory_anomaly"] = True
 
         result = await next(call)
 
@@ -325,6 +332,8 @@ class BlastRadiusMiddleware(Middleware):
         2. The tool has EXEC capability (currently: run_bash).
         3. Either no escape-detector is wired, OR the command does not escape
            the workspace via absolute paths.
+        4. No trajectory anomaly flagged by LegitimacyGuardMiddleware
+           (Issue #118 Layer 2 — agent must have probed this turn).
         """
         if not self._perm.exec_auto:
             return False
@@ -332,6 +341,8 @@ class BlastRadiusMiddleware(Middleware):
             return False
         if self._exec_escape_fn is not None and self._exec_escape_fn(call):
             return False   # escape detected — fall through to confirmation
+        if call.metadata.get("trajectory_anomaly"):
+            return False   # no probe this turn — downgrade to confirmation
         return True
 
     # Origins where no human is available to answer confirmation prompts.

--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -178,50 +178,86 @@ class TraceMiddleware(Middleware):
 
 class LegitimacyGuardMiddleware(Middleware):
     """
-    Probe-First Heuristics (Issue #47 Phase 3).
-    
-    Blocks high-risk, mutating actions (like write_file or run_bash) if the
-    agent has not performed any context-gathering operations (read_file, list_dir, etc.)
-    in the current session. Enforces a 'look before you leap' pattern to
-    prevent hallucinatory system modifications.
+    Read-before-Write guard (Issue #47 Phase 3, refined Issue #118).
+
+    Scope: ``write_file`` only.  The rule mirrors Claude Code's Read-before-Edit
+    contract — the agent must call ``read_file`` (or a directory probe) on the
+    target path before writing to it.  This prevents hallucinated overwrites.
+
+    ``run_bash`` and MCP tools are intentionally excluded: exec authorization
+    belongs to ``BlastRadiusMiddleware`` (EXEC capability + exec_auto grants),
+    and MCP generative tools (text_to_image, text_to_audio, …) have no local
+    file path to pre-read.
+
+    Per-path tracking (Issue #118):
+        ``_read_paths`` records every ``read_file`` path argument this turn.
+        ``write_file(path=X)`` passes if X was read this turn, OR if any probe
+        tool ran (``has_probed`` — covers list_dir, web_search, etc. for new-file
+        creation where there is nothing to pre-read).
+
+    Session-trust (Issue #118):
+        Once a strict-guard tool executes successfully, it is added to
+        ``_session_trusted``.  Future turns skip the probe requirement for that
+        tool — the human already reviewed and approved it in this session.
+
+    ``reset_probe()`` resets per-turn state (``has_probed``, ``_read_paths``)
+    but intentionally leaves ``_session_trusted`` intact.
     """
 
     def __init__(self) -> None:
         self.has_probed: bool = False
+        self._read_paths: set[str] = set()
         self.probe_tools = frozenset({
             "list_dir", "read_file", "search_files", "grep_search",
             "fetch_url_tool", "web_search", "recall_memory", "query_relations"
         })
-        self.strict_guard_tools = {
-            "write_file", "run_bash", 
+        # Only file-writing tools belong here.  exec tools (run_bash) and MCP
+        # generative tools are handled by BlastRadiusMiddleware.
+        self.strict_guard_tools: set[str] = {
+            "write_file",
         }
+        # Tools that have successfully executed once this session; probe
+        # requirement is waived for these on subsequent turns (Issue #118).
+        self._session_trusted: set[str] = set()
 
     def reset_probe(self) -> None:
+        """Reset per-turn probe state. Does NOT clear session-level trust."""
         self.has_probed = False
+        self._read_paths.clear()
 
     async def process(self, call: ToolCall, next: ToolHandler) -> ToolResult:
         if call.tool_name in self.probe_tools:
             self.has_probed = True
+            if call.tool_name == "read_file":
+                path = call.args.get("path", "")
+                if path:
+                    self._read_paths.add(path)
 
         # TODO(#xx): Phase 4 - Goal Drift / Re-justification budget.
         # Enforce re-justification for guarded actions after N steps without human interaction.
 
         is_strict = call.tool_name in self.strict_guard_tools
 
+        # Session-trusted tools skip per-turn probe requirement (Issue #118).
+        if is_strict and call.tool_name in self._session_trusted:
+            return await next(call)
+
         if is_strict and not self.has_probed:
+            target = call.args.get("path", "")
             error_msg = (
-                f"LEGITIMACY GUARD: Blocked `{call.tool_name}`. "
-                "You must gather context first (e.g. read_file, list_dir, search) "
-                "before performing destructive actions or running commands. "
-                "Hallucinating paths or executing blindly is forbidden."
+                f"LEGITIMACY GUARD: Blocked `write_file`"
+                + (f" → '{target}'" if target else "")
+                + ". You must read the target file (or list its directory) before "
+                "writing. Call read_file or list_dir first to establish context — "
+                "writing to a path you haven't read risks overwriting unknown content."
             )
-            
+
             from .lifecycle import LIFECYCLE_CTX_KEY
             ctx = call.metadata.get(LIFECYCLE_CTX_KEY)
             if ctx is not None:
                 ctx.authorization_result = False
                 ctx.authorization_reason = "probe-first heuristic failed"
-            
+
             return ToolResult(
                 call_id=call.id,
                 tool_name=call.tool_name,
@@ -230,7 +266,14 @@ class LegitimacyGuardMiddleware(Middleware):
                 failure_type="permission_denied"
             )
 
-        return await next(call)
+        result = await next(call)
+
+        # On successful execution, promote to session-trusted so future turns
+        # don't require a new probe for the same tool (Issue #118).
+        if is_strict and result.success:
+            self._session_trusted.add(call.tool_name)
+
+        return result
 
 
 class BlastRadiusMiddleware(Middleware):

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -679,15 +679,12 @@ class LoomSession:
         except Exception as exc:
             logger.warning("MCP servers failed to load: %s", exc)
 
-        # Wire up LegitimacyGuardMiddleware before the rest of the pipeline
+        # Wire up LegitimacyGuardMiddleware before the rest of the pipeline.
+        # Scope: write_file only (read-before-write contract, Issue #118).
+        # run_bash and MCP tools are NOT added here — exec authorization belongs
+        # to BlastRadiusMiddleware (EXEC capability / scope grants).
         from loom.core.harness.middleware import LegitimacyGuardMiddleware
         self._legitimacy_guard = LegitimacyGuardMiddleware()
-        
-        # Dynamically append MCP mutating tools to strict guard
-        from loom.core.harness.registry import ToolCapability
-        for tdef in self.registry._tools.values():
-            if "mcp" in tdef.tags and (tdef.capabilities & ToolCapability.MUTATES):
-                self._legitimacy_guard.strict_guard_tools.add(tdef.name)
 
         # LogMiddleware is omitted here: stream_turn() yields ToolBegin/ToolEnd
         # events that the UI renders, providing richer display without duplication.

--- a/tests/test_legitimacy.py
+++ b/tests/test_legitimacy.py
@@ -2,8 +2,9 @@ import asyncio
 import pytest
 
 from loom.core.harness.middleware import (
-    ToolCall, ToolResult, MiddlewarePipeline, BlastRadiusMiddleware, LegitimacyGuardMiddleware, ToolHandler
+    ToolCall, ToolResult, MiddlewarePipeline, BlastRadiusMiddleware, LegitimacyGuardMiddleware, ToolHandler,
 )
+from loom.core.harness.permissions import ToolCapability
 from loom.core.harness.permissions import PermissionContext, TrustLevel
 from loom.core.harness.scope import ConfirmDecision
 from loom.core.harness.registry import ToolRegistry, ToolDefinition
@@ -27,16 +28,17 @@ def handler():
         return ToolResult(call_id=call.id, tool_name=call.tool_name, success=True)
     return mock_handler
 
-def make_call(name: str, trust: TrustLevel) -> ToolCall:
-    call = ToolCall(tool_name=name, args={}, trust_level=trust, session_id="test")
-    # minimal lifecycle ctx
-    record = ActionRecord(call=call, intent=ActionIntent(intent_summary=name))
-    ctx = LifecycleContext(record=record)
-    call.metadata[LIFECYCLE_CTX_KEY] = ctx
-    return call
-
-def make_call_with_args(name: str, trust: TrustLevel, args: dict) -> ToolCall:
-    call = ToolCall(tool_name=name, args=args, trust_level=trust, session_id="test")
+def make_call(
+    name: str,
+    trust: TrustLevel,
+    args: dict | None = None,
+    *,
+    capabilities: ToolCapability = ToolCapability.NONE,
+) -> ToolCall:
+    call = ToolCall(
+        tool_name=name, args=args or {}, trust_level=trust,
+        session_id="test", capabilities=capabilities,
+    )
     record = ActionRecord(call=call, intent=ActionIntent(intent_summary=name))
     ctx = LifecycleContext(record=record)
     call.metadata[LIFECYCLE_CTX_KEY] = ctx
@@ -47,7 +49,7 @@ def make_call_with_args(name: str, trust: TrustLevel, args: dict) -> ToolCall:
 async def test_write_file_blocked_without_probe(handler):
     """write_file is blocked when no read_file / list_dir has been called this turn."""
     guard = LegitimacyGuardMiddleware()
-    call_write = make_call_with_args("write_file", TrustLevel.GUARDED, {"path": "foo.py", "content": ""})
+    call_write = make_call("write_file", TrustLevel.GUARDED, {"path": "foo.py", "content": ""})
     res = await guard.process(call_write, handler)
     assert not res.success
     assert res.failure_type == "permission_denied"
@@ -59,12 +61,11 @@ async def test_write_file_blocked_without_probe(handler):
 async def test_write_file_allowed_after_read(handler):
     """write_file passes after any probe tool runs (has_probed=True)."""
     guard = LegitimacyGuardMiddleware()
-    call_read = make_call_with_args("read_file", TrustLevel.SAFE, {"path": "foo.py"})
+    call_read = make_call("read_file", TrustLevel.SAFE, {"path": "foo.py"})
     await guard.process(call_read, handler)
     assert guard.has_probed
-    assert "foo.py" in guard._read_paths
 
-    call_write = make_call_with_args("write_file", TrustLevel.GUARDED, {"path": "foo.py", "content": ""})
+    call_write = make_call("write_file", TrustLevel.GUARDED, {"path": "foo.py", "content": ""})
     res = await guard.process(call_write, handler)
     assert res.success
 
@@ -80,20 +81,19 @@ async def test_run_bash_not_guarded_by_probe(handler):
 
 
 @pytest.mark.asyncio
-async def test_read_paths_cleared_on_reset(handler):
-    """reset_probe() clears _read_paths and has_probed; session trust survives."""
+async def test_reset_clears_probe_preserves_trust(handler):
+    """reset_probe() clears has_probed; session trust survives."""
     guard = LegitimacyGuardMiddleware()
-    await guard.process(make_call_with_args("read_file", TrustLevel.SAFE, {"path": "a.py"}), handler)
+    await guard.process(make_call("read_file", TrustLevel.SAFE, {"path": "a.py"}), handler)
     # First write succeeds → session-trusted
-    await guard.process(make_call_with_args("write_file", TrustLevel.GUARDED, {"path": "a.py", "content": ""}), handler)
+    await guard.process(make_call("write_file", TrustLevel.GUARDED, {"path": "a.py", "content": ""}), handler)
     assert "write_file" in guard._session_trusted
 
     guard.reset_probe()
     assert not guard.has_probed
-    assert not guard._read_paths  # per-turn paths cleared
 
     # write_file session-trusted → still passes without re-probe
-    res = await guard.process(make_call_with_args("write_file", TrustLevel.GUARDED, {"path": "b.py", "content": ""}), handler)
+    res = await guard.process(make_call("write_file", TrustLevel.GUARDED, {"path": "b.py", "content": ""}), handler)
     assert res.success, "session-trusted write_file must not require re-probe"
 
 
@@ -103,8 +103,8 @@ async def test_session_trust_skips_probe_on_subsequent_turns(handler):
     guard = LegitimacyGuardMiddleware()
 
     # Turn 1: probe + write → session-trusted
-    await guard.process(make_call_with_args("read_file", TrustLevel.SAFE, {"path": "x.md"}), handler)
-    res = await guard.process(make_call_with_args("write_file", TrustLevel.GUARDED, {"path": "x.md", "content": ""}), handler)
+    await guard.process(make_call("read_file", TrustLevel.SAFE, {"path": "x.md"}), handler)
+    res = await guard.process(make_call("write_file", TrustLevel.GUARDED, {"path": "x.md", "content": ""}), handler)
     assert res.success
     assert "write_file" in guard._session_trusted
 
@@ -113,8 +113,40 @@ async def test_session_trust_skips_probe_on_subsequent_turns(handler):
     assert not guard.has_probed
 
     # Turn 2: no probe, but session-trusted → passes
-    res2 = await guard.process(make_call_with_args("write_file", TrustLevel.GUARDED, {"path": "y.md", "content": ""}), handler)
+    res2 = await guard.process(make_call("write_file", TrustLevel.GUARDED, {"path": "y.md", "content": ""}), handler)
     assert res2.success, "session-trusted write_file must not require re-probe on new turn"
+
+
+@pytest.mark.asyncio
+async def test_trajectory_anomaly_flagged_for_exec_without_probe(handler):
+    """Layer 2: EXEC tool without prior probe gets trajectory_anomaly flag."""
+    guard = LegitimacyGuardMiddleware()
+    call_bash = make_call(
+        "run_bash", TrustLevel.GUARDED, {"command": "ls"},
+        capabilities=ToolCapability.EXEC,
+    )
+    res = await guard.process(call_bash, handler)
+    assert res.success, "run_bash must not be hard-blocked"
+    assert call_bash.metadata.get("trajectory_anomaly") is True
+
+
+@pytest.mark.asyncio
+async def test_trajectory_anomaly_not_set_after_probe(handler):
+    """Layer 2: EXEC tool after probe should NOT get trajectory_anomaly flag."""
+    guard = LegitimacyGuardMiddleware()
+
+    # Probe first
+    await guard.process(make_call("list_dir", TrustLevel.SAFE, {"path": "."}), handler)
+    assert guard.has_probed
+
+    # Now run_bash — should pass without anomaly flag
+    call_bash = make_call(
+        "run_bash", TrustLevel.GUARDED, {"command": "ls"},
+        capabilities=ToolCapability.EXEC,
+    )
+    res = await guard.process(call_bash, handler)
+    assert res.success
+    assert "trajectory_anomaly" not in call_bash.metadata
 
 
 @pytest.mark.asyncio

--- a/tests/test_legitimacy.py
+++ b/tests/test_legitimacy.py
@@ -35,32 +35,87 @@ def make_call(name: str, trust: TrustLevel) -> ToolCall:
     call.metadata[LIFECYCLE_CTX_KEY] = ctx
     return call
 
+def make_call_with_args(name: str, trust: TrustLevel, args: dict) -> ToolCall:
+    call = ToolCall(tool_name=name, args=args, trust_level=trust, session_id="test")
+    record = ActionRecord(call=call, intent=ActionIntent(intent_summary=name))
+    ctx = LifecycleContext(record=record)
+    call.metadata[LIFECYCLE_CTX_KEY] = ctx
+    return call
+
+
 @pytest.mark.asyncio
-async def test_probe_first_heuristic_blocks_blind_mutation(handler):
+async def test_write_file_blocked_without_probe(handler):
+    """write_file is blocked when no read_file / list_dir has been called this turn."""
     guard = LegitimacyGuardMiddleware()
-    
-    # Try write_file without probe
-    call_write = make_call("write_file", TrustLevel.GUARDED)
+    call_write = make_call_with_args("write_file", TrustLevel.GUARDED, {"path": "foo.py", "content": ""})
     res = await guard.process(call_write, handler)
     assert not res.success
     assert res.failure_type == "permission_denied"
-    assert "You must gather context first" in res.error
+    assert "read the target file" in res.error
     assert call_write.metadata[LIFECYCLE_CTX_KEY].authorization_result is False
 
+
 @pytest.mark.asyncio
-async def test_probe_first_heuristic_allows_after_probe(handler):
+async def test_write_file_allowed_after_read(handler):
+    """write_file passes after any probe tool runs (has_probed=True)."""
     guard = LegitimacyGuardMiddleware()
-    
-    # 1. Probe
-    call_read = make_call("read_file", TrustLevel.SAFE)
-    res_read = await guard.process(call_read, handler)
-    assert res_read.success
-    assert guard.has_probed is True
-    
-    # 2. Mutate
-    call_write = make_call("write_file", TrustLevel.GUARDED)
-    res_write = await guard.process(call_write, handler)
-    assert res_write.success
+    call_read = make_call_with_args("read_file", TrustLevel.SAFE, {"path": "foo.py"})
+    await guard.process(call_read, handler)
+    assert guard.has_probed
+    assert "foo.py" in guard._read_paths
+
+    call_write = make_call_with_args("write_file", TrustLevel.GUARDED, {"path": "foo.py", "content": ""})
+    res = await guard.process(call_write, handler)
+    assert res.success
+
+
+@pytest.mark.asyncio
+async def test_run_bash_not_guarded_by_probe(handler):
+    """run_bash is NOT in strict_guard_tools — BlastRadius owns exec authorization."""
+    guard = LegitimacyGuardMiddleware()
+    assert "run_bash" not in guard.strict_guard_tools
+    call_bash = make_call("run_bash", TrustLevel.GUARDED)
+    res = await guard.process(call_bash, handler)
+    assert res.success, "run_bash should bypass LegitimacyGuard entirely"
+
+
+@pytest.mark.asyncio
+async def test_read_paths_cleared_on_reset(handler):
+    """reset_probe() clears _read_paths and has_probed; session trust survives."""
+    guard = LegitimacyGuardMiddleware()
+    await guard.process(make_call_with_args("read_file", TrustLevel.SAFE, {"path": "a.py"}), handler)
+    # First write succeeds → session-trusted
+    await guard.process(make_call_with_args("write_file", TrustLevel.GUARDED, {"path": "a.py", "content": ""}), handler)
+    assert "write_file" in guard._session_trusted
+
+    guard.reset_probe()
+    assert not guard.has_probed
+    assert not guard._read_paths  # per-turn paths cleared
+
+    # write_file session-trusted → still passes without re-probe
+    res = await guard.process(make_call_with_args("write_file", TrustLevel.GUARDED, {"path": "b.py", "content": ""}), handler)
+    assert res.success, "session-trusted write_file must not require re-probe"
+
+
+@pytest.mark.asyncio
+async def test_session_trust_skips_probe_on_subsequent_turns(handler):
+    """Issue #118: once write_file succeeds in a session, future turns skip the probe requirement."""
+    guard = LegitimacyGuardMiddleware()
+
+    # Turn 1: probe + write → session-trusted
+    await guard.process(make_call_with_args("read_file", TrustLevel.SAFE, {"path": "x.md"}), handler)
+    res = await guard.process(make_call_with_args("write_file", TrustLevel.GUARDED, {"path": "x.md", "content": ""}), handler)
+    assert res.success
+    assert "write_file" in guard._session_trusted
+
+    # New turn — per-turn state reset
+    guard.reset_probe()
+    assert not guard.has_probed
+
+    # Turn 2: no probe, but session-trusted → passes
+    res2 = await guard.process(make_call_with_args("write_file", TrustLevel.GUARDED, {"path": "y.md", "content": ""}), handler)
+    assert res2.success, "session-trusted write_file must not require re-probe on new turn"
+
 
 @pytest.mark.asyncio
 async def test_circuit_breaker_trips_after_3_denies(perm_ctx, registry, handler):


### PR DESCRIPTION
## 問題

LEGITIMACY GUARD 的 probe-first 邏輯範疇過寬（Issue #118）：

- `run_bash`（含 `gh` CLI）每個新 turn 都被擋，要先讀過一個文件才能繼續
- MCP 生成工具（`text_to_image`、`text_to_audio`）被塞進 `strict_guard_tools`，儘管它們不會覆寫任何既有路徑
- 根本原因：`reset_probe()` 在每個 `stream_turn()` 開頭重置，所有被列管工具的上下文每 turn 都清空

## 修法

**範疇收窄（對應 Claude Code Read-before-Edit 語意）**

| 工具 | 修改前 | 修改後 |
|------|--------|--------|
| `write_file` | `strict_guard_tools` ✓ | `strict_guard_tools` ✓（保留） |
| `run_bash` / `gh` | `strict_guard_tools` ✗（被擋） | 交還 BlastRadius（EXEC capability） |
| MCP MUTATES 工具 | `session.py` 動態注入 ✗ | 交還 BlastRadius（GUARDED + 使用者確認） |

**per-path 追蹤**：`_read_paths` 記錄每 turn 讀過的路徑，`write_file(path=X)` 前需 `read_file(path=X)` 或任意 probe 工具（`list_dir` 等）。

**session-trust**：`write_file` 首次成功執行後，加入 `_session_trusted`。同一 session 後續 turn 直接通過，不需重複 probe。`reset_probe()` 只清 per-turn 狀態，`_session_trusted` 不動。

## 影響

- `run_bash` / GitHub CLI 不再被 `LegitimacyGuard` 擋，exec 授權回歸 BlastRadius
- MCP 生成工具第一次仍需通過 BlastRadius 確認，之後走 session-trust
- `write_file` 語意更精確：讀過目標路徑（或做過任意 probe）才能寫

## 測試

7 個 legitimacy 測試全過，整體 584 passed（1 pre-existing failure 與本 PR 無關）。