### PR TITLE
fix: Batch 1 hardening — SQLite lock, trajectory anomaly UX, scanner repositioning

### DIFF
--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -272,6 +272,16 @@ class LegitimacyGuardMiddleware(Middleware):
         if not is_strict and not self.has_probed:
             if call.capabilities & ToolCapability.EXEC:
                 call.metadata["trajectory_anomaly"] = True
+                # Issue #168: surface the soft-guard trip so operators (and log
+                # readers) can see why an EXEC call lost its exec_auto fast-pass.
+                # Without this, autonomous runs that get blocked by the soft
+                # guard look indistinguishable from a generic permission denial.
+                _log.warning(
+                    "Trajectory anomaly: %s called with EXEC capability before "
+                    "any probe this turn (origin=%s); exec_auto fast-pass will "
+                    "be revoked downstream.",
+                    call.tool_name, call.origin,
+                )
 
         result = await next(call)
 
@@ -360,14 +370,29 @@ class BlastRadiusMiddleware(Middleware):
         )
         self._notify_lifecycle(call, False, f"unattended-deny ({call.origin}, {verdict})")
         call.metadata["user_decision"] = False
-        return ToolResult(
-            call_id=call.id, tool_name=call.tool_name,
-            success=False,
-            error=(
+
+        # Issue #168: when the trajectory_anomaly soft-guard tripped, the agent
+        # called an EXEC tool without probing first this turn. Tell it that
+        # explicitly so it can self-correct (probe, then retry) instead of
+        # looping on a generic "no permission" message.
+        if call.metadata.get("trajectory_anomaly"):
+            error = (
+                f"Permission denied: {call.tool_name} requires a probe tool "
+                f"(read_file, list_dir, search_files, ...) to run earlier in "
+                f"this turn before the auto-approval path will fire. Origin "
+                f"'{call.origin}' cannot prompt a human, so the call was failed "
+                f"fast. Probe the relevant context first, then re-issue."
+            )
+        else:
+            error = (
                 f"Permission denied: {call.tool_name} requires scope authorization "
                 f"not covered by existing grants. Origin '{call.origin}' cannot "
                 f"request new permissions interactively."
-            ),
+            )
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=False,
+            error=error,
             failure_type="permission_denied",
         )
 

--- a/loom/core/memory/store.py
+++ b/loom/core/memory/store.py
@@ -236,6 +236,10 @@ class SQLiteStore:
     async def initialize(self) -> None:
         """Create tables and indexes if they do not exist."""
         async with aiosqlite.connect(self.path) as db:
+            # Issue #166: wait up to 5s on a write lock instead of failing
+            # immediately with `database is locked`. Pairs with WAL mode set in
+            # SCHEMA — WAL allows concurrent readers, but writes still serialize.
+            await db.execute("PRAGMA busy_timeout = 5000;")
             await db.executescript(SCHEMA)
             await db.commit()
             # Runtime migrations: ALTER TABLE for columns added in later versions.
@@ -290,6 +294,10 @@ class SQLiteStore:
         async with aiosqlite.connect(self.path) as db:
             await db.enable_load_extension(True)
             await db.load_extension(sqlite_vec.loadable_path())
+            # Issue #166: wait up to 5s on a write lock under concurrency
+            # (Discord daemon + CLI session + Dreaming jobs hitting WAL together)
+            # instead of immediately raising `database is locked`.
+            await db.execute("PRAGMA busy_timeout = 5000;")
             yield db
 
     @staticmethod

--- a/loom/core/security/command_scanner.py
+++ b/loom/core/security/command_scanner.py
@@ -1,13 +1,27 @@
 """
-Command content scanner — Issue #100.
+Command content scanner — Issue #100, repositioned in Issue #165.
 
-Scans shell command strings for injection patterns before execution.
-Complements the SelfTerminationGuard (Issue #98) which only checks
-self-termination patterns.
+Scans shell command strings for injection / exfiltration patterns before
+execution.  Complements ``SelfTerminationGuard`` (Issue #98), which only
+checks self-termination patterns.
 
-Patterns are deliberately focused on high-confidence threats.  Low-
-confidence patterns (e.g. bare ``$()`` in any context) are excluded
-to avoid false positives in normal development workflows.
+**What this is.**  A defense-in-depth *tripwire* and *audit signal*.  The
+patterns target the shapes that prompt-injected LLMs and unsophisticated
+attackers tend to emit verbatim — `curl ... | sh`, `>/dev/tcp/`,
+`base64 -d | sh`, ``$VAR`` env-var exfiltration, etc.  When one fires,
+the call is blocked or warned and a structured log line is emitted for
+later auditing.
+
+**What this is not.**  A security boundary.  Regex sanitization of shell
+input is fundamentally bypassable via obfuscation
+(`w""g""e""t`, base64-staged scripts, here-docs writing intermediate
+files, etc.).  Do not rely on it to contain a determined adversary —
+that job belongs to OS / container isolation (Issue #29).
+
+**Layering.**  Scanner = tripwire / audit signal.  ``TrustLevel`` /
+``BlastRadiusMiddleware`` = policy.  Sandbox (Issue #29) = the actual
+wall.  Each layer is meant to fail open into the next, not to stand
+alone.
 
 Usage::
 

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -512,10 +512,23 @@ def make_run_bash_tool(
         if verdict.verdict == "warn":
             _log.warning("Self-termination guard warning: %s", verdict.description)
 
-        # Issue #100: shell injection command scanner
+        # Issue #100 / #165: shell injection scanner. This is a defense-in-depth
+        # tripwire + audit signal, NOT a security boundary — see the module
+        # docstring in loom/core/security/command_scanner.py. Every hit emits a
+        # structured log line so downstream tooling (Discord notify, audit
+        # pipelines) can subscribe to "command_scanner_*" without re-parsing.
         scan_verdict = _cmd_scanner.check(command)
         if scan_verdict.verdict == "block":
-            _log.warning("Command scanner blocked: %s", scan_verdict.description)
+            _log.warning(
+                "Command scanner blocked: %s", scan_verdict.description,
+                extra={
+                    "event": "command_scanner_block",
+                    "pattern_key": scan_verdict.pattern_key,
+                    "tool_name": call.tool_name,
+                    "session_id": getattr(call, "session_id", ""),
+                    "origin": getattr(call, "origin", ""),
+                },
+            )
             return ToolResult(
                 call_id=call.id, tool_name=call.tool_name,
                 success=False,
@@ -523,7 +536,16 @@ def make_run_bash_tool(
                 failure_type="security_block",
             )
         if scan_verdict.verdict == "warn":
-            _log.warning("Command scanner warning: %s", scan_verdict.description)
+            _log.warning(
+                "Command scanner warning: %s", scan_verdict.description,
+                extra={
+                    "event": "command_scanner_warn",
+                    "pattern_key": scan_verdict.pattern_key,
+                    "tool_name": call.tool_name,
+                    "session_id": getattr(call, "session_id", ""),
+                    "origin": getattr(call, "origin", ""),
+                },
+            )
 
         timeout = call.args.get("timeout", 30)
         cwd = str(workspace) if strict_sandbox else None

--- a/tests/test_legitimacy.py
+++ b/tests/test_legitimacy.py
@@ -150,6 +150,47 @@ async def test_trajectory_anomaly_not_set_after_probe(handler):
 
 
 @pytest.mark.asyncio
+async def test_trajectory_anomaly_emits_warning_log(handler, caplog):
+    """Issue #168: tripping the soft guard must emit a structured warning so
+    operators can distinguish a soft-guard demotion from a generic auth deny."""
+    import logging
+    guard = LegitimacyGuardMiddleware()
+    call_bash = make_call(
+        "run_bash", TrustLevel.GUARDED, {"command": "ls"},
+        capabilities=ToolCapability.EXEC,
+    )
+    with caplog.at_level(logging.WARNING, logger="loom.core.harness.middleware"):
+        await guard.process(call_bash, handler)
+    assert any("Trajectory anomaly" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_unattended_trajectory_anomaly_returns_specific_error(perm_ctx, registry, handler):
+    """Issue #168: unattended autonomy origin hitting trajectory_anomaly must
+    fail fast with a probe-first explanation, not the generic 'no scope' deny."""
+    async def never_called(call):
+        raise AssertionError("confirm_fn must not be called for unattended origin")
+
+    bmw = BlastRadiusMiddleware(
+        perm_ctx=perm_ctx,
+        confirm_fn=never_called,
+        registry=registry,
+    )
+    call = make_call(
+        "run_bash", TrustLevel.GUARDED, {"command": "ls"},
+        capabilities=ToolCapability.EXEC,
+    )
+    call.origin = "autonomy"
+    call.metadata["trajectory_anomaly"] = True
+
+    res = await bmw.process(call, handler)
+    assert not res.success
+    assert res.failure_type == "permission_denied"
+    assert "probe" in res.error.lower()
+    assert "autonomy" in res.error
+
+
+@pytest.mark.asyncio
 async def test_circuit_breaker_trips_after_3_denies(perm_ctx, registry, handler):
     deny_count = 0
     async def always_deny(call) -> ConfirmDecision:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -75,6 +75,19 @@ class TestSQLiteStore:
         assert expected.issubset(tables)
 
     @pytest.mark.asyncio
+    async def test_connect_sets_busy_timeout(self, store):
+        """Issue #166: connections opened via connect() must wait on a
+        write lock instead of failing immediately with `database is locked`.
+        WAL mode (set in SCHEMA) lets readers and writers coexist, but writes
+        still serialize — without busy_timeout, concurrent writers (Discord
+        daemon + CLI session + Dreaming jobs) hit OperationalError instantly.
+        """
+        async with store.connect() as db:
+            cur = await db.execute("PRAGMA busy_timeout")
+            (timeout_ms,) = await cur.fetchone()
+        assert timeout_ms >= 5000
+
+    @pytest.mark.asyncio
     async def test_initialize_migrates_pre_compressed_at_schema(self, tmp_db):
         """Regression: initialize() must not explode on databases that
         predate the compressed_at column. The partial index that references


### PR DESCRIPTION
## Summary

Three small, related consolidation changes bundled for one review pass.

- **#166 SQLite busy_timeout** — add `PRAGMA busy_timeout = 5000` to `SQLiteStore.connect()` and `initialize()`. WAL allows concurrent readers, but writes still serialize; without busy_timeout, a Discord daemon + CLI session + Dreaming jobs hitting the store at once raise `database is locked` immediately instead of queueing for ~5s.
- **#168 Trajectory Anomaly soft-guard UX** — emit a `_log.warning` the moment `LegitimacyGuardMiddleware` flags `trajectory_anomaly`, and return a probe-first error from `BlastRadiusMiddleware._deny_unattended()` when that flag is what landed us there. Autonomous origins now self-correct (probe → retry) instead of looping on the generic "no scope grant" message.
- **#165 Reposition CommandScanner** — *not* removed (defense-in-depth). Reframe the module docstring: regex sanitization is bypassable and is **not** a security boundary; it's a tripwire + audit signal that complements `TrustLevel` policy and the OS-level sandbox (#29). Upgrade scanner log lines in `make_run_bash_tool` to structured form (`extra={"event": "command_scanner_block|warn", ...}`) so audit/notify pipelines can subscribe without re-parsing strings.

## Why these three together

All three are small surface, low blast-radius, and share a theme: surface real signals (lock contention, soft-guard trips, scanner hits) instead of hiding them behind generic failures. Bundled to keep the review cheap.

## Test plan

- [x] `pytest tests/test_memory.py tests/test_legitimacy.py -q` — 47 passing, including 3 new regression cases
- [x] Full suite `pytest tests/ --ignore=tests/test_integration.py -q` — 922 passing
- [ ] Manual: trigger an EXEC tool from autonomy without a probe → confirm the new probe-first error message reaches the LLM (will verify post-merge in next autonomy run)
- [ ] Manual: spin up Discord bot + CLI session against the same `~/.loom/memory.db`, fire concurrent writes → confirm no `database is locked`

Closes #166
Closes #168
Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)