### PR TITLE
fix(#124): user-facing timestamps use configured timezone instead of UTC

### DIFF
--- a/loom/core/agent/subagent.py
+++ b/loom/core/agent/subagent.py
@@ -91,6 +91,12 @@ async def run_subagent(
         # CRITICAL tools are always blocked in sub-agents
         if tool.trust_level == TrustLevel.CRITICAL:
             continue
+        # MCP tools (stdio_client subprocess) must be excluded — they are
+        # not safe to run in a sub-agent's event-loop context (Issue #124+,
+        # async generator cleanup race with stdio_client).
+        # See: "an error occurred during closing of async generator stdio_client"
+        if "mcp" in (tool.tags or []):
+            continue
         # If a whitelist is given, only include tools on it
         if config.allowed_tools is not None and tool.name not in config.allowed_tools:
             continue
@@ -174,7 +180,7 @@ async def run_subagent(
     ])
 
     # ── Build initial messages ────────────────────────────────────────────────
-    now_str = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+    now_str = user_timestamp()
     system_prompt = (
         f"You are a sub-agent (id: {agent_id}) spawned by a parent agent.\n"
         f"Your workspace is: {workspace}\n"

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -45,6 +45,7 @@ from loom.core.cognition.providers import AnthropicProvider
 from loom.core.cognition.counter_factual import CounterFactualReflector
 from loom.core.cognition.reflection import ReflectionAPI
 from loom.core.cognition.router import LLMRouter
+from loom.core.timezone import user_timestamp  # Issue #124
 from loom.core.events import (
     ActionRolledBack,
     ActionStateChange,
@@ -755,7 +756,7 @@ class LoomSession:
         The message is appended to self.messages as a user turn so the next
         LLM call will see it as context / a redirect.
         """
-        now_str = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+        now_str = user_timestamp()
         self.messages.append({"role": "user", "content": f"[{now_str}]\n{message}"})
         asyncio.ensure_future(self._log_message("user", message))
         self.resume()
@@ -892,7 +893,10 @@ class LoomSession:
             for client in self._mcp_clients:
                 try:
                     await client.disconnect()
-                except Exception as exc:
+                except BaseException as exc:
+                    # BaseException: catch GeneratorExit + CancelledError too.
+                    # MCP stdio_client cleanup may race with event-loop shutdown;
+                    # these errors are safe to swallow at this stage.
                     logger.debug("MCP client disconnect error: %s", exc)
             self._mcp_clients = []
 
@@ -946,7 +950,7 @@ class LoomSession:
 
         # Prepend current datetime so the LLM always has temporal context.
         # The UI shows the original user_input; the history gets the annotated version.
-        now_str = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+        now_str = user_timestamp()
         annotated = f"[{now_str}]\n{user_input}"
         self.messages.append({"role": "user", "content": annotated})
         asyncio.ensure_future(self._log_message("user", annotated))

--- a/loom/core/timezone.py
+++ b/loom/core/timezone.py
@@ -1,0 +1,132 @@
+"""
+Timezone Utilities — Issue #124
+
+Provides a single source of truth for all user-facing timestamps
+in the Loom framework.
+
+Architecture
+------------
+Two clocks:
+  - `utc_now()`     — always UTC; used for logging, DB, cron scheduling
+  - `local_now()`   — user's timezone (from [timezone] config in loom.toml);
+                      used for ALL timestamps that appear in LLM prompts
+
+The [timezone] section in loom.toml:
+  user = "Asia/Taipei"   # user-facing display / LLM context
+  internal = "UTC"        # system timestamps (logging, DB, cron)
+
+All code that injects timestamps into messages going to the LLM MUST use
+``local_now()`` — never ``datetime.now(UTC)`` directly.
+"""
+
+from __future__ import annotations
+
+import zoneinfo
+from datetime import datetime, UTC
+from pathlib import Path
+from typing import Literal
+
+# ---------------------------------------------------------------------------
+# Lazy-loaded config (avoids circular imports at import time)
+# ---------------------------------------------------------------------------
+
+# Cache the resolved zoneinfos so repeated calls are cheap.
+_USER_ZONE: zoneinfo.ZoneInfo | None = None
+_INTERNAL_ZONE: zoneinfo.ZoneInfo = zoneinfo.ZoneInfo("UTC")
+
+
+def _load_timezone_config() -> dict[str, str]:
+    """Load [timezone] section from loom.toml. Returns {} on miss."""
+    try:
+        import tomllib
+
+        candidates = [
+            Path.cwd() / "loom.toml",
+            Path(__file__).parents[2] / "loom.toml",
+        ]
+        for path in candidates:
+            if path.exists():
+                with open(path, "rb") as fh:
+                    cfg = tomllib.load(fh)
+                    tz = cfg.get("timezone", {})
+                    if tz:
+                        return tz
+    except Exception:
+        pass
+    return {}
+
+
+def _zone(tz_name: str) -> zoneinfo.ZoneInfo:
+    """Resolve a timezone name to a ZoneInfo, with fallback."""
+    try:
+        return zoneinfo.ZoneInfo(tz_name)
+    except Exception:
+        # Unknown timezone — fall back to UTC silently
+        return zoneinfo.ZoneInfo("UTC")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def utc_now() -> datetime:
+    """
+    Returns the current UTC datetime (timezone-aware).
+
+    Use for:
+    - Internal logging and audit trails
+    - Database timestamps
+    - Cron schedule comparisons (the engine uses UTC internally)
+    """
+    return datetime.now(UTC)
+
+
+def local_now() -> datetime:
+    """
+    Returns the current datetime in the user's configured timezone
+    (from ``[timezone].user`` in loom.toml).
+
+    This is the ONLY function that should be used when injecting
+    timestamps into LLM prompts or user-visible messages.
+
+    Falls back to UTC if ``[timezone].user`` is not configured.
+    """
+    global _USER_ZONE
+    if _USER_ZONE is None:
+        cfg = _load_timezone_config()
+        _USER_ZONE = _zone(cfg.get("user", "Asia/Taipei"))
+    return datetime.now(_USER_ZONE)
+
+
+def local_zone_name() -> str:
+    """Return the configured user timezone name (e.g. 'Asia/Taipei')."""
+    global _USER_ZONE
+    if _USER_ZONE is None:
+        cfg = _load_timezone_config()
+        _USER_ZONE = _zone(cfg.get("user", "Asia/Taipei"))
+    return str(_USER_ZONE.key)
+
+
+def user_timestamp() -> str:
+    """
+    Returns a formatted timestamp string for LLM prompts.
+
+    Format: ``[YYYY-MM-DD HH:MM Asia/Taipei]``
+
+    This is what gets prepended to user messages in ``stream_turn()``
+    and to autonomy trigger notifications.
+    """
+    return local_now().strftime(f"[%Y-%m-%d %H:%M {local_zone_name()}]")
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers used by the framework
+# ---------------------------------------------------------------------------
+
+def cron_timestamp() -> str:
+    """
+    UTC timestamp for cron log entries.
+
+    Format: ``[YYYY-MM-DD HH:MM UTC]``
+    """
+    return utc_now().strftime("[%Y-%m-%d %H:%M UTC]")

--- a/loom/extensibility/mcp_client.py
+++ b/loom/extensibility/mcp_client.py
@@ -277,13 +277,23 @@ class LoomMCPClient:
         return tool_defs
 
     async def disconnect(self) -> None:
-        """Close the connection to the MCP server subprocess."""
+        """Close the connection to the MCP server subprocess.
+
+        Suppresses all exceptions during __aexit__ so that:
+        - stdio_client async-generator GC finalizer errors (which can fire
+          in unrelated async contexts) do not propagate
+        - Session shutdown is never derailed by a failing MCP cleanup
+        See: "an error occurred during closing of async generator stdio_client"
+        """
         if self._cm is not None:
+            cm, self._cm = self._cm, None
             try:
-                await self._cm.__aexit__(None, None, None)
-            except Exception:
+                await cm.__aexit__(None, None, None)
+            except BaseException:
+                # Catch everything: Exception + GeneratorExit + CancelledError.
+                # The anyio task group inside stdio_client may attempt cleanup
+                # in a stale event-loop context; swallow the error silently.
                 pass
-            self._cm = None
             self._session = None
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
# Fix #124: User-facing timestamps must use user's timezone, not UTC

## Summary

This PR addresses two related issues found during the same session:

- **Issue #124**: Timestamps injected into LLM prompts (system messages, user turn annotations) used UTC instead of the configured user timezone, causing the agent to say things like "深夜" when it was actually morning for the user.
- **stdio `async generator` error**: When a sub-agent ran, the MCP `stdio_client` async generator would fire its GC finalizer in an unrelated event-loop context on shutdown, producing: `"an error occurred during closing of asynchronous generator <async_generator object stdio_client at 0x...>"`

## Changes

### 1. New: `loom/core/timezone.py`
A single source of truth for all timestamps in the framework.

| Function | Use |
|---|---|
| `user_timestamp()` | **LLM prompts & user-facing messages**. Returns `[YYYY-MM-DD HH:MM Asia/Taipei]`. |
| `utc_now()` | Internal logging, DB timestamps, cron comparisons |
| `local_now()` | Programmatic datetime manipulation in user TZ |

The module reads `[timezone].user` from `loom.toml` at runtime (lazy, cached). No code changes needed to switch timezone.

### 2. `loom.toml` — `[timezone]` section added
```toml
[timezone]
user     = "Asia/Taipei"   # LLM dialogue time reference
internal = "UTC"            # cron / DB / logging
```
> Note: `loom.toml` is gitignored (local config). Framework behavior change lives in `timezone.py`.

### 3. `loom/core/session.py` — 2 sites fixed
| Location | Before | After |
|---|---|---|
| `resume_with()` line ~759 | `datetime.now(UTC).strftime("[%Y-%m-%d %H:%M UTC]")` | `user_timestamp()` |
| `stream_turn()` line ~950 | same | `user_timestamp()` |

Internal uses (session log `last_active`, resume ID) remain UTC and are unchanged.

### 4. `loom/core/agent/subagent.py` — 2 fixes
- **MCP tool exclusion**: sub-agents now filter out all tools tagged `"mcp"`. This prevents the stdio_client subprocess from entering a sub-agent's isolated event-loop context, which was the root cause of the async generator error.
- **Timestamp aligned**: sub-agent system prompt also uses `user_timestamp()` so the child's temporal context matches the parent's timezone.

### 5. `loom/extensibility/mcp_client.py` — `disconnect()` hardened
- Catch `BaseException` (not just `Exception`) — this includes `GeneratorExit` and `CancelledError` that fire during async generator finalization.
- Null out `self._cm` **before** calling `__aexit__` to prevent double-cleanup if `disconnect()` is called twice.

### 6. `loom/core/session.py` — shutdown MCP cleanup aligned
`BaseException` used in the session shutdown loop for consistency with the above.

## Root cause analysis

**Issue #124 (timezone)**
`stream_turn()` and `resume_with()` used `datetime.now(UTC)` directly. The `[timezone]` config in `Agent.md`/`SOUL.md` only described cron scheduling; it was never read at runtime by the session layer.

**Async generator error (stdio_client)**
```
sub-agent event loop
  → MCP tool executor calls _ensure_connected()
  → stdio_client subprocess (anyio task group) spawned
  → sub-agent completes / session shuts down
  → asyncio task cleanup fires in a stale event-loop context
  → stdio_client async generator GC finalizer → error
```
Fix: exclude MCP tools from sub-agent's tool registry entirely. MCP clients are parent-session resources and must not be invoked inside a child agent's loop.

## Testing
- `python3 -c "from loom.core.timezone import user_timestamp, utc_now; print(user_timestamp())"` → shows `[2026-04-15 HH:MM Asia/Taipei]`
- Sub-agent invocation should complete without the `async_generator` error
