### PR TITLE
refactor(harness): READ_PROBE capability replaces hardcoded probe_tools (#167)

### DIFF
--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -199,6 +199,22 @@ class LegitimacyGuardMiddleware(Middleware):
     require human confirmation.  This is a *soft* guard: the call is not
     blocked, just stripped of its fast-pass.
 
+    **What counts as a probe (Issue #167)**
+
+    A call is treated as a probe when *either* of the following holds:
+
+    1. ``call.capabilities & ToolCapability.READ_PROBE`` — explicit opt-in
+       on the ``ToolDefinition``.  Use this for GUARDED read tools (e.g.
+       ``web_search``) and for MCP tools that need to be recognized as
+       reads but cannot be classified by trust alone.
+    2. ``call.trust_level == TrustLevel.SAFE`` — by definition SAFE means
+       read-only, local, and fully reversible, which is exactly what the
+       probe-first heuristic wants to count.
+
+    The previous implementation hardcoded a tool-name allowlist, which
+    silently broke when tools were renamed and could not recognize MCP
+    or plugin-provided read tools at all.
+
     **Session-trust (Issue #118)**
 
     Once a strict-guard tool executes successfully, it is added to
@@ -211,10 +227,6 @@ class LegitimacyGuardMiddleware(Middleware):
 
     def __init__(self) -> None:
         self.has_probed: bool = False
-        self.probe_tools = frozenset({
-            "list_dir", "read_file", "search_files", "grep_search",
-            "fetch_url_tool", "web_search", "recall_memory", "query_relations"
-        })
         # Only file-writing tools belong here.  exec tools (run_bash) and MCP
         # generative tools are handled by BlastRadiusMiddleware.
         self.strict_guard_tools: set[str] = {
@@ -224,12 +236,19 @@ class LegitimacyGuardMiddleware(Middleware):
         # requirement is waived for these on subsequent turns (Issue #118).
         self._session_trusted: set[str] = set()
 
+    @staticmethod
+    def _is_probe(call: ToolCall) -> bool:
+        """Issue #167: capability flag OR SAFE trust counts as a probe."""
+        if call.capabilities & ToolCapability.READ_PROBE:
+            return True
+        return call.trust_level == TrustLevel.SAFE
+
     def reset_probe(self) -> None:
         """Reset per-turn probe state. Does NOT clear session-level trust."""
         self.has_probed = False
 
     async def process(self, call: ToolCall, next: ToolHandler) -> ToolResult:
-        if call.tool_name in self.probe_tools:
+        if self._is_probe(call):
             self.has_probed = True
 
         # TODO(#xx): Phase 4 - Goal Drift / Re-justification budget.

--- a/loom/core/harness/permissions.py
+++ b/loom/core/harness/permissions.py
@@ -29,6 +29,13 @@ class ToolCapability(Flag):
     NETWORK    = auto()      # makes outbound network calls
     AGENT_SPAN = auto()      # spawns one or more sub-agents
     MUTATES    = auto()      # modifies files, memory, or persistent state
+    READ_PROBE = auto()      # counts as a "probe" for LegitimacyGuard's
+                             # probe-first heuristic — gathers context without
+                             # mutating it. SAFE-trust tools satisfy the
+                             # heuristic implicitly (see LegitimacyGuard);
+                             # set this flag explicitly on GUARDED read tools
+                             # such as web_search, or on MCP tools that would
+                             # otherwise be unrecognized.
 
 
 class TrustLevel(Enum):

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -2056,7 +2056,10 @@ def make_web_search_tool(brave_api_key: str) -> ToolDefinition:
             "Use this to find current information, documentation, or answers that aren't in memory."
         ),
         trust_level=TrustLevel.GUARDED,
-        capabilities=ToolCapability.NETWORK,
+        # Issue #167: GUARDED trust (NETWORK side-effect) but read-only in
+        # intent — explicitly mark it as a probe so LegitimacyGuard counts it
+        # toward the probe-first heuristic. SAFE tools get this for free.
+        capabilities=ToolCapability.NETWORK | ToolCapability.READ_PROBE,
         input_schema={
             "type": "object",
             "properties": {

--- a/tests/test_legitimacy.py
+++ b/tests/test_legitimacy.py
@@ -71,6 +71,54 @@ async def test_write_file_allowed_after_read(handler):
 
 
 @pytest.mark.asyncio
+async def test_safe_tool_counts_as_probe(handler):
+    """Issue #167: any SAFE-trust tool should satisfy the probe-first heuristic
+    without an explicit READ_PROBE flag — SAFE means read-only and reversible."""
+    guard = LegitimacyGuardMiddleware()
+    # A SAFE tool the old hardcoded set never knew about
+    call_safe = make_call("introspect_self", TrustLevel.SAFE, {})
+    await guard.process(call_safe, handler)
+    assert guard.has_probed
+
+    call_write = make_call("write_file", TrustLevel.GUARDED, {"path": "x", "content": ""})
+    res = await guard.process(call_write, handler)
+    assert res.success
+
+
+@pytest.mark.asyncio
+async def test_explicit_read_probe_capability_counts_as_probe(handler):
+    """Issue #167: GUARDED tools (e.g. web_search, MCP read tools) opt in via
+    ToolCapability.READ_PROBE. Trust stays GUARDED but the probe heuristic
+    recognizes the call."""
+    guard = LegitimacyGuardMiddleware()
+    call_search = make_call(
+        "github:search_repos", TrustLevel.GUARDED, {"q": "loom"},
+        capabilities=ToolCapability.NETWORK | ToolCapability.READ_PROBE,
+    )
+    await guard.process(call_search, handler)
+    assert guard.has_probed
+
+
+@pytest.mark.asyncio
+async def test_guarded_tool_without_read_probe_does_not_count(handler):
+    """Issue #167: a GUARDED tool with no READ_PROBE flag must NOT satisfy
+    the heuristic, otherwise write_file could waltz through after any
+    network/exec call."""
+    guard = LegitimacyGuardMiddleware()
+    call_unrelated = make_call(
+        "some_mcp:do_thing", TrustLevel.GUARDED, {},
+        capabilities=ToolCapability.NETWORK,
+    )
+    await guard.process(call_unrelated, handler)
+    assert not guard.has_probed
+
+    call_write = make_call("write_file", TrustLevel.GUARDED, {"path": "x", "content": ""})
+    res = await guard.process(call_write, handler)
+    assert not res.success
+    assert res.failure_type == "permission_denied"
+
+
+@pytest.mark.asyncio
 async def test_run_bash_not_guarded_by_probe(handler):
     """run_bash is NOT in strict_guard_tools — BlastRadius owns exec authorization."""
     guard = LegitimacyGuardMiddleware()


### PR DESCRIPTION
## Summary

`LegitimacyGuardMiddleware` previously identified probe tools by a hardcoded frozenset of names. The list was already half-broken (4 of 8 names were typos or referenced removed tools — `search_files`, `grep_search`, `fetch_url_tool`, `recall_memory`), and any MCP- or plugin-provided read tool was invisible. So calling `github:read_repo` and then `write_file` was incorrectly blocked.

Move the source of truth to the `ToolDefinition` itself.

- **Add `ToolCapability.READ_PROBE`** — explicit opt-in for tools that should count as a probe.
- **`LegitimacyGuard._is_probe(call)`** treats a call as a probe when *either*: `call.capabilities & READ_PROBE`, or `call.trust_level == SAFE`. SAFE already means read-only and fully reversible per the trust hierarchy docstring, so the implicit rule keeps existing behavior for the common case without forcing every SAFE tool to add a flag.
- **Mark `web_search`** (GUARDED + NETWORK, but read-only in intent) with `READ_PROBE` explicitly. The other previously-recognized probes (`read_file`, `list_dir`, `recall`, `query_relations`, `fetch_url`) are SAFE and satisfy the rule implicitly.

## Why no plumbing change

Capability already flows `ToolDefinition.capabilities` → `ToolCall.capabilities` at three dispatch sites (`loom/core/session.py:2220`, `loom/core/agent/subagent.py:251`, `loom/extensibility/mcp_server.py:146`). Declaring the flag is enough.

## Out of scope

- MCP-side heuristic auto-detection of READ_PROBE (option C from design discussion). MCP servers should self-declare; we don't infer from name.
- Existing audit of "is this SAFE tool actually read-only?" (e.g. `tasklist_create` mutates TaskList state but is registered SAFE). Separate concern from probe semantics.

## Test plan

- [x] `pytest tests/test_legitimacy.py -q` — 14 passing, +3 new cases:
  - SAFE-trust tool auto-counts as probe (e.g. `introspect_self`)
  - GUARDED tool with explicit `READ_PROBE` counts (MCP-style)
  - GUARDED tool *without* `READ_PROBE` must NOT count (regression guard)
- [x] Full suite `pytest tests/ --ignore=tests/test_integration.py -q` — 925 passing
- [ ] Manual: declare an MCP read tool with READ_PROBE in a real config → confirm `write_file` after it succeeds without "probe-first heuristic failed"

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)