### PR TITLE
fix(memory): soft-delete compressed episodic entries

### DIFF
--- a/doc/37-loom-toml-參考.md
+++ b/doc/37-loom-toml-參考.md
@@ -105,24 +105,30 @@ episodic_compress_threshold = 30
 | `db_path` | string | `"~/.loom/memory.db"` | SQLite 檔案路徑（支援 `~` 展開） |
 | `episodic_retention_days` | integer | `7` | Episodic entries 保留天數 |
 | `skill_deprecation_threshold` | float | `0.3` | Skill EMA confidence 低於此值標記為 deprecated |
-| `episodic_compress_threshold` | integer | `30` | 每 session 累積多少條 episodic entries 就壓縮成 semantic facts；Discord 長跑 session 建議調低至 `10` |
+| `episodic_compress_threshold` | integer | `30` | 每 session 累積多少條**未壓縮** episodic entries 就壓縮成 semantic facts；Discord 長跑 session 建議調低至 `10`。單批上限 60 條（超過的最舊部分會被截斷）。 |
 
 ### 記憶壓縮流程
 
 ```
 每次 tool call → EpisodicMemory.write()
     ↓
-每個 turn 結束，若 episodic count ≥ episodic_compress_threshold
+每個 turn 結束，若未壓縮 episodic count ≥ episodic_compress_threshold
     → compress_session()
     → Admission Gate（MemoryGovernor）過濾低品質事實
     → 轉換為 FACT → MemoryGovernor.governed_upsert()
     → 矛盾偵測 → SemanticMemory.upsert() 或跳過
-    → 舊 episodic entries 刪除
+    → 舊 episodic entries soft-delete（compressed_at 標記）
     ↓
 Bot 關機 / session.stop()
     → 最終一次 compress_session()
-    → MemoryGovernor.run_decay_cycle()（清除 TTL 過期 + 衰減條目）
+    → MemoryGovernor.run_decay_cycle()（TTL 硬刪 compressed_at 過期行 + 衰減條目）
 ```
+
+**Soft-delete 設計**：壓縮後的 episodic rows 不立即刪除，只在 `compressed_at` 寫入時間戳；
+- `count_session()` / `compress_session()` 預設只看未壓縮 rows，避免重複處理
+- `read_session()` 預設讀全部（包含已壓縮），reflection / session_summary 仍能取得完整軌跡
+- TTL 到期由 `MemoryGovernor._prune_episodic_ttl` 統一硬刪，依 `episodic_retention_days`
+- 若 LLM 抽 FACT 時漏掉關鍵資訊，原始 episodic 仍在磁碟上,可在保留期內 audit / 重抽
 
 ---
 

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -70,9 +70,14 @@ episodic_retention_days = 7
 # Skills whose EMA confidence drops below this are marked deprecated.
 skill_deprecation_threshold = 0.3
 
-# Compress episodic → semantic after this many entries accumulate per session.
-# Lower values keep semantic memory fresher; 10 is recommended for long-running
-# Discord sessions, 30 is fine for short CLI sessions.
+# Compress episodic → semantic after this many **uncompressed** entries
+# accumulate per session. Already-compressed rows are excluded from the count
+# and kept on disk (soft-delete) for audit and recovery — TTL prune eventually
+# clears them per ``episodic_retention_days``. The LLM compression pass caps
+# at 60 entries per batch, so values above ~55 will silently drop the oldest.
+# Lower values keep semantic memory fresher but shrink each batch, which can
+# hurt fact-extraction quality. 10 is fine for long-running Discord sessions,
+# 30 for short CLI sessions.
 episodic_compress_threshold = 30
 
 # ─────────────────────────────────────────────

--- a/loom/core/memory/episodic.py
+++ b/loom/core/memory/episodic.py
@@ -22,6 +22,7 @@ class EpisodicEntry:
     metadata: dict[str, Any] = field(default_factory=dict)
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    compressed_at: datetime | None = None
 
 
 class EpisodicMemory:
@@ -48,12 +49,28 @@ class EpisodicMemory:
         )
         await self._db.commit()
 
-    async def read_session(self, session_id: str) -> list[EpisodicEntry]:
-        cursor = await self._db.execute(
-            "SELECT id, session_id, event_type, content, metadata, created_at "
-            "FROM episodic_entries WHERE session_id = ? ORDER BY created_at",
-            (session_id,),
+    async def read_session(
+        self,
+        session_id: str,
+        *,
+        uncompressed_only: bool = False,
+    ) -> list[EpisodicEntry]:
+        """Read episodic entries for *session_id*.
+
+        When ``uncompressed_only`` is True, excludes entries already folded
+        into semantic memory (compressed_at IS NOT NULL). The compression
+        path uses this to avoid re-processing; callers that want to replay
+        the full session trace should leave it False (default).
+        """
+        sql = (
+            "SELECT id, session_id, event_type, content, metadata, "
+            "created_at, compressed_at "
+            "FROM episodic_entries WHERE session_id = ?"
         )
+        if uncompressed_only:
+            sql += " AND compressed_at IS NULL"
+        sql += " ORDER BY created_at"
+        cursor = await self._db.execute(sql, (session_id,))
         rows = await cursor.fetchall()
         return [
             EpisodicEntry(
@@ -63,20 +80,59 @@ class EpisodicMemory:
                 content=r[3],
                 metadata=json.loads(r[4]),
                 created_at=datetime.fromisoformat(r[5]),
+                compressed_at=datetime.fromisoformat(r[6]) if r[6] else None,
             )
             for r in rows
         ]
 
-    async def count_session(self, session_id: str) -> int:
-        cursor = await self._db.execute(
-            "SELECT COUNT(*) FROM episodic_entries WHERE session_id = ?",
-            (session_id,),
-        )
+    async def count_session(
+        self,
+        session_id: str,
+        *,
+        uncompressed_only: bool = False,
+    ) -> int:
+        """Count episodic entries for *session_id*.
+
+        The compression trigger passes ``uncompressed_only=True`` so that
+        re-compressed rows don't keep the threshold permanently satisfied.
+        """
+        sql = "SELECT COUNT(*) FROM episodic_entries WHERE session_id = ?"
+        if uncompressed_only:
+            sql += " AND compressed_at IS NULL"
+        cursor = await self._db.execute(sql, (session_id,))
         row = await cursor.fetchone()
         return row[0] if row else 0
 
+    async def mark_compressed(
+        self,
+        entry_ids: list[str],
+        *,
+        compressed_at: datetime | None = None,
+    ) -> int:
+        """Mark the given entries as compressed (soft-delete).
+
+        Preserves the original rows for audit and potential recovery; the
+        TTL prune in ``MemoryGovernor._prune_episodic_ttl`` eventually hard-
+        deletes them based on ``created_at``.
+        """
+        if not entry_ids:
+            return 0
+        stamp = (compressed_at or datetime.now(UTC)).isoformat()
+        placeholders = ",".join("?" * len(entry_ids))
+        cursor = await self._db.execute(
+            f"UPDATE episodic_entries SET compressed_at = ? "
+            f"WHERE id IN ({placeholders}) AND compressed_at IS NULL",
+            (stamp, *entry_ids),
+        )
+        await self._db.commit()
+        return cursor.rowcount or 0
+
     async def delete_session(self, session_id: str) -> int:
-        """Delete all episodic entries for *session_id*. Returns count deleted."""
+        """Hard-delete all episodic entries for *session_id*. Returns count deleted.
+
+        No longer used by the compression path (which now soft-deletes via
+        ``mark_compressed``). Retained for user-initiated purge and tests.
+        """
         cursor = await self._db.execute(
             "DELETE FROM episodic_entries WHERE session_id = ?",
             (session_id,),

--- a/loom/core/memory/store.py
+++ b/loom/core/memory/store.py
@@ -17,12 +17,13 @@ SCHEMA = """
 PRAGMA journal_mode=WAL;
 
 CREATE TABLE IF NOT EXISTS episodic_entries (
-    id          TEXT PRIMARY KEY,
-    session_id  TEXT NOT NULL,
-    event_type  TEXT NOT NULL,
-    content     TEXT NOT NULL,
-    metadata    TEXT NOT NULL DEFAULT '{}',
-    created_at  TEXT NOT NULL
+    id            TEXT PRIMARY KEY,
+    session_id    TEXT NOT NULL,
+    event_type    TEXT NOT NULL,
+    content       TEXT NOT NULL,
+    metadata      TEXT NOT NULL DEFAULT '{}',
+    created_at    TEXT NOT NULL,
+    compressed_at TEXT  -- NULL = uncompressed; ISO timestamp once folded into semantic memory
 );
 
 CREATE TABLE IF NOT EXISTS semantic_entries (
@@ -79,6 +80,9 @@ CREATE TABLE IF NOT EXISTS relational_entries (
 
 CREATE INDEX IF NOT EXISTS idx_episodic_session   ON episodic_entries(session_id);
 CREATE INDEX IF NOT EXISTS idx_episodic_created   ON episodic_entries(created_at);
+-- Issue #142 soft-delete: fast filter for uncompressed rows (hot path on every turn).
+CREATE INDEX IF NOT EXISTS idx_episodic_session_uncompressed
+    ON episodic_entries(session_id) WHERE compressed_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_semantic_key        ON semantic_entries(key);
 CREATE INDEX IF NOT EXISTS idx_audit_session       ON audit_log(session_id);
 CREATE TABLE IF NOT EXISTS trigger_history (
@@ -198,6 +202,9 @@ class SQLiteStore:
                 "ALTER TABLE audit_log ADD COLUMN details TEXT NOT NULL DEFAULT '{}'",
                 # Issue #64: skill-declared precondition check references
                 "ALTER TABLE skill_genomes ADD COLUMN precondition_check_refs TEXT NOT NULL DEFAULT '[]'",
+                # Issue #142 soft-delete: mark compressed entries instead of deleting
+                # them so compression losses can be audited and recovered.
+                "ALTER TABLE episodic_entries ADD COLUMN compressed_at TEXT",
             ]:
                 try:
                     await db.execute(_migration)
@@ -207,6 +214,8 @@ class SQLiteStore:
             # Ensure new indexes exist even on pre-existing databases.
             for _index_sql in [
                 "CREATE INDEX IF NOT EXISTS idx_session_log_role ON session_log(session_id, role)",
+                "CREATE INDEX IF NOT EXISTS idx_episodic_session_uncompressed "
+                "ON episodic_entries(session_id) WHERE compressed_at IS NULL",
             ]:
                 try:
                     await db.execute(_index_sql)

--- a/loom/core/memory/store.py
+++ b/loom/core/memory/store.py
@@ -80,9 +80,12 @@ CREATE TABLE IF NOT EXISTS relational_entries (
 
 CREATE INDEX IF NOT EXISTS idx_episodic_session   ON episodic_entries(session_id);
 CREATE INDEX IF NOT EXISTS idx_episodic_created   ON episodic_entries(created_at);
--- Issue #142 soft-delete: fast filter for uncompressed rows (hot path on every turn).
-CREATE INDEX IF NOT EXISTS idx_episodic_session_uncompressed
-    ON episodic_entries(session_id) WHERE compressed_at IS NULL;
+-- Note: idx_episodic_session_uncompressed (partial index on WHERE compressed_at
+-- IS NULL) is built in the runtime migration block below, **after** the ALTER
+-- TABLE that adds the column. Defining it here would break upgrades from
+-- pre-compressed_at databases — the executescript would fail on the first
+-- initialize() call because the partial predicate references a column that
+-- doesn't exist yet.
 CREATE INDEX IF NOT EXISTS idx_semantic_key        ON semantic_entries(key);
 CREATE INDEX IF NOT EXISTS idx_audit_session       ON audit_log(session_id);
 CREATE TABLE IF NOT EXISTS trigger_history (

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -131,16 +131,18 @@ async def compress_session(
     *,
     governor: "MemoryGovernor | None" = None,
 ) -> int:
-    """Compress unprocessed episodic entries to semantic facts, then delete them.
+    """Compress unprocessed episodic entries to semantic facts.
 
     Uses a timestamp in the semantic key so repeated compressions (mid-session
-    and on close) never overwrite each other.  Episodic entries are deleted
-    after a successful compression to prevent redundant re-processing.
+    and on close) never overwrite each other. Processed entries are **soft-
+    deleted** via ``mark_compressed`` rather than removed, so the original
+    trace remains available for audit and recovery until TTL prune aged
+    them out (``MemoryGovernor._prune_episodic_ttl``).
 
     When a MemoryGovernor is provided, candidate facts are filtered through
     the admission gate before being written to semantic memory (Issue #43).
     """
-    entries = await episodic.read_session(session_id)
+    entries = await episodic.read_session(session_id, uncompressed_only=True)
     if not entries:
         return 0
 
@@ -184,9 +186,12 @@ async def compress_session(
         else:
             await semantic.upsert(entry)
 
-    # Delete processed episodic entries so they aren't re-compressed on next stop()
+    # Soft-delete: mark the rows we read as compressed so they aren't
+    # re-processed on the next trigger, but keep the content on disk for
+    # audit and potential backfill (the admission gate or the LLM may drop
+    # something that later turns out to matter).
     if facts:
-        await episodic.delete_session(session_id)
+        await episodic.mark_compressed([e.id for e in entries])
 
     return len(facts)
 
@@ -1308,8 +1313,13 @@ class LoomSession:
 
                 # Mid-session episodic compression: configurable via loom.toml
                 # [memory] episodic_compress_threshold (default 30).
+                # Count only *uncompressed* rows so soft-deleted entries from
+                # prior compressions don't keep the threshold permanently
+                # satisfied (would re-trigger the LLM every turn).
                 try:
-                    ep_count = await self._episodic.count_session(self.session_id)
+                    ep_count = await self._episodic.count_session(
+                        self.session_id, uncompressed_only=True,
+                    )
                     if ep_count >= self._episodic_compress_threshold:
                         fact_count = await compress_session(
                             self.session_id, self._episodic, self._semantic,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -412,6 +412,46 @@ class TestSessionCompression:
         assert chat_called == []   # router never called for empty session
 
     @pytest.mark.asyncio
+    async def test_compress_soft_deletes_entries(self, db_conn):
+        """Issue #142: compress_session must mark entries compressed, not delete."""
+        em = EpisodicMemory(db_conn)
+        sm = SemanticMemory(db_conn)
+
+        ids: list[str] = []
+        for i in range(3):
+            entry = EpisodicEntry(
+                session_id="soft-comp", event_type="tool_result",
+                content=f"tool call {i}",
+            )
+            ids.append(entry.id)
+            await em.write(entry)
+
+        mock_router = _make_mock_router("FACT: Something happened\n")
+
+        count = await compress_session(
+            session_id="soft-comp",
+            episodic=em, semantic=sm,
+            router=mock_router, model="MiniMax-M2.7",
+        )
+        assert count == 1
+
+        # Entries still exist — but all flagged compressed_at
+        all_rows = await em.read_session("soft-comp")
+        assert len(all_rows) == 3
+        assert all(r.compressed_at is not None for r in all_rows)
+
+        # Uncompressed view is empty — so the threshold won't re-trigger
+        assert await em.count_session("soft-comp", uncompressed_only=True) == 0
+
+        # A subsequent compress_session does nothing (no fresh input)
+        count2 = await compress_session(
+            session_id="soft-comp",
+            episodic=em, semantic=sm,
+            router=mock_router, model="MiniMax-M2.7",
+        )
+        assert count2 == 0
+
+    @pytest.mark.asyncio
     async def test_compress_facts_have_correct_source(self, db_conn):
         em = EpisodicMemory(db_conn)
         sm = SemanticMemory(db_conn)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -139,6 +139,72 @@ class TestEpisodicMemory:
         entries = await em.read_session("s5")
         assert entries[0].metadata == meta
 
+    # Issue #142 — soft-delete behaviour
+    @pytest.mark.asyncio
+    async def test_mark_compressed_stamps_and_is_queryable(self, db_conn):
+        em = EpisodicMemory(db_conn)
+        ids: list[str] = []
+        for i in range(3):
+            entry = EpisodicEntry(
+                session_id="soft", event_type="tool_result", content=f"step {i}",
+            )
+            ids.append(entry.id)
+            await em.write(entry)
+
+        # Mark the first two
+        marked = await em.mark_compressed(ids[:2])
+        assert marked == 2
+
+        all_rows = await em.read_session("soft")
+        assert len(all_rows) == 3  # read_session default includes compressed rows
+        stamped = [r for r in all_rows if r.compressed_at is not None]
+        assert {r.id for r in stamped} == set(ids[:2])
+
+        uncompressed = await em.read_session("soft", uncompressed_only=True)
+        assert [r.id for r in uncompressed] == [ids[2]]
+
+    @pytest.mark.asyncio
+    async def test_count_session_uncompressed_only(self, db_conn):
+        em = EpisodicMemory(db_conn)
+        ids: list[str] = []
+        for _ in range(4):
+            entry = EpisodicEntry(
+                session_id="count", event_type="message", content="x",
+            )
+            ids.append(entry.id)
+            await em.write(entry)
+
+        # Before marking: both counts agree
+        assert await em.count_session("count") == 4
+        assert await em.count_session("count", uncompressed_only=True) == 4
+
+        await em.mark_compressed(ids[:3])
+
+        # After marking: total unchanged, uncompressed drops
+        assert await em.count_session("count") == 4
+        assert await em.count_session("count", uncompressed_only=True) == 1
+
+    @pytest.mark.asyncio
+    async def test_mark_compressed_is_idempotent(self, db_conn):
+        em = EpisodicMemory(db_conn)
+        e = EpisodicEntry(session_id="idem", event_type="system", content="x")
+        await em.write(e)
+
+        first = await em.mark_compressed([e.id])
+        second = await em.mark_compressed([e.id])
+        assert first == 1
+        # Second call skips already-compressed rows (WHERE compressed_at IS NULL)
+        assert second == 0
+
+        # Stamp is preserved, not overwritten
+        rows = await em.read_session("idem")
+        assert rows[0].compressed_at is not None
+
+    @pytest.mark.asyncio
+    async def test_mark_compressed_empty_list_is_noop(self, db_conn):
+        em = EpisodicMemory(db_conn)
+        assert await em.mark_compressed([]) == 0
+
 
 # ---------------------------------------------------------------------------
 # SemanticMemory

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -74,6 +74,61 @@ class TestSQLiteStore:
                     "skill_genomes", "audit_log"}
         assert expected.issubset(tables)
 
+    @pytest.mark.asyncio
+    async def test_initialize_migrates_pre_compressed_at_schema(self, tmp_db):
+        """Regression: initialize() must not explode on databases that
+        predate the compressed_at column. The partial index that references
+        that column has to be built *after* the ALTER TABLE migration adds
+        it — never as part of the main SCHEMA script.
+        """
+        import aiosqlite
+        import sqlite_vec
+
+        async with aiosqlite.connect(tmp_db) as db:
+            await db.enable_load_extension(True)
+            await db.load_extension(sqlite_vec.loadable_path())
+            # Pre-soft-delete table shape — no compressed_at column.
+            await db.execute(
+                """
+                CREATE TABLE episodic_entries (
+                    id         TEXT PRIMARY KEY,
+                    session_id TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    content    TEXT NOT NULL,
+                    metadata   TEXT NOT NULL DEFAULT '{}',
+                    created_at TEXT NOT NULL
+                )
+                """
+            )
+            await db.execute(
+                "INSERT INTO episodic_entries VALUES (?, ?, ?, ?, ?, ?)",
+                ("e1", "s1", "msg", "legacy", "{}", "2026-01-01T00:00:00+00:00"),
+            )
+            await db.commit()
+
+        # Should migrate cleanly, not raise.
+        s = SQLiteStore(tmp_db)
+        await s.initialize()
+
+        async with s.connect() as db:
+            cur = await db.execute("PRAGMA table_info(episodic_entries)")
+            cols = {r[1] for r in await cur.fetchall()}
+            assert "compressed_at" in cols
+
+            cur = await db.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' "
+                "AND tbl_name='episodic_entries'"
+            )
+            indexes = {r[0] for r in await cur.fetchall()}
+            assert "idx_episodic_session_uncompressed" in indexes
+
+            # Pre-existing row survives migration with NULL compressed_at
+            em = EpisodicMemory(db)
+            rows = await em.read_session("s1")
+            assert len(rows) == 1
+            assert rows[0].compressed_at is None
+            assert await em.count_session("s1", uncompressed_only=True) == 1
+
 
 # ---------------------------------------------------------------------------
 # EpisodicMemory


### PR DESCRIPTION
## Summary

`compress_session()` previously hard-deleted every processed episodic row the moment a `FACT` was extracted. If the LLM's extractor — or the admission gate — missed something, the original trace was gone and couldn't be recovered. Frequent compression on long sessions amplified the risk: small batches produce lower-quality facts, and the raw data that might have repaired them had already been erased.

This PR adds a `compressed_at` column and replaces the hard-delete in the compression path with a soft-delete stamp. Rows remain on disk and stay auditable until the existing TTL prune (`MemoryGovernor._prune_episodic_ttl`) ages them out per `episodic_retention_days`.

## Changes

- **Schema**: `episodic_entries.compressed_at TEXT` (nullable) — added via `SCHEMA` for fresh DBs and a runtime `ALTER TABLE` migration for existing ones. Partial index `idx_episodic_session_uncompressed ON (session_id) WHERE compressed_at IS NULL` keeps the turn-boundary count query fast.
- **`EpisodicMemory.mark_compressed(ids)`** — new soft-delete op. `UPDATE ... WHERE compressed_at IS NULL` so the stamp is never overwritten on re-runs.
- **`read_session()` / `count_session()`** — both grow an `uncompressed_only` kwarg. `compress_session()` and the turn-boundary count pass `True` so already-folded rows don't keep the threshold permanently satisfied. Default `False` so `reflection.session_summary()` / `recent_tool_calls()` still see the full trace.
- **`compress_session()`** — replaces `delete_session()` with `mark_compressed([e.id for e in entries])`. `delete_session()` is retained for user-initiated purge.
- **Docs** (`doc/37-loom-toml-參考.md`, `loom.toml.example`) — document the new soft-delete flow and the `entries[:60]` per-batch cap.

## Design notes

- The 60-entry batch cap in `compress_session()` is **not** addressed here — it's a separate quality concern. With a default threshold of 30, it shouldn't bite; the docs now flag it for users who raise the threshold.
- TTL-based hard delete in `_prune_episodic_ttl` is unchanged — it already uses `created_at` and will eventually clear compressed rows naturally, so disk growth stays bounded by `episodic_retention_days`.
- This is the prerequisite for the upcoming `#142` telemetry PR, which will expose a `fact_yield_ratio` metric and benefits from having compressed entries still on disk for back-testing.

## Test plan

- [x] `tests/test_memory.py::TestEpisodicMemory` — four new tests covering `mark_compressed` stamping, idempotency, empty-list no-op, and the `uncompressed_only` filter on both `read_session` and `count_session`.
- [x] `tests/test_integration.py::TestSessionCompression::test_compress_soft_deletes_entries` — confirms `compress_session()` leaves rows on disk with `compressed_at` set, that `count_session(uncompressed_only=True)` returns 0 afterward, and that a second `compress_session()` call is a no-op.
- [x] Local full suite: 787 passed, 2 pre-existing failures in `TestBuildEmbeddingProvider` (unrelated — fail on `origin/master` without this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)