### PR TITLE
feat(#154): JobStore + Scratchpad — harness-layer async tool concurrency

### DIFF
--- a/Agent.md.example
+++ b/Agent.md.example
@@ -53,6 +53,23 @@
 
 ---
 
+## 背景任務（Async Jobs）
+
+> Issue #154：IO 類工具（`fetch_url`、`run_bash`）可用 `async_mode=True` 派到背景執行，結果落入 session-scoped Scratchpad。
+
+**何時用**：多個獨立 IO（抓 N 個 URL、同時跑長時間 shell），不想串列等待。
+**何時不用**：單一操作、結果立刻要用的操作——直接同步最簡單。
+
+**Autonomy 預設同步**。穩定與可預期優先於壁鐘時間；除非明確有並行意義且你會 `jobs_await`，否則 autonomy path 都走 `async_mode=False`。
+
+**工具鏈**：`jobs_list` / `jobs_status` / `jobs_await(ids, timeout)` / `jobs_cancel(id, reason)` / `scratchpad_read(ref)`。
+
+**Cancel 必帶 reason**——軌跡留在 `jobs_list()`，未來回頭可追。Session 結束 harness 自動 `cancel_all(reason="session_ended")`，Scratchpad 清空。
+
+**Turn 邊界自動通知**：若有新完成或仍在 running 的背景 job，在你送出最終回應前 harness 會注入 `[Jobs update]` 提醒——不用自己 polling。
+
+---
+
 ## 工具分類（信任層級）
 
 | 層級 | 行為 | 觸發時機 |

--- a/loom/core/jobs/__init__.py
+++ b/loom/core/jobs/__init__.py
@@ -1,0 +1,4 @@
+from .store import Job, JobState, JobStore
+from .scratchpad import Scratchpad
+
+__all__ = ["Job", "JobState", "JobStore", "Scratchpad"]

--- a/loom/core/jobs/scratchpad.py
+++ b/loom/core/jobs/scratchpad.py
@@ -1,0 +1,86 @@
+"""
+Scratchpad — session-scoped ephemeral store for in-flight job artifacts.
+
+Strictly separated from the long-term memory system. Intermediate job
+outputs live here and are cleared on session end; final products go
+through the memory system or are written to disk by the agent.
+
+Design origin: Issue #154.
+"""
+
+from __future__ import annotations
+
+URI_PREFIX = "scratchpad://"
+
+
+class Scratchpad:
+    """In-memory, session-scoped key→bytes store.
+
+    Not thread-safe by design — the harness drives everything through a
+    single asyncio loop. Writes are bytes; text convenience helpers
+    encode as UTF-8.
+    """
+
+    def __init__(self) -> None:
+        self._data: dict[str, bytes] = {}
+
+    def write(self, ref: str, content: str | bytes) -> str:
+        if not ref or "/" in ref or ref.startswith("."):
+            raise ValueError(f"Invalid scratchpad ref: {ref!r}")
+        payload = content.encode("utf-8") if isinstance(content, str) else bytes(content)
+        self._data[ref] = payload
+        return f"{URI_PREFIX}{ref}"
+
+    def read(self, ref: str, section: str | None = None) -> str:
+        ref = self._strip_uri(ref)
+        if ref not in self._data:
+            raise KeyError(f"Scratchpad ref not found: {ref}")
+        text = self._data[ref].decode("utf-8", errors="replace")
+        if section is None:
+            return text
+        return _apply_section(text, section)
+
+    def size(self, ref: str) -> int:
+        ref = self._strip_uri(ref)
+        if ref not in self._data:
+            raise KeyError(f"Scratchpad ref not found: {ref}")
+        return len(self._data[ref])
+
+    def list_refs(self) -> list[str]:
+        return sorted(self._data.keys())
+
+    def clear(self) -> None:
+        self._data.clear()
+
+    def __contains__(self, ref: str) -> bool:
+        return self._strip_uri(ref) in self._data
+
+    @staticmethod
+    def _strip_uri(ref: str) -> str:
+        return ref[len(URI_PREFIX):] if ref.startswith(URI_PREFIX) else ref
+
+
+def _apply_section(text: str, section: str) -> str:
+    """Apply a section filter matching task_read semantics.
+
+    Supported:
+      - "head"     → first 50 lines
+      - "tail"     → last 50 lines
+      - "N-M"      → lines N..M inclusive (1-indexed)
+      - any other  → treat as keyword; return lines containing it
+    """
+    lines = text.splitlines()
+    if section == "head":
+        return "\n".join(lines[:50])
+    if section == "tail":
+        return "\n".join(lines[-50:])
+    if "-" in section:
+        try:
+            lo, hi = section.split("-", 1)
+            i, j = int(lo), int(hi)
+            if i >= 1 and j >= i:
+                return "\n".join(lines[i - 1:j])
+        except ValueError:
+            pass
+    matches = [line for line in lines if section in line]
+    return "\n".join(matches)

--- a/loom/core/jobs/scratchpad.py
+++ b/loom/core/jobs/scratchpad.py
@@ -31,14 +31,32 @@ class Scratchpad:
         self._data[ref] = payload
         return f"{URI_PREFIX}{ref}"
 
-    def read(self, ref: str, section: str | None = None) -> str:
+    def read(
+        self,
+        ref: str,
+        section: str | None = None,
+        max_bytes: int | None = None,
+    ) -> str:
+        """Read a scratchpad entry as text.
+
+        ``max_bytes`` caps the decoded payload before section filtering — a
+        safety net for tools that may return multi-megabyte bodies. When the
+        cap trims content, a truncation notice is appended.
+        """
         ref = self._strip_uri(ref)
         if ref not in self._data:
             raise KeyError(f"Scratchpad ref not found: {ref}")
-        text = self._data[ref].decode("utf-8", errors="replace")
-        if section is None:
-            return text
-        return _apply_section(text, section)
+        raw = self._data[ref]
+        truncated = False
+        if max_bytes is not None and len(raw) > max_bytes:
+            raw = raw[:max_bytes]
+            truncated = True
+        text = raw.decode("utf-8", errors="replace")
+        if section is not None:
+            text = _apply_section(text, section)
+        if truncated:
+            text = text + f"\n\n[scratchpad_read: output truncated at {max_bytes} bytes]"
+        return text
 
     def size(self, ref: str) -> int:
         ref = self._strip_uri(ref)

--- a/loom/core/jobs/store.py
+++ b/loom/core/jobs/store.py
@@ -1,0 +1,193 @@
+"""
+JobStore — session-scoped async job registry.
+
+Lets tools submit background work (IO-heavy operations) and return a
+job_id immediately, instead of forcing the agent to block. The harness
+reaps completed jobs at turn boundaries and injects a status update so
+the agent can notice progress without polling.
+
+Design origin: Issue #154.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Awaitable, Callable
+
+
+class JobState(Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    DONE = "done"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+TERMINAL_STATES = (JobState.DONE, JobState.FAILED, JobState.CANCELLED)
+
+
+@dataclass
+class Job:
+    id: str
+    fn_name: str
+    args: dict[str, Any]
+    state: JobState = JobState.PENDING
+    submitted_at: float = field(default_factory=time.time)
+    started_at: float | None = None
+    finished_at: float | None = None
+    result_ref: str | None = None           # scratchpad URI, if any
+    result_summary: str | None = None       # short blurb for the inject message
+    error: str | None = None
+    cancel_reason: str | None = None
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.state in TERMINAL_STATES
+
+    @property
+    def elapsed_seconds(self) -> float | None:
+        if self.started_at is None:
+            return None
+        end = self.finished_at or time.time()
+        return end - self.started_at
+
+
+class JobStore:
+    """Registry of async jobs scoped to a single session.
+
+    Not thread-safe. All mutation happens on the session's asyncio loop.
+    """
+
+    def __init__(self) -> None:
+        self._jobs: dict[str, Job] = {}
+        self._tasks: dict[str, asyncio.Task] = {}
+        self._reaped_ids: set[str] = set()
+
+    # -- submission ----------------------------------------------------
+
+    def submit(
+        self,
+        fn_name: str,
+        args: dict[str, Any],
+        coro_factory: Callable[[], Awaitable[tuple[str | None, str | None, str | None]]],
+    ) -> str:
+        """Submit an async job.
+
+        ``coro_factory`` is a zero-arg callable that returns a fresh coroutine
+        each call. When awaited, it must resolve to a tuple:
+            (result_ref, result_summary, error)
+        where at most one of result_ref/error is non-None.
+
+        Returns the job_id.
+        """
+        job_id = f"job_{uuid.uuid4().hex[:8]}"
+        job = Job(id=job_id, fn_name=fn_name, args=dict(args))
+        self._jobs[job_id] = job
+
+        task = asyncio.create_task(self._run(job_id, coro_factory))
+        self._tasks[job_id] = task
+        return job_id
+
+    async def _run(
+        self,
+        job_id: str,
+        coro_factory: Callable[[], Awaitable[tuple[str | None, str | None, str | None]]],
+    ) -> None:
+        job = self._jobs[job_id]
+        job.state = JobState.RUNNING
+        job.started_at = time.time()
+        try:
+            result_ref, summary, error = await coro_factory()
+        except asyncio.CancelledError:
+            # Cooperative cancel — cancel() already wrote the reason.
+            raise
+        except Exception as exc:
+            job.finished_at = time.time()
+            job.state = JobState.FAILED
+            job.error = f"{type(exc).__name__}: {exc}"
+            return
+        job.finished_at = time.time()
+        if error:
+            job.state = JobState.FAILED
+            job.error = error
+        else:
+            job.state = JobState.DONE
+            job.result_ref = result_ref
+            job.result_summary = summary
+
+    # -- inspection ----------------------------------------------------
+
+    def get(self, job_id: str) -> Job | None:
+        return self._jobs.get(job_id)
+
+    def list_active(self) -> list[Job]:
+        return [j for j in self._jobs.values() if not j.is_terminal]
+
+    def list_all(self) -> list[Job]:
+        return list(self._jobs.values())
+
+    # -- reaping -------------------------------------------------------
+
+    def reap_since_last(self) -> tuple[list[Job], list[Job]]:
+        """Return (newly_finished, still_running) since the last call.
+
+        Idempotent: jobs that were already reported as finished in a prior
+        call are excluded from ``newly_finished``.
+        """
+        new_finished: list[Job] = []
+        for job in self._jobs.values():
+            if job.is_terminal and job.id not in self._reaped_ids:
+                new_finished.append(job)
+                self._reaped_ids.add(job.id)
+        running = [j for j in self._jobs.values() if not j.is_terminal]
+        return new_finished, running
+
+    # -- cancellation --------------------------------------------------
+
+    def cancel(self, job_id: str, reason: str) -> None:
+        if not reason:
+            raise ValueError("cancel() requires a non-empty reason")
+        job = self._jobs.get(job_id)
+        if job is None:
+            raise KeyError(f"Unknown job_id: {job_id}")
+        if job.is_terminal:
+            return
+        task = self._tasks.get(job_id)
+        if task and not task.done():
+            task.cancel()
+        job.state = JobState.CANCELLED
+        job.cancel_reason = reason
+        job.finished_at = time.time()
+
+    async def cancel_all(self, reason: str) -> None:
+        if not reason:
+            raise ValueError("cancel_all() requires a non-empty reason")
+        active_ids = [j.id for j in self.list_active()]
+        for jid in active_ids:
+            self.cancel(jid, reason)
+        if self._tasks:
+            await asyncio.gather(
+                *(t for t in self._tasks.values() if not t.done()),
+                return_exceptions=True,
+            )
+
+    # -- awaits --------------------------------------------------------
+
+    async def await_jobs(
+        self, job_ids: list[str], timeout: float | None = None
+    ) -> tuple[list[Job], list[Job]]:
+        """Wait for all given jobs to terminate (or timeout).
+
+        Returns (finished, still_running). Does not raise on timeout.
+        Unknown IDs are silently skipped.
+        """
+        tasks = [self._tasks[jid] for jid in job_ids if jid in self._tasks]
+        if tasks:
+            await asyncio.wait(tasks, timeout=timeout)
+        finished = [self._jobs[jid] for jid in job_ids if jid in self._jobs and self._jobs[jid].is_terminal]
+        running = [self._jobs[jid] for jid in job_ids if jid in self._jobs and not self._jobs[jid].is_terminal]
+        return finished, running

--- a/loom/core/jobs/store.py
+++ b/loom/core/jobs/store.py
@@ -137,6 +137,13 @@ class JobStore:
 
         Idempotent: jobs that were already reported as finished in a prior
         call are excluded from ``newly_finished``.
+
+        First-call semantics: any job already in a terminal state at the
+        time of the first call **will** appear in ``newly_finished``. In
+        the current lifecycle this is impossible — ``submit()`` is the
+        only entry point and the first reap happens at the earliest
+        ``end_turn`` boundary — but remember this when debugging unusual
+        first-turn injection messages.
         """
         new_finished: list[Job] = []
         for job in self._jobs.values():
@@ -149,6 +156,14 @@ class JobStore:
     # -- cancellation --------------------------------------------------
 
     def cancel(self, job_id: str, reason: str) -> None:
+        """Cancel a running/pending job.
+
+        - Empty ``reason`` → ``ValueError`` (trace must be preserved).
+        - Unknown ``job_id`` → ``KeyError`` (fail loudly; bogus id is a
+          caller bug, not a silent no-op we want to hide).
+        - Already-terminal job → silent no-op (race-free idempotency for
+          ``cancel_all`` and for tools that catch up after completion).
+        """
         if not reason:
             raise ValueError("cancel() requires a non-empty reason")
         job = self._jobs.get(job_id)

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -286,6 +286,40 @@ def _parse_skill_frontmatter(raw: str) -> tuple[str, str, list[str], list[dict]]
     return name, description, tags, valid_refs
 
 
+def _build_jobs_inject_message(jobstore: Any) -> str | None:
+    """Issue #154: render a pre-final-response reminder about background jobs.
+
+    Returns None when there is nothing to report — no new completions and no
+    still-running jobs. Only items finished since the last call are listed
+    under 'Completed since last turn' (JobStore.reap_since_last is idempotent).
+    """
+    new_finished, running = jobstore.reap_since_last()
+    if not new_finished and not running:
+        return None
+
+    lines = ["[Jobs update]"]
+    if new_finished:
+        lines.append("Completed since last turn:")
+        for j in new_finished:
+            if j.state.value == "done":
+                ref = f"scratchpad://{j.result_ref}" if j.result_ref else "(no output)"
+                size = f" ({j.result_summary})" if j.result_summary else ""
+                lines.append(f"  - {j.id} ({j.fn_name}): done → {ref}{size}")
+            elif j.state.value == "failed":
+                lines.append(f"  - {j.id} ({j.fn_name}): failed — {j.error}")
+            elif j.state.value == "cancelled":
+                lines.append(f"  - {j.id} ({j.fn_name}): cancelled — {j.cancel_reason}")
+    if running:
+        if new_finished:
+            lines.append("")
+        lines.append("Still running:")
+        for j in running:
+            elapsed = j.elapsed_seconds
+            elapsed_str = f" ({elapsed:.0f}s elapsed)" if elapsed else ""
+            lines.append(f"  - {j.id} ({j.fn_name}): {j.state.value}{elapsed_str}")
+    return "\n".join(lines)
+
+
 def build_router() -> LLMRouter:
     """
     Build the LLM router with all available providers registered.
@@ -437,8 +471,20 @@ class LoomSession:
         _strict_sandbox: bool = config.get("harness", {}).get("strict_sandbox", False)
         self._strict_sandbox = _strict_sandbox
         self.registry = ToolRegistry()
+        # Issue #154: JobStore + Scratchpad must exist before tools that may
+        # submit to them (run_bash, fetch_url). Session-scoped, in-memory,
+        # cleared on stop(). Final products go through memory system.
+        from loom.core.jobs import JobStore, Scratchpad
+        self._jobstore = JobStore()
+        self._scratchpad = Scratchpad()
+
         from loom.platform.cli.tools import make_run_bash_tool, make_filesystem_tools
-        _run_bash_tool = make_run_bash_tool(self.workspace, strict_sandbox=_strict_sandbox)
+        _run_bash_tool = make_run_bash_tool(
+            self.workspace,
+            strict_sandbox=_strict_sandbox,
+            jobstore=self._jobstore,
+            scratchpad=self._scratchpad,
+        )
         self.registry.register(_run_bash_tool)
         _fs_tools = make_filesystem_tools(self.workspace)
         for tool in _fs_tools:
@@ -672,7 +718,10 @@ class LoomSession:
         ))
 
         # Register web tools (Phase 5D)
-        self.registry.register(make_fetch_url_tool())
+        self.registry.register(make_fetch_url_tool(
+            jobstore=self._jobstore,
+            scratchpad=self._scratchpad,
+        ))
         env = _load_env()
         brave_key = env.get("brave_search_key") or env.get("BRAVE_SEARCH_KEY", "")
         if brave_key:
@@ -698,6 +747,22 @@ class LoomSession:
         self.registry.register(make_task_modify_tool(self._tasklist_manager))
         self.registry.register(make_task_done_tool(self._tasklist_manager))
         self.registry.register(make_task_read_tool(self._tasklist_manager))
+
+        # Issue #154: async job inspection tools. The JobStore + Scratchpad
+        # themselves are created in __init__ so run_bash/fetch_url can close
+        # over them; only the inspection tools are registered here.
+        from loom.platform.cli.tools import (
+            make_jobs_list_tool,
+            make_jobs_status_tool,
+            make_jobs_await_tool,
+            make_jobs_cancel_tool,
+            make_scratchpad_read_tool,
+        )
+        self.registry.register(make_jobs_list_tool(self._jobstore))
+        self.registry.register(make_jobs_status_tool(self._jobstore))
+        self.registry.register(make_jobs_await_tool(self._jobstore))
+        self.registry.register(make_jobs_cancel_tool(self._jobstore))
+        self.registry.register(make_scratchpad_read_tool(self._scratchpad))
 
         # Plugin scan (4D): load ~/.loom/plugins/*.py + workspace loom_tools.py.
         # New plugin files require one-time GUARDED approval stored in
@@ -791,6 +856,16 @@ class LoomSession:
     async def stop(self) -> None:
         if self._db is None:
             return
+        # Issue #154: cancel any in-flight background jobs with trace.
+        # Must run BEFORE clearing self._db so any tool_end emissions still
+        # have a live state to write to. Scratchpad is then cleared.
+        if hasattr(self, "_jobstore"):
+            try:
+                await self._jobstore.cancel_all(reason="session_ended")
+            except Exception as exc:
+                logger.error("JobStore.cancel_all failed: %s", exc, exc_info=True)
+        if hasattr(self, "_scratchpad"):
+            self._scratchpad.clear()
         # Issue #64: unmount all skill-declared checks before closing
         if hasattr(self, "_skill_check_manager"):
             self._skill_check_manager.unmount_all()
@@ -1020,6 +1095,10 @@ class LoomSession:
         # at most once per stream_turn if the list still has active nodes,
         # nudging the agent to either continue executing or mark abandonment.
         _tasklist_selfcheck_done = False
+        # Issue #154: Jobs status injection, also at most once per stream_turn.
+        # Reports newly-finished and still-running background jobs so the
+        # agent can absorb progress without polling.
+        _jobs_inject_done = False
 
         while True:
             # Check abort signal at top of each LLM call iteration.
@@ -1203,6 +1282,23 @@ class LoomSession:
                             "content": f"<system-reminder>\n{reminder}\n</system-reminder>",
                         })
                         _tasklist_selfcheck_done = True
+                        continue
+
+                # Issue #154: after TaskList self-check, report background
+                # jobs status if there's something new to say. Order matters:
+                # TaskList comes first so the agent sees planning context
+                # before absorbing IO updates.
+                if (
+                    not _jobs_inject_done
+                    and hasattr(self, "_jobstore")
+                ):
+                    jobs_msg = _build_jobs_inject_message(self._jobstore)
+                    if jobs_msg:
+                        self.messages.append({
+                            "role": "user",
+                            "content": f"<system-reminder>\n{jobs_msg}\n</system-reminder>",
+                        })
+                        _jobs_inject_done = True
                         continue
 
                 self._turn_index += 1

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import re
 import subprocess
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -470,7 +471,12 @@ def make_exec_escape_fn(workspace: Path):
     return _would_escape
 
 
-def make_run_bash_tool(workspace: Path, strict_sandbox: bool = False) -> ToolDefinition:
+def make_run_bash_tool(
+    workspace: Path,
+    strict_sandbox: bool = False,
+    jobstore: Any = None,
+    scratchpad: Any = None,
+) -> ToolDefinition:
     """
     Return the ``run_bash`` tool definition.
 
@@ -479,9 +485,15 @@ def make_run_bash_tool(workspace: Path, strict_sandbox: bool = False) -> ToolDef
     relative paths and shell builtins stay inside the project folder.  This
     does not prevent absolute-path escapes at the OS level — for full
     confinement use an OS sandbox (e.g. Docker).
+
+    Issue #154: when ``async_mode=True`` is passed in call.args and a jobstore
+    is available, the shell invocation is submitted as a background Job and
+    the tool returns immediately with ``{"job_id": "..."}``.  Results land in
+    the Scratchpad; harness injects status updates at turn boundaries.
     """
     async def _run_bash(call: ToolCall) -> ToolResult:
         command = call.args.get("command", "")
+        async_mode = bool(call.args.get("async_mode", False))
 
         # Issue #98: self-termination guard — before ANY other processing
         verdict = _self_term_guard.check(command)
@@ -511,6 +523,20 @@ def make_run_bash_tool(workspace: Path, strict_sandbox: bool = False) -> ToolDef
 
         timeout = call.args.get("timeout", 30)
         cwd = str(workspace) if strict_sandbox else None
+
+        if async_mode and jobstore is not None and scratchpad is not None:
+            job_id = jobstore.submit(
+                "run_bash",
+                {"command": command, "timeout": timeout},
+                lambda: _run_bash_job(command, cwd, timeout, scratchpad),
+            )
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=True,
+                output=f"Submitted as {job_id}. Poll with jobs_status or jobs_await.",
+                metadata={"job_id": job_id, "async": True},
+            )
+
         try:
             proc = await asyncio.create_subprocess_shell(
                 command,
@@ -539,9 +565,13 @@ def make_run_bash_tool(workspace: Path, strict_sandbox: bool = False) -> ToolDef
                               success=False, error=str(exc))
 
     sandbox_note = " Shell is confined to the workspace directory." if strict_sandbox else ""
+    async_note = (
+        " Pass async_mode=True to run in the background and receive a job_id; "
+        "poll via jobs_status / jobs_await; read output with scratchpad_read."
+    ) if jobstore is not None else ""
     return ToolDefinition(
         name="run_bash",
-        description=f"Execute a shell command and return stdout/stderr.{sandbox_note}",
+        description=f"Execute a shell command and return stdout/stderr.{sandbox_note}{async_note}",
         trust_level=TrustLevel.GUARDED,
         capabilities=ToolCapability.EXEC,
         input_schema={
@@ -549,6 +579,7 @@ def make_run_bash_tool(workspace: Path, strict_sandbox: bool = False) -> ToolDef
             "properties": {
                 "command": {"type": "string", "description": "Shell command to run"},
                 "timeout": {"type": "integer", "description": "Timeout in seconds (default 30)"},
+                "async_mode": {"type": "boolean", "description": "Run in background; return job_id immediately (default false)."},
                 "justification": {"type": "string", "description": "簡短說明為何在目前的脈絡下執行此工具是合理且必要的（給人類審核看）。"},
             },
             "required": ["command", "justification"],
@@ -562,6 +593,35 @@ def make_run_bash_tool(workspace: Path, strict_sandbox: bool = False) -> ToolDef
         ],
         scope_resolver=_make_run_bash_resolver(workspace),
     )
+
+
+async def _run_bash_job(
+    command: str,
+    cwd: str | None,
+    timeout: int,
+    scratchpad: Any,
+) -> tuple[str | None, str | None, str | None]:
+    """Execute run_bash in background; write stdout to Scratchpad."""
+    try:
+        proc = await asyncio.create_subprocess_shell(
+            command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            cwd=cwd,
+        )
+        try:
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except asyncio.TimeoutError:
+            proc.kill()
+            return None, None, f"Command timed out after {timeout}s"
+        output = stdout.decode("utf-8", errors="replace")
+        ref = f"bash_{uuid.uuid4().hex[:8]}"
+        scratchpad.write(ref, output)
+        if proc.returncode != 0:
+            return ref, f"exit {proc.returncode}, {len(output)} chars", None
+        return ref, f"exit 0, {len(output)} chars", None
+    except Exception as exc:
+        return None, None, f"{type(exc).__name__}: {exc}"
 
 
 # ------------------------------------------------------------------
@@ -1288,15 +1348,37 @@ def sanitize_untrusted_text(text: str) -> str:
     return f"<untrusted_external_content>\n{safe_text}\n</untrusted_external_content>"
 
 
-def make_fetch_url_tool() -> ToolDefinition:
-    """Return a SAFE tool that fetches a URL and returns cleaned text."""
+def make_fetch_url_tool(
+    jobstore: Any = None,
+    scratchpad: Any = None,
+) -> ToolDefinition:
+    """Return a SAFE tool that fetches a URL and returns cleaned text.
+
+    Issue #154: when ``async_mode=True`` is passed and a jobstore is
+    available, the fetch is submitted as a background Job; the tool
+    returns a job_id immediately and the body lands in Scratchpad.
+    """
 
     async def _fetch_url(call: ToolCall) -> ToolResult:
         url = call.args.get("url", "").strip()
+        async_mode = bool(call.args.get("async_mode", False))
         abort = call.abort_signal
         if not url:
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
                               success=False, error="'url' argument is required")
+
+        if async_mode and jobstore is not None and scratchpad is not None:
+            job_id = jobstore.submit(
+                "fetch_url",
+                {"url": url},
+                lambda: _fetch_url_job(url, scratchpad),
+            )
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=True,
+                output=f"Submitted as {job_id}. Poll with jobs_status or jobs_await.",
+                metadata={"job_id": job_id, "async": True},
+            )
 
         async def _get():
             async with httpx.AsyncClient(follow_redirects=True,
@@ -1328,12 +1410,16 @@ def make_fetch_url_tool() -> ToolDefinition:
         return ToolResult(call_id=call.id, tool_name=call.tool_name,
                           success=True, output=output)
 
+    async_note = (
+        " Pass async_mode=True to fetch in the background and receive a job_id; "
+        "the full body lands in Scratchpad."
+    ) if jobstore is not None else ""
     return ToolDefinition(
         name="fetch_url",
         description=(
             "Fetch a URL and return the page title and cleaned body text (scripts/styles removed). "
             "Use this to read web pages, documentation, or articles. "
-            "Output is truncated to 2000 chars."
+            f"Synchronous output is truncated to 2000 chars.{async_note}"
         ),
         trust_level=TrustLevel.SAFE,
         capabilities=ToolCapability.NETWORK,
@@ -1341,6 +1427,7 @@ def make_fetch_url_tool() -> ToolDefinition:
             "type": "object",
             "properties": {
                 "url": {"type": "string", "description": "Full URL to fetch (http/https)"},
+                "async_mode": {"type": "boolean", "description": "Fetch in background; return job_id (default false)."},
             },
             "required": ["url"],
         },
@@ -1350,6 +1437,32 @@ def make_fetch_url_tool() -> ToolDefinition:
         scope_descriptions=["connects to the requested URL domain"],
         scope_resolver=_fetch_url_resolver,
     )
+
+
+async def _fetch_url_job(
+    url: str,
+    scratchpad: Any,
+) -> tuple[str | None, str | None, str | None]:
+    """Fetch a URL in the background; write the body to Scratchpad."""
+    try:
+        async with httpx.AsyncClient(follow_redirects=True,
+                                     timeout=_WEB_TIMEOUT) as client:
+            r = await client.get(url, headers={"User-Agent": "Loom/0.3"})
+            r.raise_for_status()
+        content_type = r.headers.get("content-type", "")
+        if "html" in content_type:
+            title, body = _html_to_text(r.text)
+            raw = f"Title: {title}\n\n{body}" if title else body
+        else:
+            raw = r.text
+        clean = sanitize_untrusted_text(raw)
+        ref = f"fetch_{uuid.uuid4().hex[:8]}"
+        scratchpad.write(ref, clean)
+        return ref, f"{len(clean)} chars from {url}", None
+    except httpx.HTTPStatusError as exc:
+        return None, None, f"HTTP {exc.response.status_code}: {url}"
+    except Exception as exc:
+        return None, None, f"{type(exc).__name__}: {exc}"
 
 
 def make_web_search_tool(brave_api_key: str) -> ToolDefinition:
@@ -1951,5 +2064,247 @@ def make_task_read_tool(manager: "TaskListManager") -> ToolDefinition:
         },
         executor=_task_read,
         tags=["task", "read"],
+        impact_scope="agent",
+    )
+
+
+# ------------------------------------------------------------------
+# Issue #154: Job inspection & Scratchpad tools
+# ------------------------------------------------------------------
+
+
+def _fmt_job(job: Any) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "id": job.id,
+        "fn": job.fn_name,
+        "state": job.state.value,
+        "submitted_at": job.submitted_at,
+    }
+    if job.started_at is not None:
+        out["started_at"] = job.started_at
+    if job.finished_at is not None:
+        out["finished_at"] = job.finished_at
+    if job.elapsed_seconds is not None:
+        out["elapsed_seconds"] = round(job.elapsed_seconds, 2)
+    if job.result_ref:
+        out["result_ref"] = f"scratchpad://{job.result_ref}"
+    if job.result_summary:
+        out["summary"] = job.result_summary
+    if job.error:
+        out["error"] = job.error
+    if job.cancel_reason:
+        out["cancel_reason"] = job.cancel_reason
+    return out
+
+
+def make_jobs_list_tool(jobstore: Any) -> ToolDefinition:
+    """List all jobs in the current session (active + terminal)."""
+
+    async def _jobs_list(call: ToolCall) -> ToolResult:
+        filter_state = (call.args.get("state") or "").strip().lower()
+        jobs = jobstore.list_all()
+        if filter_state == "active":
+            jobs = [j for j in jobs if not j.is_terminal]
+        elif filter_state:
+            jobs = [j for j in jobs if j.state.value == filter_state]
+        payload = {
+            "count": len(jobs),
+            "jobs": [_fmt_job(j) for j in jobs],
+        }
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=True, output=json.dumps(payload, indent=2),
+        )
+
+    return ToolDefinition(
+        name="jobs_list",
+        description=(
+            "List background jobs in the current session. "
+            "Optional 'state' filter: 'active' (running+pending), or a specific "
+            "state like 'done'/'failed'/'cancelled'."
+        ),
+        trust_level=TrustLevel.SAFE,
+        capabilities=ToolCapability.NONE,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "state": {"type": "string", "description": "Optional filter"},
+            },
+        },
+        executor=_jobs_list,
+        tags=["jobs"],
+        impact_scope="agent",
+    )
+
+
+def make_jobs_status_tool(jobstore: Any) -> ToolDefinition:
+    """Look up a single job by id."""
+
+    async def _jobs_status(call: ToolCall) -> ToolResult:
+        job_id = (call.args.get("job_id") or "").strip()
+        if not job_id:
+            return ToolResult(call_id=call.id, tool_name=call.tool_name,
+                              success=False, error="'job_id' is required")
+        job = jobstore.get(job_id)
+        if job is None:
+            return ToolResult(call_id=call.id, tool_name=call.tool_name,
+                              success=False, error=f"Unknown job_id: {job_id}")
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=True, output=json.dumps(_fmt_job(job), indent=2),
+        )
+
+    return ToolDefinition(
+        name="jobs_status",
+        description="Get the detailed status of a single background job.",
+        trust_level=TrustLevel.SAFE,
+        capabilities=ToolCapability.NONE,
+        input_schema={
+            "type": "object",
+            "properties": {"job_id": {"type": "string"}},
+            "required": ["job_id"],
+        },
+        executor=_jobs_status,
+        tags=["jobs"],
+        impact_scope="agent",
+    )
+
+
+def make_jobs_await_tool(jobstore: Any) -> ToolDefinition:
+    """Block until given jobs terminate or timeout expires."""
+
+    async def _jobs_await(call: ToolCall) -> ToolResult:
+        ids = call.args.get("job_ids") or []
+        if isinstance(ids, str):
+            ids = [ids]
+        if not ids:
+            return ToolResult(call_id=call.id, tool_name=call.tool_name,
+                              success=False, error="'job_ids' is required (list of job IDs)")
+        timeout = call.args.get("timeout")
+        try:
+            timeout_f = float(timeout) if timeout is not None else None
+        except (TypeError, ValueError):
+            return ToolResult(call_id=call.id, tool_name=call.tool_name,
+                              success=False, error="'timeout' must be a number (seconds)")
+
+        finished, running = await jobstore.await_jobs(ids, timeout=timeout_f)
+        payload = {
+            "finished": [_fmt_job(j) for j in finished],
+            "still_running": [_fmt_job(j) for j in running],
+            "timeout_hit": len(running) > 0,
+        }
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=True, output=json.dumps(payload, indent=2),
+        )
+
+    return ToolDefinition(
+        name="jobs_await",
+        description=(
+            "Wait for one or more jobs to terminate, up to a timeout. "
+            "Returns finished and still_running lists; unfinished jobs keep running."
+        ),
+        trust_level=TrustLevel.SAFE,
+        capabilities=ToolCapability.NONE,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "job_ids": {"type": "array", "items": {"type": "string"}},
+                "timeout": {"type": "number", "description": "Seconds; omit to wait indefinitely (not recommended)."},
+            },
+            "required": ["job_ids"],
+        },
+        executor=_jobs_await,
+        tags=["jobs"],
+        impact_scope="agent",
+    )
+
+
+def make_jobs_cancel_tool(jobstore: Any) -> ToolDefinition:
+    """Cancel a running or pending job. Reason is mandatory for traceability."""
+
+    async def _jobs_cancel(call: ToolCall) -> ToolResult:
+        job_id = (call.args.get("job_id") or "").strip()
+        reason = (call.args.get("reason") or "").strip()
+        if not job_id:
+            return ToolResult(call_id=call.id, tool_name=call.tool_name,
+                              success=False, error="'job_id' is required")
+        if not reason:
+            return ToolResult(call_id=call.id, tool_name=call.tool_name,
+                              success=False, error="'reason' is required — cancellation trace must be preserved")
+        try:
+            jobstore.cancel(job_id, reason=reason)
+        except KeyError:
+            return ToolResult(call_id=call.id, tool_name=call.tool_name,
+                              success=False, error=f"Unknown job_id: {job_id}")
+        job = jobstore.get(job_id)
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=True, output=json.dumps(_fmt_job(job), indent=2),
+        )
+
+    return ToolDefinition(
+        name="jobs_cancel",
+        description=(
+            "Cancel a running/pending job. Requires 'reason' — the trace is "
+            "preserved so you (and future turns) can see why it was stopped."
+        ),
+        trust_level=TrustLevel.SAFE,
+        capabilities=ToolCapability.NONE,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "job_id": {"type": "string"},
+                "reason": {"type": "string", "description": "Why the job is being cancelled."},
+            },
+            "required": ["job_id", "reason"],
+        },
+        executor=_jobs_cancel,
+        tags=["jobs"],
+        impact_scope="agent",
+    )
+
+
+def make_scratchpad_read_tool(scratchpad: Any) -> ToolDefinition:
+    """Read content from the session's Scratchpad."""
+
+    async def _scratchpad_read(call: ToolCall) -> ToolResult:
+        ref = (call.args.get("ref") or "").strip()
+        if not ref:
+            refs = scratchpad.list_refs()
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=True,
+                output=json.dumps({"available_refs": refs}, indent=2),
+            )
+        section = call.args.get("section")
+        try:
+            content = scratchpad.read(ref, section=section)
+        except KeyError as exc:
+            return ToolResult(call_id=call.id, tool_name=call.tool_name,
+                              success=False, error=str(exc))
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=True, output=content,
+        )
+
+    return ToolDefinition(
+        name="scratchpad_read",
+        description=(
+            "Read content from the session Scratchpad. Omit 'ref' to list "
+            "available refs. Supports section filter: 'head', 'tail', 'N-M' "
+            "for line range, or any string to grep matching lines."
+        ),
+        trust_level=TrustLevel.SAFE,
+        capabilities=ToolCapability.NONE,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "ref": {"type": "string", "description": "Scratchpad ref (with or without scratchpad:// prefix). Omit to list all refs."},
+                "section": {"type": "string", "description": "Optional filter: head/tail/N-M/keyword."},
+            },
+        },
+        executor=_scratchpad_read,
+        tags=["jobs", "scratchpad"],
         impact_scope="agent",
     )

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -2202,7 +2202,8 @@ def make_jobs_await_tool(jobstore: Any) -> ToolDefinition:
         name="jobs_await",
         description=(
             "Wait for one or more jobs to terminate, up to a timeout. "
-            "Returns finished and still_running lists; unfinished jobs keep running."
+            "Returns finished and still_running lists; unfinished jobs keep running. "
+            "Does NOT raise on timeout — check 'timeout_hit' in the result."
         ),
         trust_level=TrustLevel.SAFE,
         capabilities=ToolCapability.NONE,
@@ -2265,6 +2266,9 @@ def make_jobs_cancel_tool(jobstore: Any) -> ToolDefinition:
     )
 
 
+_SCRATCHPAD_DEFAULT_MAX_BYTES = 200_000
+
+
 def make_scratchpad_read_tool(scratchpad: Any) -> ToolDefinition:
     """Read content from the session's Scratchpad."""
 
@@ -2278,8 +2282,21 @@ def make_scratchpad_read_tool(scratchpad: Any) -> ToolDefinition:
                 output=json.dumps({"available_refs": refs}, indent=2),
             )
         section = call.args.get("section")
+        raw_max = call.args.get("max_bytes")
+        if raw_max is None:
+            max_bytes = _SCRATCHPAD_DEFAULT_MAX_BYTES
+        else:
+            try:
+                max_bytes = int(raw_max)
+                if max_bytes <= 0:
+                    max_bytes = _SCRATCHPAD_DEFAULT_MAX_BYTES
+            except (TypeError, ValueError):
+                return ToolResult(
+                    call_id=call.id, tool_name=call.tool_name,
+                    success=False, error="'max_bytes' must be a positive integer",
+                )
         try:
-            content = scratchpad.read(ref, section=section)
+            content = scratchpad.read(ref, section=section, max_bytes=max_bytes)
         except KeyError as exc:
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
                               success=False, error=str(exc))
@@ -2293,7 +2310,9 @@ def make_scratchpad_read_tool(scratchpad: Any) -> ToolDefinition:
         description=(
             "Read content from the session Scratchpad. Omit 'ref' to list "
             "available refs. Supports section filter: 'head', 'tail', 'N-M' "
-            "for line range, or any string to grep matching lines."
+            f"for line range, or any string to grep matching lines. Output is "
+            f"capped at {_SCRATCHPAD_DEFAULT_MAX_BYTES} bytes by default — "
+            "raise 'max_bytes' for larger payloads."
         ),
         trust_level=TrustLevel.SAFE,
         capabilities=ToolCapability.NONE,
@@ -2302,6 +2321,7 @@ def make_scratchpad_read_tool(scratchpad: Any) -> ToolDefinition:
             "properties": {
                 "ref": {"type": "string", "description": "Scratchpad ref (with or without scratchpad:// prefix). Omit to list all refs."},
                 "section": {"type": "string", "description": "Optional filter: head/tail/N-M/keyword."},
+                "max_bytes": {"type": "integer", "description": f"Byte cap on raw payload before section filter (default {_SCRATCHPAD_DEFAULT_MAX_BYTES})."},
             },
         },
         executor=_scratchpad_read,

--- a/skills/async_jobs/SKILL.md
+++ b/skills/async_jobs/SKILL.md
@@ -31,7 +31,7 @@ at turn boundaries — you never need to poll blindly.
 | `run_bash(command, async_mode=True)` | Submit shell command; returns `{job_id}` |
 | `jobs_list(state=?)` | List all jobs; optionally filter by `active`/`done`/`failed`/`cancelled` |
 | `jobs_status(job_id)` | Full state for one job |
-| `jobs_await(job_ids, timeout)` | Block until all complete or timeout (returns finished + still_running) |
+| `jobs_await(job_ids, timeout)` | Block until all complete or timeout. Does not raise on timeout — check `timeout_hit` in the result and decide (cancel vs. keep waiting) |
 | `jobs_cancel(job_id, reason)` | Cancel in-flight job — `reason` is mandatory |
 | `scratchpad_read(ref, section?)` | Read the body; omit `ref` to list available refs |
 

--- a/skills/async_jobs/SKILL.md
+++ b/skills/async_jobs/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: async_jobs
+description: Background job submission and Scratchpad for parallel IO (fetch_url, run_bash in async_mode). Use when multiple independent IO operations should not block sequentially.
+tags: [core, concurrency, io]
+---
+
+# Async Jobs — Parallel IO without Sub-Agents
+
+`async_mode=True` lets IO tools (`fetch_url`, `run_bash`) run in the
+background and return a `job_id` immediately. Results land in a
+session-scoped **Scratchpad**. The harness tells you which jobs finished
+at turn boundaries — you never need to poll blindly.
+
+## When to use
+
+- Fetching multiple URLs whose bodies don't depend on each other
+- Long-running shell commands (builds, test runs) where you have other
+  work to do in parallel
+- Any IO batch where serial execution wastes wall-clock time
+
+**Do NOT use** for:
+- Single operations — `async_mode=False` is simpler and faster for one-shot work
+- Operations whose result you need **immediately** to decide the next step — just await
+- Anything where the output is only a few hundred bytes — the bookkeeping overhead beats the latency win
+
+## Tool chain
+
+| Tool | Purpose |
+|------|---------|
+| `fetch_url(url, async_mode=True)` | Submit URL fetch; returns `{job_id}` |
+| `run_bash(command, async_mode=True)` | Submit shell command; returns `{job_id}` |
+| `jobs_list(state=?)` | List all jobs; optionally filter by `active`/`done`/`failed`/`cancelled` |
+| `jobs_status(job_id)` | Full state for one job |
+| `jobs_await(job_ids, timeout)` | Block until all complete or timeout (returns finished + still_running) |
+| `jobs_cancel(job_id, reason)` | Cancel in-flight job — `reason` is mandatory |
+| `scratchpad_read(ref, section?)` | Read the body; omit `ref` to list available refs |
+
+## Typical flow (parallel fetch)
+
+```
+1. fetch_url(url=A, async_mode=True)  → job_a
+2. fetch_url(url=B, async_mode=True)  → job_b
+3. fetch_url(url=C, async_mode=True)  → job_c
+4. jobs_await(job_ids=[a,b,c], timeout=60)
+5. scratchpad_read(ref=job_a.result_ref)   # now go through the bodies
+6. scratchpad_read(ref=job_b.result_ref)
+7. scratchpad_read(ref=job_c.result_ref)
+```
+
+## Rules
+
+- **Autonomy defaults to `async_mode=False`.** Autonomy has time; stability
+  and predictability matter more than wall-clock wins. Only turn on
+  `async_mode` in autonomy if the parallel benefit is clearly worth it
+  and you explicitly `jobs_await` the results.
+- **Cancel always requires a reason.** The trace is preserved in
+  `jobs_list()` so you (and future turns) can see why it was stopped.
+- **Trust/confirm happens at submit time**, not at reap. A denied job
+  won't be submitted, so you won't end up holding a stale job_id.
+- **Scratchpad is ephemeral** — cleared on session end. If you need the
+  content long-term, pull it with `scratchpad_read` and write it to a
+  file (or semantic memory) while the session is still open.
+- **Harness injects a jobs update** before you send a final response,
+  whenever a job has newly completed or is still running. No polling
+  required — just react to the reminder when it arrives.
+
+## Cancel on session end
+
+Session stop calls `cancel_all(reason="session_ended")` automatically;
+Scratchpad is cleared. Any in-flight work at that point is lost — if
+stability matters more than parallelism for this task, just use
+synchronous mode.

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,352 @@
+"""Tests for Issue #154 — JobStore + Scratchpad."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from loom.core.jobs import Job, JobState, JobStore, Scratchpad
+
+
+# --- Scratchpad ------------------------------------------------------
+
+
+class TestScratchpad:
+    def test_write_returns_uri(self):
+        pad = Scratchpad()
+        uri = pad.write("abc", "hello")
+        assert uri == "scratchpad://abc"
+
+    def test_read_roundtrip_text(self):
+        pad = Scratchpad()
+        pad.write("abc", "hello world")
+        assert pad.read("abc") == "hello world"
+
+    def test_read_accepts_full_uri(self):
+        pad = Scratchpad()
+        pad.write("abc", "data")
+        assert pad.read("scratchpad://abc") == "data"
+
+    def test_read_bytes_decode(self):
+        pad = Scratchpad()
+        pad.write("b", b"bytes payload")
+        assert pad.read("b") == "bytes payload"
+
+    def test_size_counts_bytes(self):
+        pad = Scratchpad()
+        pad.write("x", "héllo")
+        assert pad.size("x") == len("héllo".encode("utf-8"))
+
+    def test_missing_ref_raises(self):
+        pad = Scratchpad()
+        with pytest.raises(KeyError):
+            pad.read("nope")
+
+    def test_invalid_ref_rejected(self):
+        pad = Scratchpad()
+        with pytest.raises(ValueError):
+            pad.write("with/slash", "x")
+        with pytest.raises(ValueError):
+            pad.write("", "x")
+        with pytest.raises(ValueError):
+            pad.write(".hidden", "x")
+
+    def test_clear_removes_all(self):
+        pad = Scratchpad()
+        pad.write("a", "1")
+        pad.write("b", "2")
+        pad.clear()
+        assert pad.list_refs() == []
+
+    def test_list_refs_sorted(self):
+        pad = Scratchpad()
+        pad.write("zeta", "z")
+        pad.write("alpha", "a")
+        pad.write("mid", "m")
+        assert pad.list_refs() == ["alpha", "mid", "zeta"]
+
+    def test_contains(self):
+        pad = Scratchpad()
+        pad.write("x", "1")
+        assert "x" in pad
+        assert "scratchpad://x" in pad
+        assert "nope" not in pad
+
+    def test_section_head(self):
+        pad = Scratchpad()
+        body = "\n".join(f"line-{i}" for i in range(1, 101))
+        pad.write("log", body)
+        result = pad.read("log", section="head")
+        assert result.splitlines() == [f"line-{i}" for i in range(1, 51)]
+
+    def test_section_tail(self):
+        pad = Scratchpad()
+        body = "\n".join(f"line-{i}" for i in range(1, 101))
+        pad.write("log", body)
+        result = pad.read("log", section="tail")
+        assert result.splitlines() == [f"line-{i}" for i in range(51, 101)]
+
+    def test_section_range(self):
+        pad = Scratchpad()
+        pad.write("log", "a\nb\nc\nd\ne")
+        assert pad.read("log", section="2-4") == "b\nc\nd"
+
+    def test_section_keyword(self):
+        pad = Scratchpad()
+        pad.write("log", "apple\nbanana\napricot\ncarrot")
+        assert pad.read("log", section="ap") == "apple\napricot"
+
+
+# --- JobStore: submission + completion -------------------------------
+
+
+class TestJobStoreSubmit:
+    async def test_submit_returns_id_and_runs(self):
+        store = JobStore()
+
+        async def run():
+            return "ref_done", "42 bytes", None
+
+        job_id = store.submit("fake_fn", {"a": 1}, run)
+        assert job_id.startswith("job_")
+
+        # Give the task a chance to run
+        for _ in range(20):
+            if store.get(job_id).is_terminal:
+                break
+            await asyncio.sleep(0.01)
+
+        job = store.get(job_id)
+        assert job is not None
+        assert job.state == JobState.DONE
+        assert job.result_ref == "ref_done"
+        assert job.result_summary == "42 bytes"
+        assert job.error is None
+        assert job.started_at is not None
+        assert job.finished_at is not None
+
+    async def test_submit_captures_exception(self):
+        store = JobStore()
+
+        async def boom():
+            raise RuntimeError("kapow")
+
+        job_id = store.submit("fake_fn", {}, boom)
+        for _ in range(20):
+            if store.get(job_id).is_terminal:
+                break
+            await asyncio.sleep(0.01)
+
+        job = store.get(job_id)
+        assert job.state == JobState.FAILED
+        assert "kapow" in job.error
+
+    async def test_submit_soft_error(self):
+        """Factory returns error in the third tuple slot — job goes FAILED."""
+        store = JobStore()
+
+        async def soft_fail():
+            return None, None, "permission denied"
+
+        job_id = store.submit("fake_fn", {}, soft_fail)
+        for _ in range(20):
+            if store.get(job_id).is_terminal:
+                break
+            await asyncio.sleep(0.01)
+
+        job = store.get(job_id)
+        assert job.state == JobState.FAILED
+        assert job.error == "permission denied"
+
+
+# --- JobStore: reaping ----------------------------------------------
+
+
+class TestJobStoreReap:
+    async def test_reap_since_last_idempotent(self):
+        store = JobStore()
+
+        async def quick():
+            return "r", "done", None
+
+        job_id = store.submit("fake", {}, quick)
+        for _ in range(20):
+            if store.get(job_id).is_terminal:
+                break
+            await asyncio.sleep(0.01)
+
+        new, running = store.reap_since_last()
+        assert [j.id for j in new] == [job_id]
+        assert running == []
+
+        # Second reap: already reported, should be empty
+        new2, running2 = store.reap_since_last()
+        assert new2 == []
+        assert running2 == []
+
+    async def test_reap_reports_running(self):
+        store = JobStore()
+        gate = asyncio.Event()
+
+        async def slow():
+            await gate.wait()
+            return "r", "done", None
+
+        job_id = store.submit("slow", {}, slow)
+        # Let it enter RUNNING
+        await asyncio.sleep(0.02)
+
+        new, running = store.reap_since_last()
+        assert new == []
+        assert [j.id for j in running] == [job_id]
+
+        gate.set()
+        for _ in range(20):
+            if store.get(job_id).is_terminal:
+                break
+            await asyncio.sleep(0.01)
+
+        new, running = store.reap_since_last()
+        assert [j.id for j in new] == [job_id]
+        assert running == []
+
+    async def test_list_active_excludes_terminal(self):
+        store = JobStore()
+
+        async def quick():
+            return None, "ok", None
+
+        async def slow():
+            await asyncio.sleep(5)
+            return None, "nope", None
+
+        q = store.submit("q", {}, quick)
+        s = store.submit("s", {}, slow)
+
+        for _ in range(20):
+            if store.get(q).is_terminal:
+                break
+            await asyncio.sleep(0.01)
+
+        active_ids = [j.id for j in store.list_active()]
+        assert q not in active_ids
+        assert s in active_ids
+
+        store.cancel(s, reason="cleanup")
+
+
+# --- JobStore: cancel ------------------------------------------------
+
+
+class TestJobStoreCancel:
+    async def test_cancel_requires_reason(self):
+        store = JobStore()
+
+        async def noop():
+            return None, None, None
+
+        job_id = store.submit("x", {}, noop)
+        with pytest.raises(ValueError):
+            store.cancel(job_id, "")
+
+    async def test_cancel_preserves_trace(self):
+        store = JobStore()
+
+        async def slow():
+            await asyncio.sleep(5)
+            return None, None, None
+
+        job_id = store.submit("s", {}, slow)
+        await asyncio.sleep(0.02)
+
+        store.cancel(job_id, reason="user_abort")
+
+        job = store.get(job_id)
+        assert job.state == JobState.CANCELLED
+        assert job.cancel_reason == "user_abort"
+        assert job.finished_at is not None
+
+        # Cancelled jobs are still in list_all
+        assert any(j.id == job_id for j in store.list_all())
+
+    async def test_cancel_terminal_is_noop(self):
+        store = JobStore()
+
+        async def quick():
+            return None, None, None
+
+        job_id = store.submit("q", {}, quick)
+        for _ in range(20):
+            if store.get(job_id).is_terminal:
+                break
+            await asyncio.sleep(0.01)
+
+        # Already DONE — cancel should be silent
+        store.cancel(job_id, reason="too_late")
+        assert store.get(job_id).state == JobState.DONE
+        assert store.get(job_id).cancel_reason is None
+
+    async def test_cancel_unknown_raises(self):
+        store = JobStore()
+        with pytest.raises(KeyError):
+            store.cancel("job_nonexistent", reason="x")
+
+    async def test_cancel_all(self):
+        store = JobStore()
+
+        async def slow():
+            await asyncio.sleep(5)
+            return None, None, None
+
+        ids = [store.submit(f"s{i}", {}, slow) for i in range(3)]
+        await asyncio.sleep(0.02)
+
+        await store.cancel_all(reason="session_ended")
+
+        for jid in ids:
+            job = store.get(jid)
+            assert job.state == JobState.CANCELLED
+            assert job.cancel_reason == "session_ended"
+
+    async def test_cancel_all_requires_reason(self):
+        store = JobStore()
+        with pytest.raises(ValueError):
+            await store.cancel_all("")
+
+
+# --- JobStore: await -------------------------------------------------
+
+
+class TestJobStoreAwait:
+    async def test_await_all_complete(self):
+        store = JobStore()
+
+        async def quick():
+            await asyncio.sleep(0.01)
+            return None, "ok", None
+
+        ids = [store.submit("q", {}, quick) for _ in range(3)]
+        finished, running = await store.await_jobs(ids, timeout=1.0)
+        assert len(finished) == 3
+        assert running == []
+
+    async def test_await_timeout_returns_running(self):
+        store = JobStore()
+
+        async def slow():
+            await asyncio.sleep(5)
+            return None, None, None
+
+        job_id = store.submit("s", {}, slow)
+        finished, running = await store.await_jobs([job_id], timeout=0.05)
+        assert finished == []
+        assert [j.id for j in running] == [job_id]
+
+        store.cancel(job_id, reason="cleanup")
+
+    async def test_await_unknown_ids_silent(self):
+        store = JobStore()
+        finished, running = await store.await_jobs(["job_nope"], timeout=0.1)
+        assert finished == []
+        assert running == []

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -97,6 +97,26 @@ class TestScratchpad:
         pad.write("log", "apple\nbanana\napricot\ncarrot")
         assert pad.read("log", section="ap") == "apple\napricot"
 
+    def test_max_bytes_truncates_with_notice(self):
+        pad = Scratchpad()
+        pad.write("big", "x" * 1000)
+        result = pad.read("big", max_bytes=100)
+        assert result.startswith("x" * 100)
+        assert "truncated at 100 bytes" in result
+
+    def test_max_bytes_not_applied_when_under(self):
+        pad = Scratchpad()
+        pad.write("small", "tiny")
+        assert pad.read("small", max_bytes=1000) == "tiny"
+
+    def test_max_bytes_with_section(self):
+        """max_bytes trims raw bytes first, section filter runs on the trim."""
+        pad = Scratchpad()
+        pad.write("log", "aaa\nbbb\nccc\nddd")
+        result = pad.read("log", section="head", max_bytes=7)
+        assert "aaa\nbbb" in result
+        assert "truncated at 7 bytes" in result
+
 
 # --- JobStore: submission + completion -------------------------------
 

--- a/tests/test_jobs_tools.py
+++ b/tests/test_jobs_tools.py
@@ -230,6 +230,32 @@ class TestScratchpadTool:
         r = await tool.executor(_call("scratchpad_read", {"ref": "nope"}))
         assert not r.success
 
+    async def test_default_max_bytes_caps_output(self):
+        pad = Scratchpad()
+        pad.write("big", "y" * 1_000_000)
+        tool = make_scratchpad_read_tool(pad)
+        r = await tool.executor(_call("scratchpad_read", {"ref": "big"}))
+        assert r.success
+        # Default cap is 200_000; trailing truncation notice adds a few bytes
+        assert len(r.output) < 210_000
+        assert "truncated" in r.output
+
+    async def test_explicit_max_bytes_override(self):
+        pad = Scratchpad()
+        pad.write("med", "z" * 5_000)
+        tool = make_scratchpad_read_tool(pad)
+        r = await tool.executor(_call("scratchpad_read", {"ref": "med", "max_bytes": 1000}))
+        assert r.success
+        assert "truncated at 1000 bytes" in r.output
+
+    async def test_max_bytes_rejects_non_int(self):
+        pad = Scratchpad()
+        pad.write("x", "hi")
+        tool = make_scratchpad_read_tool(pad)
+        r = await tool.executor(_call("scratchpad_read", {"ref": "x", "max_bytes": "many"}))
+        assert not r.success
+        assert "max_bytes" in r.error
+
 
 # --- event injection helper ----------------------------------------
 

--- a/tests/test_jobs_tools.py
+++ b/tests/test_jobs_tools.py
@@ -1,0 +1,313 @@
+"""Integration tests for Issue #154 — job tools + async_mode paths."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from loom.core.jobs import JobStore, Scratchpad
+from loom.core.harness.middleware import ToolCall, ToolResult
+from loom.core.harness.permissions import TrustLevel
+from loom.core.session import _build_jobs_inject_message
+from loom.platform.cli.tools import (
+    make_fetch_url_tool,
+    make_run_bash_tool,
+    make_jobs_await_tool,
+    make_jobs_cancel_tool,
+    make_jobs_list_tool,
+    make_jobs_status_tool,
+    make_scratchpad_read_tool,
+)
+
+
+def _call(tool_name: str, args: dict) -> ToolCall:
+    return ToolCall(
+        id=f"call_{tool_name}",
+        tool_name=tool_name,
+        args=args,
+        trust_level=TrustLevel.SAFE,
+        session_id="test_session",
+        abort_signal=None,
+    )
+
+
+# --- async_mode on run_bash -----------------------------------------
+
+
+class TestRunBashAsyncMode:
+    async def test_async_mode_submits_job_and_writes_scratchpad(self, tmp_path: Path):
+        store = JobStore()
+        pad = Scratchpad()
+        tool = make_run_bash_tool(tmp_path, jobstore=store, scratchpad=pad)
+
+        result = await tool.executor(_call("run_bash", {
+            "command": "echo hello async",
+            "justification": "test",
+            "async_mode": True,
+        }))
+        assert result.success
+        assert result.metadata["async"] is True
+        job_id = result.metadata["job_id"]
+
+        finished, _ = await store.await_jobs([job_id], timeout=5.0)
+        assert len(finished) == 1
+        job = finished[0]
+        assert job.state.value == "done"
+        assert job.result_ref
+        body = pad.read(job.result_ref)
+        assert "hello async" in body
+
+    async def test_sync_mode_unchanged(self, tmp_path: Path):
+        store = JobStore()
+        pad = Scratchpad()
+        tool = make_run_bash_tool(tmp_path, jobstore=store, scratchpad=pad)
+
+        result = await tool.executor(_call("run_bash", {
+            "command": "echo sync path",
+            "justification": "test",
+        }))
+        assert result.success
+        assert "sync path" in result.output
+        assert not result.metadata.get("async", False)
+        assert store.list_all() == []  # no jobs submitted
+
+    async def test_async_mode_without_jobstore_falls_back(self, tmp_path: Path):
+        """If jobstore/scratchpad aren't wired, async_mode silently degrades."""
+        tool = make_run_bash_tool(tmp_path)  # no jobstore
+        result = await tool.executor(_call("run_bash", {
+            "command": "echo fallback",
+            "justification": "test",
+            "async_mode": True,
+        }))
+        assert result.success
+        assert "fallback" in result.output
+
+
+# --- jobs_* tools ----------------------------------------------------
+
+
+class TestJobsTools:
+    async def test_jobs_list_and_status(self):
+        store = JobStore()
+
+        async def quick():
+            return "r1", "summary", None
+
+        job_id = store.submit("demo", {}, quick)
+        await store.await_jobs([job_id], timeout=1.0)
+
+        list_tool = make_jobs_list_tool(store)
+        status_tool = make_jobs_status_tool(store)
+
+        lst = await list_tool.executor(_call("jobs_list", {}))
+        payload = json.loads(lst.output)
+        assert payload["count"] == 1
+        assert payload["jobs"][0]["id"] == job_id
+        assert payload["jobs"][0]["state"] == "done"
+        assert payload["jobs"][0]["result_ref"] == "scratchpad://r1"
+
+        s = await status_tool.executor(_call("jobs_status", {"job_id": job_id}))
+        assert s.success
+        body = json.loads(s.output)
+        assert body["state"] == "done"
+        assert body["summary"] == "summary"
+
+    async def test_jobs_list_filter_active(self):
+        store = JobStore()
+
+        async def slow():
+            await asyncio.sleep(5)
+            return None, None, None
+
+        async def quick():
+            return None, "done", None
+
+        s_id = store.submit("slow", {}, slow)
+        q_id = store.submit("quick", {}, quick)
+        await store.await_jobs([q_id], timeout=1.0)
+
+        tool = make_jobs_list_tool(store)
+        result = await tool.executor(_call("jobs_list", {"state": "active"}))
+        payload = json.loads(result.output)
+        ids = [j["id"] for j in payload["jobs"]]
+        assert s_id in ids
+        assert q_id not in ids
+
+        store.cancel(s_id, reason="cleanup")
+
+    async def test_jobs_status_unknown_id(self):
+        store = JobStore()
+        tool = make_jobs_status_tool(store)
+        r = await tool.executor(_call("jobs_status", {"job_id": "job_nope"}))
+        assert not r.success
+        assert "Unknown" in r.error
+
+    async def test_jobs_await_timeout(self):
+        store = JobStore()
+
+        async def slow():
+            await asyncio.sleep(5)
+            return None, None, None
+
+        job_id = store.submit("slow", {}, slow)
+        tool = make_jobs_await_tool(store)
+
+        r = await tool.executor(_call("jobs_await", {
+            "job_ids": [job_id],
+            "timeout": 0.05,
+        }))
+        assert r.success
+        payload = json.loads(r.output)
+        assert payload["timeout_hit"] is True
+        assert payload["finished"] == []
+        assert len(payload["still_running"]) == 1
+
+        store.cancel(job_id, reason="cleanup")
+
+    async def test_jobs_cancel_requires_reason(self):
+        store = JobStore()
+
+        async def noop():
+            return None, None, None
+
+        job_id = store.submit("x", {}, noop)
+        tool = make_jobs_cancel_tool(store)
+
+        r = await tool.executor(_call("jobs_cancel", {"job_id": job_id}))
+        assert not r.success
+        assert "reason" in r.error.lower()
+
+        r2 = await tool.executor(_call("jobs_cancel", {"job_id": job_id, "reason": "got it"}))
+        assert r2.success
+        # Note: job may have been DONE already when cancel_terminal is a no-op
+        # so we don't strictly assert CANCELLED state here.
+
+    async def test_jobs_await_requires_ids(self):
+        store = JobStore()
+        tool = make_jobs_await_tool(store)
+        r = await tool.executor(_call("jobs_await", {}))
+        assert not r.success
+
+
+# --- scratchpad_read -----------------------------------------------
+
+
+class TestScratchpadTool:
+    async def test_read_by_ref(self):
+        pad = Scratchpad()
+        pad.write("log", "hello world")
+        tool = make_scratchpad_read_tool(pad)
+
+        r = await tool.executor(_call("scratchpad_read", {"ref": "log"}))
+        assert r.success
+        assert r.output == "hello world"
+
+    async def test_read_strips_uri_prefix(self):
+        pad = Scratchpad()
+        pad.write("log", "abc")
+        tool = make_scratchpad_read_tool(pad)
+        r = await tool.executor(_call("scratchpad_read", {"ref": "scratchpad://log"}))
+        assert r.success
+        assert r.output == "abc"
+
+    async def test_list_when_no_ref(self):
+        pad = Scratchpad()
+        pad.write("a", "1")
+        pad.write("b", "2")
+        tool = make_scratchpad_read_tool(pad)
+        r = await tool.executor(_call("scratchpad_read", {}))
+        assert r.success
+        payload = json.loads(r.output)
+        assert payload["available_refs"] == ["a", "b"]
+
+    async def test_missing_ref_error(self):
+        pad = Scratchpad()
+        tool = make_scratchpad_read_tool(pad)
+        r = await tool.executor(_call("scratchpad_read", {"ref": "nope"}))
+        assert not r.success
+
+
+# --- event injection helper ----------------------------------------
+
+
+class TestJobsInjectMessage:
+    async def test_empty_returns_none(self):
+        store = JobStore()
+        assert _build_jobs_inject_message(store) is None
+
+    async def test_reports_completed(self):
+        store = JobStore()
+
+        async def quick():
+            return "ref1", "1.2KB", None
+
+        job_id = store.submit("fetch_url", {"url": "x"}, quick)
+        await store.await_jobs([job_id], timeout=1.0)
+
+        msg = _build_jobs_inject_message(store)
+        assert msg is not None
+        assert "[Jobs update]" in msg
+        assert "Completed since last turn" in msg
+        assert job_id in msg
+        assert "fetch_url" in msg
+        assert "scratchpad://ref1" in msg
+
+    async def test_idempotent(self):
+        store = JobStore()
+
+        async def quick():
+            return None, "ok", None
+
+        job_id = store.submit("fn", {}, quick)
+        await store.await_jobs([job_id], timeout=1.0)
+
+        # First call reports it
+        first = _build_jobs_inject_message(store)
+        assert first and job_id in first
+
+        # Second call: already reaped, nothing to say
+        second = _build_jobs_inject_message(store)
+        assert second is None
+
+    async def test_reports_running(self):
+        store = JobStore()
+
+        async def slow():
+            await asyncio.sleep(5)
+            return None, None, None
+
+        job_id = store.submit("slow_fn", {}, slow)
+        await asyncio.sleep(0.02)  # let RUNNING transition happen
+
+        msg = _build_jobs_inject_message(store)
+        assert msg is not None
+        assert "Still running" in msg
+        assert job_id in msg
+        assert "running" in msg
+
+        store.cancel(job_id, reason="cleanup")
+
+    async def test_reports_failure_and_cancellation(self):
+        store = JobStore()
+
+        async def boom():
+            return None, None, "kaboom"
+
+        async def slow():
+            await asyncio.sleep(5)
+            return None, None, None
+
+        f_id = store.submit("f", {}, boom)
+        s_id = store.submit("s", {}, slow)
+        await store.await_jobs([f_id], timeout=1.0)
+        store.cancel(s_id, reason="unneeded")
+
+        msg = _build_jobs_inject_message(store)
+        assert msg and "failed" in msg
+        assert "kaboom" in msg
+        assert "cancelled" in msg
+        assert "unneeded" in msg


### PR DESCRIPTION
## Summary

IO tools (`fetch_url`, `run_bash`) now accept `async_mode=True` — they submit a background job, return `{"job_id"}` immediately, and the result body lands in a session-scoped Scratchpad. Harness injects a `[Jobs update]` reminder at turn boundaries so the agent never polls blindly.

Absorbs the "4 parallel URL fetches" case at the harness/tool layer instead of spawning sub-agents — main agent stays hands-on (#153 design principle) while still claiming the wall-clock win.

## Design guidelines (from discussion)

- **Lightweight**: `asyncio.create_task` wrapping existing handlers; no threadpool, no new deps.
- **Low agent burden**: harness tells agent what finished; agent reacts.
- **Observable**: `jobs_list` / `jobs_status` plus automatic `[Jobs update]` injection.
- **Autonomy = stability first**: `async_mode` defaults to False; parallelism is opt-in.

## What's in this PR

### Core (`loom/core/jobs/`)
- **`store.py` — JobStore**: session-scoped registry. States `PENDING/RUNNING/DONE/FAILED/CANCELLED`. `submit()` uses `asyncio.create_task`. `reap_since_last()` is idempotent (drives event injection). `cancel()` / `cancel_all()` **require a reason** — trace preserved in `list_all()`. `await_jobs(ids, timeout)` blocks until settled.
- **`scratchpad.py` — Scratchpad**: in-memory `ref → bytes`, section filter (`head`/`tail`/`N-M`/keyword). Strictly ephemeral: cleared on `session.stop()`. Separate from the memory system — final products still go through memory/disk.

### Tool surface
- `fetch_url` / `run_bash` — add `async_mode=True`. Sync path unchanged. Trust/BlastRadius evaluation still at submit time (not at reap).
- **New tools (all SAFE)**: `jobs_list` (optional `state` filter), `jobs_status`, `jobs_await(ids, timeout)`, `jobs_cancel(id, reason)` (reason mandatory), `scratchpad_read(ref, section?)`.

### Session lifecycle
- `__init__` creates JobStore + Scratchpad early so `run_bash` can close over them; `start()` registers the 5 inspection tools.
- `stop()` calls `cancel_all(reason=\"session_ended\")` **before** closing the DB, then clears Scratchpad.
- `stream_turn` `end_turn` hook: after the #153 TaskList self-check, injects a one-shot `<system-reminder>` `[Jobs update]` when there's newly-finished or still-running work. Order: TaskList → Jobs (planning context before IO update).

### Docs
- `skills/async_jobs/SKILL.md` — Tier-1 skill genome (discoverable without memorizing).
- `Agent.md.example` — new 背景任務 section. Autonomy defaults to `async_mode=False`.

## Cancel trace requirement

Per the discussion: no silent drops.
- `jobs_cancel(id, reason)` — reason required at the schema level.
- Session end → `cancel_all(reason=\"session_ended\")`.
- Cancelled jobs stay in `list_all()` with `cancel_reason` so future turns can see why.

## Test plan

- [x] `pytest tests/test_jobs.py tests/test_jobs_tools.py` — 47/47
- [x] `pytest tests/` — 776 / 778 (2 pre-existing MiniMax embedding failures, unrelated)
- [ ] **Siyi (Loom agent) real-world smoke** — let the agent self-discover `async_jobs` skill and attempt a multi-URL fetch; observe whether the injection message reads cleanly, whether she reaches for `jobs_await` appropriately, and whether autonomy still defaults to sync mode
- [ ] Manual: `loom discord start` — confirm a session where an async job is submitted, turn ends, and the next turn surfaces the `[Jobs update]`
- [ ] Manual: Ctrl+C / `session.stop()` mid-flight — confirm `cancel_all` fires, cancel_reason recorded as `session_ended`, Scratchpad cleared

Closes #154. Complements #153.

## Follow-ups (not in scope)

- Per-tool timeouts from `loom.toml [jobs.per_tool]` — deferred until real usage surfaces the need.
- `jobs_await` periodic injection during long waits — deferred; start with pre-final-response only and see if it's enough.
- Web search / spawn_agent `async_mode` — second batch if first batch works out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)