### PR TITLE
feat(cognition): skill lifecycle — shadow / promote / rollback (Issue #120 PR 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,8 @@ skills/silky_minimax_draw
 skills/deep_researcher
 skills/github_cli
 skills/silky_tts
+personalities/personality_sisi_tarot_mood.md
+skills/sisi_mood_tarot
 
 # Personal config (use loom.toml.example as template)
 loom.toml

--- a/doc/10-Skill-Genome.md
+++ b/doc/10-Skill-Genome.md
@@ -213,6 +213,8 @@ alpha=0.15 意味著新評分佔 15% 權重，歷史值佔 85%——穩定但仍
 
 ## Evolution Hook — 主動進化
 
+> 🔗 **想要讓 skill body 本身被改寫、shadow 試用、promote / rollback？** 進一步的三段式進化鏈請見 [10b-Skill-Evolution.md](10b-Skill-Evolution.md)。本節描述的是較早期的 hint-only 機制，候選改寫是 Issue #120 的後續擴充。
+
 `SkillEvolutionHook` 在 session 結束（`stop()`）時觸發，對 confidence 低、使用次數足夠的技能生成改進建議：
 
 **觸發條件：**

--- a/doc/10b-Skill-Evolution.md
+++ b/doc/10b-Skill-Evolution.md
@@ -1,0 +1,208 @@
+# Skill Evolution — 技能進化生命週期
+
+> Issue #120 — 讓 SKILL.md 在使用中被自己改寫。
+
+## 為什麼需要這一層
+
+[10-Skill-Genome.md](10-Skill-Genome.md) 的 EMA confidence 能告訴你「這個 skill 狀況不好」，但改不了 skill 本身。長期下來 skill body 會落後於實際需要。
+
+Issue #120 在 EMA 自評之上補了一條完整的進化鏈：**每輪結束時寫一份 TaskDiagnostic → 低分時 LLM 改寫 SKILL.md 成候選 → 候選先在 shadow 模式小規模試用 → 驗證好再 promote → 不對勁就 rollback**。整條鏈預設只開到 diagnostic；開一個開關才會開始改寫 skill，再開一個才會真的替換。
+
+## 三段式 PR 骨架
+
+| PR | 模組 | 職責 |
+|----|------|------|
+| PR 1 | `TaskReflector` | 每輪 TurnDone 產出結構化 `TaskDiagnostic`（instructions_followed / violated / quality_score / mutation_suggestions…） |
+| PR 2 | `SkillMutator` | 看到低分 diagnostic 就呼叫 LLM 改寫 parent SKILL.md → 存成 `SkillCandidate`（狀態 `generated`） |
+| PR 3 | `SkillPromoter` + `SkillGate` | 狀態機 `generated → shadow → promoted` / `deprecated` / `rolled_back`；載入時決定要服務 parent 還是 shadow body |
+
+## 資料流一覽
+
+```text
+turn done
+   ↓
+TaskReflector.reflect()
+   ├─▶ TaskDiagnostic（skill:<name>:diagnostic:<ts>）
+   │      quality_score 1–5 / mutation_suggestions[]
+   │      instructions_violated[] / failure_patterns[]
+   ↓  （fire-and-forget）
+SkillMutator.should_propose?
+   ├─ quality_score ≤ quality_ceiling
+   ├─ len(mutation_suggestions) ≥ min_suggestions
+   ├─ mutation.enabled = true
+   ↓  LLM 改寫 SKILL.md（保留 frontmatter）
+SkillCandidate(status="generated")
+   ↓  （fire-and-forget）
+SkillPromoter.maybe_auto_shadow()
+   ├─ shadow_mode = "auto_c"
+   ├─ parent.confidence ≤ auto_shadow_confidence_ceiling
+   ↓
+SkillCandidate(status="shadow")
+
+後續 load_skill("<name>")：
+SkillGate.resolve()
+   ├─ off → parent
+   ├─ manual_b → parent（除非有 force_shadow 覆寫）
+   └─ auto_c → 用 SHA1(session_id|skill_name) 切分，
+               決定這個 session 看 parent 還是 shadow body
+
+使用者或 agent 判斷 shadow 表現夠好：
+   loom skill promote <candidate_id>  或 tool promote_skill_candidate
+   ↓
+skill_version_history 封存 parent 舊 body
+parent.body = candidate.candidate_body
+parent.version += 1
+parent.confidence = 1.0（重新累積信心）
+sibling shadows → deprecated
+
+後悔的話：
+   loom skill rollback <skill_name>  或 tool rollback_skill
+   ↓
+skill_version_history 也封存現況
+parent.body ← 先前版本
+parent.version += 1
+promoted candidate → rolled_back
+```
+
+## 三個 SQL 表（新增/擴充）
+
+```sql
+-- PR 2
+CREATE TABLE skill_candidates (
+    id TEXT PRIMARY KEY,
+    parent_skill_name TEXT NOT NULL,
+    parent_version INTEGER NOT NULL,
+    candidate_body TEXT NOT NULL,
+    mutation_strategy TEXT NOT NULL,     -- 目前只有 "apply_suggestions"
+    status TEXT NOT NULL DEFAULT 'generated',
+    pareto_scores TEXT,                  -- JSON dict[task_type, score]
+    diagnostic_keys TEXT,                -- JSON list[semantic_key]
+    origin_session_id TEXT,
+    notes TEXT,
+    created_at TEXT NOT NULL
+);
+
+-- PR 3
+CREATE TABLE skill_version_history (
+    id TEXT PRIMARY KEY,
+    skill_name TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    body TEXT NOT NULL,
+    reason TEXT NOT NULL DEFAULT 'promote',   -- promote / rollback / manual
+    source_candidate_id TEXT,
+    archived_at TEXT NOT NULL,
+    UNIQUE(skill_name, version, archived_at)
+);
+```
+
+五種候選狀態：
+
+| 狀態 | 意義 | 可以轉到 |
+|------|------|----------|
+| `generated` | Mutator 剛產出，還沒服務任何 session | `shadow` / `deprecated` / `promoted` |
+| `shadow` | 被 Gate 分流給一部分 session 實測中 | `promoted` / `deprecated` |
+| `promoted` | 已替換 parent body | `rolled_back`（透過 rollback） |
+| `deprecated` | 人為或系統淘汰 | 終端狀態 |
+| `rolled_back` | 被 promote 後又 rollback | 終端狀態 |
+
+## SkillGate 的決策
+
+| `shadow_mode` | 行為 |
+|---------------|------|
+| `off` | 永遠服務 parent body，lifecycle 指令還是可以用 |
+| `auto_c`（預設）| 有 shadow 候選時，用 SHA1(`session_id\|skill_name`) 的 first-4-byte int 對 `shadow_fraction` 做確定性切分；同一個 session 看到的永遠同一側 |
+| `manual_b` | 不自動切分，要用 `SkillGate.force_shadow(skill_name, candidate_id)` 明確指定才會服務 shadow |
+
+確定性切分的用意是讓 TaskReflector 能乾淨做 A/B 比較——同一 session 整段歷史只看過同一個 body，對應出來的 quality_score 才不會混進另一側。
+
+## loom.toml 配置
+
+```toml
+[mutation]
+# PR 2 — 候選產出
+enabled          = false     # 預設關閉；打開才會開始改寫
+model            = "auto"
+quality_ceiling  = 3.5       # diagnostic.quality_score ≤ 這個值才改寫
+min_suggestions  = 1
+max_body_chars   = 6000
+
+# PR 3 — 生命週期路由
+shadow_mode      = "auto_c"  # off / auto_c / manual_b
+shadow_fraction  = 0.5       # auto_c 下有多少比例 session 會看到 shadow
+auto_shadow_confidence_ceiling = 0.7  # parent confidence 超過這個就不 auto_shadow
+```
+
+兩個開關都預設安全值：`mutation.enabled = false` 就不會改寫任何東西；`shadow_mode = auto_c` 即便開了 mutation 也只對 confidence 不到 0.7 的 skill 自動試驗。
+
+## 使用者操作面
+
+### CLI
+
+| 指令 | 作用 |
+|------|------|
+| `loom skill candidates [--skill NAME] [--status STATUS] [--show-body]` | 列出候選池 |
+| `loom skill promote <candidate_id_prefix> [--reason ...]` | 把候選升為 parent；支援 8 字元 prefix |
+| `loom skill rollback <skill_name> [--to-version N] [--reason ...]` | 回滾到先前版本（預設最近一筆 archive） |
+| `loom skill history <skill_name>` | 看某個 skill 的版本封存紀錄 |
+
+promote / rollback 都是 GUARDED 級別——走到 `BlastRadiusMiddleware`、會要求授權。
+
+### Agent tools
+
+同樣兩個操作也以 tool 形式暴露給 agent：
+
+- `promote_skill_candidate(candidate_id, reason?)` — GUARDED
+- `rollback_skill(skill_name, to_version?, reason?)` — GUARDED
+
+agent 可以在發現某個 shadow 明顯表現更好時自行 promote；但因為 trust level 是 GUARDED，仍會受 session 授權配置約束（沒授權就會進 confirm flow）。
+
+### Session 訂閱事件
+
+每次狀態機轉換會發 `PromotionEvent`（`promote` / `rollback` / `auto_shadow` / `deprecate`）。三個平台各自掛了訂閱者：
+
+- **CLI** — 轉換時 dim 色印一行，不打斷對話流
+- **TUI** — `app.notify(...)`，rollback / deprecate 會升 severity=warning
+- **Discord** — 在 session thread 發獨立訊息，前面帶 icon（🔁 / ↩️ / 🫥 / 🗑️）
+
+要自訂訂閱者：
+
+```python
+session.subscribe_promotion(my_callback)  # 可以是 sync / async
+```
+
+## 怎麼讓一個 skill 真的進化
+
+### 最小驗證路徑（都不影響生產 skill）
+
+1. 打開 `loom.toml`：`[reflection] auto_reflect = true`（通常已預設開啟）
+2. 驗證 PR 1：跑 `loom chat` 幾輪，`loom memory list` 應該有 `skill:<name>:diagnostic:<ts>` 類 semantic key
+3. 打開 `[mutation] enabled = true`，模擬幾個低分 turn（故意違反 skill 的指示），`loom skill candidates` 應該會有新列
+4. 確認 `shadow_mode = auto_c` 且該 skill `confidence ≤ 0.7`：幾輪之後 candidate status 會變 `shadow`
+5. `loom skill promote <prefix>` → `loom skill history <name>` 看到 archive；`load_skill` 應該取得新 body
+6. `loom skill rollback <name>` 再跑一次 history，body 回到舊版、版本繼續 +1
+
+### Mode 選擇建議
+
+- **想看 agent 自主進化，但又怕被改壞** → `shadow_mode = auto_c`、`shadow_fraction` 先放 0.2~0.3；觀察 shadow 和 parent 兩側的 diagnostic
+- **所有改寫都要自己批** → `shadow_mode = manual_b`；候選只會落在 `generated`，等 `loom skill promote` 才動
+- **只想收集候選不上線** → 開 `mutation.enabled = true`、`shadow_mode = off`；候選會累積但永遠不會服務
+
+## 邊界與注意事項
+
+- **Mutation 失敗 non-fatal**：LLM 超時 / 輸出不像 SKILL.md / embedding 失敗——全部 swallow + debug log。`stream_turn` 不會因此中斷。
+- **Candidate plausibility 檢查**：`_looks_like_skill_md()` 會要求候選與 parent 至少共享一行，避免完全不相干的輸出污染候選池。
+- **確定性切分不會重新洗牌**：`shadow_fraction` 從 0.5 改成 0.3 不會把原本分到 shadow 的 session 改回 parent——切分是 stateless hash，調整當下剛好 hash < 0.3 的 session 才會被分到 shadow。
+- **Sibling shadow 去重**：promote 一個候選後，同一個 parent 下其他還是 shadow 的候選會被標成 deprecated（shadowing 一個已經不存在的 body 沒意義）。
+- **Rollback 連鎖**：rollback 本身也會封存當下的 body 到 history，所以可以 rollback 後再 rollback 回來。
+
+## 與既有機制的關係
+
+| | EMA self-assessment（10-Skill-Genome）| Skill Evolution（10b 本篇）|
+|---|---|---|
+| **改什麼** | `SkillGenome.confidence` / `success_rate` | `SkillGenome.body` |
+| **單位** | 數字（1–5 → 0–1）| 整份 SKILL.md |
+| **頻率** | 每次 `load_skill` → TurnDone | 低分 turn 才觸發 |
+| **可逆** | EMA 本身是累加——無法「回滾某一次評分」| 有 `skill_version_history`，可以精確回到任一版本 |
+| **預設開關** | 隨 reflection 打開 | `enabled=false`（保守） |
+
+兩層互補：EMA 告訴你 skill 品質趨勢，Evolution 在趨勢不好時提案修改 body；提案透過 shadow A/B 實測，真的有改善才會落地。

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -34,6 +34,7 @@
 | [08b-Memory-Governance.md](08b-Memory-Governance.md) | Trust Tier 分級、矛盾偵測 + 自動解決、Admission Gate、Decay Cycle |
 | [09-四種記憶詳解.md](09-四種記憶詳解.md) | Episodic / Semantic（含 Trust Tier + Anti-pattern）/ Procedural / Relational |
 | [10-Skill-Genome.md](10-Skill-Genome.md) | EMA confidence 機制與自動廢棄 |
+| [10b-Skill-Evolution.md](10b-Skill-Evolution.md) | Issue #120：TaskReflector → SkillMutator → SkillPromoter + SkillGate 的三段式進化生命週期 |
 | [11-Memory-Search.md](11-Memory-Search.md) | Phase 5 向量相似度 → FTS5 BM25 → recency 三層混合搜尋 |
 | [12-Memory-Index.md](12-Memory-Index.md) | 輕量目錄，含 Anti-pattern count 與 Self-Portrait |
 

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -106,16 +106,34 @@ auto_reflect = true
 visibility = "summary"
 
 # ─────────────────────────────────────────────
-# Skill Mutation (Issue #120 PR 2) — candidate revisions of SKILL.md
+# Skill Mutation + Lifecycle (Issue #120 PR 2 + PR 3)
 # ─────────────────────────────────────────────
 # After TaskReflector emits a diagnostic, SkillMutator can ask the LLM to
 # rewrite the SKILL.md body incorporating the ``mutation_suggestions``.
-# The result is stored in the ``skill_candidates`` pool (status=generated)
-# alongside the parent — it is NOT auto-promoted.  PR 3 will add shadow
-# mode and lifecycle management; meanwhile candidates can be listed with
-# ``loom skill candidates``.
+# The rewrite lands in the ``skill_candidates`` pool (status=generated).
 #
-# Defaults keep this OFF so enabling reflection alone does not start
+# PR 3 adds the lifecycle:
+#   generated ──(auto_shadow | manual)──► shadow
+#     │                                     │
+#     └──────── (deprecate) ────────►  deprecated
+#                                           │
+#                                       (promote)
+#                                           ▼
+#                                       promoted
+#                                           │
+#                                       (rollback)
+#                                           ▼
+#                                       rolled_back
+#
+# Shadow candidates are served to a deterministic slice of sessions in
+# auto_c mode, so TaskReflector can A/B-compare the two bodies.  Promote
+# archives the previous body to ``skill_version_history`` — rollback
+# restores from there.  Candidates can be inspected with
+# ``loom skill candidates`` and promoted/rolled back via
+# ``loom skill promote`` / ``loom skill rollback`` or the matching agent
+# tools (``promote_skill_candidate`` / ``rollback_skill``).
+#
+# Defaults keep mutation OFF so enabling reflection alone does not start
 # writing candidate bodies.  Turn it on once you want the candidate pool
 # to accumulate.
 
@@ -130,6 +148,22 @@ min_suggestions  = 1
 # Truncate the parent SKILL.md body in the rewrite prompt at this many
 # characters to keep the request cheap.
 max_body_chars   = 6000
+
+# PR 3 — lifecycle routing
+# "off"       — never serve a shadow candidate; lifecycle tools still work.
+# "auto_c"    — default.  ``generated`` candidates auto-transition to
+#               ``shadow`` when the parent is under-performing; shadow
+#               candidates are served to ``shadow_fraction`` of sessions.
+# "manual_b"  — candidates stay ``generated`` until an explicit promote
+#               call.  Nothing is auto-served.
+shadow_mode      = "auto_c"
+# Fraction of sessions (0.0–1.0) that see the shadow body in auto_c mode.
+# 0.5 keeps A/B evenly split; lower values ease candidates in slowly.
+shadow_fraction  = 0.5
+# Auto-shadow only fires when the parent SkillGenome.confidence is at or
+# below this ceiling (i.e. the parent is actually struggling enough to
+# warrant an A/B trial).  Range 0.0–1.0.
+auto_shadow_confidence_ceiling = 0.7
 
 # ─────────────────────────────────────────────
 # Telemetry (Issue #142) — Agent self-observability

--- a/loom/core/cognition/skill_gate.py
+++ b/loom/core/cognition/skill_gate.py
@@ -42,7 +42,7 @@ class GateDecision:
 
     body: str
     source: str                   # "parent" | "shadow"
-    served_version: int           # parent.version for "parent"; parent.version for "shadow" (candidate is parent_version + 1 once promoted)
+    served_version: int           # skill.version at decision time — always reflects the genome row, not a future projected value
     candidate_id: str | None = None
     shadow_mode: str = "off"
 

--- a/loom/core/cognition/skill_gate.py
+++ b/loom/core/cognition/skill_gate.py
@@ -1,0 +1,211 @@
+"""
+Skill Gate — load-time routing between parent and shadow SKILL.md (Issue #120 PR 3).
+
+When a ``load_skill`` call resolves a ``SkillGenome`` from ProceduralMemory,
+the gate decides whether to serve the parent body or a shadow candidate that
+is currently being trialled.  The decision is **deterministic per session**:
+the same session always sees the same side of the shadow split for a given
+skill, so TaskReflector can cleanly attribute quality outcomes.
+
+Modes (``[mutation].shadow_mode`` in loom.toml):
+- ``off``        — always serve parent. No candidate ever served.
+- ``auto_c``     — mode C (default): candidates that reach ``shadow`` status
+                   are split by ``shadow_fraction`` of sessions.
+- ``manual_b``   — mode B: shadow candidates are only served when the user
+                   (or an agent tool) explicitly requests the shadow side.
+
+The gate is a pure lookup — it does not mutate any state.  The actual
+transition ``generated → shadow`` is owned by ``SkillPromoter`` and happens
+in the TaskReflector mutation post-hook (auto_c) or via the promote tool /
+CLI (manual_b).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from loom.core.memory.procedural import ProceduralMemory, SkillGenome
+
+logger = logging.getLogger(__name__)
+
+
+SHADOW_MODES: tuple[str, ...] = ("off", "auto_c", "manual_b")
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """Resolved body + audit metadata for a single ``load_skill`` call."""
+
+    body: str
+    source: str                   # "parent" | "shadow"
+    served_version: int           # parent.version for "parent"; parent.version for "shadow" (candidate is parent_version + 1 once promoted)
+    candidate_id: str | None = None
+    shadow_mode: str = "off"
+
+    @property
+    def is_shadow(self) -> bool:
+        return self.source == "shadow"
+
+    def audit_tag(self) -> str:
+        """Compact string for logging / diagnostic metadata."""
+        if self.source == "shadow":
+            return f"shadow:{self.candidate_id[:8] if self.candidate_id else '?'}"
+        return "parent"
+
+
+class SkillGate:
+    """Decides which SKILL.md body to serve on each ``load_skill``.
+
+    Parameters
+    ----------
+    procedural:
+        Memory layer used to look up shadow candidates on demand.
+    shadow_mode:
+        One of ``SHADOW_MODES``.  Invalid values fall back to ``"off"``.
+    shadow_fraction:
+        Fraction of sessions (0.0–1.0) that should see the shadow side in
+        ``auto_c`` mode.  Clamped on the way in.
+    session_id:
+        Used to deterministically assign a session to a shadow slice.
+
+    Notes
+    -----
+    The gate only *reads* ProceduralMemory.  Any lifecycle transition
+    (``generated → shadow``, promote, rollback) is SkillPromoter's job;
+    the gate sees the result of those transitions on the next call.
+    """
+
+    def __init__(
+        self,
+        procedural: "ProceduralMemory",
+        shadow_mode: str = "auto_c",
+        shadow_fraction: float = 0.5,
+        session_id: str = "",
+    ) -> None:
+        self._procedural = procedural
+        self._session_id = session_id or ""
+
+        if shadow_mode not in SHADOW_MODES:
+            logger.debug(
+                "SkillGate: unknown shadow_mode %r — falling back to 'off'",
+                shadow_mode,
+            )
+            shadow_mode = "off"
+        self._shadow_mode = shadow_mode
+        self._shadow_fraction = max(0.0, min(1.0, float(shadow_fraction)))
+
+        # Per-session force overrides set via ``force_shadow`` / ``force_parent``
+        # (mode B manual path, or CLI ``loom skill shadow --sticky``).  Keyed
+        # by skill_name; value is the candidate_id for force_shadow, "" for
+        # force_parent.
+        self._overrides: dict[str, str] = {}
+
+    # ------------------------------------------------------------------
+    # Configuration / introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def shadow_mode(self) -> str:
+        return self._shadow_mode
+
+    @property
+    def shadow_fraction(self) -> float:
+        return self._shadow_fraction
+
+    def force_shadow(self, skill_name: str, candidate_id: str) -> None:
+        """Pin this session to the shadow side for ``skill_name``."""
+        self._overrides[skill_name] = candidate_id
+
+    def force_parent(self, skill_name: str) -> None:
+        """Pin this session to the parent body for ``skill_name``."""
+        self._overrides[skill_name] = ""
+
+    def clear_override(self, skill_name: str) -> None:
+        self._overrides.pop(skill_name, None)
+
+    # ------------------------------------------------------------------
+    # Core decision
+    # ------------------------------------------------------------------
+
+    async def resolve(self, skill: "SkillGenome") -> GateDecision:
+        """Return the body + audit metadata to serve for one ``load_skill`` call."""
+        parent_decision = GateDecision(
+            body=skill.body,
+            source="parent",
+            served_version=skill.version,
+            candidate_id=None,
+            shadow_mode=self._shadow_mode,
+        )
+
+        if self._shadow_mode == "off":
+            return parent_decision
+
+        # Explicit per-session override wins over slicing.
+        if skill.name in self._overrides:
+            override = self._overrides[skill.name]
+            if not override:
+                return parent_decision
+            cand = await self._procedural.get_candidate(override)
+            if cand is not None and cand.status == "shadow":
+                return GateDecision(
+                    body=cand.candidate_body,
+                    source="shadow",
+                    served_version=skill.version,
+                    candidate_id=cand.id,
+                    shadow_mode=self._shadow_mode,
+                )
+            # Override no longer valid — clear it and fall through.
+            self._overrides.pop(skill.name, None)
+
+        # Look up the freshest shadow candidate for this skill.
+        candidates = await self._procedural.list_candidates(
+            parent_skill_name=skill.name, status="shadow", limit=1,
+        )
+        if not candidates:
+            return parent_decision
+        shadow = candidates[0]
+
+        if self._shadow_mode == "manual_b":
+            # Mode B requires explicit opt-in; auto-slicing never fires.
+            return parent_decision
+
+        # Mode C — deterministic slicing.
+        if not self._session_in_shadow_slice(skill.name):
+            return parent_decision
+
+        return GateDecision(
+            body=shadow.candidate_body,
+            source="shadow",
+            served_version=skill.version,
+            candidate_id=shadow.id,
+            shadow_mode=self._shadow_mode,
+        )
+
+    # ------------------------------------------------------------------
+    # Slicing
+    # ------------------------------------------------------------------
+
+    def _session_in_shadow_slice(self, skill_name: str) -> bool:
+        """Deterministic yes/no based on (session_id, skill_name).
+
+        Hashing keeps the assignment stable across reloads — the same
+        session + skill always resolves the same way, which is critical
+        for A/B comparisons in TaskReflector.
+        """
+        if self._shadow_fraction <= 0.0:
+            return False
+        if self._shadow_fraction >= 1.0:
+            return True
+        digest = hashlib.sha1(
+            f"{self._session_id}|{skill_name}".encode("utf-8"),
+        ).digest()
+        # Use the first 4 bytes → int32, map to [0, 1).
+        bucket = int.from_bytes(digest[:4], "big") / 0xFFFFFFFF
+        return bucket < self._shadow_fraction
+
+
+__all__ = ["SHADOW_MODES", "GateDecision", "SkillGate"]

--- a/loom/core/cognition/skill_promoter.py
+++ b/loom/core/cognition/skill_promoter.py
@@ -1,0 +1,466 @@
+"""
+Skill Promoter — the lifecycle engine for Issue #120 PR 3.
+
+Turns ``SkillCandidate`` rows from the ``generated`` / ``shadow`` states into
+the live SKILL.md served by the session:
+
+    generated ──(auto_shadow)──► shadow ──(promote)──► promoted
+        │                           │
+        └──────── (deprecate)──────▶  deprecated
+
+Rollback restores a previously-promoted body from ``skill_version_history``
+and marks the candidate that had been serving as ``rolled_back``.
+
+Design notes
+------------
+- The promoter is a **pure state-machine over ProceduralMemory**; it does not
+  touch SKILL.md files on disk.  PR 3's on-disk archive (``~/.loom/skills/
+  .history/``) is handled by a thin adapter in Session so the core logic stays
+  testable without a filesystem.
+- ``PromotionEvent`` is broadcast to subscribers after every successful
+  transition so CLI / TUI / Discord can surface the change.
+- All transitions are idempotent at the status level: attempting to promote
+  a candidate that is already ``promoted`` is a no-op that returns the
+  existing skill (logged at debug).  Illegal transitions raise ``ValueError``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, UTC
+from typing import TYPE_CHECKING, Awaitable, Callable
+
+from loom.core.memory.procedural import (
+    CANDIDATE_STATUSES,
+    SkillCandidate,
+    SkillGenome,
+    SkillVersionRecord,
+)
+
+if TYPE_CHECKING:
+    from loom.core.memory.procedural import ProceduralMemory
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Event
+# ---------------------------------------------------------------------------
+
+PROMOTION_EVENT_KINDS: tuple[str, ...] = (
+    "auto_shadow",
+    "promote",
+    "rollback",
+    "deprecate",
+)
+
+
+@dataclass
+class PromotionEvent:
+    """Announcement of a lifecycle transition on a skill.
+
+    Emitted after ProceduralMemory has been updated — subscribers see the
+    post-transition state.  The skill body is intentionally omitted to keep
+    notification payloads small; subscribers fetch on demand if they need it.
+    """
+
+    kind: str                              # see PROMOTION_EVENT_KINDS
+    skill_name: str
+    candidate_id: str | None
+    from_version: int | None
+    to_version: int
+    reason: str | None = None
+    session_id: str | None = None
+    occurred_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def __post_init__(self) -> None:
+        if self.kind not in PROMOTION_EVENT_KINDS:
+            raise ValueError(
+                f"Invalid promotion event kind {self.kind!r}; "
+                f"expected one of {PROMOTION_EVENT_KINDS}"
+            )
+
+    def one_line_summary(self) -> str:
+        tail = f" ({self.reason})" if self.reason else ""
+        if self.kind == "rollback":
+            return (
+                f"{self.skill_name}: rollback "
+                f"v{self.from_version}→v{self.to_version}{tail}"
+            )
+        if self.kind == "deprecate":
+            return f"{self.skill_name}: deprecated candidate {self.candidate_id}{tail}"
+        if self.kind == "auto_shadow":
+            return f"{self.skill_name}: candidate → shadow{tail}"
+        # promote
+        return f"{self.skill_name}: promoted v{self.from_version}→v{self.to_version}{tail}"
+
+
+PromotionSubscriber = Callable[[PromotionEvent], Awaitable[None]]
+
+
+# ---------------------------------------------------------------------------
+# Promoter
+# ---------------------------------------------------------------------------
+
+
+class SkillPromoter:
+    """Lifecycle engine for ``SkillCandidate`` rows.
+
+    Parameters
+    ----------
+    procedural:
+        The memory layer that owns ``skill_genomes``, ``skill_candidates``
+        and ``skill_version_history``.
+    session_id:
+        Propagated onto every PromotionEvent so subscribers can correlate.
+    """
+
+    def __init__(
+        self,
+        procedural: "ProceduralMemory",
+        session_id: str | None = None,
+        shadow_mode: str = "auto_c",
+        auto_shadow_confidence_ceiling: float = 0.7,
+    ) -> None:
+        self._procedural = procedural
+        self._session_id = session_id
+        self._shadow_mode = shadow_mode
+        self._auto_shadow_confidence_ceiling = max(
+            0.0, min(1.0, float(auto_shadow_confidence_ceiling))
+        )
+        self._subscribers: list[PromotionSubscriber] = []
+
+    # ------------------------------------------------------------------
+    # Configuration getters
+    # ------------------------------------------------------------------
+
+    @property
+    def shadow_mode(self) -> str:
+        return self._shadow_mode
+
+    # ------------------------------------------------------------------
+    # Subscribers
+    # ------------------------------------------------------------------
+
+    def subscribe(self, callback: PromotionSubscriber) -> None:
+        """Register a coroutine that receives each ``PromotionEvent``."""
+        self._subscribers.append(callback)
+
+    async def _broadcast(self, event: PromotionEvent) -> None:
+        for cb in list(self._subscribers):
+            try:
+                await cb(event)
+            except Exception as exc:
+                logger.debug("Promotion subscriber failed: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Shadow transition (PR 3: mode C auto, mode B manual)
+    # ------------------------------------------------------------------
+
+    async def shadow(
+        self,
+        candidate_id: str,
+        reason: str | None = None,
+    ) -> SkillCandidate | None:
+        """Move a ``generated`` candidate to ``shadow``.
+
+        Idempotent: if the candidate is already ``shadow`` the call returns
+        the existing row.  Raises ``ValueError`` if the candidate is in a
+        terminal state (promoted / deprecated / rolled_back).
+        """
+        candidate = await self._procedural.get_candidate(candidate_id)
+        if candidate is None:
+            return None
+
+        if candidate.status == "shadow":
+            return candidate
+        if candidate.status != "generated":
+            raise ValueError(
+                f"Cannot shadow candidate in status {candidate.status!r}; "
+                f"only 'generated' candidates can move to 'shadow'."
+            )
+
+        updated_notes = _append_note(candidate.notes, f"shadow: {reason}" if reason else "shadow")
+        await self._procedural.update_candidate_status(
+            candidate_id, "shadow", notes=updated_notes,
+        )
+        refreshed = await self._procedural.get_candidate(candidate_id)
+
+        await self._broadcast(PromotionEvent(
+            kind="auto_shadow",
+            skill_name=candidate.parent_skill_name,
+            candidate_id=candidate.id,
+            from_version=candidate.parent_version,
+            to_version=candidate.parent_version,  # parent untouched in shadow
+            reason=reason,
+            session_id=self._session_id,
+        ))
+        return refreshed
+
+    async def maybe_auto_shadow(
+        self,
+        candidate_id: str,
+        reason: str | None = None,
+    ) -> SkillCandidate | None:
+        """Auto-transition ``generated → shadow`` when mode + parent allow it.
+
+        Fires only when:
+          - ``shadow_mode`` is ``"auto_c"``
+          - the candidate exists and is still in ``generated`` status
+          - the parent's EMA confidence is at or below
+            ``auto_shadow_confidence_ceiling`` (i.e. the parent is actually
+            underperforming enough to warrant an A/B trial)
+
+        Returns the updated candidate on transition, ``None`` otherwise.
+        Mode ``manual_b`` and ``off`` are handled by ignoring this call —
+        the candidate stays ``generated`` until explicit promotion.
+        """
+        if self._shadow_mode != "auto_c":
+            return None
+
+        candidate = await self._procedural.get_candidate(candidate_id)
+        if candidate is None or candidate.status != "generated":
+            return None
+
+        parent = await self._procedural.get(candidate.parent_skill_name)
+        if parent is None:
+            return None
+        if parent.confidence > self._auto_shadow_confidence_ceiling:
+            return None
+
+        return await self.shadow(candidate_id, reason=reason or "auto")
+
+    # ------------------------------------------------------------------
+    # Promotion
+    # ------------------------------------------------------------------
+
+    async def promote(
+        self,
+        candidate_id: str,
+        reason: str | None = None,
+    ) -> SkillGenome | None:
+        """Swap the parent SKILL.md for the candidate body.
+
+        Steps, in order:
+          1. Fetch candidate + parent; refuse if either is missing.
+          2. Archive the current parent body to ``skill_version_history``
+             with ``reason='promote'`` so rollback has a target.
+          3. Overwrite ``SkillGenome.body`` with ``candidate_body`` and
+             increment ``version``.  ``confidence`` / ``success_rate`` are
+             **reset** to the skill's own starting defaults so the new body
+             earns its own track record.
+          4. Mark the candidate ``promoted``; mark any other candidates for
+             the same parent that are still ``shadow`` as ``deprecated``
+             (they were shadowing a body that no longer exists).
+          5. Broadcast a PromotionEvent.
+
+        Returns the updated ``SkillGenome``, or ``None`` if the candidate or
+        parent could not be resolved.
+        """
+        candidate = await self._procedural.get_candidate(candidate_id)
+        if candidate is None:
+            logger.debug("SkillPromoter.promote: candidate %s not found", candidate_id)
+            return None
+        if candidate.status == "promoted":
+            # Idempotent — return the current parent.
+            return await self._procedural.get(candidate.parent_skill_name)
+        if candidate.status not in ("generated", "shadow"):
+            raise ValueError(
+                f"Cannot promote candidate in status {candidate.status!r}; "
+                f"only 'generated' or 'shadow' are promotable."
+            )
+
+        parent = await self._procedural.get(candidate.parent_skill_name)
+        if parent is None:
+            logger.debug(
+                "SkillPromoter.promote: parent %s missing for candidate %s",
+                candidate.parent_skill_name, candidate_id,
+            )
+            return None
+
+        # (2) Archive current parent before overwrite.
+        await self._procedural.archive_version(SkillVersionRecord(
+            skill_name=parent.name,
+            version=parent.version,
+            body=parent.body,
+            reason="promote",
+            source_candidate_id=candidate.id,
+        ))
+
+        # (3) Swap + bump version + reset confidence track.
+        from_version = parent.version
+        parent.body = candidate.candidate_body
+        parent.version = from_version + 1
+        parent.confidence = 1.0
+        parent.success_rate = 1.0
+        parent.usage_count = 0
+        parent.updated_at = datetime.now(UTC)
+        await self._procedural.upsert(parent)
+
+        # (4a) Mark candidate promoted.
+        updated_notes = _append_note(candidate.notes, f"promote: {reason}" if reason else "promote")
+        await self._procedural.update_candidate_status(
+            candidate.id, "promoted", notes=updated_notes,
+        )
+
+        # (4b) Deprecate sibling shadows (stale — they'd shadow the old body).
+        siblings = await self._procedural.list_candidates(
+            parent_skill_name=parent.name, status="shadow",
+        )
+        for sib in siblings:
+            if sib.id == candidate.id:
+                continue
+            await self._procedural.update_candidate_status(
+                sib.id, "deprecated",
+                notes=_append_note(sib.notes, f"superseded by {candidate.id}"),
+            )
+
+        # (5) Announce.
+        await self._broadcast(PromotionEvent(
+            kind="promote",
+            skill_name=parent.name,
+            candidate_id=candidate.id,
+            from_version=from_version,
+            to_version=parent.version,
+            reason=reason,
+            session_id=self._session_id,
+        ))
+        return parent
+
+    # ------------------------------------------------------------------
+    # Rollback
+    # ------------------------------------------------------------------
+
+    async def rollback(
+        self,
+        skill_name: str,
+        to_version: int | None = None,
+        reason: str | None = None,
+    ) -> SkillGenome | None:
+        """Restore a previous SKILL.md body from ``skill_version_history``.
+
+        ``to_version=None`` rolls back to the **most recently archived**
+        version (i.e. undo the latest promote).  Otherwise the specific
+        version is fetched.  The current body is archived under
+        ``reason='rollback'`` before the swap so the rollback itself is
+        reversible.  Any candidate that had been ``promoted`` into the
+        current version is marked ``rolled_back``.
+        """
+        parent = await self._procedural.get(skill_name)
+        if parent is None:
+            logger.debug("SkillPromoter.rollback: skill %s not found", skill_name)
+            return None
+
+        target: SkillVersionRecord | None
+        if to_version is None:
+            target = await self._procedural.latest_history(skill_name)
+        else:
+            target = await self._procedural.get_history_version(skill_name, to_version)
+        if target is None:
+            logger.debug(
+                "SkillPromoter.rollback: no history entry for %s%s",
+                skill_name, f" v{to_version}" if to_version else "",
+            )
+            return None
+
+        # Archive current body before swapping it out (in case the operator
+        # wants to roll the rollback back).
+        await self._procedural.archive_version(SkillVersionRecord(
+            skill_name=parent.name,
+            version=parent.version,
+            body=parent.body,
+            reason="rollback",
+            source_candidate_id=None,
+        ))
+
+        # Swap body; bump version so the audit trail stays monotonic even
+        # though the body is logically regressing.  Reset confidence track.
+        from_version = parent.version
+        parent.body = target.body
+        parent.version = from_version + 1
+        parent.confidence = 1.0
+        parent.success_rate = 1.0
+        parent.usage_count = 0
+        parent.updated_at = datetime.now(UTC)
+        await self._procedural.upsert(parent)
+
+        # Mark the most recent promoted candidate as rolled_back so the audit
+        # chain connects: a candidate was promoted, then reverted.
+        promoted = await self._procedural.list_candidates(
+            parent_skill_name=skill_name, status="promoted", limit=1,
+        )
+        if promoted:
+            top = promoted[0]
+            await self._procedural.update_candidate_status(
+                top.id, "rolled_back",
+                notes=_append_note(top.notes, f"rolled back: {reason}" if reason else "rolled back"),
+            )
+
+        await self._broadcast(PromotionEvent(
+            kind="rollback",
+            skill_name=parent.name,
+            candidate_id=promoted[0].id if promoted else None,
+            from_version=from_version,
+            to_version=parent.version,
+            reason=reason,
+            session_id=self._session_id,
+        ))
+        return parent
+
+    # ------------------------------------------------------------------
+    # Deprecation (reject without promotion)
+    # ------------------------------------------------------------------
+
+    async def deprecate(
+        self,
+        candidate_id: str,
+        reason: str | None = None,
+    ) -> SkillCandidate | None:
+        """Mark a candidate ``deprecated`` without touching the parent."""
+        candidate = await self._procedural.get_candidate(candidate_id)
+        if candidate is None:
+            return None
+        if candidate.status == "deprecated":
+            return candidate
+        if candidate.status not in ("generated", "shadow"):
+            raise ValueError(
+                f"Cannot deprecate candidate in status {candidate.status!r}."
+            )
+
+        await self._procedural.update_candidate_status(
+            candidate.id, "deprecated",
+            notes=_append_note(candidate.notes, f"deprecated: {reason}" if reason else "deprecated"),
+        )
+        refreshed = await self._procedural.get_candidate(candidate.id)
+
+        await self._broadcast(PromotionEvent(
+            kind="deprecate",
+            skill_name=candidate.parent_skill_name,
+            candidate_id=candidate.id,
+            from_version=candidate.parent_version,
+            to_version=candidate.parent_version,
+            reason=reason,
+            session_id=self._session_id,
+        ))
+        return refreshed
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _append_note(existing: str | None, addition: str) -> str:
+    if not existing:
+        return addition
+    return f"{existing}; {addition}"
+
+
+# Re-export so callers only import from this module.
+__all__ = [
+    "CANDIDATE_STATUSES",
+    "PROMOTION_EVENT_KINDS",
+    "PromotionEvent",
+    "PromotionSubscriber",
+    "SkillPromoter",
+]

--- a/loom/core/cognition/skill_promoter.py
+++ b/loom/core/cognition/skill_promoter.py
@@ -11,6 +11,10 @@ the live SKILL.md served by the session:
 Rollback restores a previously-promoted body from ``skill_version_history``
 and marks the candidate that had been serving as ``rolled_back``.
 
+History writes: only ``promote`` and ``rollback`` append rows to
+``skill_version_history`` (body-mutating operations).  ``deprecate`` and
+``auto_shadow`` only update candidate status and never write history.
+
 Design notes
 ------------
 - The promoter is a **pure state-machine over ProceduralMemory**; it does not

--- a/loom/core/cognition/task_reflector.py
+++ b/loom/core/cognition/task_reflector.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable
 if TYPE_CHECKING:
     from loom.core.cognition.router import LLMRouter
     from loom.core.cognition.skill_mutator import MutationProposal, SkillMutator
+    from loom.core.cognition.skill_promoter import SkillPromoter
     from loom.core.events import ExecutionEnvelopeView
     from loom.core.memory.episodic import EpisodicMemory
     from loom.core.memory.procedural import ProceduralMemory
@@ -212,6 +213,7 @@ class TaskReflector:
         enabled: bool = True,
         visibility: str = "summary",
         mutator: "SkillMutator | None" = None,
+        promoter: "SkillPromoter | None" = None,
     ) -> None:
         self._router = router
         self._model = model
@@ -223,6 +225,7 @@ class TaskReflector:
         self._enabled = enabled
         self._visibility = visibility if visibility in ("off", "summary", "verbose") else "summary"
         self._mutator = mutator
+        self._promoter = promoter
         self._subscribers: list[DiagnosticSubscriber] = []
         self._mutation_subscribers: list[MutationSubscriber] = []
 
@@ -481,6 +484,18 @@ class TaskReflector:
                     proposal.candidate.parent_version,
                     proposal.candidate.id,
                 )
+                # Issue #120 PR 3: auto-shadow (mode C) — promote generated →
+                # shadow when the promoter says the parent is underperforming.
+                # No-op in modes manual_b / off, or when the confidence gate
+                # declines.
+                if self._promoter is not None:
+                    try:
+                        await self._promoter.maybe_auto_shadow(
+                            proposal.candidate.id,
+                            reason=f"auto_c:diagnostic q={diagnostic.quality_score:.1f}",
+                        )
+                    except Exception as exc:
+                        logger.debug("auto_shadow failed: %s", exc)
                 await self._notify_mutation_subscribers(proposal)
             except Exception as exc:
                 logger.debug("Mutation post-hook failed: %s", exc)

--- a/loom/core/memory/procedural.py
+++ b/loom/core/memory/procedural.py
@@ -105,6 +105,42 @@ class SkillGenome:
         self.updated_at = datetime.now(UTC)
 
 
+# ---------------------------------------------------------------------------
+# Skill version history reasons (Issue #120 PR 3)
+# ---------------------------------------------------------------------------
+
+HISTORY_REASONS: tuple[str, ...] = (
+    "promote",   # archived because a candidate was promoted over it
+    "rollback",  # archived as part of a rollback operation
+    "manual",    # explicit archive call
+)
+
+
+@dataclass
+class SkillVersionRecord:
+    """Snapshot of a SKILL.md body captured before a lifecycle transition.
+
+    Written whenever ``SkillPromoter`` replaces the active body — either by
+    promoting a candidate or by rolling back to an earlier version.  The
+    archive survives the swap so rollback can restore any prior revision.
+    """
+
+    skill_name: str
+    version: int
+    body: str
+    reason: str = "promote"
+    source_candidate_id: str | None = None
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    archived_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def __post_init__(self) -> None:
+        if self.reason not in HISTORY_REASONS:
+            raise ValueError(
+                f"Invalid history reason {self.reason!r}; "
+                f"expected one of {HISTORY_REASONS}"
+            )
+
+
 @dataclass
 class SkillCandidate:
     """A proposed revision of a parent ``SkillGenome`` (Issue #120 PR 2).
@@ -323,6 +359,94 @@ class ProceduralMemory:
             )
         await self._db.commit()
         return cursor.rowcount > 0
+
+
+    # ------------------------------------------------------------------
+    # Skill version history (Issue #120 PR 3)
+    # ------------------------------------------------------------------
+
+    async def archive_version(self, record: SkillVersionRecord) -> None:
+        """Persist a pre-swap snapshot of a SKILL.md body."""
+        await self._db.execute(
+            """
+            INSERT INTO skill_version_history
+                (id, skill_name, version, body, reason,
+                 source_candidate_id, archived_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                record.id,
+                record.skill_name,
+                record.version,
+                record.body,
+                record.reason,
+                record.source_candidate_id,
+                record.archived_at.isoformat(),
+            ),
+        )
+        await self._db.commit()
+
+    async def list_history(
+        self,
+        skill_name: str,
+        limit: int = 50,
+    ) -> list[SkillVersionRecord]:
+        """Return archived versions of a skill, newest first."""
+        cursor = await self._db.execute(
+            "SELECT id, skill_name, version, body, reason, "
+            "source_candidate_id, archived_at "
+            "FROM skill_version_history "
+            "WHERE skill_name = ? "
+            "ORDER BY archived_at DESC LIMIT ?",
+            (skill_name, limit),
+        )
+        rows = await cursor.fetchall()
+        return [_row_to_history(r) for r in rows]
+
+    async def get_history_version(
+        self,
+        skill_name: str,
+        version: int,
+    ) -> SkillVersionRecord | None:
+        """Fetch the most recent archive of a specific version."""
+        cursor = await self._db.execute(
+            "SELECT id, skill_name, version, body, reason, "
+            "source_candidate_id, archived_at "
+            "FROM skill_version_history "
+            "WHERE skill_name = ? AND version = ? "
+            "ORDER BY archived_at DESC LIMIT 1",
+            (skill_name, version),
+        )
+        row = await cursor.fetchone()
+        return _row_to_history(row) if row else None
+
+    async def latest_history(
+        self,
+        skill_name: str,
+    ) -> SkillVersionRecord | None:
+        """Most recently archived version — used as the default rollback target."""
+        cursor = await self._db.execute(
+            "SELECT id, skill_name, version, body, reason, "
+            "source_candidate_id, archived_at "
+            "FROM skill_version_history "
+            "WHERE skill_name = ? "
+            "ORDER BY archived_at DESC LIMIT 1",
+            (skill_name,),
+        )
+        row = await cursor.fetchone()
+        return _row_to_history(row) if row else None
+
+
+def _row_to_history(row: tuple) -> SkillVersionRecord:
+    return SkillVersionRecord(
+        id=row[0],
+        skill_name=row[1],
+        version=row[2],
+        body=row[3],
+        reason=row[4],
+        source_candidate_id=row[5],
+        archived_at=datetime.fromisoformat(row[6]),
+    )
 
 
 def _row_to_candidate(row: tuple) -> SkillCandidate:

--- a/loom/core/memory/store.py
+++ b/loom/core/memory/store.py
@@ -161,6 +161,21 @@ CREATE TABLE IF NOT EXISTS skill_candidates (
 CREATE INDEX IF NOT EXISTS idx_skill_candidates_parent ON skill_candidates(parent_skill_name);
 CREATE INDEX IF NOT EXISTS idx_skill_candidates_status ON skill_candidates(status);
 
+-- Issue #120 PR 3: SKILL.md version history (snapshot before each promote/rollback)
+CREATE TABLE IF NOT EXISTS skill_version_history (
+    id                   TEXT PRIMARY KEY,
+    skill_name           TEXT NOT NULL,
+    version              INTEGER NOT NULL,
+    body                 TEXT NOT NULL,
+    reason               TEXT NOT NULL DEFAULT 'promote',  -- 'promote' | 'rollback' | 'manual'
+    source_candidate_id  TEXT,                             -- NULL for rollbacks / manual archives
+    archived_at          TEXT NOT NULL,
+    UNIQUE(skill_name, version, archived_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_skill_history_name    ON skill_version_history(skill_name);
+CREATE INDEX IF NOT EXISTS idx_skill_history_version ON skill_version_history(skill_name, version);
+
 -- Issue #142: Agent self-observability snapshots (one row per dimension per session)
 CREATE TABLE IF NOT EXISTS agent_telemetry (
     dimension   TEXT NOT NULL,

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -45,7 +45,9 @@ from loom.core.cognition.providers import AnthropicProvider
 from loom.core.cognition.counter_factual import CounterFactualReflector
 from loom.core.cognition.reflection import ReflectionAPI
 from loom.core.cognition.router import LLMRouter
+from loom.core.cognition.skill_gate import SkillGate
 from loom.core.cognition.skill_mutator import SkillMutator
+from loom.core.cognition.skill_promoter import PromotionEvent, SkillPromoter
 from loom.core.cognition.task_reflector import TaskDiagnostic, TaskReflector
 from loom.core.timezone import user_timestamp  # Issue #124
 from loom.core.events import (
@@ -562,7 +564,23 @@ class LoomSession:
         self._mutation_max_body_chars: int = int(
             _mut_cfg.get("max_body_chars", 6000)
         )
+        # PR 3: lifecycle routing.  These keys live under the same
+        # ``[mutation]`` section — mutation produces candidates, lifecycle
+        # decides what happens to them.
+        shadow_mode_raw = str(_mut_cfg.get("shadow_mode", "auto_c")).lower()
+        if shadow_mode_raw not in ("off", "auto_c", "manual_b"):
+            shadow_mode_raw = "auto_c"
+        self._shadow_mode: str = shadow_mode_raw
+        self._shadow_fraction: float = max(
+            0.0, min(1.0, float(_mut_cfg.get("shadow_fraction", 0.5)))
+        )
+        self._auto_shadow_confidence_ceiling: float = max(
+            0.0, min(1.0, float(_mut_cfg.get("auto_shadow_confidence_ceiling", 0.7)))
+        )
         self._skill_mutator: SkillMutator | None = None
+        self._skill_promoter: SkillPromoter | None = None
+        self._skill_gate: SkillGate | None = None
+        self._promotion_subscribers: list[Callable[[PromotionEvent], Any]] = []
 
         self._mcp_clients: list[Any] = []
 
@@ -737,6 +755,8 @@ class LoomSession:
             make_memory_health_tool,
             make_query_relations_tool,
             make_recall_tool,
+            make_skill_promote_tool,
+            make_skill_rollback_tool,
             make_relate_tool,
             make_spawn_agent_tool,
             make_web_search_tool,
@@ -771,6 +791,35 @@ class LoomSession:
             max_body_chars=self._mutation_max_body_chars,
         )
 
+        # Issue #120 PR 3: lifecycle.  The promoter owns the state-machine
+        # (generated/shadow/promoted/deprecated/rolled_back) and the gate
+        # decides which body `load_skill` serves.  Both are always
+        # instantiated — they cost nothing when the mutation feature is off,
+        # and operators can still run rollback/history against a skill even
+        # without mutation enabled.
+        self._skill_promoter = SkillPromoter(
+            procedural=self._procedural,
+            session_id=self.session_id,
+            shadow_mode=self._shadow_mode,
+            auto_shadow_confidence_ceiling=self._auto_shadow_confidence_ceiling,
+        )
+        self._skill_gate = SkillGate(
+            procedural=self._procedural,
+            shadow_mode=self._shadow_mode,
+            shadow_fraction=self._shadow_fraction,
+            session_id=self.session_id,
+        )
+
+        async def _fan_promotion(event: PromotionEvent) -> None:
+            for cb in list(self._promotion_subscribers):
+                try:
+                    result = cb(event)
+                    if asyncio.iscoroutine(result):
+                        await result
+                except Exception as exc:
+                    logger.debug("Promotion subscriber failed: %s", exc)
+        self._skill_promoter.subscribe(_fan_promotion)
+
         # Issue #120 PR1: TaskReflector produces structured diagnostics at
         # each TurnDone, replacing the scalar self-assessment path.
         self._task_reflector = TaskReflector(
@@ -784,6 +833,9 @@ class LoomSession:
             enabled=self._reflection_enabled,
             visibility=self._reflection_visibility,
             mutator=self._skill_mutator if self._skill_mutator.enabled else None,
+            # Pass the promoter only when the mutator is actually going to
+            # write candidates; otherwise there's nothing to auto-shadow.
+            promoter=self._skill_promoter if self._skill_mutator.enabled else None,
         )
         skills_dirs = [
             self.workspace / "skills",
@@ -808,6 +860,7 @@ class LoomSession:
             skill_check_manager=self._skill_check_manager,
             relational=self._relational,
             confirm_fn=lambda call: self._confirm_fn(call),
+            skill_gate=self._skill_gate,
         ))
 
         # Issue #64 Phase B: Register unload_skill tool
@@ -815,6 +868,10 @@ class LoomSession:
         self.registry.register(make_unload_skill_tool(
             self._skill_check_manager,
         ))
+
+        # Issue #120 PR 3: promote / rollback lifecycle tools.
+        self.registry.register(make_skill_promote_tool(self._skill_promoter))
+        self.registry.register(make_skill_rollback_tool(self._skill_promoter))
 
         # Register web tools (Phase 5D)
         self.registry.register(make_fetch_url_tool(
@@ -1713,6 +1770,18 @@ class LoomSession:
         """
         if self._task_reflector is not None:
             self._task_reflector.subscribe(callback)
+
+    def subscribe_promotion(
+        self, callback: "Callable[[PromotionEvent], Any]",
+    ) -> None:
+        """Register a platform callback for each skill lifecycle transition.
+
+        Fires on ``promote`` / ``rollback`` / ``auto_shadow`` / ``deprecate``
+        events from :class:`SkillPromoter`.  CLI / TUI / Discord use this to
+        surface lifecycle changes to the user.  Callbacks may be sync or
+        async; failures are swallowed and logged at debug by the fan-out.
+        """
+        self._promotion_subscribers.append(callback)
 
     def _trigger_skill_assessment(self) -> None:
         """

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -147,6 +147,20 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
 
     session.subscribe_diagnostic(_cli_diagnostic)
 
+    # Issue #120 PR3: surface skill lifecycle transitions inline.
+    async def _cli_promotion(event) -> None:
+        colour = {
+            "promote": "green",
+            "rollback": "yellow",
+            "auto_shadow": "cyan",
+            "deprecate": "red",
+        }.get(event.kind, "white")
+        console.print(
+            f"[dim]  ⇢ [/dim][{colour}]{event.one_line_summary()}[/{colour}]"
+        )
+
+    session.subscribe_promotion(_cli_promotion)
+
     console.print(render_header(model, db))
 
     if not session._memory_index.is_empty:
@@ -1016,6 +1030,24 @@ async def _chat_tui(model: str, db: str, resume_session_id: str | None = None) -
 
         session.subscribe_diagnostic(_tui_diagnostic)
 
+        # Issue #120 PR3: notify on skill lifecycle transitions.
+        async def _tui_promotion(event) -> None:
+            try:
+                severity = {
+                    "rollback": "warning",
+                    "deprecate": "warning",
+                }.get(event.kind, "information")
+                app.notify(
+                    event.one_line_summary(),
+                    title="Skill lifecycle",
+                    severity=severity,
+                    timeout=5,
+                )
+            except Exception:
+                pass
+
+        session.subscribe_promotion(_tui_promotion)
+
         result = await app.run_async()
         # /sessions exits with a session_id string → resume that session.
         # /new exits with "__new__" sentinel → start a fresh session (no resume).
@@ -1551,6 +1583,135 @@ async def _skill_candidates(
             console.print(c.candidate_body)
             console.print(Rule(style="dim"))
         console.print()
+
+
+@skill.command("promote")
+@click.argument("candidate_id")
+@click.option("--reason", default=None, help="Audit note attached to the transition.")
+@click.option("--db", default="~/.loom/memory.db", show_default=True)
+def skill_promote(candidate_id: str, reason: str | None, db: str) -> None:
+    """Swap the parent SKILL.md for the given candidate body."""
+    asyncio.run(_skill_promote(candidate_id, reason, db))
+
+
+async def _skill_promote(candidate_id: str, reason: str | None, db: str) -> None:
+    from loom.core.cognition.skill_promoter import SkillPromoter
+    from loom.core.memory.procedural import ProceduralMemory
+
+    store = SQLiteStore(db)
+    await store.initialize()
+    async with store.connect() as conn:
+        proc = ProceduralMemory(conn)
+        # Resolve short (8-char) prefixes for operator ergonomics.
+        resolved = await _resolve_candidate_id(proc, candidate_id)
+        if resolved is None:
+            console.print(f"[red]No candidate matches id prefix {candidate_id!r}.[/red]")
+            return
+        promoter = SkillPromoter(procedural=proc)
+        try:
+            parent = await promoter.promote(resolved, reason=reason)
+        except ValueError as exc:
+            console.print(f"[red]Refused:[/red] {exc}")
+            return
+    if parent is None:
+        console.print(f"[red]Promotion failed — candidate or parent missing.[/red]")
+        return
+    console.print(
+        f"[green]Promoted[/green] [bold cyan]{parent.name}[/bold cyan] "
+        f"→ v{parent.version}"
+    )
+
+
+@skill.command("rollback")
+@click.argument("skill_name")
+@click.option("--to-version", type=int, default=None,
+              help="Target version. Defaults to the most recently archived body.")
+@click.option("--reason", default=None, help="Audit note attached to the transition.")
+@click.option("--db", default="~/.loom/memory.db", show_default=True)
+def skill_rollback(
+    skill_name: str, to_version: int | None, reason: str | None, db: str,
+) -> None:
+    """Restore a previous SKILL.md body from history."""
+    asyncio.run(_skill_rollback(skill_name, to_version, reason, db))
+
+
+async def _skill_rollback(
+    skill_name: str, to_version: int | None, reason: str | None, db: str,
+) -> None:
+    from loom.core.cognition.skill_promoter import SkillPromoter
+    from loom.core.memory.procedural import ProceduralMemory
+
+    store = SQLiteStore(db)
+    await store.initialize()
+    async with store.connect() as conn:
+        proc = ProceduralMemory(conn)
+        promoter = SkillPromoter(procedural=proc)
+        parent = await promoter.rollback(skill_name, to_version=to_version, reason=reason)
+    if parent is None:
+        suffix = f" v{to_version}" if to_version else ""
+        console.print(
+            f"[red]Rollback failed — no history entry for {skill_name}{suffix}.[/red]"
+        )
+        return
+    console.print(
+        f"[yellow]Rolled back[/yellow] [bold cyan]{parent.name}[/bold cyan] "
+        f"→ v{parent.version}"
+    )
+
+
+@skill.command("history")
+@click.argument("skill_name")
+@click.option("--limit", default=20, show_default=True, type=int)
+@click.option("--db", default="~/.loom/memory.db", show_default=True)
+def skill_history(skill_name: str, limit: int, db: str) -> None:
+    """Show archived SKILL.md versions for a skill."""
+    asyncio.run(_skill_history(skill_name, limit, db))
+
+
+async def _skill_history(skill_name: str, limit: int, db: str) -> None:
+    from loom.core.memory.procedural import ProceduralMemory
+
+    store = SQLiteStore(db)
+    await store.initialize()
+    async with store.connect() as conn:
+        proc = ProceduralMemory(conn)
+        records = await proc.list_history(skill_name, limit=limit)
+
+    if not records:
+        console.print(f"[dim]No archived versions for {skill_name}.[/dim]")
+        return
+
+    console.print(Rule(f"[cyan]{skill_name} — version history[/cyan]"))
+    reason_color = {"promote": "green", "rollback": "yellow", "manual": "dim"}
+    for r in records:
+        ts = r.archived_at.strftime("%Y-%m-%d %H:%M")
+        colour = reason_color.get(r.reason, "white")
+        src = (
+            f"  [dim]from candidate {r.source_candidate_id[:8]}[/dim]"
+            if r.source_candidate_id else ""
+        )
+        console.print(
+            f"[dim]{ts}[/dim]  v{r.version}  "
+            f"[{colour}]{r.reason}[/{colour}]{src}"
+        )
+
+
+async def _resolve_candidate_id(proc: "ProceduralMemory", prefix: str) -> str | None:
+    """Accept either a full uuid or a short prefix (≥4 chars).
+
+    If the prefix matches exactly one candidate, return its full id.  Longer
+    matches or non-matches return ``None`` so the caller can surface a clean
+    error.
+    """
+    if len(prefix) >= 32:
+        return prefix
+    if len(prefix) < 4:
+        return None
+    rows = await proc.list_candidates(limit=500)
+    matches = [c.id for c in rows if c.id.startswith(prefix)]
+    if len(matches) == 1:
+        return matches[0]
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -37,6 +37,8 @@ _cmd_scanner = CommandScanner()
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from loom.core.cognition.skill_gate import SkillGate
+    from loom.core.cognition.skill_promoter import SkillPromoter
     from loom.core.harness.skill_checks import SkillCheckManager
     from loom.core.memory.procedural import ProceduralMemory, SkillGenome
     from loom.core.memory.relational import RelationalMemory
@@ -1038,6 +1040,7 @@ def make_load_skill_tool(
     skill_check_manager: "SkillCheckManager | None" = None,
     relational: "RelationalMemory | None" = None,
     confirm_fn: "Callable | None" = None,
+    skill_gate: "SkillGate | None" = None,
 ) -> ToolDefinition:
     """
     Create a SAFE ``load_skill`` tool that loads full skill instructions.
@@ -1092,8 +1095,15 @@ def make_load_skill_tool(
                 error=f"Skill '{name}' not found. Available: {available or '(none)'}",
             )
 
-        # Build structured <skill_content> output
-        body = skill.body or "(no instructions)"
+        # Issue #120 PR 3: resolve parent vs shadow candidate body.  Decision
+        # is deterministic per (session_id, skill_name); audit tag is carried
+        # back in the tool result metadata so diagnostics can A/B compare.
+        gate_decision = None
+        if skill_gate is not None:
+            gate_decision = await skill_gate.resolve(skill)
+            body = gate_decision.body or "(no instructions)"
+        else:
+            body = skill.body or "(no instructions)"
 
         # Strip YAML frontmatter from body (it's metadata, already parsed)
         body = _strip_frontmatter(body)
@@ -1150,10 +1160,16 @@ def make_load_skill_tool(
             _turn = turn_index_fn() if turn_index_fn else 0
             outcome_tracker.record_activation(name, _turn)
 
+        metadata: dict = {"skill_name": name, "skill_confidence": skill.confidence}
+        if gate_decision is not None:
+            metadata["skill_source"] = gate_decision.audit_tag()
+            metadata["shadow_mode"] = gate_decision.shadow_mode
+            if gate_decision.candidate_id is not None:
+                metadata["shadow_candidate_id"] = gate_decision.candidate_id
         return ToolResult(
             call_id=call.id, tool_name=call.tool_name,
             success=True, output=output,
-            metadata={"skill_name": name, "skill_confidence": skill.confidence},
+            metadata=metadata,
         )
 
     async def _mount_skill_checks(
@@ -1319,6 +1335,150 @@ def make_unload_skill_tool(
         },
         executor=_unload_skill,
         tags=["skill", "memory"],
+        impact_scope="memory",
+    )
+
+
+# ------------------------------------------------------------------
+# Skill lifecycle tools (Issue #120 PR 3)
+# ------------------------------------------------------------------
+
+
+def make_skill_promote_tool(promoter: "SkillPromoter") -> ToolDefinition:
+    """Create a GUARDED ``promote_skill_candidate`` tool.
+
+    Swaps the parent SKILL.md for the candidate body, archives the old
+    body to ``skill_version_history``, and bumps the skill version.  Used
+    primarily in mode B (manual promotion) but also available to the
+    agent in mode C when it wants to accelerate a pending shadow.
+    """
+    async def _promote(call: ToolCall) -> ToolResult:
+        candidate_id = call.args.get("candidate_id", "").strip()
+        reason = (call.args.get("reason") or "").strip() or None
+        if not candidate_id:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error="'candidate_id' is required",
+            )
+        try:
+            skill = await promoter.promote(candidate_id, reason=reason)
+        except ValueError as exc:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error=str(exc),
+            )
+        if skill is None:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error=f"Candidate {candidate_id} or its parent not found",
+            )
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=True,
+            output=f"Promoted candidate {candidate_id[:8]} → {skill.name} v{skill.version}",
+            metadata={"skill_name": skill.name, "new_version": skill.version},
+        )
+
+    return ToolDefinition(
+        name="promote_skill_candidate",
+        description=(
+            "Promote a candidate SKILL.md revision to replace the parent. "
+            "Archives the current body to version history and bumps the skill version. "
+            "Use when a shadow candidate has proven itself or when manually "
+            "accepting a generated proposal."
+        ),
+        trust_level=TrustLevel.GUARDED,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "candidate_id": {
+                    "type": "string",
+                    "description": "ID of the candidate to promote (see `loom skill candidates`).",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Optional free-text reason stored in audit notes.",
+                },
+            },
+            "required": ["candidate_id"],
+        },
+        executor=_promote,
+        tags=["skill", "memory", "lifecycle"],
+        impact_scope="memory",
+    )
+
+
+def make_skill_rollback_tool(promoter: "SkillPromoter") -> ToolDefinition:
+    """Create a GUARDED ``rollback_skill`` tool.
+
+    Restores a previous SKILL.md body from history — by default the most
+    recently archived version, i.e. undoing the latest promote.  The
+    current body is re-archived so the rollback itself is reversible.
+    """
+    async def _rollback(call: ToolCall) -> ToolResult:
+        name = call.args.get("skill_name", "").strip()
+        to_version = call.args.get("to_version")
+        reason = (call.args.get("reason") or "").strip() or None
+        if not name:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error="'skill_name' is required",
+            )
+        version_arg: int | None
+        if to_version is None or to_version == "":
+            version_arg = None
+        else:
+            try:
+                version_arg = int(to_version)
+            except (TypeError, ValueError):
+                return ToolResult(
+                    call_id=call.id, tool_name=call.tool_name,
+                    success=False, error=f"'to_version' must be an integer, got {to_version!r}",
+                )
+        skill = await promoter.rollback(name, to_version=version_arg, reason=reason)
+        if skill is None:
+            where = f" v{version_arg}" if version_arg is not None else ""
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False,
+                error=f"No history entry to roll back to for '{name}'{where}",
+            )
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=True,
+            output=f"Rolled back {name} → v{skill.version} (body restored from history)",
+            metadata={"skill_name": name, "new_version": skill.version},
+        )
+
+    return ToolDefinition(
+        name="rollback_skill",
+        description=(
+            "Roll a skill back to a previously-archived SKILL.md body. "
+            "Without ``to_version`` the latest archived entry is restored "
+            "(i.e. undo the most recent promote). The current body is "
+            "re-archived before the swap so rollbacks are themselves reversible."
+        ),
+        trust_level=TrustLevel.GUARDED,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "skill_name": {
+                    "type": "string",
+                    "description": "Name of the skill to roll back.",
+                },
+                "to_version": {
+                    "type": "integer",
+                    "description": "Specific historic version to restore. Omit for the most recent archive.",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Optional free-text reason stored in audit notes.",
+                },
+            },
+            "required": ["skill_name"],
+        },
+        executor=_rollback,
+        tags=["skill", "memory", "lifecycle"],
         impact_scope="memory",
     )
 

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -462,6 +462,23 @@ class LoomDiscordBot:
 
         session.subscribe_diagnostic(_discord_diagnostic)
 
+        # Issue #120 PR3: echo skill lifecycle transitions into the thread.
+        async def _discord_promotion(event) -> None:
+            if thread_ref is None:
+                return
+            try:
+                icon = {
+                    "promote": "🔁",
+                    "rollback": "↩️",
+                    "auto_shadow": "🫥",
+                    "deprecate": "🗑️",
+                }.get(event.kind, "•")
+                await thread_ref.send(f"{icon} **Skill lifecycle:** {event.one_line_summary()}")
+            except Exception:
+                pass
+
+        session.subscribe_promotion(_discord_promotion)
+
         self._sessions[thread_id] = session
         return session
 

--- a/tests/test_skill_promoter.py
+++ b/tests/test_skill_promoter.py
@@ -1,0 +1,753 @@
+"""
+Tests for Issue #120 PR 3 — SkillPromoter + SkillGate + lifecycle tools + CLI.
+
+Covers:
+- ``SkillPromoter`` state transitions: shadow, maybe_auto_shadow, promote,
+  rollback, deprecate — including idempotency and illegal-transition errors.
+- ``SkillGate.resolve`` routing: off / auto_c / manual_b, deterministic
+  slicing, per-session overrides, fallbacks when candidate is missing.
+- Agent tools: ``skill_promote`` / ``skill_rollback`` invoke promoter and
+  return terse summaries.
+- CLI: ``_resolve_candidate_id`` short-prefix resolution; ``_skill_history``
+  renders archived versions via Rich console.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from loom.core.harness.middleware import ToolCall
+from loom.core.harness.permissions import TrustLevel
+from loom.core.cognition.skill_gate import (
+    GateDecision,
+    SHADOW_MODES,
+    SkillGate,
+)
+from loom.core.cognition.skill_promoter import (
+    PROMOTION_EVENT_KINDS,
+    PromotionEvent,
+    SkillPromoter,
+)
+from loom.core.memory.procedural import (
+    ProceduralMemory,
+    SkillCandidate,
+    SkillGenome,
+    SkillVersionRecord,
+)
+from loom.core.memory.store import SQLiteStore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_PARENT_BODY = "---\nname: s1\n---\n\n# S1\nOriginal body.\n"
+SAMPLE_CANDIDATE_BODY = "---\nname: s1\n---\n\n# S1\nImproved body.\n"
+
+
+@pytest.fixture
+async def store(tmp_path):
+    db_path = tmp_path / "memory.db"
+    store = SQLiteStore(str(db_path))
+    await store.initialize()
+    yield store
+
+
+async def _seed_parent(proc: ProceduralMemory, *, name="s1", version=1, body=SAMPLE_PARENT_BODY, confidence=0.5) -> SkillGenome:
+    skill = SkillGenome(name=name, body=body, version=version, confidence=confidence, success_rate=confidence, usage_count=3)
+    await proc.upsert(skill)
+    return skill
+
+
+async def _seed_candidate(
+    proc: ProceduralMemory,
+    *,
+    parent_name="s1",
+    parent_version=1,
+    body=SAMPLE_CANDIDATE_BODY,
+    status="generated",
+) -> SkillCandidate:
+    cand = SkillCandidate(
+        parent_skill_name=parent_name,
+        parent_version=parent_version,
+        candidate_body=body,
+        mutation_strategy="apply_suggestions",
+        status=status,
+    )
+    await proc.insert_candidate(cand)
+    return cand
+
+
+# ---------------------------------------------------------------------------
+# PromotionEvent
+# ---------------------------------------------------------------------------
+
+
+class TestPromotionEvent:
+    def test_invalid_kind_raises(self):
+        with pytest.raises(ValueError):
+            PromotionEvent(
+                kind="bogus", skill_name="s1", candidate_id=None,
+                from_version=1, to_version=2,
+            )
+
+    def test_kinds_include_all_four(self):
+        for k in ("auto_shadow", "promote", "rollback", "deprecate"):
+            assert k in PROMOTION_EVENT_KINDS
+
+    def test_one_line_summary_shapes(self):
+        promote = PromotionEvent(
+            kind="promote", skill_name="s1", candidate_id="abc",
+            from_version=1, to_version=2, reason="apply",
+        )
+        assert "promoted" in promote.one_line_summary()
+        assert "v1→v2" in promote.one_line_summary()
+
+        rollback = PromotionEvent(
+            kind="rollback", skill_name="s1", candidate_id=None,
+            from_version=5, to_version=6,
+        )
+        assert "rollback" in rollback.one_line_summary()
+        assert "v5→v6" in rollback.one_line_summary()
+
+        shadow = PromotionEvent(
+            kind="auto_shadow", skill_name="s1", candidate_id="abc",
+            from_version=1, to_version=1,
+        )
+        assert "shadow" in shadow.one_line_summary()
+
+        dep = PromotionEvent(
+            kind="deprecate", skill_name="s1", candidate_id="abcdef",
+            from_version=1, to_version=1, reason="stale",
+        )
+        assert "deprecated" in dep.one_line_summary()
+        assert "abcdef" in dep.one_line_summary()
+
+
+# ---------------------------------------------------------------------------
+# SkillPromoter — shadow / maybe_auto_shadow
+# ---------------------------------------------------------------------------
+
+
+class TestShadow:
+    @pytest.mark.asyncio
+    async def test_shadow_moves_generated_to_shadow(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            await _seed_parent(proc)
+            cand = await _seed_candidate(proc)
+            promoter = SkillPromoter(procedural=proc)
+            events: list[PromotionEvent] = []
+            promoter.subscribe(lambda e: _collect(events, e))
+
+            updated = await promoter.shadow(cand.id, reason="trial")
+
+            assert updated is not None
+            assert updated.status == "shadow"
+            assert "shadow: trial" in (updated.notes or "")
+            assert len(events) == 1
+            assert events[0].kind == "auto_shadow"
+            assert events[0].reason == "trial"
+
+    @pytest.mark.asyncio
+    async def test_shadow_is_idempotent_when_already_shadow(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            await _seed_parent(proc)
+            cand = await _seed_candidate(proc, status="shadow")
+            promoter = SkillPromoter(procedural=proc)
+            events: list[PromotionEvent] = []
+            promoter.subscribe(lambda e: _collect(events, e))
+
+            result = await promoter.shadow(cand.id)
+
+            assert result is not None
+            assert result.status == "shadow"
+            assert events == []  # no transition → no event
+
+    @pytest.mark.asyncio
+    async def test_shadow_rejects_terminal_state(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            await _seed_parent(proc)
+            cand = await _seed_candidate(proc, status="promoted")
+            promoter = SkillPromoter(procedural=proc)
+
+            with pytest.raises(ValueError):
+                await promoter.shadow(cand.id)
+
+    @pytest.mark.asyncio
+    async def test_shadow_returns_none_for_missing_candidate(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            promoter = SkillPromoter(procedural=proc)
+            assert await promoter.shadow("no-such-id") is None
+
+    @pytest.mark.asyncio
+    async def test_maybe_auto_shadow_fires_when_under_ceiling(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            await _seed_parent(proc, confidence=0.6)  # ≤ ceiling 0.7
+            cand = await _seed_candidate(proc)
+            promoter = SkillPromoter(
+                procedural=proc, shadow_mode="auto_c",
+                auto_shadow_confidence_ceiling=0.7,
+            )
+
+            result = await promoter.maybe_auto_shadow(cand.id)
+            assert result is not None
+            assert result.status == "shadow"
+
+    @pytest.mark.asyncio
+    async def test_maybe_auto_shadow_skips_when_parent_above_ceiling(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            await _seed_parent(proc, confidence=0.95)  # above 0.7
+            cand = await _seed_candidate(proc)
+            promoter = SkillPromoter(procedural=proc, shadow_mode="auto_c")
+
+            assert await promoter.maybe_auto_shadow(cand.id) is None
+            latest = await proc.get_candidate(cand.id)
+            assert latest.status == "generated"
+
+    @pytest.mark.asyncio
+    async def test_maybe_auto_shadow_disabled_in_manual_b(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            await _seed_parent(proc, confidence=0.1)
+            cand = await _seed_candidate(proc)
+            promoter = SkillPromoter(procedural=proc, shadow_mode="manual_b")
+
+            assert await promoter.maybe_auto_shadow(cand.id) is None
+
+
+# ---------------------------------------------------------------------------
+# SkillPromoter — promote
+# ---------------------------------------------------------------------------
+
+
+class TestPromote:
+    @pytest.mark.asyncio
+    async def test_promote_swaps_body_and_bumps_version(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            await _seed_parent(proc, confidence=0.4)
+            cand = await _seed_candidate(proc)
+            promoter = SkillPromoter(procedural=proc)
+            events: list[PromotionEvent] = []
+            promoter.subscribe(lambda e: _collect(events, e))
+
+            new_parent = await promoter.promote(cand.id, reason="apply")
+
+            assert new_parent is not None
+            assert new_parent.version == 2
+            assert new_parent.body == SAMPLE_CANDIDATE_BODY
+            # Confidence reset to track the new body.
+            assert new_parent.confidence == 1.0
+            assert new_parent.success_rate == 1.0
+            assert new_parent.usage_count == 0
+
+            updated_cand = await proc.get_candidate(cand.id)
+            assert updated_cand.status == "promoted"
+
+            # Old body archived.
+            history = await proc.list_history("s1")
+            assert len(history) == 1
+            assert history[0].body == SAMPLE_PARENT_BODY
+            assert history[0].reason == "promote"
+            assert history[0].source_candidate_id == cand.id
+
+            assert len(events) == 1
+            assert events[0].kind == "promote"
+            assert events[0].from_version == 1
+            assert events[0].to_version == 2
+
+    @pytest.mark.asyncio
+    async def test_promote_deprecates_sibling_shadows(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            await _seed_parent(proc)
+            winner = await _seed_candidate(proc, status="shadow")
+            sibling = await _seed_candidate(proc, status="shadow", body="---\nname: s1\n---\n\n# S1\nOther trial.\n")
+            promoter = SkillPromoter(procedural=proc)
+
+            await promoter.promote(winner.id)
+
+            refreshed_sib = await proc.get_candidate(sibling.id)
+            assert refreshed_sib.status == "deprecated"
+            assert winner.id in (refreshed_sib.notes or "")
+
+    @pytest.mark.asyncio
+    async def test_promote_is_idempotent(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            await _seed_parent(proc)
+            cand = await _seed_candidate(proc, status="promoted")
+            promoter = SkillPromoter(procedural=proc)
+
+            parent = await promoter.promote(cand.id)
+            assert parent is not None
+            assert parent.version == 1  # nothing happened
+
+    @pytest.mark.asyncio
+    async def test_promote_rejects_terminal_state(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            await _seed_parent(proc)
+            cand = await _seed_candidate(proc, status="deprecated")
+            promoter = SkillPromoter(procedural=proc)
+
+            with pytest.raises(ValueError):
+                await promoter.promote(cand.id)
+
+    @pytest.mark.asyncio
+    async def test_promote_returns_none_for_missing_parent(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            cand = await _seed_candidate(proc)  # no parent seeded
+            promoter = SkillPromoter(procedural=proc)
+
+            assert await promoter.promote(cand.id) is None
+
+
+# ---------------------------------------------------------------------------
+# SkillPromoter — rollback
+# ---------------------------------------------------------------------------
+
+
+class TestRollback:
+    @pytest.mark.asyncio
+    async def test_rollback_to_latest_archived(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            await _seed_parent(proc)
+            cand = await _seed_candidate(proc)
+            promoter = SkillPromoter(procedural=proc)
+            events: list[PromotionEvent] = []
+
+            await promoter.promote(cand.id, reason="apply")
+            promoter.subscribe(lambda e: _collect(events, e))
+            result = await promoter.rollback("s1", reason="regression")
+
+            assert result is not None
+            assert result.body == SAMPLE_PARENT_BODY
+            assert result.version == 3  # promote bumped to 2, rollback to 3
+
+            refreshed_cand = await proc.get_candidate(cand.id)
+            assert refreshed_cand.status == "rolled_back"
+
+            assert len(events) == 1
+            assert events[0].kind == "rollback"
+            assert events[0].reason == "regression"
+
+    @pytest.mark.asyncio
+    async def test_rollback_to_specific_version(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            await _seed_parent(proc)
+            c1 = await _seed_candidate(proc)
+            promoter = SkillPromoter(procedural=proc)
+
+            await promoter.promote(c1.id)
+            # Second promote → another archive entry at v2.
+            c2 = await _seed_candidate(proc, parent_version=2, body="---\nname: s1\n---\n\n# S1\nThird.\n")
+            await promoter.promote(c2.id)
+
+            restored = await promoter.rollback("s1", to_version=1)
+            assert restored is not None
+            assert restored.body == SAMPLE_PARENT_BODY  # v1 restored
+
+    @pytest.mark.asyncio
+    async def test_rollback_returns_none_when_no_history(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            await _seed_parent(proc)
+            promoter = SkillPromoter(procedural=proc)
+
+            assert await promoter.rollback("s1") is None
+
+    @pytest.mark.asyncio
+    async def test_rollback_returns_none_for_missing_skill(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            promoter = SkillPromoter(procedural=proc)
+            assert await promoter.rollback("no-such-skill") is None
+
+
+# ---------------------------------------------------------------------------
+# SkillPromoter — deprecate
+# ---------------------------------------------------------------------------
+
+
+class TestDeprecate:
+    @pytest.mark.asyncio
+    async def test_deprecate_generated_candidate(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            await _seed_parent(proc)
+            cand = await _seed_candidate(proc)
+            promoter = SkillPromoter(procedural=proc)
+            events: list[PromotionEvent] = []
+            promoter.subscribe(lambda e: _collect(events, e))
+
+            result = await promoter.deprecate(cand.id, reason="bad idea")
+            assert result is not None
+            assert result.status == "deprecated"
+            assert events and events[0].kind == "deprecate"
+
+    @pytest.mark.asyncio
+    async def test_deprecate_idempotent(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            await _seed_parent(proc)
+            cand = await _seed_candidate(proc, status="deprecated")
+            promoter = SkillPromoter(procedural=proc)
+
+            result = await promoter.deprecate(cand.id)
+            assert result.status == "deprecated"
+
+    @pytest.mark.asyncio
+    async def test_deprecate_rejects_promoted(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            await _seed_parent(proc)
+            cand = await _seed_candidate(proc, status="promoted")
+            promoter = SkillPromoter(procedural=proc)
+            with pytest.raises(ValueError):
+                await promoter.deprecate(cand.id)
+
+
+# ---------------------------------------------------------------------------
+# SkillGate
+# ---------------------------------------------------------------------------
+
+
+class TestSkillGate:
+    @pytest.mark.asyncio
+    async def test_off_mode_always_returns_parent(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            skill = await _seed_parent(proc)
+            await _seed_candidate(proc, status="shadow")
+
+            gate = SkillGate(procedural=proc, shadow_mode="off", session_id="sess-1")
+            decision = await gate.resolve(skill)
+            assert decision.source == "parent"
+            assert decision.is_shadow is False
+            assert decision.audit_tag() == "parent"
+
+    @pytest.mark.asyncio
+    async def test_manual_b_never_auto_serves_shadow(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            skill = await _seed_parent(proc)
+            await _seed_candidate(proc, status="shadow")
+
+            gate = SkillGate(
+                procedural=proc, shadow_mode="manual_b",
+                shadow_fraction=1.0, session_id="sess-1",
+            )
+            decision = await gate.resolve(skill)
+            assert decision.source == "parent"
+
+    @pytest.mark.asyncio
+    async def test_auto_c_serves_shadow_when_fraction_is_one(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            skill = await _seed_parent(proc)
+            cand = await _seed_candidate(proc, status="shadow")
+
+            gate = SkillGate(
+                procedural=proc, shadow_mode="auto_c",
+                shadow_fraction=1.0, session_id="sess-1",
+            )
+            decision = await gate.resolve(skill)
+            assert decision.source == "shadow"
+            assert decision.candidate_id == cand.id
+            assert decision.body == SAMPLE_CANDIDATE_BODY
+            assert decision.audit_tag().startswith("shadow:")
+
+    @pytest.mark.asyncio
+    async def test_auto_c_serves_parent_when_fraction_is_zero(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            skill = await _seed_parent(proc)
+            await _seed_candidate(proc, status="shadow")
+
+            gate = SkillGate(
+                procedural=proc, shadow_mode="auto_c",
+                shadow_fraction=0.0, session_id="sess-1",
+            )
+            decision = await gate.resolve(skill)
+            assert decision.source == "parent"
+
+    @pytest.mark.asyncio
+    async def test_auto_c_slicing_is_deterministic_per_session(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            skill = await _seed_parent(proc)
+            await _seed_candidate(proc, status="shadow")
+
+            gate = SkillGate(
+                procedural=proc, shadow_mode="auto_c",
+                shadow_fraction=0.5, session_id="stable-session",
+            )
+            d1 = await gate.resolve(skill)
+            d2 = await gate.resolve(skill)
+            assert d1.source == d2.source  # same side twice
+
+    @pytest.mark.asyncio
+    async def test_force_shadow_overrides_slicing(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            skill = await _seed_parent(proc)
+            cand = await _seed_candidate(proc, status="shadow")
+
+            gate = SkillGate(
+                procedural=proc, shadow_mode="manual_b",
+                shadow_fraction=0.0, session_id="s",
+            )
+            gate.force_shadow("s1", cand.id)
+
+            decision = await gate.resolve(skill)
+            assert decision.source == "shadow"
+            assert decision.candidate_id == cand.id
+
+    @pytest.mark.asyncio
+    async def test_force_parent_overrides(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            skill = await _seed_parent(proc)
+            await _seed_candidate(proc, status="shadow")
+
+            gate = SkillGate(
+                procedural=proc, shadow_mode="auto_c",
+                shadow_fraction=1.0, session_id="s",
+            )
+            gate.force_parent("s1")
+            decision = await gate.resolve(skill)
+            assert decision.source == "parent"
+
+    @pytest.mark.asyncio
+    async def test_clear_override_returns_to_slicing(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            skill = await _seed_parent(proc)
+            await _seed_candidate(proc, status="shadow")
+
+            gate = SkillGate(
+                procedural=proc, shadow_mode="auto_c",
+                shadow_fraction=1.0, session_id="s",
+            )
+            gate.force_parent("s1")
+            gate.clear_override("s1")
+            decision = await gate.resolve(skill)
+            assert decision.source == "shadow"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_parent_when_no_shadow_exists(self, store):
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            skill = await _seed_parent(proc)
+            # Candidate exists but only in 'generated' state.
+            await _seed_candidate(proc, status="generated")
+
+            gate = SkillGate(
+                procedural=proc, shadow_mode="auto_c",
+                shadow_fraction=1.0, session_id="s",
+            )
+            decision = await gate.resolve(skill)
+            assert decision.source == "parent"
+
+    def test_unknown_shadow_mode_falls_back_to_off(self, store):
+        # Store fixture provided just for symmetry; gate doesn't use it here.
+        gate = SkillGate(procedural=object(), shadow_mode="nonsense")
+        assert gate.shadow_mode == "off"
+
+    def test_shadow_fraction_is_clamped(self, store):
+        gate = SkillGate(procedural=object(), shadow_fraction=5.0)
+        assert gate.shadow_fraction == 1.0
+        gate = SkillGate(procedural=object(), shadow_fraction=-1.0)
+        assert gate.shadow_fraction == 0.0
+
+    def test_shadow_modes_tuple(self):
+        assert SHADOW_MODES == ("off", "auto_c", "manual_b")
+
+    def test_gate_decision_audit_tag_truncates(self):
+        d = GateDecision(
+            body="b", source="shadow", served_version=1,
+            candidate_id="0123456789abcdef",
+        )
+        assert d.audit_tag() == "shadow:01234567"
+
+
+# ---------------------------------------------------------------------------
+# Agent tools — skill_promote / skill_rollback
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_call(tool_name: str, args: dict) -> ToolCall:
+    return ToolCall(
+        tool_name=tool_name, args=args,
+        trust_level=TrustLevel.GUARDED, session_id="sess-test",
+    )
+
+
+class TestSkillTools:
+    @pytest.mark.asyncio
+    async def test_promote_tool_calls_promoter(self, store):
+        from loom.platform.cli.tools import make_skill_promote_tool
+
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            await _seed_parent(proc)
+            cand = await _seed_candidate(proc)
+            promoter = SkillPromoter(procedural=proc)
+
+            tool = make_skill_promote_tool(promoter)
+            assert tool.trust_level == TrustLevel.GUARDED
+            call = _make_tool_call("promote_skill_candidate", {
+                "candidate_id": cand.id, "reason": "test",
+            })
+            result = await tool.executor(call)
+            assert result.success is True
+            assert "v2" in (result.output or "")
+            assert result.metadata["new_version"] == 2
+
+    @pytest.mark.asyncio
+    async def test_promote_tool_handles_missing_candidate(self, store):
+        from loom.platform.cli.tools import make_skill_promote_tool
+
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            promoter = SkillPromoter(procedural=proc)
+            tool = make_skill_promote_tool(promoter)
+
+            result = await tool.executor(
+                _make_tool_call("promote_skill_candidate", {"candidate_id": "no-such-id"})
+            )
+            assert result.success is False
+            assert "not found" in (result.error or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_promote_tool_requires_candidate_id(self, store):
+        from loom.platform.cli.tools import make_skill_promote_tool
+
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            tool = make_skill_promote_tool(SkillPromoter(procedural=proc))
+            result = await tool.executor(
+                _make_tool_call("promote_skill_candidate", {})
+            )
+            assert result.success is False
+            assert "candidate_id" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_rollback_tool_calls_promoter(self, store):
+        from loom.platform.cli.tools import make_skill_rollback_tool
+
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            await _seed_parent(proc)
+            cand = await _seed_candidate(proc)
+            promoter = SkillPromoter(procedural=proc)
+            await promoter.promote(cand.id)
+
+            tool = make_skill_rollback_tool(promoter)
+            assert tool.trust_level == TrustLevel.GUARDED
+            result = await tool.executor(
+                _make_tool_call("rollback_skill", {"skill_name": "s1", "reason": "revert"})
+            )
+            assert result.success is True
+            assert "v3" in (result.output or "")
+
+    @pytest.mark.asyncio
+    async def test_rollback_tool_handles_bad_version(self, store):
+        from loom.platform.cli.tools import make_skill_rollback_tool
+
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            tool = make_skill_rollback_tool(SkillPromoter(procedural=proc))
+            result = await tool.executor(
+                _make_tool_call("rollback_skill", {"skill_name": "s1", "to_version": "abc"})
+            )
+            assert result.success is False
+            assert "integer" in (result.error or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_rollback_tool_requires_skill_name(self, store):
+        from loom.platform.cli.tools import make_skill_rollback_tool
+
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            tool = make_skill_rollback_tool(SkillPromoter(procedural=proc))
+            result = await tool.executor(
+                _make_tool_call("rollback_skill", {})
+            )
+            assert result.success is False
+            assert "skill_name" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# CLI helpers
+# ---------------------------------------------------------------------------
+
+
+class TestCLIHelpers:
+    @pytest.mark.asyncio
+    async def test_resolve_candidate_id_short_prefix_unique(self, store):
+        from loom.platform.cli.main import _resolve_candidate_id
+
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            cand = await _seed_candidate(proc)
+            prefix = cand.id[:8]
+
+            resolved = await _resolve_candidate_id(proc, prefix)
+            assert resolved == cand.id
+
+    @pytest.mark.asyncio
+    async def test_resolve_candidate_id_full_id_passthrough(self, store):
+        from loom.platform.cli.main import _resolve_candidate_id
+
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            # Full-length uuid (≥32 chars) passes through without lookup.
+            full = "a" * 36
+            resolved = await _resolve_candidate_id(proc, full)
+            assert resolved == full
+
+    @pytest.mark.asyncio
+    async def test_resolve_candidate_id_rejects_short_prefix(self, store):
+        from loom.platform.cli.main import _resolve_candidate_id
+
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            assert await _resolve_candidate_id(proc, "ab") is None
+
+    @pytest.mark.asyncio
+    async def test_resolve_candidate_id_returns_none_on_no_match(self, store):
+        from loom.platform.cli.main import _resolve_candidate_id
+
+        async with store.connect() as conn:
+            proc = ProceduralMemory(conn)
+            await _seed_candidate(proc)
+            assert await _resolve_candidate_id(proc, "deadbeef") is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _collect(bucket: list, event):
+    """Sync helper used as an async subscriber.
+
+    SkillPromoter awaits whatever the subscriber returns; returning the
+    coroutine from ``_append`` keeps the contract while letting tests use a
+    plain list.
+    """
+    async def _append():
+        bucket.append(event)
+    return _append()


### PR DESCRIPTION
## Summary

完成 Issue #120 的三段式骨架最後一塊：把 PR 2 產出的候選 SKILL.md 從純記錄昇級成可路由、可回滾的生命週期。

- **SkillPromoter** — 狀態機 `generated → shadow → promoted → deprecated / rolled_back`，每次轉換廣播 `PromotionEvent`；同一 status 的重複呼叫是 no-op，非法轉換 raise。
- **SkillGate** — `load_skill` 時決定要送 parent 還是 shadow body。Mode C 用 SHA1(`session_id|skill_name`) 確定性切分（同一 session 對同一 skill 永遠看同一側），方便 TaskReflector 做 A/B 比較。
- **自動 shadow** — TaskReflector mutation post-hook 在 mode C 下、parent.confidence ≤ ceiling 時自動把新 candidate 移到 shadow。
- **skill_version_history** — promote 前先封存舊 body，rollback 就從這裡取回；rollback 本身也再封存一次，所以可以連續反悔。
- **Agent tools** — `promote_skill_candidate` / `rollback_skill`（GUARDED）
- **CLI** — `loom skill promote|rollback|history`，支援 8-char prefix 解析 candidate id
- **平台訂閱** — CLI inline、TUI notification、Discord thread 即時顯示 lifecycle 事件
- **`loom.toml`** — 新增 `shadow_mode` / `shadow_fraction` / `auto_shadow_confidence_ceiling`

預設 `mutation.enabled = false`、`shadow_mode = auto_c` — 只開 reflection 不會自動動 skill，要到開 mutation 才會開始產生 candidate。

45 新測試，全測試 900 綠。

## Test plan

自動化：
- [x] `pytest tests/test_skill_promoter.py` — 45 passed
- [x] `pytest tests/` — 900 passed
- [x] Syntax check on all touched modules

手動驗證（麻煩 Dakai 幫忙跑一次）：
- [ ] `loom chat` → 隨便觸發一個會 activate skill 的 turn，看 reflection 正常（PR 2 行為不變）
- [ ] 在 `loom.toml` 開 `[mutation].enabled = true`，再跑幾輪低分 turn，確認 `loom skill candidates` 能看到產出；`shadow_mode = auto_c` 下會自動轉 shadow
- [ ] `loom skill promote <candidate_id_prefix>` → `loom skill history <name>` 能看到新 archive 條目
- [ ] `loom skill rollback <name>` → 再跑一次 history，確認 body 回到原版且 version 遞增
- [ ] TUI 裡開 mutation 後，促成 promote/rollback 應該會跳 Skill lifecycle notification
- [ ] Discord thread：促成 promote/rollback 應該在 thread 有 lifecycle 訊息

有問題或想改 shadow_fraction 的 default 可以直接在 review 提。

🤖 Generated with [Claude Code](https://claude.com/claude-code)