### PR TITLE
feat(memory): MemoryFacade write paths + agent tool migration (#147 Phase B)

### DIFF
--- a/loom/core/memory/facade.py
+++ b/loom/core/memory/facade.py
@@ -1,46 +1,56 @@
 """
 MemoryFacade — unified entry point for the four memory subsystems.
 
-Issue #147 階段 A.  Establishes a single object that owns the four memory
-subsystems (``SemanticMemory`` / ``ProceduralMemory`` / ``RelationalMemory``
-/ ``EpisodicMemory``) plus the ``MemorySearch`` index.  ``LoomSession``
-holds it as ``self._memory`` and forwards subsystem references through
-the facade's handles.
+Issue #147 — single object that owns the four memory subsystems
+(``SemanticMemory`` / ``ProceduralMemory`` / ``RelationalMemory`` /
+``EpisodicMemory``) plus the ``MemorySearch`` index and an optional
+``MemoryGovernor``.  ``LoomSession`` holds it as ``self._memory`` and
+forwards subsystem references through the facade's handles.
 
-Phase A scope (read-only, additive):
+Phase A (read API): :meth:`search` / :meth:`get_fact` /
+:meth:`query_relations` — what the agent ``recall`` / ``query_relations``
+tools need.
 
-* High-level read API: :meth:`search`, :meth:`get_fact`,
-  :meth:`query_relations` — covers what the agent ``recall`` / ``memorize``
-  / ``query_relations`` tools actually use.
-* Subsystem handles (``.semantic`` / ``.procedural`` / ``.relational`` /
-  ``.episodic`` / ``.search_index``) for callers that haven't been
-  migrated yet.  Existing tools and plugins continue to receive the raw
-  subsystems — no caller is forced to change in Phase A.
+Phase B (write API + agent tool migration):
 
-Phase B (write-path centralisation: ``memorize`` / ``relate``,
-embedding-failure handling) and Phase C (caller migration + removal of
-the direct subsystem imports) are tracked separately on Issue #147.
+* :meth:`memorize` — semantic write through ``MemoryGovernor`` (or a
+  direct ``SemanticMemory.upsert`` fallback when no governor is wired).
+  Surfaces embedding-write failures via a structured WARN log so callers
+  no longer need to inspect ``MemoryHealthTracker`` themselves.
+* :meth:`relate` — relational triple upsert.
+* :meth:`prune_decayed` — wraps ``SemanticMemory.prune_decayed`` so the
+  ``memory_prune`` cron tool (and any future caller) goes through one
+  entry point.
+
+Phase C (caller migration + removal of the direct subsystem imports) is
+tracked separately on Issue #147.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from loom.core.memory.episodic import EpisodicMemory
+    from loom.core.memory.governance import GovernedWriteResult, MemoryGovernor
     from loom.core.memory.procedural import ProceduralMemory
     from loom.core.memory.relational import RelationalEntry, RelationalMemory
     from loom.core.memory.search import MemorySearch, MemorySearchResult
     from loom.core.memory.semantic import SemanticEntry, SemanticMemory
 
 
+logger = logging.getLogger(__name__)
+
+
 class MemoryFacade:
-    """Single owner of all memory subsystems with a small read API.
+    """Single owner of all memory subsystems with a small read+write API.
 
     The facade is instantiated once per ``LoomSession`` after the four
-    memory subsystems and the ``MemorySearch`` index have been created.
-    It does not reach into any subsystem's private state — each method
-    delegates to the public API of the appropriate subsystem.
+    memory subsystems, the ``MemorySearch`` index, and (optionally) the
+    ``MemoryGovernor`` have been created.  It does not reach into any
+    subsystem's private state — each method delegates to the public API
+    of the appropriate subsystem.
     """
 
     def __init__(
@@ -51,19 +61,21 @@ class MemoryFacade:
         relational: "RelationalMemory",
         episodic: "EpisodicMemory",
         search: "MemorySearch",
+        governor: "MemoryGovernor | None" = None,
     ) -> None:
         self.semantic = semantic
         self.procedural = procedural
         self.relational = relational
         self.episodic = episodic
         self.search_index = search
+        self.governor = governor
 
     # ── read API ─────────────────────────────────────────────────────────
 
     async def search(
         self,
         query: str,
-        type: Literal["semantic", "skill", "all"] = "all",
+        kind: Literal["semantic", "skill", "all"] = "all",
         limit: int = 5,
     ) -> list["MemorySearchResult"]:
         """BM25 + embedding ranked retrieval across semantic + procedural memory.
@@ -71,8 +83,13 @@ class MemoryFacade:
         Wraps :meth:`MemorySearch.recall`.  Equivalent to the agent
         ``recall`` tool, but exposed as a method on the facade so callers
         do not need to know about the search index as a separate object.
+
+        ``kind`` (formerly ``type`` in Phase A) selects which memory
+        backend to hit: ``"semantic"`` facts only, ``"skill"`` for
+        procedural skills only, or ``"all"`` (default).  Renamed to
+        avoid shadowing the ``type`` builtin.
         """
-        return await self.search_index.recall(query, type=type, limit=limit)
+        return await self.search_index.recall(query, type=kind, limit=limit)
 
     async def get_fact(self, key: str) -> "SemanticEntry | None":
         """Direct semantic-memory lookup by exact key."""
@@ -91,3 +108,88 @@ class MemoryFacade:
         the underlying :meth:`RelationalMemory.query` signature.
         """
         return await self.relational.query(subject=subject, predicate=predicate)
+
+    # ── write API ────────────────────────────────────────────────────────
+
+    async def memorize(self, entry: "SemanticEntry") -> "GovernedWriteResult":
+        """Persist a semantic fact through the governance pipeline.
+
+        When a :class:`MemoryGovernor` is wired, delegates to
+        :meth:`MemoryGovernor.governed_upsert` (trust classification +
+        contradiction detection + audit log).  Without a governor — only
+        in tests / minimal setups — falls back to a plain
+        :meth:`SemanticMemory.upsert` and synthesises an equivalent
+        ``GovernedWriteResult`` so the caller's contract stays uniform.
+
+        Embedding failures are silent inside ``SemanticMemory.upsert`` by
+        design (Issue #133 / #147 contract), but the
+        ``MemoryHealthTracker`` records them.  This method snapshots the
+        tracker's ``embedding_write`` failure count before and after the
+        write and emits a structured WARN log if a new failure landed.
+        Callers no longer need to poke at the health tracker directly.
+        """
+        from loom.core.memory.governance import GovernedWriteResult
+
+        before = self._embedding_failure_count()
+
+        if self.governor is not None:
+            result = await self.governor.governed_upsert(entry)
+        else:
+            conflicted = await self.semantic.upsert(entry)
+            result = GovernedWriteResult(
+                written=True,
+                trust_tier="unknown",
+                adjusted_confidence=entry.confidence,
+                contradictions_found=0,
+                resolution="replaced" if conflicted else None,
+            )
+
+        after = self._embedding_failure_count()
+        if after > before:
+            logger.warning(
+                "memorize: embedding write failed for key=%r — entry "
+                "stored but semantic search will miss it (see "
+                "memory_health for details)",
+                entry.key,
+            )
+
+        return result
+
+    async def relate(self, entry: "RelationalEntry") -> None:
+        """Upsert a relational (subject, predicate, object) triple.
+
+        Thin wrapper around :meth:`RelationalMemory.upsert` so callers
+        that already hold a facade do not need a second handle for
+        relational writes.  Relational memory has no governance hooks
+        today; this method exists so future governance can be added in
+        one place.
+        """
+        await self.relational.upsert(entry)
+
+    async def prune_decayed(
+        self,
+        threshold: float = 0.1,
+        dry_run: bool = False,
+    ) -> dict:
+        """Prune semantic entries whose effective confidence has decayed.
+
+        Wraps :meth:`SemanticMemory.prune_decayed`.  Returns the same
+        ``{examined, pruned, retained, threshold, dry_run}`` dict.
+        """
+        return await self.semantic.prune_decayed(
+            threshold=threshold, dry_run=dry_run,
+        )
+
+    # ── internal helpers ────────────────────────────────────────────────
+
+    def _embedding_failure_count(self) -> int:
+        """Read the current ``embedding_write`` failure count from the
+        governor's health tracker, or 0 when no governor is wired.
+
+        Used by :meth:`memorize` to detect whether a new failure landed
+        during the write so it can be surfaced through a structured log.
+        """
+        if self.governor is None:
+            return 0
+        op = self.governor.health.report().operations.get("embedding_write")
+        return op.failure_count if op else 0

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -772,10 +772,12 @@ class LoomSession:
         search = MemorySearch(self._semantic, self._procedural)
         search._health = self._governor.health
 
-        # Issue #147 階段 A: single owner of the four memory subsystems +
-        # search index. Existing self._semantic / _procedural / _relational
-        # / _episodic attributes still point at the same instances, so
-        # callers that reach into them keep working until 階段 B/C.
+        # Issue #147 階段 B: single owner of the four memory subsystems +
+        # search index + governor. The four agent memory tools below are
+        # wired through the facade. Existing self._semantic /
+        # _procedural / _relational / _episodic attributes still point
+        # at the same instances, so wider callers keep working until
+        # 階段 C migrates them too.
         from loom.core.memory.facade import MemoryFacade
         self._memory = MemoryFacade(
             semantic=self._semantic,
@@ -783,12 +785,13 @@ class LoomSession:
             relational=self._relational,
             episodic=self._episodic,
             search=search,
+            governor=self._governor,
         )
 
-        self.registry.register(make_recall_tool(search))
-        self.registry.register(make_memorize_tool(self._semantic, governor=self._governor))
-        self.registry.register(make_relate_tool(self._relational))
-        self.registry.register(make_query_relations_tool(self._relational))
+        self.registry.register(make_recall_tool(self._memory))
+        self.registry.register(make_memorize_tool(self._memory))
+        self.registry.register(make_relate_tool(self._memory))
+        self.registry.register(make_query_relations_tool(self._memory))
         self.registry.register(make_memory_health_tool(self._governor))
 
         # Issue #149: dream_cycle / memory_prune are now first-class memory

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from loom.core.cognition.skill_mutator import SkillMutator
     from loom.core.cognition.skill_promoter import SkillPromoter
     from loom.core.harness.skill_checks import SkillCheckManager
+    from loom.core.memory.facade import MemoryFacade
     from loom.core.memory.procedural import ProceduralMemory, SkillGenome
     from loom.core.memory.relational import RelationalMemory
     from loom.core.memory.search import MemorySearch
@@ -655,11 +656,12 @@ async def _run_bash_job(
 # Close over live memory store instances; call from LoomSession.start().
 # ------------------------------------------------------------------
 
-def make_recall_tool(search: "MemorySearch") -> ToolDefinition:
+def make_recall_tool(memory: "MemoryFacade") -> ToolDefinition:
     """
-    Create a SAFE ``recall`` tool bound to the given MemorySearch instance.
+    Create a SAFE ``recall`` tool bound to the given MemoryFacade.
 
-    The tool performs BM25-ranked retrieval across semantic facts and skills.
+    The tool performs BM25-ranked retrieval across semantic facts and
+    skills via :meth:`MemoryFacade.search`.
     """
     async def _recall(call: ToolCall) -> ToolResult:
         query = call.args.get("query", "").strip()
@@ -673,7 +675,7 @@ def make_recall_tool(search: "MemorySearch") -> ToolDefinition:
         if mem_type not in ("semantic", "skill", "all"):
             mem_type = "all"
 
-        results = await search.recall(query, type=mem_type, limit=limit)  # type: ignore[arg-type]
+        results = await memory.search(query, kind=mem_type, limit=limit)  # type: ignore[arg-type]
 
         if not results:
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
@@ -723,16 +725,16 @@ def make_recall_tool(search: "MemorySearch") -> ToolDefinition:
     )
 
 
-def make_memorize_tool(
-    semantic: "SemanticMemory",
-    governor: "MemoryGovernor | None" = None,
-) -> ToolDefinition:
+def make_memorize_tool(memory: "MemoryFacade") -> ToolDefinition:
     """
-    Create a GUARDED ``memorize`` tool bound to the given SemanticMemory instance.
+    Create a GUARDED ``memorize`` tool bound to the given MemoryFacade.
 
     Stores a key→value fact in semantic memory for future sessions.
-    When a MemoryGovernor is provided, writes go through the governance
-    pipeline (trust classification + contradiction detection).
+    The facade routes the write through ``MemoryGovernor`` when one is
+    wired (trust classification + contradiction detection); otherwise it
+    falls back to a direct semantic upsert.  Either way the result shape
+    (``GovernedWriteResult``) is uniform, and embedding-write failures
+    are surfaced through a structured WARN log inside the facade.
     """
     from loom.core.memory.semantic import SemanticEntry
 
@@ -746,31 +748,26 @@ def make_memorize_tool(
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
                               success=False, error="Both 'key' and 'value' are required")
 
-        # Agent-invoked memorize is treated as user_explicit trust
         entry = SemanticEntry(key=key, value=value, confidence=confidence, source="memorize")
+        gov_result = await memory.memorize(entry)
 
-        if governor is not None:
-            gov_result = await governor.governed_upsert(entry)
-            if not gov_result.written:
-                msg = (
-                    f"Memorize skipped for {key!r}: existing entry has higher trust "
-                    f"(tier={gov_result.trust_tier}, contradictions={gov_result.contradictions_found})"
-                )
-                return ToolResult(call_id=call.id, tool_name=call.tool_name,
-                                  success=True, output=msg)
-            if gov_result.contradictions_found > 0:
-                msg = (
-                    f"Memorized: {key!r} (resolved {gov_result.contradictions_found} "
-                    f"contradiction(s) — {gov_result.resolution})"
-                )
-            else:
-                msg = f"Memorized: {key!r}"
+        if not gov_result.written:
+            msg = (
+                f"Memorize skipped for {key!r}: existing entry has higher trust "
+                f"(tier={gov_result.trust_tier}, contradictions={gov_result.contradictions_found})"
+            )
+            return ToolResult(call_id=call.id, tool_name=call.tool_name,
+                              success=True, output=msg)
+
+        if gov_result.contradictions_found > 0:
+            msg = (
+                f"Memorized: {key!r} (resolved {gov_result.contradictions_found} "
+                f"contradiction(s) — {gov_result.resolution})"
+            )
+        elif gov_result.resolution == "replaced":
+            msg = f"Memorized: {key!r} (overwrote previous value — history preserved)"
         else:
-            conflicted = await semantic.upsert(entry)
-            if conflicted:
-                msg = f"Memorized: {key!r} (overwrote previous value — history preserved)"
-            else:
-                msg = f"Memorized: {key!r}"
+            msg = f"Memorized: {key!r}"
 
         return ToolResult(call_id=call.id, tool_name=call.tool_name,
                           success=True, output=msg,
@@ -783,7 +780,7 @@ def make_memorize_tool(
             return ToolResult(call_id=call.id, tool_name="memorize",
                               success=False, error="No key to rollback")
         try:
-            await semantic.delete(key)
+            await memory.semantic.delete(key)
             return ToolResult(call_id=call.id, tool_name="memorize",
                               success=True, output=f"Rolled back: deleted key {key!r}")
         except Exception as exc:
@@ -927,11 +924,12 @@ def make_agent_health_tool(tracker: "AgentTelemetryTracker") -> ToolDefinition:
     )
 
 
-def make_relate_tool(relational: "RelationalMemory") -> ToolDefinition:
+def make_relate_tool(memory: "MemoryFacade") -> ToolDefinition:
     """
-    Create a GUARDED ``relate`` tool bound to the given RelationalMemory instance.
+    Create a GUARDED ``relate`` tool bound to the given MemoryFacade.
 
-    Stores a (subject, predicate, object) triple — e.g.
+    Stores a (subject, predicate, object) triple via
+    :meth:`MemoryFacade.relate` — e.g.
     relate(subject="user", predicate="prefers", object="concise responses").
     """
     from loom.core.memory.relational import RelationalEntry
@@ -954,7 +952,7 @@ def make_relate_tool(relational: "RelationalMemory") -> ToolDefinition:
             confidence=confidence,
             source="agent",
         )
-        await relational.upsert(entry)
+        await memory.relate(entry)
         return ToolResult(call_id=call.id, tool_name=call.tool_name,
                           success=True, output=f"Stored: {subject!r} {predicate!r} {obj!r}",
                           metadata={"_subject": subject, "_predicate": predicate})
@@ -967,7 +965,7 @@ def make_relate_tool(relational: "RelationalMemory") -> ToolDefinition:
             return ToolResult(call_id=call.id, tool_name="relate",
                               success=False, error="No subject/predicate to rollback")
         try:
-            await relational.delete(subject, predicate)
+            await memory.relational.delete(subject, predicate)
             return ToolResult(call_id=call.id, tool_name="relate",
                               success=True,
                               output=f"Rolled back: deleted ({subject!r}, {predicate!r})")
@@ -1002,11 +1000,12 @@ def make_relate_tool(relational: "RelationalMemory") -> ToolDefinition:
     )
 
 
-def make_query_relations_tool(relational: "RelationalMemory") -> ToolDefinition:
+def make_query_relations_tool(memory: "MemoryFacade") -> ToolDefinition:
     """
-    Create a SAFE ``query_relations`` tool bound to the given RelationalMemory instance.
+    Create a SAFE ``query_relations`` tool bound to the given MemoryFacade.
 
-    Returns all triples matching the given subject and/or predicate filters.
+    Returns all triples matching the given subject and/or predicate
+    filters via :meth:`MemoryFacade.query_relations`.
     """
     async def _query_relations(call: ToolCall) -> ToolResult:
         subject = call.args.get("subject", "").strip() or None
@@ -1016,7 +1015,7 @@ def make_query_relations_tool(relational: "RelationalMemory") -> ToolDefinition:
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
                               success=False, error="At least one of 'subject' or 'predicate' is required")
 
-        entries = await relational.query(subject=subject, predicate=predicate)
+        entries = await memory.query_relations(subject=subject, predicate=predicate)
         if not entries:
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
                               success=True, output="No matching relationships found.")

--- a/tests/test_memory_facade.py
+++ b/tests/test_memory_facade.py
@@ -1,20 +1,24 @@
 """
-Issue #147 階段 A — MemoryFacade.
+Issue #147 — MemoryFacade.
 
-Verifies the facade owns the four memory subsystems plus the search
-index, and that its three high-level read methods (``search`` /
-``get_fact`` / ``query_relations``) delegate to the right subsystem.
-Also verifies handle identity so ``LoomSession`` callers that still
-reach through ``self._semantic`` etc. keep seeing the same object the
-facade holds.
+Verifies the facade owns the four memory subsystems + search index +
+optional governor, and that its read API (``search`` / ``get_fact`` /
+``query_relations``) and write API (``memorize`` / ``relate`` /
+``prune_decayed``) delegate to the right subsystem.  Also verifies
+handle identity so ``LoomSession`` callers that still reach through
+``self._semantic`` etc. keep seeing the same object the facade holds.
 """
 from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
 
 from loom.core.memory.episodic import EpisodicMemory
 from loom.core.memory.facade import MemoryFacade
+from loom.core.memory.governance import GovernedWriteResult, MemoryGovernor
 from loom.core.memory.procedural import ProceduralMemory
 from loom.core.memory.relational import RelationalEntry, RelationalMemory
 from loom.core.memory.search import MemorySearch
@@ -104,7 +108,7 @@ async def test_search_delegates_to_search_index(facade):
         key="topic:loom", value="loom is a memory-native agent framework",
         confidence=0.9, source="user_explicit",
     ))
-    results = await facade.search("memory framework", type="semantic", limit=5)
+    results = await facade.search("memory framework", kind="semantic", limit=5)
     assert results, "facade.search should hit the BM25 index for matching content"
     assert any("loom is a memory-native" in r.value for r in results)
 
@@ -153,6 +157,248 @@ async def test_session_holds_facade_aliased_to_subsystems(monkeypatch, tmp_path)
         assert session._memory.procedural is session._procedural
         assert session._memory.relational is session._relational
         assert session._memory.episodic is session._episodic
+    finally:
+        await session.stop()
+        registry._tools.clear()
+        registry._tools.update(original_tools)
+
+
+# ── write API: memorize (no governor — fallback path) ──────────────────────
+
+@pytest.mark.asyncio
+async def test_memorize_without_governor_falls_back_to_semantic_upsert(facade):
+    """When no governor is wired, ``memorize`` writes through the
+    semantic subsystem directly and synthesises a ``GovernedWriteResult``
+    so callers see a uniform contract."""
+    result = await facade.memorize(SemanticEntry(
+        key="loom:phaseB", value="memorize goes through facade",
+        confidence=0.85, source="test",
+    ))
+
+    assert isinstance(result, GovernedWriteResult)
+    assert result.written is True
+    assert result.contradictions_found == 0
+    assert result.trust_tier == "unknown"  # marker for governor-less path
+
+    stored = await facade.semantic.get("loom:phaseB")
+    assert stored is not None
+    assert stored.value == "memorize goes through facade"
+
+
+@pytest.mark.asyncio
+async def test_memorize_without_governor_marks_overwrite_in_resolution(facade):
+    """Synthesised GovernedWriteResult uses 'replaced' resolution when
+    upsert reports a value conflict — gives callers parity with the
+    governed path's resolution semantics."""
+    await facade.semantic.upsert(SemanticEntry(
+        key="loom:overwrite", value="original", confidence=0.5, source="test",
+    ))
+    result = await facade.memorize(SemanticEntry(
+        key="loom:overwrite", value="updated", confidence=0.5, source="test",
+    ))
+    assert result.written is True
+    assert result.resolution == "replaced"
+
+
+# ── write API: memorize (with governor) ────────────────────────────────────
+
+@pytest_asyncio.fixture
+async def governed_facade(tmp_path):
+    """Facade wired with a real MemoryGovernor so the governance path
+    can be exercised end-to-end."""
+    store = SQLiteStore(str(tmp_path / "governed.db"))
+    await store.initialize()
+    async with store.connect() as db:
+        semantic = SemanticMemory(db)
+        procedural = ProceduralMemory(db)
+        relational = RelationalMemory(db)
+        episodic = EpisodicMemory(db)
+        governor = MemoryGovernor(
+            semantic=semantic, procedural=procedural,
+            relational=relational, episodic=episodic,
+            db=db, session_id="test-session",
+        )
+        await governor.health.ensure_table()
+        semantic._health = governor.health
+        search = MemorySearch(semantic, procedural)
+        yield MemoryFacade(
+            semantic=semantic, procedural=procedural,
+            relational=relational, episodic=episodic,
+            search=search, governor=governor,
+        )
+
+
+@pytest.mark.asyncio
+async def test_memorize_with_governor_routes_through_governed_upsert(governed_facade):
+    """When a governor is wired, ``memorize`` delegates so trust
+    classification and audit logging happen for every write."""
+    result = await governed_facade.memorize(SemanticEntry(
+        key="proj:routing", value="facade routes through governor",
+        confidence=0.6, source="manual",
+    ))
+    assert result.written is True
+    # "manual" classifies as user_explicit — governor must have run
+    assert result.trust_tier == "user_explicit"
+    # Trust tier should have lifted confidence to the tier's floor (1.0)
+    assert result.adjusted_confidence == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_memorize_surfaces_embedding_failure_via_warn_log(
+    governed_facade, caplog,
+):
+    """The facade snapshots the health tracker's embedding-write
+    failure count before/after each write; if it climbs, a structured
+    WARN log is emitted so callers don't need to poll memory_health."""
+    # Simulate a downstream embedding failure landing during the write.
+    governed_facade.governor.health.record_failure(
+        "embedding_write", "simulated provider timeout",
+    )
+
+    async def fake_governed_upsert(entry):
+        # Mimic SemanticMemory recording another failure during upsert.
+        governed_facade.governor.health.record_failure(
+            "embedding_write", "second failure during upsert",
+        )
+        return GovernedWriteResult(
+            written=True, trust_tier="unknown",
+            adjusted_confidence=entry.confidence, contradictions_found=0,
+        )
+
+    governed_facade.governor.governed_upsert = fake_governed_upsert  # type: ignore[assignment]
+
+    with caplog.at_level(logging.WARNING, logger="loom.core.memory.facade"):
+        await governed_facade.memorize(SemanticEntry(
+            key="proj:warn", value="will trip the warn path",
+            confidence=0.5, source="test",
+        ))
+
+    assert any(
+        "embedding write failed" in rec.message and "proj:warn" in rec.message
+        for rec in caplog.records
+    ), "expected a structured WARN log surfacing the new embedding failure"
+
+
+@pytest.mark.asyncio
+async def test_memorize_no_warn_when_embedding_failure_count_unchanged(
+    governed_facade, caplog,
+):
+    """Negative case: a clean write must not produce the warn log."""
+    with caplog.at_level(logging.WARNING, logger="loom.core.memory.facade"):
+        await governed_facade.memorize(SemanticEntry(
+            key="proj:clean", value="clean write, no failures",
+            confidence=0.7, source="test",
+        ))
+
+    assert not any(
+        "embedding write failed" in rec.message
+        for rec in caplog.records
+    )
+
+
+# ── write API: relate ──────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_relate_upserts_into_relational_memory(facade):
+    await facade.relate(RelationalEntry(
+        subject="user", predicate="prefers", object="terse output", source="test",
+    ))
+    rels = await facade.query_relations(subject="user")
+    assert len(rels) == 1
+    assert rels[0].object == "terse output"
+
+
+@pytest.mark.asyncio
+async def test_relate_uses_facade_held_relational_instance():
+    """relate() must write to the same RelationalMemory the facade
+    exposes — otherwise tools that read via facade.query_relations
+    wouldn't see writes from facade.relate."""
+    rel_mock = AsyncMock(spec=RelationalMemory)
+    facade = MemoryFacade(
+        semantic=AsyncMock(), procedural=AsyncMock(),
+        relational=rel_mock, episodic=AsyncMock(),
+        search=AsyncMock(),
+    )
+    entry = RelationalEntry(subject="a", predicate="b", object="c", source="t")
+    await facade.relate(entry)
+    rel_mock.upsert.assert_awaited_once_with(entry)
+
+
+# ── write API: prune_decayed ───────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_prune_decayed_delegates_to_semantic(facade):
+    """Sanity check — facade.prune_decayed forwards args and returns the
+    semantic subsystem's report dict unchanged."""
+    # Empty store: examined=0, pruned=0
+    report = await facade.prune_decayed(threshold=0.2, dry_run=True)
+    assert report["examined"] == 0
+    assert report["pruned"] == 0
+    assert report["threshold"] == 0.2
+    assert report["dry_run"] is True
+
+
+@pytest.mark.asyncio
+async def test_prune_decayed_forwards_kwargs():
+    """prune_decayed must pass threshold and dry_run through verbatim."""
+    sem_mock = AsyncMock(spec=SemanticMemory)
+    sem_mock.prune_decayed.return_value = {
+        "examined": 5, "pruned": 1, "retained": 4,
+        "threshold": 0.3, "dry_run": False,
+    }
+    facade = MemoryFacade(
+        semantic=sem_mock, procedural=AsyncMock(),
+        relational=AsyncMock(), episodic=AsyncMock(), search=AsyncMock(),
+    )
+    out = await facade.prune_decayed(threshold=0.3, dry_run=False)
+    sem_mock.prune_decayed.assert_awaited_once_with(threshold=0.3, dry_run=False)
+    assert out["pruned"] == 1
+
+
+# ── session integration: agent tools wired through facade ──────────────────
+
+@pytest.mark.asyncio
+async def test_session_registers_memory_tools_through_facade(monkeypatch, tmp_path):
+    """Issue #147 階段 B: the four agent memory tools (recall, memorize,
+    relate, query_relations) must be registered with the facade — not
+    individual subsystem references — so future Phase C migrations can
+    drop the direct subsystem fields without breaking tool wiring."""
+    from unittest.mock import MagicMock
+    from rich.prompt import Confirm
+    import loom as loom_pkg
+    from loom.core import session as core_session
+
+    registry = loom_pkg._get_default_registry()
+    original_tools = dict(registry._tools)
+    registry._tools.clear()
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(core_session, "build_router", lambda: MagicMock())
+    monkeypatch.setattr(core_session, "_load_loom_config", lambda: {})
+    monkeypatch.setattr(core_session, "_load_env", lambda project_root=None: {})
+    monkeypatch.setattr(core_session, "build_embedding_provider", lambda env, cfg: None)
+    monkeypatch.setattr(Confirm, "ask", lambda *args, **kwargs: True)
+
+    from loom.core.session import LoomSession
+    session = LoomSession(
+        model="gpt-test",
+        db_path=str(tmp_path / "loom.db"),
+        workspace=workspace,
+    )
+    try:
+        await session.start()
+
+        # Phase B contract: facade carries the governor, and the four
+        # agent memory tools are present on the registry.
+        assert session._memory.governor is session._governor
+        for name in ("recall", "memorize", "relate", "query_relations"):
+            assert session.registry.get(name) is not None, (
+                f"tool {name!r} must be registered through the facade"
+            )
     finally:
         await session.stop()
         registry._tools.clear()

--- a/tests/test_memory_search.py
+++ b/tests/test_memory_search.py
@@ -39,6 +39,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 from loom.core.memory.store import SQLiteStore
 from loom.core.memory.episodic import EpisodicEntry, EpisodicMemory
+from loom.core.memory.facade import MemoryFacade
+from loom.core.memory.relational import RelationalMemory
 from loom.core.memory.semantic import SemanticEntry, SemanticMemory
 from loom.core.memory.procedural import SkillGenome, ProceduralMemory
 from loom.core.memory.search import MemorySearch, MemorySearchResult
@@ -46,6 +48,27 @@ from loom.core.memory.index import MemoryIndex, MemoryIndexer
 from loom.core.harness.middleware import ToolCall, ToolResult
 from loom.core.harness.permissions import TrustLevel
 from loom.platform.cli.tools import make_recall_tool, make_memorize_tool
+
+
+def _facade(
+    *,
+    semantic: SemanticMemory,
+    procedural: ProceduralMemory,
+    relational: RelationalMemory | None = None,
+    episodic: EpisodicMemory | None = None,
+    search: MemorySearch | None = None,
+) -> MemoryFacade:
+    """Phase-B helper: build a MemoryFacade from whatever subsystems
+    the caller already has. Tests that don't exercise relational /
+    episodic / governor pass ``MagicMock()`` for the unused handles."""
+    return MemoryFacade(
+        semantic=semantic,
+        procedural=procedural,
+        relational=relational or MagicMock(),
+        episodic=episodic or MagicMock(),
+        search=search or MemorySearch(semantic, procedural),
+        governor=None,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -283,8 +306,7 @@ class TestRecallTool:
     async def test_success_returns_formatted_output(self, semantic, procedural):
         await semantic.upsert(SemanticEntry(key="loom:core", value="Loom uses middleware pipeline"))
 
-        search = MemorySearch(semantic, procedural)
-        tool = make_recall_tool(search)
+        tool = make_recall_tool(_facade(semantic=semantic, procedural=procedural))
         call = _make_call("recall", {"query": "middleware pipeline"})
         result = await tool.executor(call)
 
@@ -293,8 +315,7 @@ class TestRecallTool:
         assert "middleware" in result.output.lower()
 
     async def test_missing_query_returns_error(self, semantic, procedural):
-        search = MemorySearch(semantic, procedural)
-        tool = make_recall_tool(search)
+        tool = make_recall_tool(_facade(semantic=semantic, procedural=procedural))
         call = _make_call("recall", {})
         result = await tool.executor(call)
 
@@ -302,8 +323,7 @@ class TestRecallTool:
         assert "query" in result.error.lower()
 
     async def test_empty_results_message(self, semantic, procedural):
-        search = MemorySearch(semantic, procedural)
-        tool = make_recall_tool(search)
+        tool = make_recall_tool(_facade(semantic=semantic, procedural=procedural))
         call = _make_call("recall", {"query": "nonexistent topic xyz"})
         result = await tool.executor(call)
 
@@ -314,8 +334,7 @@ class TestRecallTool:
         skill = SkillGenome(name="bash_skill", body="use bash for automation", tags=["bash"])
         await procedural.upsert(skill)
 
-        search = MemorySearch(semantic, procedural)
-        tool = make_recall_tool(search)
+        tool = make_recall_tool(_facade(semantic=semantic, procedural=procedural))
         call = _make_call("recall", {"query": "bash automation", "type": "skill"})
         result = await tool.executor(call)
 
@@ -325,23 +344,19 @@ class TestRecallTool:
         for i in range(15):
             await semantic.upsert(SemanticEntry(key=f"k{i}", value=f"loom fact {i}"))
 
-        search = MemorySearch(semantic, procedural)
-        tool = make_recall_tool(search)
+        tool = make_recall_tool(_facade(semantic=semantic, procedural=procedural))
         # Request 50, should be capped at 10
         call = _make_call("recall", {"query": "loom", "limit": 50})
         result = await tool.executor(call)
         assert result.success is True
 
-    def test_tool_is_safe_trust_level(self, semantic=None, procedural=None):
-        # Just check the metadata without needing DB
-        from unittest.mock import MagicMock
-        mock_search = MagicMock()
-        tool = make_recall_tool(mock_search)
+    def test_tool_is_safe_trust_level(self):
+        # Metadata-only check; facade handles can be mocks.
+        tool = make_recall_tool(MagicMock())
         assert tool.trust_level == TrustLevel.SAFE
         assert "recall" in tool.tags
 
     def test_tool_has_correct_schema(self):
-        from unittest.mock import MagicMock
         tool = make_recall_tool(MagicMock())
         assert "query" in tool.input_schema["properties"]
         assert "query" in tool.input_schema["required"]
@@ -352,8 +367,8 @@ class TestRecallTool:
 # ---------------------------------------------------------------------------
 
 class TestMemorizeTool:
-    async def test_persists_entry(self, semantic):
-        tool = make_memorize_tool(semantic)
+    async def test_persists_entry(self, semantic, procedural):
+        tool = make_memorize_tool(_facade(semantic=semantic, procedural=procedural))
         call = _make_call("memorize", {"key": "project:arch", "value": "Loom uses SQLite WAL"})
         result = await tool.executor(call)
 
@@ -363,48 +378,48 @@ class TestMemorizeTool:
         assert stored.value == "Loom uses SQLite WAL"
         assert stored.source == "memorize"
 
-    async def test_missing_key_returns_error(self, semantic):
-        tool = make_memorize_tool(semantic)
+    async def test_missing_key_returns_error(self, semantic, procedural):
+        tool = make_memorize_tool(_facade(semantic=semantic, procedural=procedural))
         call = _make_call("memorize", {"value": "some fact"})
         result = await tool.executor(call)
         assert result.success is False
 
-    async def test_missing_value_returns_error(self, semantic):
-        tool = make_memorize_tool(semantic)
+    async def test_missing_value_returns_error(self, semantic, procedural):
+        tool = make_memorize_tool(_facade(semantic=semantic, procedural=procedural))
         call = _make_call("memorize", {"key": "some_key"})
         result = await tool.executor(call)
         assert result.success is False
 
-    async def test_confidence_default(self, semantic):
-        tool = make_memorize_tool(semantic)
+    async def test_confidence_default(self, semantic, procedural):
+        tool = make_memorize_tool(_facade(semantic=semantic, procedural=procedural))
         call = _make_call("memorize", {"key": "k1", "value": "fact"})
         await tool.executor(call)
         stored = await semantic.get("k1")
         assert stored.confidence == 0.8
 
-    async def test_confidence_custom(self, semantic):
-        tool = make_memorize_tool(semantic)
+    async def test_confidence_custom(self, semantic, procedural):
+        tool = make_memorize_tool(_facade(semantic=semantic, procedural=procedural))
         call = _make_call("memorize", {"key": "k2", "value": "fact", "confidence": 0.95})
         await tool.executor(call)
         stored = await semantic.get("k2")
         assert stored.confidence == pytest.approx(0.95)
 
-    async def test_confidence_clamped_above_one(self, semantic):
-        tool = make_memorize_tool(semantic)
+    async def test_confidence_clamped_above_one(self, semantic, procedural):
+        tool = make_memorize_tool(_facade(semantic=semantic, procedural=procedural))
         call = _make_call("memorize", {"key": "k3", "value": "fact", "confidence": 5.0})
         await tool.executor(call)
         stored = await semantic.get("k3")
         assert stored.confidence <= 1.0
 
-    async def test_confidence_clamped_below_zero(self, semantic):
-        tool = make_memorize_tool(semantic)
+    async def test_confidence_clamped_below_zero(self, semantic, procedural):
+        tool = make_memorize_tool(_facade(semantic=semantic, procedural=procedural))
         call = _make_call("memorize", {"key": "k4", "value": "fact", "confidence": -1.0})
         await tool.executor(call)
         stored = await semantic.get("k4")
         assert stored.confidence >= 0.0
 
-    async def test_upsert_updates_existing(self, semantic):
-        tool = make_memorize_tool(semantic)
+    async def test_upsert_updates_existing(self, semantic, procedural):
+        tool = make_memorize_tool(_facade(semantic=semantic, procedural=procedural))
         call1 = _make_call("memorize", {"key": "shared", "value": "original"})
         call2 = _make_call("memorize", {"key": "shared", "value": "updated"})
         await tool.executor(call1)
@@ -413,9 +428,7 @@ class TestMemorizeTool:
         assert stored.value == "updated"
 
     def test_tool_is_guarded_trust_level(self):
-        from unittest.mock import MagicMock
-        mock_sem = MagicMock()
-        tool = make_memorize_tool(mock_sem)
+        tool = make_memorize_tool(MagicMock())
         assert tool.trust_level == TrustLevel.GUARDED
         assert "memorize" in tool.tags
 

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -8,7 +8,10 @@ from loom.core.agent.subagent import SubAgentConfig, run_subagent
 from loom.core.cognition.providers import LLMResponse, ToolUse
 from loom.core.harness.registry import ToolRegistry
 from loom.core.memory.episodic import EpisodicMemory
+from loom.core.memory.facade import MemoryFacade
 from loom.core.memory.procedural import ProceduralMemory
+from loom.core.memory.relational import RelationalMemory
+from loom.core.memory.search import MemorySearch
 from loom.core.memory.semantic import SemanticMemory
 from loom.core.memory.store import SQLiteStore
 from loom.platform.cli.tools import make_memorize_tool
@@ -67,7 +70,13 @@ class TestSubAgentMemorize:
         tmp_path: Path,
     ) -> None:
         registry = ToolRegistry()
-        registry.register(make_memorize_tool(semantic))
+        relational = RelationalMemory(semantic._db)
+        facade = MemoryFacade(
+            semantic=semantic, procedural=procedural,
+            relational=relational, episodic=episodic,
+            search=MemorySearch(semantic, procedural),
+        )
+        registry.register(make_memorize_tool(facade))
         router = _FakeRouter([
             LLMResponse(
                 text=None,


### PR DESCRIPTION
## Summary

- Phase B of Issue #147 — adds the writer side of `MemoryFacade` and migrates the four agent memory tools (`recall` / `memorize` / `relate` / `query_relations`) to go through it.
- New facade methods: `memorize` (governor-routed with no-governor fallback + embedding-failure WARN surfacing via `MemoryHealthTracker`), `relate`, `prune_decayed`. Constructor now accepts an optional `governor`.
- `search()`'s `type` parameter renamed to `kind` to stop shadowing the builtin (Phase A review feedback). The agent tool's JSON schema keeps `"type"` so the agent-facing contract is unchanged.
- 4 factories in `loom/platform/cli/tools.py` now take a single `MemoryFacade`; `LoomSession.start()` passes `self._memory`.

## Phase scope

| Phase | Status | What it does |
|-------|--------|--------------|
| A | merged (#174) | facade owns all subsystems + read API |
| **B** | **this PR** | write paths + governor wiring + agent tool migration |
| C | deferred | migrate the 13 wider callers (cli/main, autonomy/planner, etc.) and drop `self._semantic` / `_procedural` / `_relational` / `_episodic` from `LoomSession`. Will close #147. |

`Refs #147` (not `Closes`) — Phase C is still pending.

## Tests

- 970 passed (up from 960 — +10 new facade tests)
- New coverage: write paths through governor / no-governor, embedding-failure WARN surfacing (positive + negative), `relate` delegation, `prune_decayed` kwargs forwarding, session-integration assert that the four tools are registered through the facade.
- Updated `test_memory_search.py` + `test_subagent.py` to build a `MemoryFacade` for the migrated factories.

## Test plan

- [x] `pytest tests/test_memory_facade.py tests/test_memory_search.py tests/test_subagent.py` — 75 passed
- [x] `pytest tests/` — 970 passed
- [ ] Smoke `loom chat` after merge to confirm `recall` / `memorize` / `relate` / `query_relations` still work end-to-end through the facade
- [ ] Smoke `loom discord start --autonomy` once after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)