### PR TITLE
feat(cognition): Meta-Skill-Engineer integration (Issue #120 PR 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Semantic confidence has a 90-day half-life. Memories that are never reinforced f
 
 ---
 
-## Skills — Procedural Memory with Self-Assessment
+## Skills — Procedural Memory with Self-Evolution
 
 Skills are versioned instruction sets stored in `SkillGenome` that follow a three-tier progressive disclosure model:
 
@@ -218,9 +218,40 @@ Skills are versioned instruction sets stored in `SkillGenome` that follow a thre
 
 Drop a `SKILL.md` into your `skills/` directory — Loom auto-imports it at session start.
 
-### Self-Assessment Feedback Loop
+### Structured Diagnostic Feedback Loop
 
-After each turn where a skill was used, Loom triggers a background LLM self-assessment (scored 1–5). The result feeds into the skill's `confidence` via exponential moving average (α = 0.15). Skills that consistently underperform surface improvement suggestions in their next `load_skill()` call as `<evolution_hints>`. Skills whose confidence drops below a configurable threshold are automatically deprecated and removed from the Tier 1 catalog.
+After each turn where a skill was used, `TaskReflector` runs a background LLM self-assessment that produces a `TaskDiagnostic` — a structured record of which instructions were followed or violated, failure and success patterns, concrete `mutation_suggestions`, and a `quality_score` (1–5). The score feeds into the skill's `confidence` via EMA (α = 0.15). Skills whose confidence drops below a configurable threshold are deprecated and removed from the Tier 1 catalog.
+
+### Skill Evolution Lifecycle
+
+`TaskDiagnostic` data feeds a full candidate-pool evolution pipeline:
+
+```
+TaskReflector → TaskDiagnostic
+                      ↓
+              SkillMutator.propose_candidate()   ← single-turn background path
+              SkillMutator.from_batch_diagnostic() ← meta-skill-engineer batch path
+                      ↓
+              SkillCandidate (skill_candidates table)
+                      ↓
+         generated → shadow → promoted   (or deprecated / rolled_back)
+```
+
+**Shadow mode** — a promoted candidate serves alongside the parent. `SkillGate` A/B-routes turns to shadow or parent body, accumulating a win record before promotion is confirmed.
+
+**Fast-track** — when the `meta-skill-engineer` Grader proves ≥ 20% pass-rate improvement over the previous version, the candidate is flagged `fast_track=True` and can be promoted immediately without the shadow N-wins phase — Grader is the ground truth.
+
+**Maturity tag** — `SkillGenome.maturity_tag` (`mature` / `needs_improvement`) is set by the operator after reviewing eval history; visible in `loom review <name>`.
+
+**Version history** — every `promote` and `rollback` snapshots the previous body to `skill_version_history`. Full rollback is always available: `loom skill rollback <name>`.
+
+```bash
+loom skill candidates          # browse the candidate pool
+loom skill promote <id>        # promote a shadow candidate
+loom skill rollback <name>     # restore the previous body
+loom skill history <name>      # full version archive
+loom review <name>             # one-stop: genome · eval history · candidates · insights
+```
 
 ### Precondition Checks — Framework-Enforced Safety Rails
 

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -165,6 +165,12 @@ shadow_fraction  = 0.5
 # warrant an A/B trial).  Range 0.0–1.0.
 auto_shadow_confidence_ceiling = 0.7
 
+# PR 4 — Grader-driven fast-track.  When ``SkillMutator.from_batch_diagnostic``
+# (used by the meta-skill-engineer skill) sees ``improvement >= this threshold``,
+# the resulting candidate is flagged ``fast_track=True`` so it can be promoted
+# directly without the shadow N-wins phase.  Range 0.0–1.0.
+fast_track_threshold = 0.20
+
 # ─────────────────────────────────────────────
 # Telemetry (Issue #142) — Agent self-observability
 # ─────────────────────────────────────────────

--- a/loom/core/cognition/skill_mutator.py
+++ b/loom/core/cognition/skill_mutator.py
@@ -139,6 +139,7 @@ class SkillMutator:
         quality_ceiling: float = 3.5,
         min_suggestions: int = 1,
         max_body_chars: int = 6000,
+        fast_track_threshold: float = 0.20,
     ) -> None:
         self._router = router
         self._model = model
@@ -146,6 +147,7 @@ class SkillMutator:
         self._quality_ceiling = quality_ceiling
         self._min_suggestions = min_suggestions
         self._max_body_chars = max_body_chars
+        self._fast_track_threshold = fast_track_threshold
 
     # ------------------------------------------------------------------
     # Public
@@ -267,8 +269,8 @@ class SkillMutator:
             skill_name=parent.name,
             skill_body=parent.body[: self._max_body_chars],
             suggestions=_bullet(suggestions, limit=10),
-            violated=_bullet([], limit=5),
-            failures=_bullet([], limit=5),
+            violated=_bullet(batch.aggregated_violations, limit=5),
+            failures=_bullet(batch.aggregated_failures, limit=5),
         )
 
         raw = ""
@@ -293,7 +295,7 @@ class SkillMutator:
 
         fast_track = (
             batch.improvement is not None
-            and batch.improvement >= _FAST_TRACK_THRESHOLD
+            and batch.improvement >= self._fast_track_threshold
         )
         diagnostic_keys = [
             _diagnostic_key(d) for d in batch.diagnostics if _diagnostic_key(d)
@@ -322,8 +324,6 @@ class SkillMutator:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-_FAST_TRACK_THRESHOLD: float = 0.20  # ≥20% pass-rate improvement → skip shadow phase
 
 def _bullet(items: list[str], limit: int) -> str:
     if not items:

--- a/loom/core/cognition/skill_mutator.py
+++ b/loom/core/cognition/skill_mutator.py
@@ -34,7 +34,7 @@ from loom.core.memory.procedural import SkillCandidate
 
 if TYPE_CHECKING:
     from loom.core.cognition.router import LLMRouter
-    from loom.core.cognition.task_reflector import TaskDiagnostic
+    from loom.core.cognition.task_reflector import BatchDiagnostic, TaskDiagnostic
     from loom.core.memory.procedural import SkillGenome
 
 logger = logging.getLogger(__name__)
@@ -231,10 +231,99 @@ class SkillMutator:
             raw_response_chars=len(raw),
         )
 
+    async def from_batch_diagnostic(
+        self,
+        parent: "SkillGenome",
+        batch: "BatchDiagnostic",
+        session_id: str | None = None,
+    ) -> "MutationProposal | None":
+        """Generate a candidate from a Grader-produced ``BatchDiagnostic``.
+
+        Differs from ``propose_candidate`` in two ways:
+
+        1. **No quality_ceiling gate** — batch path is explicitly triggered by
+           meta-skill-engineer, not background reflection.
+        2. **fast_track** — if ``batch.improvement >= 0.20`` the candidate is
+           flagged so the caller can skip shadow N-wins and promote directly,
+           because Grader already proved the improvement empirically.
+        """
+        if not self._enabled:
+            logger.debug("from_batch_diagnostic: mutation disabled in config")
+            return None
+
+        suggestions = batch.aggregated_suggestions
+        if not suggestions:
+            logger.debug(
+                "from_batch_diagnostic: no mutation_suggestions in batch (skill=%s)",
+                parent.name,
+            )
+            return None
+
+        if not parent.body.strip():
+            logger.debug("from_batch_diagnostic: parent %s has empty body", parent.name)
+            return None
+
+        prompt = _MUTATION_PROMPT.format(
+            skill_name=parent.name,
+            skill_body=parent.body[: self._max_body_chars],
+            suggestions=_bullet(suggestions, limit=10),
+            violated=_bullet([], limit=5),
+            failures=_bullet([], limit=5),
+        )
+
+        raw = ""
+        try:
+            response = await self._router.chat(
+                model=self._model,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=2000,
+            )
+            raw = (response.text or "").strip()
+        except Exception as exc:
+            logger.debug("from_batch_diagnostic LLM call failed: %s", exc)
+            return None
+
+        new_body = _strip_fencing(raw)
+        if not _looks_like_skill_md(new_body, parent.body):
+            logger.debug(
+                "from_batch_diagnostic rewrite rejected: implausible body "
+                "(skill=%s len=%d)", parent.name, len(new_body),
+            )
+            return None
+
+        fast_track = (
+            batch.improvement is not None
+            and batch.improvement >= _FAST_TRACK_THRESHOLD
+        )
+        diagnostic_keys = [
+            _diagnostic_key(d) for d in batch.diagnostics if _diagnostic_key(d)
+        ]
+        candidate = SkillCandidate(
+            parent_skill_name=parent.name,
+            parent_version=parent.version,
+            candidate_body=new_body,
+            mutation_strategy="batch_meta_skill_engineer",
+            diagnostic_keys=diagnostic_keys,
+            origin_session_id=session_id,
+            pareto_scores={"pass_rate": batch.pass_rate},
+            fast_track=fast_track,
+            notes=(
+                f"batch pass_rate={batch.pass_rate:.0%}"
+                + (f" improvement={batch.improvement:+.0%}" if batch.improvement is not None else "")
+            ),
+        )
+        return MutationProposal(
+            candidate=candidate,
+            prompt_preview=prompt[:200],
+            raw_response_chars=len(raw),
+        )
+
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+_FAST_TRACK_THRESHOLD: float = 0.20  # ≥20% pass-rate improvement → skip shadow phase
 
 def _bullet(items: list[str], limit: int) -> str:
     if not items:

--- a/loom/core/cognition/task_reflector.py
+++ b/loom/core/cognition/task_reflector.py
@@ -114,6 +114,58 @@ class TaskDiagnostic:
         )
 
 
+@dataclass
+class BatchDiagnostic:
+    """Aggregate diagnostic produced by meta-skill-engineer's Grader phase.
+
+    Wraps a list of per-test ``TaskDiagnostic`` instances together with the
+    pass rate measured by the Grader.  ``previous_pass_rate`` enables
+    fast-track detection: if ``improvement >= 0.20``, ``SkillMutator``
+    will flag the resulting candidate for direct promotion without the
+    normal shadow N-wins phase.
+    """
+
+    skill_name: str
+    diagnostics: list[TaskDiagnostic]
+    pass_rate: float                     # fraction 0.0–1.0
+    previous_pass_rate: float | None = None
+
+    @property
+    def improvement(self) -> float | None:
+        if self.previous_pass_rate is None:
+            return None
+        return self.pass_rate - self.previous_pass_rate
+
+    @property
+    def avg_quality_score(self) -> float:
+        if not self.diagnostics:
+            return 0.0
+        return sum(d.quality_score for d in self.diagnostics) / len(self.diagnostics)
+
+    @property
+    def aggregated_suggestions(self) -> list[str]:
+        """Deduplicated mutation suggestions across all diagnostics."""
+        seen: set[str] = set()
+        result: list[str] = []
+        for d in self.diagnostics:
+            for s in d.mutation_suggestions:
+                if s not in seen:
+                    seen.add(s)
+                    result.append(s)
+        return result
+
+    def one_line_summary(self) -> str:
+        n = len(self.diagnostics)
+        pct = f"{self.pass_rate * 100:.0f}%"
+        imp = ""
+        if self.improvement is not None and self.improvement > 0:
+            imp = f" (+{self.improvement * 100:.0f}%)"
+        return (
+            f"{self.skill_name} · {n} tests · pass_rate={pct}{imp}"
+            f" · avg_q={self.avg_quality_score:.1f}/5"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Prompt
 # ---------------------------------------------------------------------------

--- a/loom/core/cognition/task_reflector.py
+++ b/loom/core/cognition/task_reflector.py
@@ -145,14 +145,22 @@ class BatchDiagnostic:
     @property
     def aggregated_suggestions(self) -> list[str]:
         """Deduplicated mutation suggestions across all diagnostics."""
-        seen: set[str] = set()
-        result: list[str] = []
-        for d in self.diagnostics:
-            for s in d.mutation_suggestions:
-                if s not in seen:
-                    seen.add(s)
-                    result.append(s)
-        return result
+        return _dedup_flat(d.mutation_suggestions for d in self.diagnostics)
+
+    @property
+    def aggregated_violations(self) -> list[str]:
+        """Deduplicated ``instructions_violated`` across all diagnostics.
+
+        Used by ``SkillMutator.from_batch_diagnostic`` to give the rewrite
+        prompt the same contextual fields that ``propose_candidate`` passes
+        per-turn, so batch rewrites don't lose the "why" behind suggestions.
+        """
+        return _dedup_flat(d.instructions_violated for d in self.diagnostics)
+
+    @property
+    def aggregated_failures(self) -> list[str]:
+        """Deduplicated ``failure_patterns`` across all diagnostics."""
+        return _dedup_flat(d.failure_patterns for d in self.diagnostics)
 
     def one_line_summary(self) -> str:
         n = len(self.diagnostics)
@@ -683,6 +691,18 @@ def _try_load(text: str) -> Any:
 
 def _clamp(value: float, lo: float, hi: float) -> float:
     return max(lo, min(hi, value))
+
+
+def _dedup_flat(lists: "Any") -> list[str]:
+    """Flatten an iterable of string lists, preserving first-seen order."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for lst in lists:
+        for item in lst:
+            if item not in seen:
+                seen.add(item)
+                result.append(item)
+    return result
 
 
 def _on_reflect_done(task: asyncio.Task) -> None:

--- a/loom/core/memory/procedural.py
+++ b/loom/core/memory/procedural.py
@@ -60,6 +60,7 @@ class SkillGenome:
     Each dict: {"ref": "checks.fn_name", "applies_to": ["run_bash"], "description": "..."}
     Parsed from SKILL.md frontmatter, resolved to callables at load_skill() time.
     """
+    maturity_tag: str | None = None
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
@@ -164,6 +165,7 @@ class SkillCandidate:
     status: str = "generated"
     pareto_scores: dict[str, float] = field(default_factory=dict)
     notes: str | None = None
+    fast_track: bool = False
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
@@ -189,18 +191,19 @@ class ProceduralMemory:
             INSERT INTO skill_genomes
                 (id, name, version, confidence, usage_count, success_rate,
                  parent_skill, deprecation_threshold, tags, body,
-                 precondition_check_refs, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 precondition_check_refs, maturity_tag, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(name) DO UPDATE SET
-                version                = excluded.version,
-                confidence             = excluded.confidence,
-                usage_count            = excluded.usage_count,
-                success_rate           = excluded.success_rate,
-                deprecation_threshold  = excluded.deprecation_threshold,
-                tags                   = excluded.tags,
-                body                   = excluded.body,
+                version                 = excluded.version,
+                confidence              = excluded.confidence,
+                usage_count             = excluded.usage_count,
+                success_rate            = excluded.success_rate,
+                deprecation_threshold   = excluded.deprecation_threshold,
+                tags                    = excluded.tags,
+                body                    = excluded.body,
                 precondition_check_refs = excluded.precondition_check_refs,
-                updated_at             = excluded.updated_at
+                maturity_tag            = excluded.maturity_tag,
+                updated_at              = excluded.updated_at
             """,
             (
                 skill.id, skill.name, skill.version, skill.confidence,
@@ -209,6 +212,7 @@ class ProceduralMemory:
                 json.dumps(skill.tags, ensure_ascii=False),
                 skill.body,
                 json.dumps(skill.precondition_check_refs, ensure_ascii=False),
+                skill.maturity_tag,
                 skill.created_at.isoformat(), now,
             ),
         )
@@ -218,7 +222,7 @@ class ProceduralMemory:
         cursor = await self._db.execute(
             "SELECT id, name, version, confidence, usage_count, success_rate, "
             "parent_skill, deprecation_threshold, tags, body, "
-            "precondition_check_refs, created_at, updated_at "
+            "precondition_check_refs, maturity_tag, created_at, updated_at "
             "FROM skill_genomes WHERE name = ?",
             (name,),
         )
@@ -230,8 +234,9 @@ class ProceduralMemory:
             usage_count=row[4], success_rate=row[5], parent_skill=row[6],
             deprecation_threshold=row[7], tags=json.loads(row[8]),
             body=row[9], precondition_check_refs=json.loads(row[10]),
-            created_at=datetime.fromisoformat(row[11]),
-            updated_at=datetime.fromisoformat(row[12]),
+            maturity_tag=row[11],
+            created_at=datetime.fromisoformat(row[12]),
+            updated_at=datetime.fromisoformat(row[13]),
         )
 
     async def list_active(self) -> list[SkillGenome]:
@@ -239,7 +244,7 @@ class ProceduralMemory:
         cursor = await self._db.execute(
             "SELECT id, name, version, confidence, usage_count, success_rate, "
             "parent_skill, deprecation_threshold, tags, body, "
-            "precondition_check_refs, created_at, updated_at "
+            "precondition_check_refs, maturity_tag, created_at, updated_at "
             "FROM skill_genomes "
             "WHERE confidence > deprecation_threshold "
             "   OR usage_count < ? "
@@ -253,8 +258,9 @@ class ProceduralMemory:
                 usage_count=r[4], success_rate=r[5], parent_skill=r[6],
                 deprecation_threshold=r[7], tags=json.loads(r[8]),
                 body=r[9], precondition_check_refs=json.loads(r[10]),
-                created_at=datetime.fromisoformat(r[11]),
-                updated_at=datetime.fromisoformat(r[12]),
+                maturity_tag=r[11],
+                created_at=datetime.fromisoformat(r[12]),
+                updated_at=datetime.fromisoformat(r[13]),
             )
             for r in rows
         ]
@@ -271,8 +277,8 @@ class ProceduralMemory:
             INSERT INTO skill_candidates
                 (id, parent_skill_name, parent_version, candidate_body,
                  mutation_strategy, diagnostic_keys, origin_session_id,
-                 status, pareto_scores, notes, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 status, pareto_scores, notes, fast_track, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 candidate.id,
@@ -285,6 +291,7 @@ class ProceduralMemory:
                 candidate.status,
                 json.dumps(candidate.pareto_scores, ensure_ascii=False),
                 candidate.notes,
+                1 if candidate.fast_track else 0,
                 candidate.created_at.isoformat(),
                 now,
             ),
@@ -295,7 +302,7 @@ class ProceduralMemory:
         cursor = await self._db.execute(
             "SELECT id, parent_skill_name, parent_version, candidate_body, "
             "mutation_strategy, diagnostic_keys, origin_session_id, status, "
-            "pareto_scores, notes, created_at, updated_at "
+            "pareto_scores, notes, fast_track, created_at, updated_at "
             "FROM skill_candidates WHERE id = ?",
             (candidate_id,),
         )
@@ -321,7 +328,7 @@ class ProceduralMemory:
         sql = (
             "SELECT id, parent_skill_name, parent_version, candidate_body, "
             "mutation_strategy, diagnostic_keys, origin_session_id, status, "
-            "pareto_scores, notes, created_at, updated_at "
+            "pareto_scores, notes, fast_track, created_at, updated_at "
             "FROM skill_candidates"
         )
         if where:
@@ -360,6 +367,19 @@ class ProceduralMemory:
         await self._db.commit()
         return cursor.rowcount > 0
 
+    async def update_maturity_tag(
+        self,
+        skill_name: str,
+        tag: str | None,
+    ) -> bool:
+        """Set or clear the maturity_tag on a SkillGenome. Returns True if updated."""
+        now = datetime.now(UTC).isoformat()
+        cursor = await self._db.execute(
+            "UPDATE skill_genomes SET maturity_tag = ?, updated_at = ? WHERE name = ?",
+            (tag, now, skill_name),
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0
 
     # ------------------------------------------------------------------
     # Skill version history (Issue #120 PR 3)
@@ -461,6 +481,7 @@ def _row_to_candidate(row: tuple) -> SkillCandidate:
         status=row[7],
         pareto_scores=json.loads(row[8]),
         notes=row[9],
-        created_at=datetime.fromisoformat(row[10]),
-        updated_at=datetime.fromisoformat(row[11]),
+        fast_track=bool(row[10]),
+        created_at=datetime.fromisoformat(row[11]),
+        updated_at=datetime.fromisoformat(row[12]),
     )

--- a/loom/core/memory/store.py
+++ b/loom/core/memory/store.py
@@ -253,6 +253,11 @@ class SQLiteStore:
                 # Issue #142 soft-delete: mark compressed entries instead of deleting
                 # them so compression losses can be audited and recovered.
                 "ALTER TABLE episodic_entries ADD COLUMN compressed_at TEXT",
+                # Issue #120 PR 4: maturity tag on skill genomes (mature / needs_improvement)
+                "ALTER TABLE skill_genomes ADD COLUMN maturity_tag TEXT",
+                # Issue #120 PR 4: fast-track flag bypasses shadow phase when Grader
+                # proves ≥20% pass-rate improvement over the previous version.
+                "ALTER TABLE skill_candidates ADD COLUMN fast_track INTEGER NOT NULL DEFAULT 0",
             ]:
                 try:
                     await db.execute(_migration)

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -564,6 +564,12 @@ class LoomSession:
         self._mutation_max_body_chars: int = int(
             _mut_cfg.get("max_body_chars", 6000)
         )
+        # PR 4: Grader-driven fast-track threshold for batch candidates.
+        # ``SkillMutator.from_batch_diagnostic`` sets candidate.fast_track=True
+        # when BatchDiagnostic.improvement >= this value.
+        self._mutation_fast_track_threshold: float = max(
+            0.0, min(1.0, float(_mut_cfg.get("fast_track_threshold", 0.20)))
+        )
         # PR 3: lifecycle routing.  These keys live under the same
         # ``[mutation]`` section — mutation produces candidates, lifecycle
         # decides what happens to them.
@@ -757,6 +763,8 @@ class LoomSession:
             make_recall_tool,
             make_skill_promote_tool,
             make_skill_rollback_tool,
+            make_generate_skill_candidate_from_batch_tool,
+            make_set_skill_maturity_tool,
             make_relate_tool,
             make_spawn_agent_tool,
             make_web_search_tool,
@@ -789,6 +797,7 @@ class LoomSession:
             quality_ceiling=self._mutation_quality_ceiling,
             min_suggestions=self._mutation_min_suggestions,
             max_body_chars=self._mutation_max_body_chars,
+            fast_track_threshold=self._mutation_fast_track_threshold,
         )
 
         # Issue #120 PR 3: lifecycle.  The promoter owns the state-machine
@@ -872,6 +881,14 @@ class LoomSession:
         # Issue #120 PR 3: promote / rollback lifecycle tools.
         self.registry.register(make_skill_promote_tool(self._skill_promoter))
         self.registry.register(make_skill_rollback_tool(self._skill_promoter))
+
+        # Issue #120 PR 4: meta-skill-engineer surface — agent-callable
+        # equivalents of the Grader → candidate-pool → maturity workflow so
+        # the skill can drive the whole cycle without dropping to Python.
+        self.registry.register(make_generate_skill_candidate_from_batch_tool(
+            self._skill_mutator, self._procedural, session_id=self.session_id,
+        ))
+        self.registry.register(make_set_skill_maturity_tool(self._procedural))
 
         # Register web tools (Phase 5D)
         self.registry.register(make_fetch_url_tool(

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -1696,6 +1696,46 @@ async def _skill_history(skill_name: str, limit: int, db: str) -> None:
         )
 
 
+@skill.command("set-maturity")
+@click.argument("skill_name")
+@click.argument("tag", required=False, default=None)
+@click.option("--clear", is_flag=True, help="Clear the maturity_tag (equivalent to tag='clear').")
+@click.option("--db", default="~/.loom/memory.db", show_default=True)
+def skill_set_maturity(
+    skill_name: str, tag: str | None, clear: bool, db: str,
+) -> None:
+    """Label a skill 'mature' / 'needs_improvement' — the meta-skill-engineer
+    termination signal.  Use --clear (or tag='clear') to unset."""
+    if clear:
+        tag = None
+    elif tag in ("clear", "none", "null", ""):
+        tag = None
+    elif tag is not None and tag not in ("mature", "needs_improvement"):
+        console.print(
+            f"[red]Invalid tag {tag!r}.[/red] Use 'mature', 'needs_improvement', or --clear."
+        )
+        return
+    asyncio.run(_skill_set_maturity(skill_name, tag, db))
+
+
+async def _skill_set_maturity(skill_name: str, tag: str | None, db: str) -> None:
+    from loom.core.memory.procedural import ProceduralMemory
+
+    store = SQLiteStore(db)
+    await store.initialize()
+    async with store.connect() as conn:
+        proc = ProceduralMemory(conn)
+        ok = await proc.update_maturity_tag(skill_name, tag)
+    if not ok:
+        console.print(f"[red]Skill {skill_name!r} not found.[/red]")
+        return
+    display = tag if tag is not None else "(cleared)"
+    console.print(
+        f"[green]Updated[/green] [bold cyan]{skill_name}[/bold cyan] "
+        f"maturity_tag → {display}"
+    )
+
+
 async def _resolve_candidate_id(proc: "ProceduralMemory", prefix: str) -> str | None:
     """Accept either a full uuid or a short prefix (≥4 chars).
 

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -1715,6 +1715,90 @@ async def _resolve_candidate_id(proc: "ProceduralMemory", prefix: str) -> str | 
 
 
 # ---------------------------------------------------------------------------
+# loom review command
+# ---------------------------------------------------------------------------
+
+
+@cli.command("review")
+@click.argument("skill_name")
+@click.option("--db", default="~/.loom/memory.db", show_default=True)
+def skill_review(skill_name: str, db: str) -> None:
+    """One-stop report: genome status, candidate pool, eval history."""
+    asyncio.run(_skill_review(skill_name, db))
+
+
+async def _skill_review(skill_name: str, db: str) -> None:
+    from loom.core.memory.procedural import ProceduralMemory
+    from loom.core.memory.semantic import SemanticMemory
+
+    store = SQLiteStore(db)
+    await store.initialize()
+    async with store.connect() as conn:
+        proc = ProceduralMemory(conn)
+        sem = SemanticMemory(conn)
+
+        genome = await proc.get(skill_name)
+        candidates = await proc.list_candidates(parent_skill_name=skill_name, limit=20)
+        history_records = await proc.list_history(skill_name, limit=5)
+        eval_entries = await sem.list_by_prefix(f"skill:{skill_name}:eval:", limit=20)
+        insight_entries = await sem.list_by_prefix(f"skill:{skill_name}:insight:", limit=5)
+
+    console.print(Rule(f"[bold cyan]{skill_name}[/bold cyan] — skill review"))
+
+    # ── Genome ──────────────────────────────────────────────────────────
+    if genome is None:
+        console.print("[red]No SkillGenome found for this skill.[/red]")
+    else:
+        maturity = (
+            f"  [bold yellow]{genome.maturity_tag}[/bold yellow]"
+            if genome.maturity_tag else ""
+        )
+        console.print(
+            f"  v{genome.version}  confidence=[cyan]{genome.confidence:.2f}[/cyan]"
+            f"  usage={genome.usage_count}{maturity}"
+        )
+
+    # ── Eval history ────────────────────────────────────────────────────
+    if eval_entries:
+        console.print(Rule("[dim]Grader eval history[/dim]", style="dim"))
+        for e in sorted(eval_entries, key=lambda x: x.key):
+            ts = e.created_at.strftime("%Y-%m-%d") if e.created_at else "?"
+            console.print(f"  [dim]{ts}[/dim]  [bold]{e.key.split(':')[-1]}[/bold]  {e.value[:120]}")
+    else:
+        console.print("[dim]  No Grader eval records yet.[/dim]")
+
+    # ── Insights ────────────────────────────────────────────────────────
+    if insight_entries:
+        console.print(Rule("[dim]Analyzer insights[/dim]", style="dim"))
+        for e in insight_entries:
+            console.print(f"  [dim]{e.key}[/dim]  {e.value[:120]}")
+
+    # ── Candidate pool ──────────────────────────────────────────────────
+    if candidates:
+        console.print(Rule("[dim]Candidate pool[/dim]", style="dim"))
+        status_color = {
+            "generated": "white", "shadow": "cyan", "promoted": "green",
+            "deprecated": "dim", "rolled_back": "yellow",
+        }
+        for c in candidates:
+            ts = c.created_at.strftime("%Y-%m-%d %H:%M")
+            col = status_color.get(c.status, "white")
+            ft = " [bold yellow]⚡fast-track[/bold yellow]" if c.fast_track else ""
+            console.print(
+                f"  [dim]{ts}[/dim]  [{col}]{c.status}[/{col}]"
+                f"  {c.id[:8]}  {c.mutation_strategy}{ft}"
+            )
+    else:
+        console.print("[dim]  No candidates in pool.[/dim]")
+
+    # ── Version history ─────────────────────────────────────────────────
+    if history_records:
+        console.print(Rule("[dim]Recent version history[/dim]", style="dim"))
+        for r in history_records:
+            ts = r.archived_at.strftime("%Y-%m-%d %H:%M")
+            console.print(f"  [dim]{ts}[/dim]  v{r.version}  [{r.reason}]")
+
+
 # loom import command
 # ---------------------------------------------------------------------------
 

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -1708,13 +1708,21 @@ def skill_set_maturity(
     termination signal.  Use --clear (or tag='clear') to unset."""
     if clear:
         tag = None
-    elif tag in ("clear", "none", "null", ""):
-        tag = None
-    elif tag is not None and tag not in ("mature", "needs_improvement"):
-        console.print(
-            f"[red]Invalid tag {tag!r}.[/red] Use 'mature', 'needs_improvement', or --clear."
-        )
-        return
+    elif tag is None:
+        pass
+    else:
+        # Same normalisation as the agent tool: case-insensitive, space/-
+        # collapsed to underscores.
+        normalised = tag.strip().lower().replace(" ", "_").replace("-", "_")
+        if normalised in ("", "clear", "none", "null"):
+            tag = None
+        elif normalised in ("mature", "needs_improvement"):
+            tag = normalised
+        else:
+            console.print(
+                f"[red]Invalid tag {tag!r}.[/red] Use 'mature', 'needs_improvement', or --clear."
+            )
+            return
     asyncio.run(_skill_set_maturity(skill_name, tag, db))
 
 
@@ -1787,16 +1795,40 @@ async def _skill_review(skill_name: str, db: str) -> None:
 
     # ── Genome ──────────────────────────────────────────────────────────
     if genome is None:
-        console.print("[red]No SkillGenome found for this skill.[/red]")
-    else:
-        maturity = (
-            f"  [bold yellow]{genome.maturity_tag}[/bold yellow]"
-            if genome.maturity_tag else ""
-        )
-        console.print(
-            f"  v{genome.version}  confidence=[cyan]{genome.confidence:.2f}[/cyan]"
-            f"  usage={genome.usage_count}{maturity}"
-        )
+        # Empty state: most of the time the skill name is a typo or the
+        # skill has been generated but never loaded.  Point the operator
+        # at the next action instead of just reporting absence.
+        console.print(f"[red]No SkillGenome found for '{skill_name}'.[/red]")
+        suggestions: list[str] = []
+        if candidates:
+            suggestions.append(
+                f"  • {len(candidates)} candidate(s) exist in the pool — "
+                f"run [cyan]loom skill candidates {skill_name}[/cyan] to inspect."
+            )
+        if eval_entries or insight_entries:
+            suggestions.append(
+                f"  • Grader / Analyzer records exist for this name — "
+                f"the genome may have been deprecated. Check [cyan]loom skill list[/cyan]."
+            )
+        if not suggestions:
+            suggestions.extend([
+                "  • Check the name with [cyan]loom skill list[/cyan] "
+                "(typos are the most common cause).",
+                "  • If this is a new skill, run the meta-skill-engineer workflow: "
+                "[cyan]loom chat[/cyan] → ask Loom to create a skill.",
+                "  • Pending candidates can still be listed via "
+                "[cyan]loom skill candidates[/cyan].",
+            ])
+        console.print("\n".join(suggestions))
+        return
+    maturity = (
+        f"  [bold yellow]{genome.maturity_tag}[/bold yellow]"
+        if genome.maturity_tag else ""
+    )
+    console.print(
+        f"  v{genome.version}  confidence=[cyan]{genome.confidence:.2f}[/cyan]"
+        f"  usage={genome.usage_count}{maturity}"
+    )
 
     # ── Eval history ────────────────────────────────────────────────────
     if eval_entries:

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -38,6 +38,7 @@ _cmd_scanner = CommandScanner()
 if TYPE_CHECKING:
     from collections.abc import Callable
     from loom.core.cognition.skill_gate import SkillGate
+    from loom.core.cognition.skill_mutator import SkillMutator
     from loom.core.cognition.skill_promoter import SkillPromoter
     from loom.core.harness.skill_checks import SkillCheckManager
     from loom.core.memory.procedural import ProceduralMemory, SkillGenome
@@ -1479,6 +1480,276 @@ def make_skill_rollback_tool(promoter: "SkillPromoter") -> ToolDefinition:
         },
         executor=_rollback,
         tags=["skill", "memory", "lifecycle"],
+        impact_scope="memory",
+    )
+
+
+# ------------------------------------------------------------------
+# Skill evolution tools (Issue #120 PR 4 — meta-skill-engineer surface)
+# ------------------------------------------------------------------
+
+
+_MATURITY_TAG_VALUES: tuple[str, ...] = ("mature", "needs_improvement")
+
+
+def make_generate_skill_candidate_from_batch_tool(
+    mutator: "SkillMutator",
+    procedural: "ProceduralMemory",
+    session_id: str | None = None,
+) -> ToolDefinition:
+    """Create a GUARDED ``generate_skill_candidate_from_batch`` tool.
+
+    Lets the meta-skill-engineer agent feed Grader batch results straight
+    into ``SkillMutator.from_batch_diagnostic`` without dropping to Python.
+    The agent supplies the aggregated fields (mutation_suggestions,
+    instructions_violated, failure_patterns) plus pass_rate /
+    previous_pass_rate; the tool assembles a synthetic ``BatchDiagnostic``
+    with one representative ``TaskDiagnostic`` carrying those lists,
+    persists the candidate, and returns its id + fast_track flag.
+    """
+    async def _generate(call: ToolCall) -> ToolResult:
+        from loom.core.cognition.task_reflector import BatchDiagnostic, TaskDiagnostic
+
+        args = call.args
+        skill_name = (args.get("skill_name") or "").strip()
+        if not skill_name:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error="'skill_name' is required",
+            )
+
+        try:
+            pass_rate = float(args.get("pass_rate"))
+        except (TypeError, ValueError):
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error="'pass_rate' must be a float in [0.0, 1.0]",
+            )
+        pass_rate = max(0.0, min(1.0, pass_rate))
+
+        prev_raw = args.get("previous_pass_rate")
+        previous_pass_rate: float | None = None
+        if prev_raw not in (None, ""):
+            try:
+                previous_pass_rate = max(0.0, min(1.0, float(prev_raw)))
+            except (TypeError, ValueError):
+                return ToolResult(
+                    call_id=call.id, tool_name=call.tool_name,
+                    success=False,
+                    error="'previous_pass_rate' must be a float in [0.0, 1.0] or null",
+                )
+
+        def _as_str_list(v: Any) -> list[str]:
+            if not isinstance(v, list):
+                return []
+            return [str(x).strip() for x in v if str(x).strip()]
+
+        suggestions = _as_str_list(args.get("mutation_suggestions"))
+        if not suggestions:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False,
+                error="'mutation_suggestions' must be a non-empty list of strings",
+            )
+        violations = _as_str_list(args.get("instructions_violated"))
+        failures = _as_str_list(args.get("failure_patterns"))
+
+        try:
+            avg_quality = float(args.get("avg_quality_score", 3.0))
+        except (TypeError, ValueError):
+            avg_quality = 3.0
+        avg_quality = max(1.0, min(5.0, avg_quality))
+
+        parent = await procedural.get(skill_name)
+        if parent is None:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error=f"Skill '{skill_name}' not found",
+            )
+
+        synthetic = TaskDiagnostic(
+            skill_name=skill_name,
+            session_id=session_id or "meta-skill-engineer",
+            turn_index=0,
+            task_type="workflow_composite",
+            task_type_confidence=1.0,
+            instructions_followed=[],
+            instructions_violated=violations,
+            failure_patterns=failures,
+            success_patterns=[],
+            mutation_suggestions=suggestions,
+            quality_score=avg_quality,
+        )
+        batch = BatchDiagnostic(
+            skill_name=skill_name,
+            diagnostics=[synthetic],
+            pass_rate=pass_rate,
+            previous_pass_rate=previous_pass_rate,
+        )
+
+        proposal = await mutator.from_batch_diagnostic(
+            parent=parent, batch=batch, session_id=session_id,
+        )
+        if proposal is None:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False,
+                error=(
+                    "Mutator produced no candidate — check that "
+                    "[mutation].enabled=true, the parent body is non-empty, "
+                    "and the LLM rewrite was plausible."
+                ),
+            )
+        await procedural.insert_candidate(proposal.candidate)
+        cand = proposal.candidate
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=True,
+            output=(
+                f"Candidate {cand.id[:8]} generated for {skill_name} "
+                f"(fast_track={cand.fast_track}, notes={cand.notes})"
+            ),
+            metadata={
+                "candidate_id": cand.id,
+                "fast_track": cand.fast_track,
+                "mutation_strategy": cand.mutation_strategy,
+                "parent_version": cand.parent_version,
+            },
+        )
+
+    return ToolDefinition(
+        name="generate_skill_candidate_from_batch",
+        description=(
+            "Generate a candidate SKILL.md revision from Grader batch results. "
+            "Used by the meta-skill-engineer skill after running a test set: "
+            "pass the aggregated mutation_suggestions / instructions_violated / "
+            "failure_patterns plus pass_rate (and optionally previous_pass_rate "
+            "to enable fast-track promotion when improvement ≥ threshold). "
+            "Returns the candidate_id and whether it was flagged for fast-track."
+        ),
+        trust_level=TrustLevel.GUARDED,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "skill_name": {
+                    "type": "string",
+                    "description": "Name of the parent skill being mutated.",
+                },
+                "pass_rate": {
+                    "type": "number",
+                    "description": "Fraction 0.0–1.0 of tests that passed in the current batch.",
+                },
+                "previous_pass_rate": {
+                    "type": "number",
+                    "description": (
+                        "Pass rate of the previous skill version on the same "
+                        "test set. Omit on first-ever run. When provided, "
+                        "improvement ≥ fast_track_threshold flags the candidate."
+                    ),
+                },
+                "mutation_suggestions": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Aggregated, deduplicated SKILL.md edit suggestions.",
+                },
+                "instructions_violated": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Aggregated SKILL.md instructions that were ignored or misapplied.",
+                },
+                "failure_patterns": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Aggregated recurring failure modes observed during the batch.",
+                },
+                "avg_quality_score": {
+                    "type": "number",
+                    "description": "Average quality score 1.0–5.0 across the batch (defaults to 3.0).",
+                },
+            },
+            "required": ["skill_name", "pass_rate", "mutation_suggestions"],
+        },
+        executor=_generate,
+        tags=["skill", "memory", "lifecycle", "meta"],
+        impact_scope="memory",
+    )
+
+
+def make_set_skill_maturity_tool(
+    procedural: "ProceduralMemory",
+) -> ToolDefinition:
+    """Create a GUARDED ``set_skill_maturity`` tool.
+
+    Wraps ``ProceduralMemory.update_maturity_tag`` so the meta-skill-engineer
+    can label a skill ``mature`` (stop running the Grader on it) or
+    ``needs_improvement`` (keep iterating) — or clear the tag. This is the
+    Stage 7 termination signal in the meta-skill-engineer workflow.
+    """
+    async def _set_maturity(call: ToolCall) -> ToolResult:
+        skill_name = (call.args.get("skill_name") or "").strip()
+        if not skill_name:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error="'skill_name' is required",
+            )
+
+        tag_raw = call.args.get("tag")
+        tag: str | None
+        if tag_raw in (None, "", "none", "null", "clear"):
+            tag = None
+        else:
+            tag = str(tag_raw).strip()
+            if tag not in _MATURITY_TAG_VALUES:
+                return ToolResult(
+                    call_id=call.id, tool_name=call.tool_name,
+                    success=False,
+                    error=(
+                        f"'tag' must be one of {_MATURITY_TAG_VALUES} "
+                        f"or null/'clear' to unset; got {tag_raw!r}"
+                    ),
+                )
+
+        ok = await procedural.update_maturity_tag(skill_name, tag)
+        if not ok:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error=f"Skill '{skill_name}' not found",
+            )
+        display = tag if tag is not None else "(cleared)"
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=True,
+            output=f"Skill '{skill_name}' maturity_tag set to {display}",
+            metadata={"skill_name": skill_name, "maturity_tag": tag},
+        )
+
+    return ToolDefinition(
+        name="set_skill_maturity",
+        description=(
+            "Label a skill's maturity to drive meta-skill-engineer termination. "
+            "Tag 'mature' → skill graduates, Grader stops; 'needs_improvement' → "
+            "keep iterating; null / 'clear' → unset the tag."
+        ),
+        trust_level=TrustLevel.GUARDED,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "skill_name": {
+                    "type": "string",
+                    "description": "Name of the skill to tag.",
+                },
+                "tag": {
+                    "type": "string",
+                    "description": (
+                        "One of 'mature', 'needs_improvement', or 'clear'/null "
+                        "to remove the tag."
+                    ),
+                },
+            },
+            "required": ["skill_name"],
+        },
+        executor=_set_maturity,
+        tags=["skill", "memory", "lifecycle", "meta"],
         impact_scope="memory",
     )
 

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -1695,11 +1695,19 @@ def make_set_skill_maturity_tool(
 
         tag_raw = call.args.get("tag")
         tag: str | None
-        if tag_raw in (None, "", "none", "null", "clear"):
+        # Normalise before validation so common typos (e.g. "Mature",
+        # "NEEDS_IMPROVEMENT", or Python-style "Needs Improvement") don't
+        # write dirty values into the DB. Anything else falls through to
+        # the validation error below.
+        if tag_raw is None:
             tag = None
         else:
-            tag = str(tag_raw).strip()
-            if tag not in _MATURITY_TAG_VALUES:
+            normalised = str(tag_raw).strip().lower().replace(" ", "_").replace("-", "_")
+            if normalised in ("", "none", "null", "clear"):
+                tag = None
+            elif normalised in _MATURITY_TAG_VALUES:
+                tag = normalised
+            else:
                 return ToolResult(
                     call_id=call.id, tool_name=call.tool_name,
                     success=False,

--- a/skills/meta-skill-engineer/SKILL.md
+++ b/skills/meta-skill-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: meta-skill-engineer
-description: "元技能工程師：系統化建立、評估、迭代改進 Loom 技能的技能。當使用者要求「建立一個新技能」、「改善現有技能」、「評估技能表現」、「跑技能對比測試」、「系統化迭代技能」時使用。本技能為 Skill Genome 提供評估閉環——Grader 產生 BatchDiagnostic，由 SkillMutator.from_batch_diagnostic() 轉化為候選版本，進入 shadow → promote 生命週期，形成測試→記憶→演化的完整循環。"
+description: "元技能工程師：系統化建立、評估、迭代改進 Loom 技能的技能。當使用者要求「建立一個新技能」、「改善現有技能」、「評估技能表現」、「跑技能對比測試」、「系統化迭代技能」時使用。本技能為 Skill Genome 提供評估閉環——Grader 產生 BatchDiagnostic，透過 `generate_skill_candidate_from_batch` 工具轉化為候選版本，進入 shadow → promote 生命週期，形成測試→記憶→演化的完整循環。"
 precondition_checks:
   - ref: checks.require_skills_dir_target
     applies_to: [write_file]
@@ -438,18 +438,29 @@ context: {output_a_path, output_b_path, eval_prompt, expectations}
 
 **目標：把 BatchDiagnostic 轉化為演化動力，走候選池生命週期**
 
-### 候選生成
+### 候選生成（agent 工具）
 
-呼叫 `SkillMutator.from_batch_diagnostic(parent, batch)`：
-- 以 Grader 產出的 `BatchDiagnostic`（含所有 `TaskDiagnostic` + `pass_rate`）為輸入
-- LLM 根據 `aggregated_suggestions` 重寫 SKILL.md，產出 `SkillCandidate`
-- **不直接修改 SKILL.md**——候選進入 `skill_candidates` 表，等候生命週期決策
+使用 `generate_skill_candidate_from_batch` 工具，把 Grader 匯聚的結果直接餵給 `SkillMutator`：
+
+```
+generate_skill_candidate_from_batch(
+  skill_name = "<parent>",
+  pass_rate = 0.85,
+  previous_pass_rate = 0.60,   # optional — 有舊版才填
+  mutation_suggestions = [...], # 每個 TaskDiagnostic 的建議去重彙整
+  instructions_violated = [...],# 同上
+  failure_patterns = [...],     # 同上
+  avg_quality_score = 3.8,      # 可選，預設 3.0
+)
+```
+
+工具回傳 `candidate_id` 與 `fast_track` 標記，候選進入 `skill_candidates` 表，**不直接修改 SKILL.md**——生命週期決策交給 `promote_skill_candidate` / `rollback_skill`。
 
 ### Fast-track 規則
 
 | 情境 | 候選標記 | 下一步 |
 |------|---------|--------|
-| `batch.improvement ≥ 20%`（新版 vs 舊版 pass rate） | `fast_track=True` | 直接 `loom skill promote`，跳過 shadow 階段 |
+| `batch.improvement ≥ fast_track_threshold`（預設 20%，可在 `[mutation].fast_track_threshold` 調整） | `fast_track=True` | 直接 `promote_skill_candidate` 或 `loom skill promote`，跳過 shadow 階段 |
 | 其他情況 | `fast_track=False` | 進入 shadow 模式，積累 N-wins 後 promote |
 
 Fast-track 的前提是必須有 `previous_pass_rate`（有舊版比較基線）。
@@ -460,11 +471,13 @@ Stage 7 **不再**手動調整 confidence。批次 diagnostic 的 `avg_quality_s
 
 ### Maturity Tag
 
-| 條件 | 動作 |
-|------|------|
-| 連續 3 輪 pass rate ≥ 90% | `loom skill set-maturity {name} mature` |
-| pass rate < 30% 且輪次 ≥ 5 | `loom skill set-maturity {name} needs_improvement` |
-| 清除標記 | `loom skill set-maturity {name} --clear` |
+Agent 內用 `set_skill_maturity` 工具（推薦）；CLI 用 `loom skill set-maturity`：
+
+| 條件 | Agent 工具 | CLI 等價指令 |
+|------|-----------|-------------|
+| 連續 3 輪 pass rate ≥ 90% | `set_skill_maturity(skill_name, tag="mature")` | `loom skill set-maturity {name} mature` |
+| pass rate < 30% 且輪次 ≥ 5 | `set_skill_maturity(skill_name, tag="needs_improvement")` | `loom skill set-maturity {name} needs_improvement` |
+| 清除標記 | `set_skill_maturity(skill_name, tag="clear")` | `loom skill set-maturity {name} --clear` |
 
 Maturity tag 儲存在 `SkillGenome.maturity_tag`，可在 `loom review` 中查看。
 

--- a/skills/meta-skill-engineer/SKILL.md
+++ b/skills/meta-skill-engineer/SKILL.md
@@ -35,7 +35,7 @@ precondition_checks:
   ↓
 階段 5：Comparator 對比（有舊版才做）
   ↓
-階段 6：Analyzer 因果分析
+階段 6：Analyzer 因果分析（Comparator 判定非 TIE 時啟動）
   ↓
 階段 7：SkillGenome 寫入 → 重寫 → 迭代
 ```
@@ -274,16 +274,41 @@ load_skill("my-skill")
 
 使用 Grader Agent 對每個測試案例進行評估，每個測試案例產出一個 `TaskDiagnostic`，全部完成後匯聚成一個 `BatchDiagnostic`。
 
+### 目錄約定（Grader 的檔案入口）
+
+在 Grader 開跑前，階段 3 的測試執行必須把產出寫到**可預測的路徑**，否則 Grader 無從評估：
+
+```
+skills/<skill-name>/
+├── tests/
+│   ├── test-1.md                         # 測試定義（Prompt + Expectations）
+│   ├── test-2.md
+│   └── ...
+└── runs/
+    └── r<N>/                             # 第 N 輪評估
+        ├── test-1/
+        │   ├── transcript.jsonl          # 完整對話記錄
+        │   └── output/                   # 技能產出的檔案（若有）
+        │       └── ...
+        ├── test-2/
+        │   └── ...
+        └── grader_report.md              # Grader 填這份
+```
+
+**配對規則**：`test-{N}.md` 定義 ↔ `runs/r<N>/test-{N}/` 產出。檔名編號一一對應是硬約定，Grader 就能靠 `list_dir("skills/<skill>/tests/")` 枚舉定義、再拼湊 `runs/r<N>/test-{M}/` 找到對應輸出。
+
 ### Grader 評估流程
 
-1. **讀取 Transcript**：測試執行後的完整對話記錄
-2. **檢視 Output**：技能產出的實際檔案/文字
-3. **逐一評估 Expectation**：
+1. **列出測試集**：`list_dir("skills/<skill-name>/tests/")` → 取得所有 `test-{N}.md`
+2. **逐一讀入**：`read_file("skills/<skill-name>/tests/test-{N}.md")` → 解析 Prompt 與 Expectations
+3. **讀取該 test 的 Transcript**：`read_file("skills/<skill-name>/runs/r<N>/test-{N}/transcript.jsonl")`
+4. **檢視該 test 的 Output**：`list_dir("skills/<skill-name>/runs/r<N>/test-{N}/output/")` → `read_file` 各產出檔
+5. **逐一評估 Expectation**：
    - **PASS**：有明確證據，且反映真正的任務完成，而非表面合規
    - **FAIL**：無證據，或證據與預期矛盾
    - **WEAK PASS**：正確的檔案名但內容空/錯（假精確）
-4. **同時 critique 測試本身**：指出哪個 expectation 太弱或哪個重要結果沒被檢查
-5. **每個測試案例 → 一個 `TaskDiagnostic`**，`mutation_suggestions` 填入具體改進方向
+6. **同時 critique 測試本身**：指出哪個 expectation 太弱或哪個重要結果沒被檢查
+7. **每個測試案例 → 一個 `TaskDiagnostic`**，`mutation_suggestions` 填入具體改進方向
 
 ### Grader 輸出格式
 
@@ -319,13 +344,17 @@ Grader 完成後產出：
 
 ### Grader 呼叫方式
 
-使用 `spawn_agent` 來執行 Grader sub-agent：
+使用 `spawn_agent` 來執行 Grader sub-agent。**注意：所有 agent prompt 檔案都位於本技能目錄下的 `agents/`，不是呼叫方的 workspace**：
 
 ```
-task: [Grader agent prompt from agents/grader.md]
+# 路徑：<loom_repo>/skills/meta-skill-engineer/agents/grader.md
+# 用 read_file 載入整個檔案內容作為 task prompt
+task: <讀入 skills/meta-skill-engineer/agents/grader.md 的完整內容>
 tools: ['read_file', 'list_dir', 'run_bash']
 context: {skill_name, test_case, transcript_path, output_dir}
 ```
+
+> **路徑排查小抄**：若找不到 `agents/grader.md`，先用 `list_dir` 確認 `skills/meta-skill-engineer/` 存在，再列出其下的 `agents/`。這個路徑永遠是 **repo 根目錄相對**，不會出現在使用者 workspace 中。
 
 ---
 
@@ -383,7 +412,8 @@ context: {skill_name, test_case, transcript_path, output_dir}
 ### Comparator 呼叫方式
 
 ```
-task: [Comparator agent prompt from agents/comparator.md]
+# 路徑：<loom_repo>/skills/meta-skill-engineer/agents/comparator.md
+task: <讀入 skills/meta-skill-engineer/agents/comparator.md 的完整內容>
 tools: ['read_file', 'list_dir']
 context: {output_a_path, output_b_path, eval_prompt, expectations}
 ```
@@ -393,6 +423,30 @@ context: {output_a_path, output_b_path, eval_prompt, expectations}
 ## 階段 6：Analyzer 因果分析
 
 **目標：理解「為什麼」並產出具體改進建議**
+
+### 觸發條件
+
+- **Comparator 判定 A 或 B 勝出** → 啟動 Analyzer
+- **Comparator 判定 TIE** → 跳過 Analyzer，直接走階段 7（可用 Grader 的 `mutation_suggestions` 當作改進方向）
+- **完全沒做階段 5**（首次建立技能、沒有舊版可比對）→ 跳過 Analyzer，改進建議由 Grader 階段 4 的 `mutation_suggestions` 提供
+
+### 呼叫方式
+
+Analyzer 建議用**新的 `spawn_agent` session** 執行，原因是 Comparator 在 blind 模式下不知道誰是 A/B，而 Analyzer 必須揭盲——放在同一 session 會把 blind 污染掉。
+
+```
+# 路徑：<loom_repo>/skills/meta-skill-engineer/agents/analyzer.md
+task: <讀入 skills/meta-skill-engineer/agents/analyzer.md 的完整內容>
+tools: ['read_file', 'list_dir']
+context: {
+  winner: "A" | "B",                    # 揭盲後的勝出方
+  skill_a_path: "...",                  # 兩個版本的 SKILL.md 路徑
+  skill_b_path: "...",
+  transcript_a_path: "...",             # 兩個版本的執行 transcript
+  transcript_b_path: "...",
+  comparator_report_path: "..."         # 階段 5 產出的報告
+}
+```
 
 ### Analyzer 流程
 

--- a/skills/meta-skill-engineer/SKILL.md
+++ b/skills/meta-skill-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: meta-skill-engineer
-description: "元技能工程師：系統化建立、評估、迭代改進 Loom 技能的技能。當使用者要求「建立一個新技能」、「改善現有技能」、「評估技能表現」、「跑技能對比測試」、「系統化迭代技能」時使用。本技能為 Skill Genome 提供評估閉環——Grader 的 pass/fail 分數直接寫入 SkillGenome.confidence，形成測試→記憶→演化的完整循環。"
+description: "元技能工程師：系統化建立、評估、迭代改進 Loom 技能的技能。當使用者要求「建立一個新技能」、「改善現有技能」、「評估技能表現」、「跑技能對比測試」、「系統化迭代技能」時使用。本技能為 Skill Genome 提供評估閉環——Grader 產生 BatchDiagnostic，由 SkillMutator.from_batch_diagnostic() 轉化為候選版本，進入 shadow → promote 生命週期，形成測試→記憶→演化的完整循環。"
 precondition_checks:
   - ref: checks.require_skills_dir_target
     applies_to: [write_file]
@@ -270,9 +270,9 @@ load_skill("my-skill")
 
 ## 階段 4：Grader 評估
 
-**目標：客觀測量技能表現**
+**目標：客觀測量技能表現，產出 `BatchDiagnostic`**
 
-使用 Grader Agent 對每個測試案例進行評估。
+使用 Grader Agent 對每個測試案例進行評估，每個測試案例產出一個 `TaskDiagnostic`，全部完成後匯聚成一個 `BatchDiagnostic`。
 
 ### Grader 評估流程
 
@@ -283,6 +283,7 @@ load_skill("my-skill")
    - **FAIL**：無證據，或證據與預期矛盾
    - **WEAK PASS**：正確的檔案名但內容空/錯（假精確）
 4. **同時 critique 測試本身**：指出哪個 expectation 太弱或哪個重要結果沒被檢查
+5. **每個測試案例 → 一個 `TaskDiagnostic`**，`mutation_suggestions` 填入具體改進方向
 
 ### Grader 輸出格式
 
@@ -308,11 +309,12 @@ load_skill("my-skill")
 | Weak Passes | {N} |
 | Expectation Quality Issues | {M} |
 
-## SkillGenome 寫入
+## 結構化輸出（BatchDiagnostic）
 
-- `memorize("skill:{name}:eval:r{N}", "pass_rate={Z}%, {X}/{Y} passed. [關鍵觀察]")`
-- `relate("skill:{name}", "evaluated_at", "r{N}")`
-- `relate("skill:{name}", "pass_rate", "{Z}")`
+Grader 完成後產出：
+- **per-test `TaskDiagnostic`**：每個測試案例一個，`mutation_suggestions` 填具體 SKILL.md 改動
+- **`BatchDiagnostic`**：包含所有 `TaskDiagnostic` + 整體 `pass_rate`
+- **SemanticMemory 寫入**：`memorize("skill:{name}:eval:r{N}", "pass_rate={Z}%, {X}/{Y} passed. [關鍵觀察]")`
 ```
 
 ### Grader 呼叫方式
@@ -373,9 +375,9 @@ context: {skill_name, test_case, transcript_path, output_dir}
 ## 理由
 [A/B 取勝的具體原因]
 
-## SkillGenome 寫入
-- 如果 B 勝出：`memorize("skill:{name}:compare:v{N}vsv{M}", "v{M} 勝出。理由：{摘要}")`
-- `relate("skill:{name}", "compared_versions", "v{N}v{M}")`
+## 結構化輸出
+- Blind A/B 結果寫入 `SkillCandidate.pareto_scores`（key = task_type，value = 分數差值）
+- `memorize("skill:{name}:compare:v{N}vsv{M}", "v{M} 勝出。理由：{摘要}")`
 ```
 
 ### Comparator 呼叫方式
@@ -425,40 +427,55 @@ context: {output_a_path, output_b_path, eval_prompt, expectations}
 - **問題**：{描述}
 - **修復方向**：{具體指示}
 
-## SkillGenome 寫入
+## 結構化輸出
+- 具體改進建議直接填入每個 `TaskDiagnostic.mutation_suggestions`（這正是 Analyzer 存在的意義）
 - `memorize("skill:{name}:insight:r{N}", "{Insight 內容}")`
-- `relate("skill:{name}", "learned_from", "v{M}→v{N}")`
 ```
 
 ---
 
-## 階段 7：SkillGenome 寫入 + 重寫
+## 階段 7：SkillMutator 候選生成 + 生命週期
 
-**目標：把評估結果轉化為演化的動力**
+**目標：把 BatchDiagnostic 轉化為演化動力，走候選池生命週期**
 
-### SkillGenome 更新規則
+### 候選生成
 
-| 情境 | 更新動作 |
-|------|---------|
-| Grader pass rate ≥ 80% | confidence += 0.05（上限 1.0） |
-| Grader pass rate < 50% | confidence -= 0.1 |
-| Comparator 新版勝出 | version += 1，confidence 不變 |
-| 連續 3 次 pass rate ≥ 90% | 標記為 `mature` |
-| pass rate < 30% 且 n ≥ 5 | 標記為 `needs_improvement` |
+呼叫 `SkillMutator.from_batch_diagnostic(parent, batch)`：
+- 以 Grader 產出的 `BatchDiagnostic`（含所有 `TaskDiagnostic` + `pass_rate`）為輸入
+- LLM 根據 `aggregated_suggestions` 重寫 SKILL.md，產出 `SkillCandidate`
+- **不直接修改 SKILL.md**——候選進入 `skill_candidates` 表，等候生命週期決策
 
-### 重寫觸發條件
+### Fast-track 規則
 
-當以下任一條件成立時，觸發 SKILL.md 重寫：
-- pass rate < 70%
-- Analyzer 發現系統性缺陷
-- 使用者明確要求改善
+| 情境 | 候選標記 | 下一步 |
+|------|---------|--------|
+| `batch.improvement ≥ 20%`（新版 vs 舊版 pass rate） | `fast_track=True` | 直接 `loom skill promote`，跳過 shadow 階段 |
+| 其他情況 | `fast_track=False` | 進入 shadow 模式，積累 N-wins 後 promote |
 
-### 重寫流程
+Fast-track 的前提是必須有 `previous_pass_rate`（有舊版比較基線）。
 
-1. 根據 Analyzer 的具體改進建議修改 SKILL.md
-2. 保持 description / name / 核心原則不變
-3. 只修改「工作流程」和「紀律提醒」部分
-4. 重跑測試集，驗證改善效果
+### Confidence 統一由 EMA 驅動
+
+Stage 7 **不再**手動調整 confidence。批次 diagnostic 的 `avg_quality_score` 會在後續 turns 的 `TaskReflector` EMA 路徑中自然累積。
+
+### Maturity Tag
+
+| 條件 | 動作 |
+|------|------|
+| 連續 3 輪 pass rate ≥ 90% | `loom skill set-maturity {name} mature` |
+| pass rate < 30% 且輪次 ≥ 5 | `loom skill set-maturity {name} needs_improvement` |
+| 清除標記 | `loom skill set-maturity {name} --clear` |
+
+Maturity tag 儲存在 `SkillGenome.maturity_tag`，可在 `loom review` 中查看。
+
+### 重跑驗證
+
+候選 promote 後，重跑測試集確認改善效果。若新版 pass rate 低於舊版，執行 rollback：
+
+```bash
+loom skill rollback {name}
+loom review {name}   # 確認版本已回退
+```
 
 ---
 
@@ -502,18 +519,16 @@ Loom（使用本技能）：
 
 ## loom review 指令
 
-使用 `loom_review.py` 或直接查詢 semantic memory：
-
 ```bash
 loom review {skill-name}
 ```
 
-輸出：
-- 所有測試輪次的 pass rate
-- 最近的 Grader 報告摘要
-- SkillGenome 當前 confidence 和 version
-- 已知缺口（has_known_gap）
-- 與其他技能的應用次數對比
+一站式查看技能全貌：
+- **SkillGenome 狀態**：version、confidence、maturity_tag、usage_count
+- **Grader eval 歷史**：所有 `skill:{name}:eval:r*` 記錄（pass rate 時間線）
+- **Analyzer insights**：`skill:{name}:insight:*` 記錄
+- **候選池**：所有候選的狀態、fast_track 標記、mutation_strategy
+- **版本歷史**：最近的 promote / rollback 記錄
 
 ---
 
@@ -532,6 +547,6 @@ loom review {skill-name}
 - **不跳階段**：「先給我用再說」是不可接受的——沒有測試就沒有進化
 - **Comparator 永遠不能知道誰是 A/B** — 揭盲之前的偏見是最難發現的
 - **Grader 要批判測試本身** — 通過了弱 assertion 比失敗更危險
-- **每次 Grader 後必須寫 SkillGenome** — 否則數據就散了，閉環就斷了
+- **每次 Grader 後必須產出 BatchDiagnostic 並寫 SemanticMemory** — 否則數據就散了，閉環就斷了
 - **用 `run_bash` 的技能必須有 checks** — SKILL.md 的文字紀律是給 LLM 看的，precondition_checks 是給框架執行的；兩者缺一不可
 - **checks 不可有副作用** — 純判斷、純回傳 bool，不寫檔、不改狀態、不發請求

--- a/tests/test_batch_diagnostic.py
+++ b/tests/test_batch_diagnostic.py
@@ -5,7 +5,6 @@ from datetime import datetime, UTC
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-import pytest_asyncio
 
 from loom.core.cognition.task_reflector import BatchDiagnostic, TaskDiagnostic
 from loom.core.memory.procedural import SkillCandidate, SkillGenome
@@ -20,6 +19,8 @@ def _make_diagnostic(
     skill_name: str = "test-skill",
     quality_score: float = 2.5,
     suggestions: list[str] | None = None,
+    violations: list[str] | None = None,
+    failures: list[str] | None = None,
 ) -> TaskDiagnostic:
     return TaskDiagnostic(
         skill_name=skill_name,
@@ -28,8 +29,8 @@ def _make_diagnostic(
         task_type="general",
         task_type_confidence=0.9,
         instructions_followed=["step A"],
-        instructions_violated=[],
-        failure_patterns=["skipped step B"],
+        instructions_violated=[] if violations is None else violations,
+        failure_patterns=["skipped step B"] if failures is None else failures,
         success_patterns=[],
         mutation_suggestions=["add step B after step A"] if suggestions is None else suggestions,
         quality_score=quality_score,
@@ -91,6 +92,31 @@ class TestBatchDiagnostic:
         batch = BatchDiagnostic(skill_name="s", diagnostics=[d1, d2], pass_rate=0.5)
         suggestions = batch.aggregated_suggestions
         assert suggestions == ["fix A", "fix B", "fix C"]
+
+    def test_aggregated_violations_deduplicated(self):
+        d1 = _make_diagnostic(violations=["skipped check 1", "skipped check 2"])
+        d2 = _make_diagnostic(violations=["skipped check 2", "skipped check 3"])
+        batch = BatchDiagnostic(skill_name="s", diagnostics=[d1, d2], pass_rate=0.5)
+        assert batch.aggregated_violations == [
+            "skipped check 1",
+            "skipped check 2",
+            "skipped check 3",
+        ]
+
+    def test_aggregated_failures_deduplicated(self):
+        d1 = _make_diagnostic(failures=["infinite loop", "bad cast"])
+        d2 = _make_diagnostic(failures=["bad cast", "silent swallow"])
+        batch = BatchDiagnostic(skill_name="s", diagnostics=[d1, d2], pass_rate=0.5)
+        assert batch.aggregated_failures == [
+            "infinite loop",
+            "bad cast",
+            "silent swallow",
+        ]
+
+    def test_aggregated_violations_empty_when_no_diagnostics(self):
+        batch = BatchDiagnostic(skill_name="s", diagnostics=[], pass_rate=0.0)
+        assert batch.aggregated_violations == []
+        assert batch.aggregated_failures == []
 
     def test_one_line_summary_with_improvement(self):
         batch = BatchDiagnostic(
@@ -231,12 +257,80 @@ class TestFromBatchDiagnostic:
         result = await mutator.from_batch_diagnostic(_make_genome(), batch)
         assert result is None
 
+    async def test_aggregated_violations_and_failures_appear_in_prompt(self):
+        """The batch rewrite prompt should receive violations/failures, not empty lists."""
+        from loom.core.cognition.skill_mutator import SkillMutator
+
+        router = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = _LLM_BODY
+        router.chat = AsyncMock(return_value=mock_response)
+        mutator = SkillMutator(router=router, model="test-model", enabled=True)
+
+        d1 = _make_diagnostic(violations=["ignored rule 1"], failures=["loop"])
+        d2 = _make_diagnostic(violations=["ignored rule 2"], failures=["loop", "bad cast"])
+        batch = BatchDiagnostic(
+            skill_name="test-skill", diagnostics=[d1, d2], pass_rate=0.5,
+        )
+        result = await mutator.from_batch_diagnostic(_make_genome(), batch)
+        assert result is not None
+
+        call_args = router.chat.await_args
+        prompt = call_args.kwargs["messages"][0]["content"]
+        assert "ignored rule 1" in prompt
+        assert "ignored rule 2" in prompt
+        assert "bad cast" in prompt
+        assert "loop" in prompt
+
+    async def test_fast_track_threshold_configurable(self):
+        """fast_track should respect a custom threshold passed to the constructor."""
+        from loom.core.cognition.skill_mutator import SkillMutator
+
+        router = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = _LLM_BODY
+        router.chat = AsyncMock(return_value=mock_response)
+        mutator = SkillMutator(
+            router=router, model="test-model", enabled=True,
+            fast_track_threshold=0.05,  # very lenient
+        )
+        batch = BatchDiagnostic(
+            skill_name="test-skill",
+            diagnostics=[_make_diagnostic()],
+            pass_rate=0.75,
+            previous_pass_rate=0.65,  # improvement = 0.10 ≥ 0.05
+        )
+        result = await mutator.from_batch_diagnostic(_make_genome(), batch)
+        assert result is not None
+        assert result.candidate.fast_track is True
+
+    async def test_fast_track_threshold_strict_rejects_small_improvement(self):
+        from loom.core.cognition.skill_mutator import SkillMutator
+
+        router = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = _LLM_BODY
+        router.chat = AsyncMock(return_value=mock_response)
+        mutator = SkillMutator(
+            router=router, model="test-model", enabled=True,
+            fast_track_threshold=0.50,  # very strict
+        )
+        batch = BatchDiagnostic(
+            skill_name="test-skill",
+            diagnostics=[_make_diagnostic()],
+            pass_rate=0.75,
+            previous_pass_rate=0.50,  # improvement = 0.25 < 0.50
+        )
+        result = await mutator.from_batch_diagnostic(_make_genome(), batch)
+        assert result is not None
+        assert result.candidate.fast_track is False
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def db_conn(tmp_path):
     store = SQLiteStore(str(tmp_path / "test.db"))
     await store.initialize()
@@ -324,3 +418,157 @@ class TestSchemaExtensions:
         fetched = await proc.get_candidate(candidate.id)
         assert fetched is not None
         assert fetched.fast_track is False
+
+
+# ---------------------------------------------------------------------------
+# Agent tools: generate_skill_candidate_from_batch + set_skill_maturity
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_call(tool_name: str, args: dict):
+    from loom.core.harness.middleware import ToolCall
+    from loom.core.harness.permissions import TrustLevel
+
+    return ToolCall(
+        id=f"call-{tool_name}",
+        tool_name=tool_name,
+        args=args,
+        trust_level=TrustLevel.GUARDED,
+        session_id="test-sess",
+    )
+
+
+class TestGenerateSkillCandidateFromBatchTool:
+    async def _make_env(self, db_conn, enabled: bool = True):
+        from loom.core.cognition.skill_mutator import SkillMutator
+        from loom.core.memory.procedural import ProceduralMemory
+        from loom.platform.cli.tools import make_generate_skill_candidate_from_batch_tool
+
+        proc = ProceduralMemory(db_conn)
+        parent = SkillGenome(name="batch-skill", body=_GENOME_BODY)
+        await proc.upsert(parent)
+
+        router = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = _LLM_BODY
+        router.chat = AsyncMock(return_value=mock_response)
+        mutator = SkillMutator(router=router, model="test-model", enabled=enabled)
+
+        tool = make_generate_skill_candidate_from_batch_tool(
+            mutator, proc, session_id="test-sess",
+        )
+        return proc, mutator, tool
+
+    async def test_generates_and_persists_candidate(self, db_conn):
+        proc, _, tool = await self._make_env(db_conn)
+        call = _make_tool_call("generate_skill_candidate_from_batch", {
+            "skill_name": "batch-skill",
+            "pass_rate": 0.9,
+            "previous_pass_rate": 0.6,
+            "mutation_suggestions": ["add verification step"],
+            "instructions_violated": ["skipped audit"],
+            "failure_patterns": ["silent swallow"],
+        })
+        result = await tool.executor(call)
+        assert result.success is True
+        candidate_id = result.metadata["candidate_id"]
+        assert result.metadata["fast_track"] is True
+        assert result.metadata["mutation_strategy"] == "batch_meta_skill_engineer"
+
+        fetched = await proc.get_candidate(candidate_id)
+        assert fetched is not None
+        assert fetched.parent_skill_name == "batch-skill"
+        assert fetched.fast_track is True
+
+    async def test_missing_skill_name_fails(self, db_conn):
+        _, _, tool = await self._make_env(db_conn)
+        call = _make_tool_call("generate_skill_candidate_from_batch", {
+            "pass_rate": 0.5,
+            "mutation_suggestions": ["x"],
+        })
+        result = await tool.executor(call)
+        assert result.success is False
+        assert "skill_name" in result.error
+
+    async def test_unknown_skill_fails(self, db_conn):
+        _, _, tool = await self._make_env(db_conn)
+        call = _make_tool_call("generate_skill_candidate_from_batch", {
+            "skill_name": "does-not-exist",
+            "pass_rate": 0.5,
+            "mutation_suggestions": ["x"],
+        })
+        result = await tool.executor(call)
+        assert result.success is False
+        assert "not found" in result.error
+
+    async def test_empty_suggestions_fails(self, db_conn):
+        _, _, tool = await self._make_env(db_conn)
+        call = _make_tool_call("generate_skill_candidate_from_batch", {
+            "skill_name": "batch-skill",
+            "pass_rate": 0.5,
+            "mutation_suggestions": [],
+        })
+        result = await tool.executor(call)
+        assert result.success is False
+        assert "mutation_suggestions" in result.error
+
+    async def test_mutator_disabled_returns_error(self, db_conn):
+        _, _, tool = await self._make_env(db_conn, enabled=False)
+        call = _make_tool_call("generate_skill_candidate_from_batch", {
+            "skill_name": "batch-skill",
+            "pass_rate": 0.5,
+            "mutation_suggestions": ["x"],
+        })
+        result = await tool.executor(call)
+        assert result.success is False
+        assert "no candidate" in result.error.lower()
+
+
+class TestSetSkillMaturityTool:
+    async def _make_env(self, db_conn):
+        from loom.core.memory.procedural import ProceduralMemory
+        from loom.platform.cli.tools import make_set_skill_maturity_tool
+
+        proc = ProceduralMemory(db_conn)
+        await proc.upsert(SkillGenome(name="mature-skill", body="# x"))
+        return proc, make_set_skill_maturity_tool(proc)
+
+    async def test_sets_mature_tag(self, db_conn):
+        proc, tool = await self._make_env(db_conn)
+        call = _make_tool_call("set_skill_maturity", {
+            "skill_name": "mature-skill", "tag": "mature",
+        })
+        result = await tool.executor(call)
+        assert result.success is True
+        fetched = await proc.get("mature-skill")
+        assert fetched.maturity_tag == "mature"
+
+    async def test_clears_tag_when_tag_is_clear(self, db_conn):
+        proc, tool = await self._make_env(db_conn)
+        await proc.update_maturity_tag("mature-skill", "mature")
+
+        call = _make_tool_call("set_skill_maturity", {
+            "skill_name": "mature-skill", "tag": "clear",
+        })
+        result = await tool.executor(call)
+        assert result.success is True
+        fetched = await proc.get("mature-skill")
+        assert fetched.maturity_tag is None
+
+    async def test_rejects_unknown_tag(self, db_conn):
+        _, tool = await self._make_env(db_conn)
+        call = _make_tool_call("set_skill_maturity", {
+            "skill_name": "mature-skill", "tag": "bogus",
+        })
+        result = await tool.executor(call)
+        assert result.success is False
+        assert "mature" in result.error
+
+    async def test_unknown_skill_fails(self, db_conn):
+        _, tool = await self._make_env(db_conn)
+        call = _make_tool_call("set_skill_maturity", {
+            "skill_name": "does-not-exist", "tag": "mature",
+        })
+        result = await tool.executor(call)
+        assert result.success is False
+        assert "not found" in result.error

--- a/tests/test_batch_diagnostic.py
+++ b/tests/test_batch_diagnostic.py
@@ -572,3 +572,34 @@ class TestSetSkillMaturityTool:
         result = await tool.executor(call)
         assert result.success is False
         assert "not found" in result.error
+
+    async def test_normalises_uppercase_tag(self, db_conn):
+        """Case-insensitive: 'Mature' should be accepted, not silently written."""
+        proc, tool = await self._make_env(db_conn)
+        call = _make_tool_call("set_skill_maturity", {
+            "skill_name": "mature-skill", "tag": "Mature",
+        })
+        result = await tool.executor(call)
+        assert result.success is True
+        fetched = await proc.get("mature-skill")
+        assert fetched.maturity_tag == "mature"
+
+    async def test_normalises_spaces_and_hyphens(self, db_conn):
+        """'Needs Improvement' and 'needs-improvement' should both normalise."""
+        proc, tool = await self._make_env(db_conn)
+        call = _make_tool_call("set_skill_maturity", {
+            "skill_name": "mature-skill", "tag": "Needs Improvement",
+        })
+        result = await tool.executor(call)
+        assert result.success is True
+        fetched = await proc.get("mature-skill")
+        assert fetched.maturity_tag == "needs_improvement"
+
+    async def test_typo_still_rejected(self, db_conn):
+        """'matured' (with trailing d) must NOT pass normalisation."""
+        _, tool = await self._make_env(db_conn)
+        call = _make_tool_call("set_skill_maturity", {
+            "skill_name": "mature-skill", "tag": "matured",
+        })
+        result = await tool.executor(call)
+        assert result.success is False

--- a/tests/test_batch_diagnostic.py
+++ b/tests/test_batch_diagnostic.py
@@ -1,0 +1,326 @@
+"""Tests for BatchDiagnostic and SkillMutator.from_batch_diagnostic (Issue #120 PR 4)."""
+from __future__ import annotations
+
+from datetime import datetime, UTC
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+
+from loom.core.cognition.task_reflector import BatchDiagnostic, TaskDiagnostic
+from loom.core.memory.procedural import SkillCandidate, SkillGenome
+from loom.core.memory.store import SQLiteStore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_diagnostic(
+    skill_name: str = "test-skill",
+    quality_score: float = 2.5,
+    suggestions: list[str] | None = None,
+) -> TaskDiagnostic:
+    return TaskDiagnostic(
+        skill_name=skill_name,
+        session_id="sess-1",
+        turn_index=1,
+        task_type="general",
+        task_type_confidence=0.9,
+        instructions_followed=["step A"],
+        instructions_violated=[],
+        failure_patterns=["skipped step B"],
+        success_patterns=[],
+        mutation_suggestions=["add step B after step A"] if suggestions is None else suggestions,
+        quality_score=quality_score,
+    )
+
+
+_GENOME_BODY = (
+    "---\nname: test-skill\n---\n\n# Test Skill\n\n"
+    "## Core Principles\n\n1. Always verify inputs before proceeding.\n"
+    "2. Log every significant decision for audit purposes.\n\n"
+    "## Workflow\n\n### Step One: Validate inputs\nCheck all required fields.\n"
+)
+_LLM_BODY = (
+    "---\nname: test-skill\n---\n\n# Test Skill\n\n"
+    "## Core Principles\n\n1. Always verify inputs before proceeding.\n"
+    "2. Log every significant decision for audit purposes.\n\n"
+    "## Workflow\n\n### Step One: Validate inputs\nCheck all required fields.\n"
+    "### Step Two: New step added by mutator\nDo the thing properly.\n"
+)
+
+
+def _make_genome(body: str | None = None) -> SkillGenome:
+    return SkillGenome(name="test-skill", body=body if body is not None else _GENOME_BODY)
+
+
+# ---------------------------------------------------------------------------
+# BatchDiagnostic properties
+# ---------------------------------------------------------------------------
+
+class TestBatchDiagnostic:
+    def test_avg_quality_score(self):
+        batch = BatchDiagnostic(
+            skill_name="s",
+            diagnostics=[
+                _make_diagnostic(quality_score=2.0),
+                _make_diagnostic(quality_score=4.0),
+            ],
+            pass_rate=0.5,
+        )
+        assert batch.avg_quality_score == pytest.approx(3.0)
+
+    def test_avg_quality_score_empty(self):
+        batch = BatchDiagnostic(skill_name="s", diagnostics=[], pass_rate=0.0)
+        assert batch.avg_quality_score == 0.0
+
+    def test_improvement_none_when_no_previous(self):
+        batch = BatchDiagnostic(skill_name="s", diagnostics=[], pass_rate=0.8)
+        assert batch.improvement is None
+
+    def test_improvement_calculated(self):
+        batch = BatchDiagnostic(
+            skill_name="s", diagnostics=[], pass_rate=0.9, previous_pass_rate=0.65
+        )
+        assert batch.improvement == pytest.approx(0.25)
+
+    def test_aggregated_suggestions_deduplicated(self):
+        d1 = _make_diagnostic(suggestions=["fix A", "fix B"])
+        d2 = _make_diagnostic(suggestions=["fix B", "fix C"])
+        batch = BatchDiagnostic(skill_name="s", diagnostics=[d1, d2], pass_rate=0.5)
+        suggestions = batch.aggregated_suggestions
+        assert suggestions == ["fix A", "fix B", "fix C"]
+
+    def test_one_line_summary_with_improvement(self):
+        batch = BatchDiagnostic(
+            skill_name="my-skill",
+            diagnostics=[_make_diagnostic()],
+            pass_rate=0.9,
+            previous_pass_rate=0.6,
+        )
+        summary = batch.one_line_summary()
+        assert "my-skill" in summary
+        assert "90%" in summary
+        assert "+30%" in summary
+
+    def test_one_line_summary_no_improvement(self):
+        batch = BatchDiagnostic(
+            skill_name="my-skill",
+            diagnostics=[_make_diagnostic()],
+            pass_rate=0.7,
+        )
+        summary = batch.one_line_summary()
+        assert "+" not in summary
+
+
+# ---------------------------------------------------------------------------
+# SkillMutator.from_batch_diagnostic
+# ---------------------------------------------------------------------------
+
+class TestFromBatchDiagnostic:
+    def _make_mutator(self, enabled: bool = True, llm_body: str | None = None):
+        from loom.core.cognition.skill_mutator import SkillMutator
+
+        router = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = llm_body or _LLM_BODY
+        router.chat = AsyncMock(return_value=mock_response)
+
+        return SkillMutator(router=router, model="test-model", enabled=enabled)
+
+    async def test_returns_none_when_disabled(self):
+        mutator = self._make_mutator(enabled=False)
+        batch = BatchDiagnostic(
+            skill_name="test-skill",
+            diagnostics=[_make_diagnostic()],
+            pass_rate=0.5,
+        )
+        result = await mutator.from_batch_diagnostic(_make_genome(), batch)
+        assert result is None
+
+    async def test_returns_none_when_no_suggestions(self):
+        mutator = self._make_mutator()
+        batch = BatchDiagnostic(
+            skill_name="test-skill",
+            diagnostics=[_make_diagnostic(suggestions=[])],
+            pass_rate=0.5,
+        )
+        result = await mutator.from_batch_diagnostic(_make_genome(), batch)
+        assert result is None
+
+    async def test_returns_none_when_empty_parent_body(self):
+        mutator = self._make_mutator()
+        batch = BatchDiagnostic(
+            skill_name="test-skill",
+            diagnostics=[_make_diagnostic()],
+            pass_rate=0.5,
+        )
+        result = await mutator.from_batch_diagnostic(_make_genome(body="   "), batch)
+        assert result is None
+
+    async def test_fast_track_set_when_improvement_above_threshold(self):
+        mutator = self._make_mutator()
+        batch = BatchDiagnostic(
+            skill_name="test-skill",
+            diagnostics=[_make_diagnostic()],
+            pass_rate=0.9,
+            previous_pass_rate=0.65,  # improvement = 0.25 ≥ 0.20
+        )
+        result = await mutator.from_batch_diagnostic(_make_genome(), batch)
+        assert result is not None
+        assert result.candidate.fast_track is True
+
+    async def test_fast_track_false_when_improvement_below_threshold(self):
+        mutator = self._make_mutator()
+        batch = BatchDiagnostic(
+            skill_name="test-skill",
+            diagnostics=[_make_diagnostic()],
+            pass_rate=0.75,
+            previous_pass_rate=0.65,  # improvement = 0.10 < 0.20
+        )
+        result = await mutator.from_batch_diagnostic(_make_genome(), batch)
+        assert result is not None
+        assert result.candidate.fast_track is False
+
+    async def test_fast_track_false_when_no_previous(self):
+        mutator = self._make_mutator()
+        batch = BatchDiagnostic(
+            skill_name="test-skill",
+            diagnostics=[_make_diagnostic()],
+            pass_rate=0.9,
+        )
+        result = await mutator.from_batch_diagnostic(_make_genome(), batch)
+        assert result is not None
+        assert result.candidate.fast_track is False
+
+    async def test_mutation_strategy_is_batch(self):
+        mutator = self._make_mutator()
+        batch = BatchDiagnostic(
+            skill_name="test-skill",
+            diagnostics=[_make_diagnostic()],
+            pass_rate=0.5,
+        )
+        result = await mutator.from_batch_diagnostic(_make_genome(), batch)
+        assert result is not None
+        assert result.candidate.mutation_strategy == "batch_meta_skill_engineer"
+
+    async def test_pass_rate_in_pareto_scores(self):
+        mutator = self._make_mutator()
+        batch = BatchDiagnostic(
+            skill_name="test-skill",
+            diagnostics=[_make_diagnostic()],
+            pass_rate=0.75,
+        )
+        result = await mutator.from_batch_diagnostic(_make_genome(), batch)
+        assert result is not None
+        assert result.candidate.pareto_scores.get("pass_rate") == pytest.approx(0.75)
+
+    async def test_llm_error_returns_none(self):
+        from loom.core.cognition.skill_mutator import SkillMutator
+
+        router = MagicMock()
+        router.chat = AsyncMock(side_effect=RuntimeError("network down"))
+        mutator = SkillMutator(router=router, model="test-model", enabled=True)
+
+        batch = BatchDiagnostic(
+            skill_name="test-skill",
+            diagnostics=[_make_diagnostic()],
+            pass_rate=0.5,
+        )
+        result = await mutator.from_batch_diagnostic(_make_genome(), batch)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def db_conn(tmp_path):
+    store = SQLiteStore(str(tmp_path / "test.db"))
+    await store.initialize()
+    async with store.connect() as conn:
+        yield conn
+
+
+# ---------------------------------------------------------------------------
+# SkillGenome.maturity_tag + SkillCandidate.fast_track DB roundtrip
+# ---------------------------------------------------------------------------
+
+class TestSchemaExtensions:
+    async def test_maturity_tag_roundtrip(self, db_conn):
+        from loom.core.memory.procedural import ProceduralMemory
+
+        proc = ProceduralMemory(db_conn)
+        skill = SkillGenome(name="roundtrip-skill", body="# test", maturity_tag="mature")
+        await proc.upsert(skill)
+
+        fetched = await proc.get("roundtrip-skill")
+        assert fetched is not None
+        assert fetched.maturity_tag == "mature"
+
+    async def test_update_maturity_tag(self, db_conn):
+        from loom.core.memory.procedural import ProceduralMemory
+
+        proc = ProceduralMemory(db_conn)
+        skill = SkillGenome(name="mt-skill", body="# test")
+        await proc.upsert(skill)
+
+        updated = await proc.update_maturity_tag("mt-skill", "needs_improvement")
+        assert updated is True
+
+        fetched = await proc.get("mt-skill")
+        assert fetched is not None
+        assert fetched.maturity_tag == "needs_improvement"
+
+    async def test_update_maturity_tag_clear(self, db_conn):
+        from loom.core.memory.procedural import ProceduralMemory
+
+        proc = ProceduralMemory(db_conn)
+        skill = SkillGenome(name="mt2-skill", body="# test", maturity_tag="mature")
+        await proc.upsert(skill)
+
+        await proc.update_maturity_tag("mt2-skill", None)
+        fetched = await proc.get("mt2-skill")
+        assert fetched is not None
+        assert fetched.maturity_tag is None
+
+    async def test_candidate_fast_track_roundtrip(self, db_conn):
+        from loom.core.memory.procedural import ProceduralMemory
+
+        proc = ProceduralMemory(db_conn)
+        skill = SkillGenome(name="ft-skill", body="# test")
+        await proc.upsert(skill)
+
+        candidate = SkillCandidate(
+            parent_skill_name="ft-skill",
+            parent_version=1,
+            candidate_body="# improved",
+            mutation_strategy="batch_meta_skill_engineer",
+            fast_track=True,
+        )
+        await proc.insert_candidate(candidate)
+
+        fetched = await proc.get_candidate(candidate.id)
+        assert fetched is not None
+        assert fetched.fast_track is True
+
+    async def test_candidate_fast_track_default_false(self, db_conn):
+        from loom.core.memory.procedural import ProceduralMemory
+
+        proc = ProceduralMemory(db_conn)
+        skill = SkillGenome(name="ft2-skill", body="# test")
+        await proc.upsert(skill)
+
+        candidate = SkillCandidate(
+            parent_skill_name="ft2-skill",
+            parent_version=1,
+            candidate_body="# improved",
+            mutation_strategy="apply_suggestions",
+        )
+        await proc.insert_candidate(candidate)
+
+        fetched = await proc.get_candidate(candidate.id)
+        assert fetched is not None
+        assert fetched.fast_track is False


### PR DESCRIPTION
## Summary

Connects the Grader evaluation loop to the skill lifecycle pipeline, completing Issue #120's skill evolution series.

- **BatchDiagnostic** — new dataclass in `task_reflector.py` wrapping `list[TaskDiagnostic]` + `pass_rate` + optional `previous_pass_rate`; exposes `aggregated_suggestions`, `avg_quality_score`, `improvement`
- **SkillMutator.from_batch_diagnostic()** — produces a `SkillCandidate` from Grader output; sets `fast_track=True` when `improvement ≥ 20%` (Grader has proven the lift empirically, skip shadow phase)
- **Schema** — `skill_genomes.maturity_tag` + `skill_candidates.fast_track` added via runtime `ALTER TABLE` migrations
- **`loom review <name>`** — new CLI command: one-stop report showing genome status, Grader eval history, Analyzer insights, candidate pool (with ⚡fast-track indicator), and version history
- **SKILL.md** — Stage 7 rewritten: no more ad-hoc confidence rules; all mutations go through `from_batch_diagnostic()` → candidate pool; Stages 4/5/6 updated to document structured `TaskDiagnostic`/`BatchDiagnostic` outputs

## Design decisions

**fast_track**: `SkillCandidate.fast_track=True` is a flag, not automatic promotion. The caller (Stage 7 of meta-skill-engineer) still explicitly calls `loom skill promote`. The flag documents *why* shadow was skipped and is visible in `loom review`.

**Confidence stays EMA-driven**: Stage 7 no longer manually adjusts `SkillGenome.confidence`. The `avg_quality_score` from `BatchDiagnostic` feeds into the normal `TaskReflector` EMA path in subsequent turns.

**maturity_tag is operator-set**: Checked via `loom review`, set via `ProceduralMemory.update_maturity_tag()`. The ≥90% / 3-consecutive rule is documented in SKILL.md; the operator decides when to apply it.

## Test plan

- [x] 21 new tests: `BatchDiagnostic` properties, `from_batch_diagnostic` gate logic, fast_track assignment, maturity_tag + fast_track DB roundtrip — all pass
- [x] Full suite: 921 passed, 0 failures
- [ ] End-to-end skill lifecycle test (Stage 1→7 with a new skill) — deferred to after PR 4 merges, per the agreed plan of testing the full cycle with a real skill creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)