### PR TITLE
feat(memory): MemoryFacade unified read entry point (#147 Phase A)

### DIFF
--- a/loom/core/memory/facade.py
+++ b/loom/core/memory/facade.py
@@ -1,0 +1,93 @@
+"""
+MemoryFacade — unified entry point for the four memory subsystems.
+
+Issue #147 階段 A.  Establishes a single object that owns the four memory
+subsystems (``SemanticMemory`` / ``ProceduralMemory`` / ``RelationalMemory``
+/ ``EpisodicMemory``) plus the ``MemorySearch`` index.  ``LoomSession``
+holds it as ``self._memory`` and forwards subsystem references through
+the facade's handles.
+
+Phase A scope (read-only, additive):
+
+* High-level read API: :meth:`search`, :meth:`get_fact`,
+  :meth:`query_relations` — covers what the agent ``recall`` / ``memorize``
+  / ``query_relations`` tools actually use.
+* Subsystem handles (``.semantic`` / ``.procedural`` / ``.relational`` /
+  ``.episodic`` / ``.search_index``) for callers that haven't been
+  migrated yet.  Existing tools and plugins continue to receive the raw
+  subsystems — no caller is forced to change in Phase A.
+
+Phase B (write-path centralisation: ``memorize`` / ``relate``,
+embedding-failure handling) and Phase C (caller migration + removal of
+the direct subsystem imports) are tracked separately on Issue #147.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from loom.core.memory.episodic import EpisodicMemory
+    from loom.core.memory.procedural import ProceduralMemory
+    from loom.core.memory.relational import RelationalEntry, RelationalMemory
+    from loom.core.memory.search import MemorySearch, MemorySearchResult
+    from loom.core.memory.semantic import SemanticEntry, SemanticMemory
+
+
+class MemoryFacade:
+    """Single owner of all memory subsystems with a small read API.
+
+    The facade is instantiated once per ``LoomSession`` after the four
+    memory subsystems and the ``MemorySearch`` index have been created.
+    It does not reach into any subsystem's private state — each method
+    delegates to the public API of the appropriate subsystem.
+    """
+
+    def __init__(
+        self,
+        *,
+        semantic: "SemanticMemory",
+        procedural: "ProceduralMemory",
+        relational: "RelationalMemory",
+        episodic: "EpisodicMemory",
+        search: "MemorySearch",
+    ) -> None:
+        self.semantic = semantic
+        self.procedural = procedural
+        self.relational = relational
+        self.episodic = episodic
+        self.search_index = search
+
+    # ── read API ─────────────────────────────────────────────────────────
+
+    async def search(
+        self,
+        query: str,
+        type: Literal["semantic", "skill", "all"] = "all",
+        limit: int = 5,
+    ) -> list["MemorySearchResult"]:
+        """BM25 + embedding ranked retrieval across semantic + procedural memory.
+
+        Wraps :meth:`MemorySearch.recall`.  Equivalent to the agent
+        ``recall`` tool, but exposed as a method on the facade so callers
+        do not need to know about the search index as a separate object.
+        """
+        return await self.search_index.recall(query, type=type, limit=limit)
+
+    async def get_fact(self, key: str) -> "SemanticEntry | None":
+        """Direct semantic-memory lookup by exact key."""
+        return await self.semantic.get(key)
+
+    async def query_relations(
+        self,
+        subject: str | None = None,
+        predicate: str | None = None,
+    ) -> list["RelationalEntry"]:
+        """Query relational triples by subject and/or predicate.
+
+        Pass ``subject`` to get all predicates for a subject; pass
+        ``predicate`` to find all subjects with that predicate; pass both
+        for an exact lookup; pass neither to return all entries.  Mirrors
+        the underlying :meth:`RelationalMemory.query` signature.
+        """
+        return await self.relational.query(subject=subject, predicate=predicate)

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -771,6 +771,20 @@ class LoomSession:
         )
         search = MemorySearch(self._semantic, self._procedural)
         search._health = self._governor.health
+
+        # Issue #147 階段 A: single owner of the four memory subsystems +
+        # search index. Existing self._semantic / _procedural / _relational
+        # / _episodic attributes still point at the same instances, so
+        # callers that reach into them keep working until 階段 B/C.
+        from loom.core.memory.facade import MemoryFacade
+        self._memory = MemoryFacade(
+            semantic=self._semantic,
+            procedural=self._procedural,
+            relational=self._relational,
+            episodic=self._episodic,
+            search=search,
+        )
+
         self.registry.register(make_recall_tool(search))
         self.registry.register(make_memorize_tool(self._semantic, governor=self._governor))
         self.registry.register(make_relate_tool(self._relational))

--- a/tests/test_memory_facade.py
+++ b/tests/test_memory_facade.py
@@ -1,0 +1,159 @@
+"""
+Issue #147 階段 A — MemoryFacade.
+
+Verifies the facade owns the four memory subsystems plus the search
+index, and that its three high-level read methods (``search`` /
+``get_fact`` / ``query_relations``) delegate to the right subsystem.
+Also verifies handle identity so ``LoomSession`` callers that still
+reach through ``self._semantic`` etc. keep seeing the same object the
+facade holds.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from loom.core.memory.episodic import EpisodicMemory
+from loom.core.memory.facade import MemoryFacade
+from loom.core.memory.procedural import ProceduralMemory
+from loom.core.memory.relational import RelationalEntry, RelationalMemory
+from loom.core.memory.search import MemorySearch
+from loom.core.memory.semantic import SemanticEntry, SemanticMemory
+from loom.core.memory.store import SQLiteStore
+
+
+@pytest_asyncio.fixture
+async def facade(tmp_path):
+    store = SQLiteStore(str(tmp_path / "facade.db"))
+    await store.initialize()
+    async with store.connect() as db:
+        semantic = SemanticMemory(db)
+        procedural = ProceduralMemory(db)
+        relational = RelationalMemory(db)
+        episodic = EpisodicMemory(db)
+        search = MemorySearch(semantic, procedural)
+        yield MemoryFacade(
+            semantic=semantic, procedural=procedural,
+            relational=relational, episodic=episodic, search=search,
+        )
+
+
+# ── construction & handle identity ─────────────────────────────────────────
+
+def test_facade_exposes_subsystem_handles(facade):
+    """All five attributes are present and are the exact instances passed in."""
+    assert isinstance(facade.semantic, SemanticMemory)
+    assert isinstance(facade.procedural, ProceduralMemory)
+    assert isinstance(facade.relational, RelationalMemory)
+    assert isinstance(facade.episodic, EpisodicMemory)
+    assert isinstance(facade.search_index, MemorySearch)
+
+
+def test_search_index_wraps_facade_subsystems(facade):
+    """The search index uses the same semantic + procedural instances the
+    facade exposes — no parallel object trees."""
+    assert facade.search_index._semantic is facade.semantic
+    assert facade.search_index._procedural is facade.procedural
+
+
+# ── read API: get_fact ─────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_get_fact_returns_entry_when_present(facade):
+    await facade.semantic.upsert(SemanticEntry(
+        key="loom:test", value="hello", confidence=0.9, source="user_explicit",
+    ))
+    fact = await facade.get_fact("loom:test")
+    assert fact is not None
+    assert fact.value == "hello"
+
+
+@pytest.mark.asyncio
+async def test_get_fact_returns_none_for_missing_key(facade):
+    assert await facade.get_fact("nope") is None
+
+
+# ── read API: query_relations ──────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_query_relations_filters_by_subject(facade):
+    await facade.relational.upsert(RelationalEntry(
+        subject="alice", predicate="knows", object="bob", source="user",
+    ))
+    await facade.relational.upsert(RelationalEntry(
+        subject="alice", predicate="likes", object="cake", source="user",
+    ))
+    await facade.relational.upsert(RelationalEntry(
+        subject="bob", predicate="knows", object="carol", source="user",
+    ))
+
+    alice_rels = await facade.query_relations(subject="alice")
+    assert len(alice_rels) == 2
+    assert {r.predicate for r in alice_rels} == {"knows", "likes"}
+
+    knows_rels = await facade.query_relations(predicate="knows")
+    assert len(knows_rels) == 2
+    assert {r.subject for r in knows_rels} == {"alice", "bob"}
+
+
+# ── read API: search delegates to MemorySearch ─────────────────────────────
+
+@pytest.mark.asyncio
+async def test_search_delegates_to_search_index(facade):
+    await facade.semantic.upsert(SemanticEntry(
+        key="topic:loom", value="loom is a memory-native agent framework",
+        confidence=0.9, source="user_explicit",
+    ))
+    results = await facade.search("memory framework", type="semantic", limit=5)
+    assert results, "facade.search should hit the BM25 index for matching content"
+    assert any("loom is a memory-native" in r.value for r in results)
+
+
+# ── session integration ────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_session_holds_facade_aliased_to_subsystems(monkeypatch, tmp_path):
+    """Issue #147 階段 A: ``LoomSession.start()`` builds the facade after
+    the four subsystems exist, and ``self._semantic`` / ``_procedural`` /
+    ``_relational`` / ``_episodic`` point at the same instances the
+    facade holds.  Existing callers that reach into those private
+    attributes must keep working in Phase A."""
+    from unittest.mock import MagicMock
+    from rich.prompt import Confirm
+    import loom as loom_pkg
+    from loom.core import session as core_session
+
+    # Isolate default registry so plugin probe doesn't pollute test state
+    registry = loom_pkg._get_default_registry()
+    original_tools = dict(registry._tools)
+    registry._tools.clear()
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(core_session, "build_router", lambda: MagicMock())
+    monkeypatch.setattr(core_session, "_load_loom_config", lambda: {})
+    monkeypatch.setattr(core_session, "_load_env", lambda project_root=None: {})
+    monkeypatch.setattr(core_session, "build_embedding_provider", lambda env, cfg: None)
+    monkeypatch.setattr(Confirm, "ask", lambda *args, **kwargs: True)
+
+    from loom.core.session import LoomSession
+    session = LoomSession(
+        model="gpt-test",
+        db_path=str(tmp_path / "loom.db"),
+        workspace=workspace,
+    )
+    try:
+        await session.start()
+
+        assert hasattr(session, "_memory")
+        assert session._memory.semantic is session._semantic
+        assert session._memory.procedural is session._procedural
+        assert session._memory.relational is session._relational
+        assert session._memory.episodic is session._episodic
+    finally:
+        await session.stop()
+        registry._tools.clear()
+        registry._tools.update(original_tools)


### PR DESCRIPTION
## Summary

Phase A of #147 — establishes ``MemoryFacade`` as the single owner of the four memory subsystems (``SemanticMemory`` / ``ProceduralMemory`` / ``RelationalMemory`` / ``EpisodicMemory``) plus the ``MemorySearch`` index.  ``LoomSession.start()`` instantiates it as ``self._memory``.

## Why this phase, why now

Graphify re-verification ([comment](https://github.com/Dakai666/Loom/issues/147#issuecomment-4276079092)) showed ``ProceduralMemory`` jumped from 185 → **302 inbound edges** (+63%) since 2026-04-16.  Every new skill-lifecycle tool widens the dependency surface.  Establishing the facade now caps that growth at the entry point.

## Phase A scope (read-only, additive)

- **New file** ``loom/core/memory/facade.py`` (~95 lines)
  - High-level read API: ``search()`` (delegates to MemorySearch), ``get_fact()`` (semantic exact lookup), ``query_relations()`` (RelationalMemory subject/predicate query)
  - Subsystem handles (``.semantic`` / ``.procedural`` / ``.relational`` / ``.episodic`` / ``.search_index``) for callers that haven't been migrated yet
- **``LoomSession.start()``** instantiates ``MemoryFacade`` after the four subsystems exist
- **No caller migration** — existing ``self._semantic`` / ``_procedural`` / ``_relational`` / ``_episodic`` attributes still point at the same instances the facade holds.  All 13 callers identified in the issue keep working untouched.

## Out of scope (deferred)

- Phase B — write-path centralisation (``memorize`` / ``relate``, embedding-failure handling currently silent in ``SemanticMemory.upsert()``)
- Phase C — migrate the 13 direct callers, then remove the ``self._semantic`` etc. attributes

## Test plan

- [x] 7 new tests in ``tests/test_memory_facade.py`` — construction, handle identity, ``search`` delegation, ``get_fact`` (present/missing), ``query_relations`` (subject/predicate filters), ``LoomSession.start()`` integration assert
- [x] Full suite 960 passing (was 953)

Refs #147 (kept open — closes after Phase C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)