### PR TITLE
fix(memory): eliminate silent error swallowing, add self-observable health tracking (#133)

### DIFF
--- a/loom/core/memory/governance.py
+++ b/loom/core/memory/governance.py
@@ -28,6 +28,7 @@ from loom.core.memory.contradiction import (
     ContradictionDetector,
     Resolution,
 )
+from loom.core.memory.health import MemoryHealthTracker
 from loom.core.memory.semantic import SemanticEntry, classify_source
 
 if TYPE_CHECKING:
@@ -112,6 +113,7 @@ class MemoryGovernor:
         episodic: EpisodicMemory,
         db: aiosqlite.Connection,
         config: dict | None = None,
+        session_id: str = "unknown",
     ) -> None:
         self._semantic = semantic
         self._procedural = procedural
@@ -126,6 +128,9 @@ class MemoryGovernor:
         self._semantic_decay_threshold: float = cfg.get("semantic_decay_threshold", 0.1)
         self._relational_decay_factor: float = cfg.get("relational_decay_factor", 1.5)
         self._governance_log_write_warning_emitted = False
+
+        # Issue #133: memory health tracking for agent self-observability
+        self.health = MemoryHealthTracker(db, session_id=session_id)
 
     # ------------------------------------------------------------------
     # 1. Governed upsert
@@ -402,7 +407,11 @@ class MemoryGovernor:
                 decayed = confidence * math.pow(2.0, -days / effective_half_life)
                 if decayed < self._semantic_decay_threshold:
                     to_prune.append(row_id)
-            except Exception:
+            except Exception as exc:
+                logger.debug(
+                    "Relational decay: skipping row %s (parse error): %s",
+                    row_id, exc,
+                )
                 continue
 
         if to_prune:

--- a/loom/core/memory/health.py
+++ b/loom/core/memory/health.py
@@ -1,0 +1,308 @@
+"""
+MemoryHealthTracker — self-observable memory subsystem health.
+
+Issue #133: Replaces silent error swallowing with a persistent,
+queryable health record that the agent itself can inspect.
+
+Design
+------
+- In-memory counters accumulate during a session (zero overhead on hot path)
+- ``flush()`` persists to ``memory_health`` table at session end
+- ``load_prior()`` reads last-session state at startup so the agent can
+  see problems that occurred in a previous session
+- ``report()`` produces a structured summary for agent self-diagnosis
+
+The tracker is attached to ``MemoryGovernor`` (always-on) and exposed
+to the agent via the ``memory_health`` tool.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, UTC
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+# Operations tracked by the health system
+OPERATIONS = (
+    "embedding_write",
+    "embedding_search",
+    "session_compress",
+    "session_log_write",
+    "decay_cycle",
+    "skill_evolution",
+    "governed_upsert",
+)
+
+# ── Schema (added via runtime migration in store.py) ─────────────────────
+HEALTH_TABLE_DDL = """\
+CREATE TABLE IF NOT EXISTS memory_health (
+    operation      TEXT NOT NULL,
+    session_id     TEXT NOT NULL,
+    success_count  INTEGER NOT NULL DEFAULT 0,
+    failure_count  INTEGER NOT NULL DEFAULT 0,
+    last_failure_at   TEXT,
+    last_failure_msg  TEXT,
+    updated_at     TEXT NOT NULL,
+    PRIMARY KEY (operation, session_id)
+);
+"""
+
+HEALTH_INDEX_DDL = """\
+CREATE INDEX IF NOT EXISTS idx_memory_health_updated
+ON memory_health(updated_at DESC);
+"""
+
+
+# ── Data types ────────────────────────────────────────────────────────────
+
+@dataclass
+class OperationHealth:
+    """Health counters for a single operation type."""
+    operation: str
+    success_count: int = 0
+    failure_count: int = 0
+    last_failure_at: str | None = None
+    last_failure_msg: str | None = None
+
+    @property
+    def total(self) -> int:
+        return self.success_count + self.failure_count
+
+    @property
+    def failure_rate(self) -> float:
+        return self.failure_count / self.total if self.total > 0 else 0.0
+
+    @property
+    def is_healthy(self) -> bool:
+        return self.failure_count == 0
+
+    @property
+    def status_icon(self) -> str:
+        if self.failure_count == 0:
+            return "OK"
+        if self.failure_rate < 0.1:
+            return "DEGRADED"
+        return "FAILING"
+
+
+@dataclass
+class HealthReport:
+    """Aggregate health across all tracked operations."""
+    session_id: str
+    operations: dict[str, OperationHealth] = field(default_factory=dict)
+    prior_session_issues: list[OperationHealth] = field(default_factory=list)
+
+    @property
+    def has_issues(self) -> bool:
+        return any(not op.is_healthy for op in self.operations.values())
+
+    @property
+    def has_prior_issues(self) -> bool:
+        return len(self.prior_session_issues) > 0
+
+    def render_summary(self) -> str:
+        """Human/agent-readable health summary."""
+        lines: list[str] = []
+
+        # Current session
+        current_issues = [
+            op for op in self.operations.values() if not op.is_healthy
+        ]
+        if current_issues:
+            lines.append("## Current Session Memory Health Issues")
+            for op in current_issues:
+                lines.append(
+                    f"- **{op.operation}**: {op.status_icon} "
+                    f"({op.failure_count}/{op.total} failed)"
+                )
+                if op.last_failure_msg:
+                    lines.append(f"  Last error: {op.last_failure_msg[:200]}")
+        else:
+            lines.append("## Memory Health: All systems nominal this session.")
+
+        # Prior session issues
+        if self.prior_session_issues:
+            lines.append("")
+            lines.append("## Prior Session Issues (unresolved)")
+            for op in self.prior_session_issues:
+                lines.append(
+                    f"- **{op.operation}**: {op.failure_count} failure(s) "
+                    f"at {op.last_failure_at or 'unknown time'}"
+                )
+                if op.last_failure_msg:
+                    lines.append(f"  Last error: {op.last_failure_msg[:200]}")
+
+        return "\n".join(lines)
+
+    def render_agent_context(self) -> str | None:
+        """Compact note for injection into agent system context.
+
+        Returns None when everything is healthy — no noise.
+        """
+        issues: list[str] = []
+
+        for op in self.prior_session_issues:
+            issues.append(
+                f"[PRIOR] {op.operation}: {op.failure_count} failure(s) — "
+                f"{op.last_failure_msg or 'unknown error'}"
+            )
+
+        current_issues = [
+            op for op in self.operations.values() if not op.is_healthy
+        ]
+        for op in current_issues:
+            issues.append(
+                f"[NOW] {op.operation}: {op.failure_count}/{op.total} failed — "
+                f"{op.last_failure_msg or 'unknown error'}"
+            )
+
+        if not issues:
+            return None
+
+        header = (
+            "⚠ MEMORY HEALTH ALERT — The following memory subsystems have "
+            "recorded failures. You may want to investigate or inform the user."
+        )
+        return header + "\n" + "\n".join(f"  • {i}" for i in issues)
+
+
+# ── Tracker ───────────────────────────────────────────────────────────────
+
+class MemoryHealthTracker:
+    """In-memory accumulator with DB persistence for memory health events.
+
+    Usage:
+        tracker = MemoryHealthTracker(db, session_id)
+        await tracker.ensure_table()
+        await tracker.load_prior()        # reads last-session issues
+
+        tracker.record_success("embedding_write")
+        tracker.record_failure("embedding_write", "API timeout")
+
+        report = tracker.report()          # structured report
+        await tracker.flush()              # persist to DB
+    """
+
+    def __init__(self, db: "aiosqlite.Connection", session_id: str) -> None:
+        self._db = db
+        self._session_id = session_id
+        self._counters: dict[str, OperationHealth] = {}
+        self._prior_issues: list[OperationHealth] = []
+        self._dirty = False
+
+    def _get_or_create(self, operation: str) -> OperationHealth:
+        if operation not in self._counters:
+            self._counters[operation] = OperationHealth(operation=operation)
+        return self._counters[operation]
+
+    # ── Recording (hot path — no I/O) ─────────────────────────────────
+
+    def record_success(self, operation: str) -> None:
+        """Record a successful memory operation."""
+        self._get_or_create(operation).success_count += 1
+        self._dirty = True
+
+    def record_failure(self, operation: str, error_msg: str) -> None:
+        """Record a failed memory operation."""
+        op = self._get_or_create(operation)
+        op.failure_count += 1
+        op.last_failure_at = datetime.now(UTC).isoformat()
+        op.last_failure_msg = str(error_msg)[:500]
+        self._dirty = True
+
+    # ── Persistence ───────────────────────────────────────────────────
+
+    async def ensure_table(self) -> None:
+        """Create the health table if it doesn't exist."""
+        await self._db.executescript(HEALTH_TABLE_DDL + HEALTH_INDEX_DDL)
+        await self._db.commit()
+
+    async def flush(self) -> None:
+        """Persist current session counters to DB."""
+        if not self._dirty:
+            return
+        now = datetime.now(UTC).isoformat()
+        for op in self._counters.values():
+            if op.total == 0:
+                continue
+            await self._db.execute(
+                """
+                INSERT INTO memory_health
+                    (operation, session_id, success_count, failure_count,
+                     last_failure_at, last_failure_msg, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(operation, session_id) DO UPDATE SET
+                    success_count    = excluded.success_count,
+                    failure_count    = excluded.failure_count,
+                    last_failure_at  = COALESCE(excluded.last_failure_at, memory_health.last_failure_at),
+                    last_failure_msg = COALESCE(excluded.last_failure_msg, memory_health.last_failure_msg),
+                    updated_at       = excluded.updated_at
+                """,
+                (
+                    op.operation,
+                    self._session_id,
+                    op.success_count,
+                    op.failure_count,
+                    op.last_failure_at,
+                    op.last_failure_msg,
+                    now,
+                ),
+            )
+        await self._db.commit()
+        self._dirty = False
+
+    async def load_prior(self) -> None:
+        """Load issues from recent sessions (not the current one).
+
+        Only loads operations that had failures — healthy history is
+        not interesting for self-diagnosis.
+        """
+        cursor = await self._db.execute(
+            """
+            SELECT operation,
+                   SUM(failure_count) as total_failures,
+                   MAX(last_failure_at) as latest_failure_at,
+                   last_failure_msg
+            FROM memory_health
+            WHERE session_id != ?
+              AND failure_count > 0
+              AND updated_at > datetime('now', '-7 days')
+            GROUP BY operation
+            ORDER BY latest_failure_at DESC
+            """,
+            (self._session_id,),
+        )
+        rows = await cursor.fetchall()
+        self._prior_issues = [
+            OperationHealth(
+                operation=row[0],
+                failure_count=row[1],
+                last_failure_at=row[2],
+                last_failure_msg=row[3],
+            )
+            for row in rows
+        ]
+
+    # ── Reporting ─────────────────────────────────────────────────────
+
+    def report(self) -> HealthReport:
+        """Build a structured health report."""
+        return HealthReport(
+            session_id=self._session_id,
+            operations=dict(self._counters),
+            prior_session_issues=list(self._prior_issues),
+        )
+
+    @property
+    def has_issues(self) -> bool:
+        """Quick check: any failures this session or from prior sessions?"""
+        if self._prior_issues:
+            return True
+        return any(not op.is_healthy for op in self._counters.values())

--- a/loom/core/memory/search.py
+++ b/loom/core/memory/search.py
@@ -19,12 +19,15 @@ Usage
 from __future__ import annotations
 
 import json
+import logging
 import math
 import re
 from collections import Counter
 from datetime import datetime
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
 
 from loom.core.memory.embeddings import cosine_similarity
 from loom.core.memory.procedural import ProceduralMemory
@@ -85,6 +88,7 @@ class MemorySearch:
     ) -> None:
         self._semantic = semantic
         self._procedural = procedural
+        self._health: Any = None  # Optional MemoryHealthTracker, set post-init
 
     async def recall(
         self,
@@ -123,8 +127,12 @@ class MemorySearch:
                         combined.sort(key=lambda r: r.score, reverse=True)
                         return combined[:limit]
                     return emb_results
-            except Exception:
-                pass  # Fall through to BM25
+            except Exception as exc:
+                logger.warning(
+                    "Embedding search failed, degrading to BM25: %s", exc,
+                )
+                if self._health:
+                    self._health.record_failure("embedding_search", str(exc))
 
         # ── Tier 2: BM25 keyword search ───────────────────────────────────────
         results: list[MemorySearchResult] = []

--- a/loom/core/memory/semantic.py
+++ b/loom/core/memory/semantic.py
@@ -215,8 +215,11 @@ class SemanticMemory:
                         (json.dumps(meta, ensure_ascii=False), entry.key),
                     )
                     await self._db.commit()
-                except Exception:
-                    pass  # best-effort metadata annotation
+                except Exception as ann_exc:
+                    logger.debug(
+                        "Failed to annotate embedding_status for key=%r: %s",
+                        entry.key, ann_exc,
+                    )
             else:
                 if self._health:
                     self._health.record_success("embedding_write")

--- a/loom/core/memory/semantic.py
+++ b/loom/core/memory/semantic.py
@@ -8,11 +8,14 @@ Each fact has a confidence score and can be updated or queried by key.
 from __future__ import annotations
 
 import json
+import logging
 import math
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, UTC
 from typing import TYPE_CHECKING, Any
+
+logger = logging.getLogger(__name__)
 
 import aiosqlite
 
@@ -122,6 +125,7 @@ class SemanticMemory:
     ) -> None:
         self._db = db
         self._embeddings = embedding_provider
+        self._health: Any = None  # Optional MemoryHealthTracker, set post-init
 
     @property
     def has_embeddings(self) -> bool:
@@ -138,7 +142,8 @@ class SemanticMemory:
 
         If an embedding provider is configured, computes and persists the
         vector for this entry after the upsert.  Embedding failures are
-        silently swallowed so a network error never blocks a memory write.
+        logged and the entry's metadata is marked with
+        ``embedding_status: "failed"`` so orphaned entries are auditable.
         """
         now = datetime.now(UTC).isoformat()
 
@@ -193,8 +198,28 @@ class SemanticMemory:
                         (json.dumps(vectors[0]), entry.key),
                     )
                     await self._db.commit()
-            except Exception:
-                pass  # Embedding failure must never block the memory write
+            except Exception as exc:
+                logger.warning(
+                    "Embedding write failed for key=%r — memory saved "
+                    "but semantic search will miss it: %s",
+                    entry.key, exc,
+                )
+                if self._health:
+                    self._health.record_failure("embedding_write", str(exc))
+                # Mark the entry so we can audit orphaned embeddings later
+                try:
+                    meta = dict(entry.metadata)
+                    meta["embedding_status"] = "failed"
+                    await self._db.execute(
+                        "UPDATE semantic_entries SET metadata = ? WHERE key = ?",
+                        (json.dumps(meta, ensure_ascii=False), entry.key),
+                    )
+                    await self._db.commit()
+                except Exception:
+                    pass  # best-effort metadata annotation
+            else:
+                if self._health:
+                    self._health.record_success("embedding_write")
 
         return conflicted
 

--- a/loom/core/memory/session_log.py
+++ b/loom/core/memory/session_log.py
@@ -269,8 +269,8 @@ class SessionLog:
                 try:
                     result.append(json.loads(raw_json))
                     continue
-                except Exception as exc:
-                    logger.debug("raw_json parse failed, falling back: %s", exc)
+                except Exception as parse_exc:
+                    logger.debug("raw_json parse failed, falling back: %s", parse_exc)
 
             # Priority 2: legacy raw_message stored in content column
             if role == "assistant" and meta.get("format") == "raw_message":
@@ -278,8 +278,8 @@ class SessionLog:
                     msg = json.loads(content)
                     result.append(msg)
                     continue
-                except Exception as exc:
-                    logger.debug("Legacy raw_message parse failed, falling back: %s", exc)
+                except Exception as legacy_exc:
+                    logger.debug("Legacy raw_message parse failed, falling back: %s", legacy_exc)
 
             # Priority 3: plain text
             msg: dict[str, Any] = {"role": role, "content": content}

--- a/loom/core/memory/session_log.py
+++ b/loom/core/memory/session_log.py
@@ -15,9 +15,12 @@ Design principles:
 from __future__ import annotations
 
 import json
+import logging
 import re
 from datetime import datetime, UTC
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 import aiosqlite
 
@@ -55,8 +58,8 @@ def _redact_secrets(text: str | None) -> str | None:
     try:
         for pattern, replacement in _SECRET_PATTERNS:
             text = pattern.sub(replacement, text)
-    except Exception:
-        pass  # redaction must never crash the agent
+    except Exception as exc:
+        logger.debug("Secret redaction regex failed: %s", exc)
     return text
 
 
@@ -65,6 +68,7 @@ class SessionLog:
 
     def __init__(self, db: aiosqlite.Connection) -> None:
         self._db = db
+        self._health: Any = None  # Optional MemoryHealthTracker, set post-init
 
     # ------------------------------------------------------------------
     # Write path
@@ -124,8 +128,10 @@ class SessionLog:
                 ),
             )
             await self._db.commit()
-        except Exception:
-            pass  # logging must never crash the agent
+        except Exception as exc:
+            logger.warning("Session log write failed (turn=%d): %s", turn_index, exc)
+            if self._health:
+                self._health.record_failure("session_log_write", str(exc))
 
     async def update_session(
         self,
@@ -263,8 +269,8 @@ class SessionLog:
                 try:
                     result.append(json.loads(raw_json))
                     continue
-                except Exception:
-                    pass  # fall through to legacy / plain-text path
+                except Exception as exc:
+                    logger.debug("raw_json parse failed, falling back: %s", exc)
 
             # Priority 2: legacy raw_message stored in content column
             if role == "assistant" and meta.get("format") == "raw_message":
@@ -272,8 +278,8 @@ class SessionLog:
                     msg = json.loads(content)
                     result.append(msg)
                     continue
-                except Exception:
-                    pass  # fall through to plain text reconstruction
+                except Exception as exc:
+                    logger.debug("Legacy raw_message parse failed, falling back: %s", exc)
 
             # Priority 3: plain text
             msg: dict[str, Any] = {"role": role, "content": content}

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -561,7 +561,14 @@ class LoomSession:
             episodic=self._episodic,
             db=self._db,
             config=_gov_cfg,
+            session_id=self.session_id,
         )
+        # Issue #133: initialize health tracking and load prior session issues
+        await self._governor.health.ensure_table()
+        await self._governor.health.load_prior()
+        # Inject health tracker into subsystems that record events
+        self._semantic._health = self._governor.health
+        self._session_log._health = self._governor.health
 
         # Build MemoryIndex and inject into system prompt
         # Issue #56: auto-import skills from workspace/skills/ and ~/.loom/skills/
@@ -577,6 +584,15 @@ class LoomSession:
                 self.messages[0]["content"] += f"\n\n{index_text}"
             else:
                 self.messages.insert(0, {"role": "system", "content": index_text})
+
+        # Issue #133: inject memory health alert into system context
+        # so the agent is aware of prior session failures.
+        health_ctx = self._governor.health.report().render_agent_context()
+        if health_ctx:
+            if self.messages and self.messages[0]["role"] == "system":
+                self.messages[0]["content"] += f"\n\n{health_ctx}"
+            else:
+                self.messages.insert(0, {"role": "system", "content": health_ctx})
 
         if not self._resume:
             await self._session_log.create_session(self.session_id, self.model)
@@ -599,6 +615,7 @@ class LoomSession:
             make_fetch_url_tool,
             make_load_skill_tool,
             make_memorize_tool,
+            make_memory_health_tool,
             make_query_relations_tool,
             make_recall_tool,
             make_relate_tool,
@@ -606,10 +623,12 @@ class LoomSession:
             make_web_search_tool,
         )
         search = MemorySearch(self._semantic, self._procedural)
+        search._health = self._governor.health
         self.registry.register(make_recall_tool(search))
         self.registry.register(make_memorize_tool(self._semantic, governor=self._governor))
         self.registry.register(make_relate_tool(self._relational))
         self.registry.register(make_query_relations_tool(self._relational))
+        self.registry.register(make_memory_health_tool(self._governor))
 
         # Issue #56: Register load_skill tool with outcome tracker
         from loom.core.memory.skill_outcome import SkillOutcomeTracker
@@ -758,20 +777,38 @@ class LoomSession:
         # concurrent or re-entrant call (e.g. /new → on_unmount) hits the guard above.
         db, self._db = self._db, None
         db_ctx, self._db_ctx = self._db_ctx, None
-        try:
-            console.print(Rule("[dim]Compressing session to memory…[/dim]"))
-            count = await compress_session(
-                self.session_id,
-                self._episodic,
-                self._semantic,
-                self.router,
-                self.model,
-                governor=self._governor,
-            )
-            if count:
-                console.print(f"[dim]  Saved {count} fact(s) to semantic memory.[/dim]")
+        # ── Session shutdown: each step is independently guarded ──────
+        # Issue #133: the previous monolithic try/except silently swallowed
+        # all errors — a failure in compress_session would also prevent
+        # session log update, evolution analysis, and decay from running.
+        # Alias for concise health recording
+        _health = self._governor.health if self._governor else None
 
-            # Issue #58: trigger evolution analysis for low-confidence skills
+        try:
+            # Step 1: Compress session into semantic memory
+            try:
+                console.print(Rule("[dim]Compressing session to memory…[/dim]"))
+                count = await compress_session(
+                    self.session_id,
+                    self._episodic,
+                    self._semantic,
+                    self.router,
+                    self.model,
+                    governor=self._governor,
+                )
+                if count:
+                    console.print(f"[dim]  Saved {count} fact(s) to semantic memory.[/dim]")
+                if _health:
+                    _health.record_success("session_compress")
+            except Exception as exc:
+                logger.error(
+                    "Session compress failed — episodic→semantic transfer lost: %s",
+                    exc, exc_info=True,
+                )
+                if _health:
+                    _health.record_failure("session_compress", str(exc))
+
+            # Step 2: Skill evolution analysis (Issue #58)
             if self._procedural is not None and self._semantic is not None:
                 try:
                     from loom.core.cognition.counter_factual import SkillEvolutionHook
@@ -784,10 +821,14 @@ class LoomSession:
                         console.print(
                             f"[dim]  Queued evolution analysis for {evolved} skill(s).[/dim]"
                         )
-                except Exception:
-                    pass  # evolution failure must never block shutdown
+                    if _health:
+                        _health.record_success("skill_evolution")
+                except Exception as exc:
+                    logger.warning("Skill evolution analysis failed: %s", exc)
+                    if _health:
+                        _health.record_failure("skill_evolution", str(exc))
 
-            # Issue #43: run memory decay cycle
+            # Step 3: Memory decay cycle (Issue #43)
             if self._governor is not None:
                 try:
                     decay = await self._governor.run_decay_cycle()
@@ -798,24 +839,41 @@ class LoomSession:
                             f"episodic={decay.episodic_pruned}, "
                             f"relational={decay.relational_pruned}).[/dim]"
                         )
-                except Exception:
-                    pass  # decay failure must never block shutdown
+                    if _health:
+                        _health.record_success("decay_cycle")
+                except Exception as exc:
+                    logger.warning("Memory decay cycle failed: %s", exc)
+                    if _health:
+                        _health.record_failure("decay_cycle", str(exc))
 
+            # Step 4: Update session log metadata
             if self._session_log is not None:
-                first_user = next(
-                    (m["content"] for m in self.messages if m["role"] == "user"), None
-                )
-                title = first_user[:60] if isinstance(first_user, str) else None
-                await self._session_log.update_session(
-                    self.session_id,
-                    turn_count=self._turn_index,
-                    last_active=datetime.now(UTC).isoformat(),
-                    title=title,
-                )
-        except Exception:
-            # DB connection may already be invalid when Textual cancels workers
-            # during shutdown — swallow the error so the process exits cleanly.
-            pass
+                try:
+                    first_user = next(
+                        (m["content"] for m in self.messages if m["role"] == "user"), None
+                    )
+                    title = first_user[:60] if isinstance(first_user, str) else None
+                    await self._session_log.update_session(
+                        self.session_id,
+                        turn_count=self._turn_index,
+                        last_active=datetime.now(UTC).isoformat(),
+                        title=title,
+                    )
+                except Exception as exc:
+                    logger.warning("Session log update failed: %s", exc)
+
+            # Step 5: Flush health state and show summary
+            if _health:
+                try:
+                    await _health.flush()
+                    report = _health.report()
+                    if report.has_issues:
+                        console.print(
+                            f"[yellow dim]  ⚠ Memory health issues detected "
+                            f"this session — check logs for details.[/yellow dim]"
+                        )
+                except Exception as exc:
+                    logger.debug("Health tracker flush failed: %s", exc)
         finally:
             # Issue #61 Bug 2: wait for pending skill_eval background tasks
             # before closing the DB so their upsert writes can complete.
@@ -834,8 +892,8 @@ class LoomSession:
             for client in self._mcp_clients:
                 try:
                     await client.disconnect()
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.debug("MCP client disconnect error: %s", exc)
             self._mcp_clients = []
 
             try:
@@ -843,8 +901,8 @@ class LoomSession:
                     await db_ctx.__aexit__(None, None, None)
                 elif db is not None:
                     await db.close()
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("DB close error during shutdown: %s", exc)
 
     # ------------------------------------------------------------------
     # Streaming agent loop

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from loom.core.memory.relational import RelationalMemory
     from loom.core.memory.search import MemorySearch
     from loom.core.memory.semantic import SemanticMemory
+    from loom.core.memory.governance import MemoryGovernor
     from loom.core.memory.skill_outcome import SkillOutcomeTracker
 
 _WEB_TIMEOUT = 10.0       # seconds for all HTTP calls
@@ -732,6 +733,43 @@ def make_memorize_tool(
         tags=["memory", "write", "memorize"],
         impact_scope="memory",
         rollback_fn=_memorize_rollback,
+    )
+
+
+def make_memory_health_tool(governor: "MemoryGovernor") -> ToolDefinition:
+    """
+    Create a SAFE ``memory_health`` tool for agent self-diagnosis.
+
+    Returns the current and recent-historical health status of all
+    memory subsystems so the agent can detect and report issues.
+    """
+    async def _memory_health(call: ToolCall) -> ToolResult:
+        report = governor.health.report()
+        summary = report.render_summary()
+        return ToolResult(
+            call_id=call.id,
+            tool_name=call.tool_name,
+            success=True,
+            output=summary,
+        )
+
+    return ToolDefinition(
+        name="memory_health",
+        description=(
+            "Check the health of your memory subsystems. Shows success/failure "
+            "rates for embedding writes, semantic search, session compression, "
+            "and other memory operations. Use this to self-diagnose when you "
+            "suspect memory issues, or periodically to ensure memories are "
+            "being saved correctly."
+        ),
+        trust_level=TrustLevel.SAFE,
+        input_schema={
+            "type": "object",
+            "properties": {},
+        },
+        executor=_memory_health,
+        tags=["memory", "health", "diagnostic"],
+        impact_scope="memory",
     )
 
 


### PR DESCRIPTION
## Summary

- **消除記憶系統雙重靜默異常吸收**：所有 `except: pass` 替換為結構化日誌記錄，`session.stop()` 的巨型 try/except 拆分為 5 個獨立步驟，一個失敗不再級聯跳過後續工作
- **新增 MemoryHealthTracker 自我可觀測機制**：持久化健康記錄（`memory_health` 表）+ 啟動時自動注入前次 session 失敗警報到 system prompt + `memory_health` 工具供 agent 主動自診斷
- Embedding 寫入失敗時在 metadata 標記 `embedding_status: "failed"`，可事後審計哪些記憶缺少向量索引

### 本次改動的意義

這不只是修 bug——這是記憶系統從「被動記錄」走向「自主管理」的基礎設施升級。過去錯誤蒸發後無人知曉；現在三層機制確保 agent 自己是記憶完整性的第一個守護者：

1. **Logger**（給人類）→ stderr 即時可見
2. **HealthTracker**（跨 session 持久化）→ DB 記錄，7 天回溯
3. **Agent 自感知**（system prompt 注入 + memory_health 工具）→ 自己的記憶自己維護

### 修改的檔案

| 檔案 | 改動 |
|------|------|
| `loom/core/memory/health.py` | **新增** — MemoryHealthTracker、HealthReport、memory_health 表 DDL |
| `loom/core/session.py` | stop() 拆分為獨立步驟、接入健康追蹤、啟動時注入健康警報 |
| `loom/core/memory/semantic.py` | embedding 失敗 → logger.warning + metadata 標記 + 健康記錄 |
| `loom/core/memory/search.py` | 搜尋降級 → logger.warning + 健康記錄 |
| `loom/core/memory/session_log.py` | 日誌寫入失敗 → logger.warning + 健康記錄 |
| `loom/core/memory/governance.py` | 接入 HealthTracker、relational decay 解析錯誤加日誌 |
| `loom/platform/cli/tools.py` | 新增 `memory_health` SAFE 工具 |

## Test plan

- [x] 712 tests pass
- [x] TUI smoke test — 啟動無崩潰
- [ ] 手動驗證：模擬 embedding API 失敗，確認 logger 輸出 + metadata 標記 + health 記錄
- [ ] 手動驗證：第二次 session 啟動時，確認 system prompt 含前次健康警報
- [ ] 確認 `memory_health` 工具在對話中可呼叫且返回正確報告

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)