### PR TITLE
refactor(cognition): MemoryFacade migration for multi-subsystem callers (#147 Phase C.1)

### DIFF
--- a/loom/core/cognition/counter_factual.py
+++ b/loom/core/cognition/counter_factual.py
@@ -44,13 +44,13 @@ import logging
 from datetime import datetime, UTC
 from typing import TYPE_CHECKING
 
-from loom.core.memory.relational import RelationalEntry, RelationalMemory
-from loom.core.memory.semantic import SemanticEntry, SemanticMemory
+from loom.core.memory.relational import RelationalEntry
+from loom.core.memory.semantic import SemanticEntry
 
 if TYPE_CHECKING:
     from loom.core.cognition.router import LLMRouter
     from loom.core.harness.middleware import ToolCall, ToolResult
-    from loom.core.memory.procedural import ProceduralMemory
+    from loom.core.memory.facade import MemoryFacade
 
 logger = logging.getLogger(__name__)
 
@@ -83,28 +83,25 @@ class CounterFactualReflector:
         The session LLMRouter — used to fire the reflection prompt.
     model:
         Model identifier passed to the router.
-    procedural:
-        ProceduralMemory — checked to confirm the failing tool has a
-        SkillGenome entry (only named skills are reflected on).
-    semantic:
-        SemanticMemory — destination for the anti-pattern text.
-    relational:
-        RelationalMemory — destination for ``loom-self / skill`` triples.
+    memory:
+        :class:`MemoryFacade` — provides access to procedural memory
+        (gating which tools have a tracked SkillGenome), semantic
+        memory (anti-pattern text destination), and relational memory
+        (``loom-self / skill`` triples destination).
     """
 
     def __init__(
         self,
-        router: LLMRouter,
+        router: "LLMRouter",
         model: str,
-        procedural: ProceduralMemory,
-        semantic: SemanticMemory,
-        relational: RelationalMemory,
+        memory: "MemoryFacade",
     ) -> None:
         self._router = router
         self._model = model
-        self._procedural = procedural
-        self._semantic = semantic
-        self._relational = relational
+        self._memory = memory
+        self._procedural = memory.procedural
+        self._semantic = memory.semantic
+        self._relational = memory.relational
 
     # ------------------------------------------------------------------
     # Public API
@@ -292,13 +289,13 @@ class SkillEvolutionHook:
         self,
         router: "LLMRouter",
         model: str,
-        procedural: "ProceduralMemory",
-        semantic: SemanticMemory,
+        memory: "MemoryFacade",
     ) -> None:
         self._router = router
         self._model = model
-        self._procedural = procedural
-        self._semantic = semantic
+        self._memory = memory
+        self._procedural = memory.procedural
+        self._semantic = memory.semantic
 
     async def check_all_skills(self) -> int:
         """

--- a/loom/core/cognition/reflection.py
+++ b/loom/core/cognition/reflection.py
@@ -9,24 +9,24 @@ Phase 2: query interface over episodic + procedural memory.
 Phase 3: the Autonomy Engine will call this to decide what to do next.
 """
 
-from loom.core.memory.episodic import EpisodicMemory
-from loom.core.memory.procedural import ProceduralMemory
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from loom.core.memory.facade import MemoryFacade
 
 
 class ReflectionAPI:
     """
     Read-only window into the agent's own history and skill health.
 
-    Injected with memory instances at session start.
+    Injected with the session's :class:`MemoryFacade` at start; reads
+    episodic and procedural memory through the facade's handles.
     """
 
-    def __init__(
-        self,
-        episodic: EpisodicMemory,
-        procedural: ProceduralMemory,
-    ) -> None:
-        self._episodic = episodic
-        self._procedural = procedural
+    def __init__(self, memory: "MemoryFacade") -> None:
+        self._memory = memory
+        self._episodic = memory.episodic
+        self._procedural = memory.procedural
 
     # ------------------------------------------------------------------
     # Session trace queries

--- a/loom/core/cognition/task_reflector.py
+++ b/loom/core/cognition/task_reflector.py
@@ -35,10 +35,7 @@ if TYPE_CHECKING:
     from loom.core.cognition.skill_mutator import MutationProposal, SkillMutator
     from loom.core.cognition.skill_promoter import SkillPromoter
     from loom.core.events import ExecutionEnvelopeView
-    from loom.core.memory.episodic import EpisodicMemory
-    from loom.core.memory.procedural import ProceduralMemory
-    from loom.core.memory.relational import RelationalMemory
-    from loom.core.memory.semantic import SemanticMemory
+    from loom.core.memory.facade import MemoryFacade
     from loom.core.memory.skill_outcome import SkillOutcomeTracker
 
 logger = logging.getLogger(__name__)
@@ -265,11 +262,8 @@ class TaskReflector:
         self,
         router: "LLMRouter",
         model: str,
-        procedural: "ProceduralMemory",
-        semantic: "SemanticMemory",
+        memory: "MemoryFacade",
         session_id: str,
-        relational: "RelationalMemory | None" = None,
-        episodic: "EpisodicMemory | None" = None,
         enabled: bool = True,
         visibility: str = "summary",
         mutator: "SkillMutator | None" = None,
@@ -277,10 +271,11 @@ class TaskReflector:
     ) -> None:
         self._router = router
         self._model = model
-        self._procedural = procedural
-        self._semantic = semantic
-        self._relational = relational
-        self._episodic = episodic
+        self._memory = memory
+        self._procedural = memory.procedural
+        self._semantic = memory.semantic
+        self._relational = memory.relational
+        self._episodic = memory.episodic
         self._session_id = session_id
         self._enabled = enabled
         self._visibility = visibility if visibility in ("off", "summary", "verbose") else "summary"

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -668,14 +668,10 @@ class LoomSession:
         self._semantic = SemanticMemory(self._db, embedding_provider=emb_provider)
         self._procedural = ProceduralMemory(self._db)
         self._relational = RelationalMemory(self._db)
-        self._reflection = ReflectionAPI(self._episodic, self._procedural)
-        self._reflector = CounterFactualReflector(
-            router=self.router,
-            model=self.model,
-            procedural=self._procedural,
-            semantic=self._semantic,
-            relational=self._relational,
-        )
+        # Issue #147 Phase C.1: ReflectionAPI / CounterFactualReflector
+        # now take the MemoryFacade. They are constructed below, after
+        # ``self._memory`` is built (search "Phase C.1: facade-aware
+        # cognition wiring" in this file).
         self._session_log = SessionLog(self._db)
 
         # Issue #43: Memory Governance — always-on
@@ -794,6 +790,18 @@ class LoomSession:
         self.registry.register(make_query_relations_tool(self._memory))
         self.registry.register(make_memory_health_tool(self._governor))
 
+        # Issue #147 Phase C.1: facade-aware cognition wiring.
+        # ReflectionAPI / CounterFactualReflector previously took
+        # discrete subsystems; they now take the facade so the
+        # construction site no longer reaches into ``self._semantic``
+        # etc.  TaskReflector follows the same pattern further below.
+        self._reflection = ReflectionAPI(self._memory)
+        self._reflector = CounterFactualReflector(
+            router=self.router,
+            model=self.model,
+            memory=self._memory,
+        )
+
         # Issue #149: dream_cycle / memory_prune are now first-class memory
         # tools (formerly DreamingPlugin). Wired with dependency injection
         # so the factories stay session-agnostic.
@@ -871,11 +879,8 @@ class LoomSession:
         self._task_reflector = TaskReflector(
             router=self.router,
             model=self.model,
-            procedural=self._procedural,
-            semantic=self._semantic,
+            memory=self._memory,
             session_id=self.session_id,
-            relational=self._relational,
-            episodic=self._episodic,
             enabled=self._reflection_enabled,
             visibility=self._reflection_visibility,
             mutator=self._skill_mutator if self._skill_mutator.enabled else None,
@@ -1116,12 +1121,12 @@ class LoomSession:
                     _health.record_failure("session_compress", str(exc))
 
             # Step 2: Skill evolution analysis (Issue #58)
-            if self._procedural is not None and self._semantic is not None:
+            if self._memory is not None:
                 try:
                     from loom.core.cognition.counter_factual import SkillEvolutionHook
                     evolution_hook = SkillEvolutionHook(
                         router=self.router, model=self.model,
-                        procedural=self._procedural, semantic=self._semantic,
+                        memory=self._memory,
                     )
                     evolved = await evolution_hook.check_all_skills()
                     if evolved:

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -1383,12 +1383,24 @@ def reflect(session: str | None, db: str) -> None:
 
 
 async def _reflect(session_id: str | None, db: str) -> None:
+    from loom.core.memory.facade import MemoryFacade
+    from loom.core.memory.search import MemorySearch
+
     store = SQLiteStore(db)
     await store.initialize()
     async with store.connect() as conn:
         ep = EpisodicMemory(conn)
         pr = ProceduralMemory(conn)
-        api = ReflectionAPI(ep, pr)
+        sem = SemanticMemory(conn)
+        rel = RelationalMemory(conn)
+        facade = MemoryFacade(
+            semantic=sem,
+            procedural=pr,
+            relational=rel,
+            episodic=ep,
+            search=MemorySearch(sem, pr),
+        )
+        api = ReflectionAPI(facade)
 
         if session_id is None:
             console.print("[dim]No session ID given — showing skill health only.[/dim]")

--- a/tests/test_cognition.py
+++ b/tests/test_cognition.py
@@ -18,8 +18,24 @@ from loom.core.cognition.providers import (
 from loom.core.cognition.router import LLMRouter
 from loom.core.cognition.reflection import ReflectionAPI
 from loom.core.memory.episodic import EpisodicEntry, EpisodicMemory
+from loom.core.memory.facade import MemoryFacade
 from loom.core.memory.procedural import SkillGenome, ProceduralMemory
+from loom.core.memory.relational import RelationalMemory
+from loom.core.memory.search import MemorySearch
+from loom.core.memory.semantic import SemanticMemory
 from loom.core.memory.store import SQLiteStore
+
+
+def _facade(conn) -> MemoryFacade:
+    sem = SemanticMemory(conn)
+    pr = ProceduralMemory(conn)
+    return MemoryFacade(
+        semantic=sem,
+        procedural=pr,
+        relational=RelationalMemory(conn),
+        episodic=EpisodicMemory(conn),
+        search=MemorySearch(sem, pr),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -267,17 +283,15 @@ async def reflection_db(tmp_path):
 class TestReflectionAPI:
     @pytest.mark.asyncio
     async def test_session_summary_no_entries(self, reflection_db):
-        ep = EpisodicMemory(reflection_db)
-        pr = ProceduralMemory(reflection_db)
-        api = ReflectionAPI(ep, pr)
+        api = ReflectionAPI(_facade(reflection_db))
         summary = await api.session_summary("empty")
         assert "No activity" in summary
 
     @pytest.mark.asyncio
     async def test_session_summary_with_entries(self, reflection_db):
-        ep = EpisodicMemory(reflection_db)
-        pr = ProceduralMemory(reflection_db)
-        api = ReflectionAPI(ep, pr)
+        facade = _facade(reflection_db)
+        ep = facade.episodic
+        api = ReflectionAPI(facade)
 
         await ep.write(EpisodicEntry(
             session_id="s1", event_type="message", content="User: hello"
@@ -295,9 +309,9 @@ class TestReflectionAPI:
 
     @pytest.mark.asyncio
     async def test_recent_tool_calls_order(self, reflection_db):
-        ep = EpisodicMemory(reflection_db)
-        pr = ProceduralMemory(reflection_db)
-        api = ReflectionAPI(ep, pr)
+        facade = _facade(reflection_db)
+        ep = facade.episodic
+        api = ReflectionAPI(facade)
 
         for i in range(5):
             await ep.write(EpisodicEntry(
@@ -313,9 +327,9 @@ class TestReflectionAPI:
 
     @pytest.mark.asyncio
     async def test_tool_success_rate(self, reflection_db):
-        ep = EpisodicMemory(reflection_db)
-        pr = ProceduralMemory(reflection_db)
-        api = ReflectionAPI(ep, pr)
+        facade = _facade(reflection_db)
+        ep = facade.episodic
+        api = ReflectionAPI(facade)
 
         for ok in [True, True, False]:
             await ep.write(EpisodicEntry(
@@ -330,17 +344,15 @@ class TestReflectionAPI:
 
     @pytest.mark.asyncio
     async def test_skill_health_report_empty(self, reflection_db):
-        ep = EpisodicMemory(reflection_db)
-        pr = ProceduralMemory(reflection_db)
-        api = ReflectionAPI(ep, pr)
+        api = ReflectionAPI(_facade(reflection_db))
         report = await api.skill_health_report()
         assert report == []
 
     @pytest.mark.asyncio
     async def test_skill_health_report_with_skills(self, reflection_db):
-        ep = EpisodicMemory(reflection_db)
-        pr = ProceduralMemory(reflection_db)
-        api = ReflectionAPI(ep, pr)
+        facade = _facade(reflection_db)
+        pr = facade.procedural
+        api = ReflectionAPI(facade)
 
         await pr.upsert(SkillGenome(
             name="refactor", body="extract functions", confidence=0.85,

--- a/tests/test_skill_mutator.py
+++ b/tests/test_skill_mutator.py
@@ -420,11 +420,13 @@ def _build_reflector_with_mutator(
     reflector = TaskReflector(
         router=router,
         model="test-model",
-        procedural=procedural,
-        semantic=semantic,
+        memory=MagicMock(
+            procedural=procedural,
+            semantic=semantic,
+            relational=None,
+            episodic=None,
+        ),
         session_id="session-xyz",
-        relational=None,
-        episodic=None,
         enabled=True,
         visibility="summary",
         mutator=mutator,

--- a/tests/test_skill_tools.py
+++ b/tests/test_skill_tools.py
@@ -315,8 +315,7 @@ class TestSkillEvolutionHook:
         hook = SkillEvolutionHook(
             router=MagicMock(),
             model="test",
-            procedural=MagicMock(),
-            semantic=MagicMock(),
+            memory=MagicMock(procedural=MagicMock(), semantic=MagicMock()),
         )
 
         # Mock skill with low confidence
@@ -332,8 +331,7 @@ class TestSkillEvolutionHook:
         hook = SkillEvolutionHook(
             router=MagicMock(),
             model="test",
-            procedural=MagicMock(),
-            semantic=MagicMock(),
+            memory=MagicMock(procedural=MagicMock(), semantic=MagicMock()),
         )
 
         skill = MagicMock()
@@ -348,8 +346,7 @@ class TestSkillEvolutionHook:
         hook = SkillEvolutionHook(
             router=MagicMock(),
             model="test",
-            procedural=MagicMock(),
-            semantic=MagicMock(),
+            memory=MagicMock(procedural=MagicMock(), semantic=MagicMock()),
         )
 
         skill = MagicMock()
@@ -535,8 +532,7 @@ class TestCheckAllSkillsSequential:
         hook = SkillEvolutionHook(
             router=mock_router,
             model="test",
-            procedural=mock_procedural,
-            semantic=mock_semantic,
+            memory=MagicMock(procedural=mock_procedural, semantic=mock_semantic),
         )
 
         count = await hook.check_all_skills()

--- a/tests/test_task_reflector.py
+++ b/tests/test_task_reflector.py
@@ -245,11 +245,13 @@ def _build_reflector(
     reflector = TaskReflector(
         router=router,
         model="test-model",
-        procedural=procedural,
-        semantic=semantic,
+        memory=MagicMock(
+            procedural=procedural,
+            semantic=semantic,
+            relational=None,
+            episodic=None,
+        ),
         session_id="session-xyz",
-        relational=None,
-        episodic=None,
         enabled=enabled,
         visibility=visibility,
     )


### PR DESCRIPTION
## Summary

Phase C.1 of Issue #147 — migrate the four cognition modules that already
touch **≥3 memory subsystems** to take a single ``MemoryFacade`` instead of
individual subsystem handles. This consolidates wiring and prepares the
ground for Issue #145 (SessionContext extraction).

Migrated:

| Module                       | Subsystems touched                      |
|------------------------------|------------------------------------------|
| ``ReflectionAPI``            | episodic + procedural                    |
| ``CounterFactualReflector``  | procedural + semantic + relational       |
| ``SkillEvolutionHook``       | procedural + semantic                    |
| ``TaskReflector``            | procedural + semantic + relational + episodic |

Construction sites in ``session.py`` and ``loom reflect`` (in
``platform/cli/main.py``) updated accordingly. Two cognition objects
(``ReflectionAPI`` / ``CounterFactualReflector``) had their construction
deferred until *after* ``self._memory`` is built — verified by inspection
that no intervening code consumes them.

## Scope discipline

Single-subsystem callers (``ActionPlanner``, ``SkillGate``,
``SkillPromoter``, ``SkillImportPipeline``, ``SkillOutcomeTracker``) are
intentionally **NOT** migrated. Wrapping a single-subsystem caller in a
facade would *increase* indirection without buying anything. Phase C.2
will only update their construction sites (``procedural=self._memory.procedural``)
as part of the SessionContext extraction prep — see #176 for the plan.

## Test plan

- [x] All affected unit suites pass (133 tests)
- [x] Full suite green: 970 passed
- [x] No dangling old-signature callers (verified via grep)
- [ ] Reviewer to spot-check migrated construction sites in ``session.py``

Refs #147 #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)