### PR TITLE
fix(session): reset penalty box state per-turn, extend confirm timeout (#131)

### DIFF
--- a/loom/core/events.py
+++ b/loom/core/events.py
@@ -69,7 +69,7 @@ class TurnDone:
     input_tokens: int
     output_tokens: int
     elapsed_ms: float
-    stop_reason: str = "complete"  # "complete" | "cancelled" | "circuit_breaker"
+    stop_reason: str = "complete"  # "complete" | "cancelled"
 
 
 @dataclass

--- a/loom/core/events.py
+++ b/loom/core/events.py
@@ -69,6 +69,7 @@ class TurnDone:
     input_tokens: int
     output_tokens: int
     elapsed_ms: float
+    stop_reason: str = "complete"  # "complete" | "cancelled" | "circuit_breaker"
 
 
 @dataclass

--- a/loom/core/infra/abort.py
+++ b/loom/core/infra/abort.py
@@ -67,6 +67,10 @@ class AbortController:
         """Signal cancellation to all waiting tasks."""
         self._cancelled.set()
 
+    def reset(self) -> None:
+        """Clear the abort signal so the controller can be reused for a new turn."""
+        self._cancelled.clear()
+
     @property
     def aborted(self) -> bool:
         """Return True if abort() has been called."""

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -874,6 +874,15 @@ class LoomSession:
         """
         self._current_origin = origin
 
+        # Issue #131: Reset abort signal from previous turn so the session
+        # is not permanently stuck after a circuit-breaker trip.
+        self._abort.reset()
+        self._cancel_requested = False
+
+        # Issue #131: Reset per-turn deny counter so timeouts from a previous
+        # turn don't carry over and immediately trip the circuit breaker.
+        self.perm.recent_denies = 0
+
         if hasattr(self, "_legitimacy_guard"):
             self._legitimacy_guard.reset_probe()
 
@@ -923,12 +932,14 @@ class LoomSession:
 
         _stream_retry = 0         # counts back-to-back stream_none retries
         _MAX_STREAM_RETRIES = 2  # auto-retry up to 2 times on response=None
+        _stop_reason = "complete"  # tracks why the loop exits
         while True:
             # Check abort signal at top of each LLM call iteration.
             # abort_signal is external (e.g. from AutonomyDaemon);
             # self._abort.signal is internal (from cancel()).
             sig = abort_signal if abort_signal is not None else self._abort.signal
             if sig.is_set():
+                _stop_reason = "cancelled"
                 break
             response: Any = None
             _think_shown = False  # reset per streaming call (each tool round can think again)
@@ -1315,6 +1326,7 @@ class LoomSession:
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             elapsed_ms=(time.monotonic() - t0) * 1000,
+            stop_reason=_stop_reason,
         )
 
     # ------------------------------------------------------------------

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -718,6 +718,7 @@ class LoomChatApp:
                                     used_tokens=budget.used_tokens,
                                     max_tokens=budget.total_tokens,
                                     think_text=self._session._last_think,
+                                    stop_reason=ev.stop_reason,
                                 )
                             )
                         elif isinstance(ev, ActionStateChange):

--- a/loom/platform/cli/tui/events.py
+++ b/loom/platform/cli/tui/events.py
@@ -72,6 +72,7 @@ class TurnDone(StreamEvent):
     used_tokens: int = 0    # absolute tokens used this turn
     max_tokens: int = 0     # model context window size
     think_text: str = ""    # full <think>…</think> content, if any
+    stop_reason: str = "complete"  # "complete" | "cancelled" | "circuit_breaker"
 
 
 @dataclass

--- a/loom/platform/cli/tui/events.py
+++ b/loom/platform/cli/tui/events.py
@@ -72,7 +72,7 @@ class TurnDone(StreamEvent):
     used_tokens: int = 0    # absolute tokens used this turn
     max_tokens: int = 0     # model context window size
     think_text: str = ""    # full <think>…</think> content, if any
-    stop_reason: str = "complete"  # "complete" | "cancelled" | "circuit_breaker"
+    stop_reason: str = "complete"  # "complete" | "cancelled"
 
 
 @dataclass

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -1049,7 +1049,7 @@ class LoomDiscordBot:
                 f"**`{call.tool_name}`**\n"
                 f"```\n{args_preview}\n```\n"
                 f"{just_text}"
-                f"*Timeout 60s → auto-deny*",
+                f"*Timeout 3min → auto-deny*",
                 view=view,
             )
             self._active_confirmations[thread_id] = msg

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -46,7 +46,7 @@ Confirm flow
 ------------
 BlastRadiusMiddleware.confirm_fn is patched to send a four-button message
 (Allow / Lease / Auto / Deny) in the thread and await the button interaction
-(60s timeout → deny).  Lease and Auto decisions post a follow-up message
+(180s timeout → deny).  Lease and Auto decisions post a follow-up message
 showing the TTL or grant scope.
 """
 
@@ -92,7 +92,7 @@ if TYPE_CHECKING:
 class _ConfirmView(View):
     """Discord UI view with Allow / Lease / Auto / Deny buttons for tool confirmation."""
 
-    def __init__(self, timeout: float = 60.0) -> None:
+    def __init__(self, timeout: float = 180.0) -> None:
         super().__init__(timeout=timeout)
         self._decision: ConfirmDecision | None = None
         self._done = asyncio.Event()
@@ -914,7 +914,12 @@ class LoomDiscordBot:
                         pass  # too granular for Discord display
 
                     elif isinstance(event, TurnDone):
-                        pass  # summary handled after the loop
+                        if event.stop_reason == "cancelled":
+                            await message.channel.send(
+                                "⚠️ **Turn aborted** — too many denied authorizations. "
+                                "Your session is still active; send a new message to continue."
+                            )
+                        # summary handled after the loop
 
             except asyncio.CancelledError:
                 # Cleanup any pending confirmation buttons in this thread immediately
@@ -1035,7 +1040,7 @@ class LoomDiscordBot:
             )[:120]
             trust = call.trust_level.plain
             color = "🟡" if trust == "GUARDED" else "🔴"
-            view = _ConfirmView(timeout=60.0)
+            view = _ConfirmView(timeout=180.0)
 
             just_text = f"**Justification:** *{justification}*\n" if justification else ""
 


### PR DESCRIPTION
## Summary

Fixes #131 — 連續 Confirm timeout 後 session 永久 break。

**根本原因：**
1. `recent_denies` 只在 approve 時歸零，跨 turn 持續累積 → 下一 turn 第一次 GUARDED 工具直接觸發 circuit breaker
2. Circuit breaker `call.abort_signal.set()` 設的是 session 級 `AbortController`，無 `reset()` → `stream_turn()` 永遠在迴圈頂部 break，產出 *(no response)*

**修復：**
- `AbortController.reset()` — 清除 abort signal
- `stream_turn()` 開頭重置 `_abort` + `recent_denies`（每 turn 獨立配額）
- Discord confirm timeout 60s → **180s**
- `TurnDone.stop_reason` 欄位 + Discord penalty box 提示訊息

## Changed files

| File | Change |
|------|--------|
| `loom/core/infra/abort.py` | Add `reset()` method |
| `loom/core/session.py` | Reset abort signal + deny counter at turn start; track `_stop_reason` |
| `loom/core/events.py` | `TurnDone.stop_reason` field |
| `loom/platform/cli/tui/events.py` | TUI `TurnDone.stop_reason` field |
| `loom/platform/cli/main.py` | Propagate `stop_reason` to TUI |
| `loom/platform/discord/bot.py` | Timeout 60→180s; penalty box user message |

## Test plan

- [x] 673 existing tests pass (2 pre-existing failures unrelated)
- [x] `test_legitimacy.py` — all 9 tests pass (directly tests `recent_denies`)
- [ ] Manual: Discord session with 3+ confirm timeouts → verify session recovers on next message
- [ ] Manual: Verify penalty box message appears in Discord thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)
