### PR TITLE
arch: static event contracts + TrustLevel display guidance (#146, #148)

### DIFF
--- a/loom/core/events.py
+++ b/loom/core/events.py
@@ -6,24 +6,95 @@ event type to drive their respective UIs.
 
 Keeping event types in ``loom.core`` lets every platform import them without
 depending on ``loom.platform.cli``.
+
+Stream Event Consumer Map
+-------------------------
+Producer: ``LoomSession.stream_turn()``
+
+Use this table as the authoritative contract between the harness layer and
+platform consumers.  When adding a new event type, update this table **and**
+add ``Producers:`` / ``Consumers:`` entries to the event's docstring.
+
++---------------------+-----+-----+---------+----------+
+| Event               | CLI | TUI | Discord | Required |
++=====================+=====+=====+=========+==========+
+| TextChunk           |  ✓  |  ✓  |    ✓    |   YES    |
+| ToolBegin           |  ✓  |  ✓  |    ✓    |   YES    |
+| ToolEnd             |  ✓  |  ✓  |    ✓    |   YES    |
+| TurnDone            |  ✓  |  ✓  |    ✓    |   YES    |
+| ThinkCollapsed      |  ✓  |  ✓  |    ✓    |   no     |
+| TurnPaused          |  ✓  |  ✓  |    ✓    |   no     |
+| TurnDropped         |  ✓  |  —  |    ✓    |   no     |
+| CompressDone        |  —  |  —  |    ✓    |   no     |
+| ActionStateChange   |  —  |  ✓  |  skip   |   no     |
+| ActionRolledBack    |  —  |  ✓  |    ✓    |   no     |
+| EnvelopeStarted     |  ✓  |  ✓  |    ✓    |   no     |
+| EnvelopeUpdated     |  ✓  |  ✓  |    ✓    |   no     |
+| EnvelopeCompleted   |  ✓  |  ✓  |    ✓    |   no     |
+| GrantsSnapshot      |  ✓  |  ✓  |    —    |   no     |
++---------------------+-----+-----+---------+----------+
+
+Legend:
+  ✓   = handled (active UI update)
+  —   = intentionally ignored (``else: pass`` is correct)
+  skip = received but no-op by design (too granular for that platform)
+
+``EventConsumer`` protocol
+--------------------------
+The ``EventConsumer`` Protocol at the bottom of this module describes the
+minimum surface a conforming consumer must implement.  Platform dispatch loops
+do not need to subclass it — it exists purely for static analysis (pyright /
+graphify) to verify coverage.
+
+Usage (opt-in type annotation)::
+
+    class MyConsumer:
+        async def on_text_chunk(self, event: TextChunk) -> None: ...
+        async def on_tool_begin(self, event: ToolBegin) -> None: ...
+        async def on_tool_end(self, event: ToolEnd) -> None: ...
+        async def on_turn_done(self, event: TurnDone) -> None: ...
+
+    def run(consumer: EventConsumer, ...) -> None:
+        ...
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Protocol
 
 
 @dataclass
 class TextChunk:
-    """A fragment of streaming LLM text."""
+    """A fragment of streaming LLM text.
+
+    Producers:
+        LoomSession.stream_turn() — emitted for every text delta from the
+        LLM API while the model is generating.
+
+    Consumers:
+        CLI     ✓  accumulated in text_buffer, printed character-by-character
+        TUI     ✓  dispatched as TuiChunk → MessageList
+        Discord ✓  accumulated in narration_buf, sent as a batch after turn
+    """
 
     text: str
 
 
 @dataclass
 class ToolBegin:
-    """The agent is about to call a tool."""
+    """The agent is about to call a tool.
+
+    Producers:
+        LoomSession.stream_turn() — emitted immediately before the tool
+        handler is dispatched, after BlastRadiusMiddleware has authorized.
+
+    Consumers:
+        CLI     ✓  prints spinner / tool-name line
+        TUI     ✓  dispatched as TuiToolBegin → ToolBlock
+        Discord ✓  appends symbol+tool_name to tool_buf (legacy path only;
+                    suppressed when EnvelopeStarted has fired)
+    """
 
     name: str
     args: dict[str, Any]
@@ -32,7 +103,18 @@ class ToolBegin:
 
 @dataclass
 class ToolEnd:
-    """A tool call finished."""
+    """A tool call finished.
+
+    Producers:
+        LoomSession.stream_turn() — emitted after the tool handler returns
+        and the result has been observed by LifecycleMiddleware.
+
+    Consumers:
+        CLI     ✓  cancels spinner, prints ok/error status
+        TUI     ✓  dispatched as TuiToolEnd → ToolBlock / ActivityLog
+        Discord ✓  appends ✓/✗ marker to tool_buf (legacy path only;
+                    suppressed when EnvelopeStarted has fired)
+    """
 
     name: str
     success: bool
@@ -43,27 +125,57 @@ class ToolEnd:
 
 @dataclass
 class TurnPaused:
-    """
-    The agent turn has been paused — all current tool calls are done but the
+    """The agent turn has been paused — all current tool calls are done but the
     loop is suspended, waiting for human input before continuing.
 
-    The consumer should prompt the user and then call either:
+    The consumer should prompt the user and then call either::
+
         session.resume()         — continue the turn as-is
         session.resume_with(msg) — inject a message and continue
         session.cancel()         — abandon the rest of this turn
+
+    Producers:
+        LoomSession.stream_turn() — emitted when hitl_mode is on, after each
+        tool batch completes, before the next LLM call.
+
+    Consumers:
+        CLI     ✓  blocks on input(), calls session.resume() / cancel()
+        TUI     ✓  shows PauseModal widget, awaits user decision
+        Discord ✓  sends pause message, waits for reply with client.wait_for()
     """
+
     tool_count_so_far: int = 0
 
 
 @dataclass
 class CompressDone:
-    """Episodic memory was compressed to semantic facts mid-session."""
+    """Episodic memory was compressed to semantic facts mid-session.
+
+    Producers:
+        LoomSession._smart_compact() — emitted after compression finishes.
+
+    Consumers:
+        CLI     —  intentionally not displayed (too noisy for inline chat)
+        TUI     —  intentionally not displayed
+        Discord ✓  sends a brief status message to the thread
+    """
+
     fact_count: int
 
 
 @dataclass
 class TurnDone:
-    """The complete agent turn (including all tool loops) is done."""
+    """The complete agent turn (including all tool loops) is done.
+
+    Producers:
+        LoomSession.stream_turn() — emitted once per user message, after all
+        tool calls and the final LLM response have completed.
+
+    Consumers:
+        CLI     ✓  prints token/timing footer line
+        TUI     ✓  dispatched as TuiTurnDone → BudgetPanel + ObservabilityPanel
+        Discord ✓  triggers turn summary (if summary_mode != "off") + footer
+    """
 
     tool_count: int
     input_tokens: int
@@ -86,6 +198,15 @@ class TurnDropped:
                       ``"stream_none"`` when response was None.
     ``retry_count``  — how many automatic retries have already been attempted.
     ``tool_count``   — number of tools called before the drop.
+
+    Producers:
+        LoomSession.stream_turn() — emitted instead of TurnDone when the
+        stream terminates abnormally.
+
+    Consumers:
+        CLI     ✓  prints a warning message to the console
+        TUI     —  not separately surfaced (worker catches the exception)
+        Discord ✓  sends a ⚠️ status message with stop_reason details
     """
 
     stop_reason: str
@@ -96,7 +217,18 @@ class TurnDropped:
 
 @dataclass
 class ActionStateChange:
-    """An action transitioned to a new lifecycle state (Issue #42)."""
+    """An action transitioned to a new lifecycle state (Issue #42).
+
+    Producers:
+        LifecycleMiddleware / LifecycleGateMiddleware — emitted on every
+        ActionRecord state transition (DECLARED → AUTHORIZED → … → MEMORIALIZED).
+
+    Consumers:
+        CLI     —  intentionally not displayed (too granular for terminal chat)
+        TUI     ✓  dispatched as TuiActionStateChange → ExecutionDashboard
+        Discord skip  received but a no-op (``pass``) — too granular for chat
+    """
+
     action_id: str
     tool_name: str
     call_id: str
@@ -107,7 +239,18 @@ class ActionStateChange:
 
 @dataclass
 class ActionRolledBack:
-    """An action was rolled back after post-validation failure (Issue #42)."""
+    """An action was rolled back after post-validation failure (Issue #42).
+
+    Producers:
+        LifecycleMiddleware — emitted when a tool's post-execution validator
+        returns False and the rollback handler is invoked.
+
+    Consumers:
+        CLI     —  not yet surfaced (post-validation rarely fires in CLI)
+        TUI     ✓  dispatched as TuiActionRolledBack → ExecutionDashboard
+        Discord ✓  appends ↩ rollback line to tool_buf
+    """
+
     action_id: str
     tool_name: str
     call_id: str
@@ -124,6 +267,15 @@ class ThinkCollapsed:
 
     ``summary`` — first ~120 chars of the reasoning block, single line.
     ``full``    — complete think content for the detail view.
+
+    Producers:
+        LoomSession.stream_turn() — emitted when a ``</think>`` tag is
+        detected in the streamed output.
+
+    Consumers:
+        CLI     ✓  prints a dim "thinking…" indicator
+        TUI     ✓  dispatched as TuiThinkCollapsed → MessageList
+        Discord ✓  sends as a -# small message with 💭 prefix
     """
 
     summary: str
@@ -142,13 +294,14 @@ class ExecutionNodeView:
     presentation layer needs — no mutable state, no references to
     middleware internals.
     """
+
     node_id: str           # ActionRecord.id
     call_id: str           # ToolCall.id
     action_id: str | None  # same as node_id (for API clarity)
     tool_name: str
     level: int             # parallel level (0 = all current dispatch)
     state: str             # ActionState.value
-    trust_level: str       # SAFE / GUARDED / CRITICAL
+    trust_level: str       # SAFE / GUARDED / CRITICAL  (use TrustLevel.plain)
     capabilities: list[str] = field(default_factory=list)
     args_preview: str = ""
     duration_ms: float = 0.0
@@ -171,6 +324,7 @@ class ExecutionEnvelopeView:
     and yielded as part of ``EnvelopeStarted / Updated / Completed``
     stream events.  TUI and Discord both consume this same structure.
     """
+
     envelope_id: str       # human-readable, e.g. "e1", "e2"
     session_id: str
     turn_index: int
@@ -184,25 +338,60 @@ class ExecutionEnvelopeView:
 
 @dataclass
 class EnvelopeStarted:
-    """A new tool-use batch (envelope) has been created and dispatch begins."""
+    """A new tool-use batch (envelope) has been created and dispatch begins.
+
+    Producers:
+        LoomSession.stream_turn() — emitted when a new parallel tool batch
+        starts executing, before any individual tool completes.
+
+    Consumers:
+        CLI     ✓  renders envelope header in status area
+        TUI     ✓  dispatched as TuiEnvelopeStarted → ExecutionDashboard
+        Discord ✓  sends formatted envelope status to status_msg, sets
+                    _envelope_active=True to suppress legacy ToolBegin display
+    """
+
     envelope: ExecutionEnvelopeView
 
 
 @dataclass
 class EnvelopeUpdated:
-    """A node inside the current envelope changed state (e.g. tool finished)."""
+    """A node inside the current envelope changed state (e.g. tool finished).
+
+    Producers:
+        LoomSession.stream_turn() — emitted after each individual tool
+        completes within an active envelope.
+
+    Consumers:
+        CLI     ✓  re-renders envelope status (debounced)
+        TUI     ✓  dispatched as TuiEnvelopeUpdated → ExecutionDashboard
+        Discord ✓  edits status_msg with updated envelope (debounced 0.5s)
+    """
+
     envelope: ExecutionEnvelopeView
 
 
 @dataclass
 class EnvelopeCompleted:
-    """All nodes in the envelope have reached terminal states."""
+    """All nodes in the envelope have reached terminal states.
+
+    Producers:
+        LoomSession.stream_turn() — emitted when every node in the envelope
+        is in a terminal state (memorialized / denied / aborted / reverted).
+
+    Consumers:
+        CLI     ✓  renders final envelope state, clears active indicator
+        TUI     ✓  dispatched as TuiEnvelopeCompleted → ExecutionDashboard
+        Discord ✓  freezes status_msg as permanent record, opens new placeholder
+    """
+
     envelope: ExecutionEnvelopeView
 
 
 @dataclass
 class GrantSummary:
     """One active scope grant — lightweight UI projection (#112)."""
+
     grant_id: str          # unique identifier for tracking expiry transitions
     tool_name: str         # e.g. "write_file"
     selector: str          # e.g. "/workspace/doc/"
@@ -212,10 +401,82 @@ class GrantSummary:
 
 @dataclass
 class GrantsSnapshot:
-    """Current state of active scope grants for UI display (#108, #112)."""
+    """Current state of active scope grants for UI display (#108, #112).
+
+    Producers:
+        LoomSession.stream_turn() — emitted after each tool call that results
+        in a new grant being created or an existing one expiring.
+
+    Consumers:
+        CLI     ✓  updates status bar grant count
+        TUI     ✓  dispatched as TuiGrantsUpdate → BudgetPanel / StatusBar
+        Discord —  grants are displayed inline via /scope command, not streamed
+    """
+
     active_count: int
     next_expiry_secs: float = 0.0  # seconds until nearest expiry; 0 = none
     grants: list[GrantSummary] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Issue #146: EventConsumer Protocol
+# ---------------------------------------------------------------------------
+
+class EventConsumer(Protocol):
+    """Protocol for objects that consume ``LoomSession.stream_turn()`` events.
+
+    Conforming consumers must implement handlers for all **required** events
+    (``TextChunk``, ``ToolBegin``, ``ToolEnd``, ``TurnDone``) and may freely
+    ignore optional ones.
+
+    This Protocol exists for **static analysis only** — platform dispatch
+    loops do not need to subclass it.  It enables pyright / graphify to:
+
+    1. Verify that a consumer implements the minimum required surface.
+    2. Track the event-flow graph from producer (stream_turn) to consumers.
+
+    Usage (opt-in type annotation)::
+
+        def build_consumer(...) -> EventConsumer:
+            ...
+
+    Required events
+    ---------------
+    All platform consumers (CLI, TUI, Discord) MUST handle these four events.
+    Failing to handle them will result in missed output or a silent turn with
+    no user feedback:
+
+    - ``TextChunk``  — streaming LLM text
+    - ``ToolBegin``  — tool dispatch started
+    - ``ToolEnd``    — tool dispatch finished
+    - ``TurnDone``   — turn complete
+
+    Optional events
+    ---------------
+    Consumers may ignore these safely (``else: pass`` is correct behaviour).
+    See the Consumer Map in the module docstring for platform-specific coverage:
+
+    ``ThinkCollapsed``, ``TurnPaused``, ``TurnDropped``, ``CompressDone``,
+    ``ActionStateChange``, ``ActionRolledBack``,
+    ``EnvelopeStarted``, ``EnvelopeUpdated``, ``EnvelopeCompleted``,
+    ``GrantsSnapshot``
+    """
+
+    async def on_text_chunk(self, event: TextChunk) -> None:
+        """Handle a streaming LLM text fragment."""
+        ...
+
+    async def on_tool_begin(self, event: ToolBegin) -> None:
+        """Handle tool dispatch start."""
+        ...
+
+    async def on_tool_end(self, event: ToolEnd) -> None:
+        """Handle tool dispatch completion."""
+        ...
+
+    async def on_turn_done(self, event: TurnDone) -> None:
+        """Handle turn completion (all tools + final LLM response done)."""
+        ...
 
 
 __all__ = [
@@ -225,6 +486,7 @@ __all__ = [
     "EnvelopeCompleted",
     "EnvelopeStarted",
     "EnvelopeUpdated",
+    "EventConsumer",
     "ExecutionEnvelopeView",
     "ExecutionNodeView",
     "GrantSummary",

--- a/loom/core/harness/permissions.py
+++ b/loom/core/harness/permissions.py
@@ -47,6 +47,31 @@ class TrustLevel(Enum):
                 or explicit user confirmation.
     CRITICAL — destructive, cross-system, irreversible → always requires fresh
                 human confirmation and is written to the immutable audit log.
+
+    Display methods
+    ---------------
+    This enum provides two rendering paths.  **Always** choose the right one
+    for the output channel — mixing them will corrupt output in non-Rich
+    environments.
+
+    ``.plain`` / ``.display_plain``
+        Plain uppercase ASCII string (``"SAFE"``, ``"GUARDED"``, ``"CRITICAL"``).
+        **Use everywhere except Rich console output:**
+
+        - Discord messages / embeds
+        - TUI widget labels and inline widgets
+        - JSON / log fields
+        - ``ExecutionNodeView.trust_level``
+        - Any non-Rich ``print()`` call
+
+    ``.label`` / ``.display_rich``
+        Rich markup string (e.g. ``"[green]SAFE[/green]"``).
+        **Use ONLY with** ``console.print()`` in CLI/Terminal contexts.
+        Passing ``.label`` to Discord or a TUI widget will render the raw
+        markup as literal text (e.g. ``"[green]SAFE[/green]"``).
+
+    Issue #148: enforcement is centralised here; platforms only call
+    ``.plain`` or ``.label`` — they do not implement trust-tier logic.
     """
     SAFE = "safe"
     GUARDED = "guarded"
@@ -54,18 +79,46 @@ class TrustLevel(Enum):
 
     @property
     def plain(self) -> str:
-        """Plain uppercase name — use when the caller controls styling."""
+        """Plain uppercase name — use when the caller controls styling.
+
+        Suitable for Discord, TUI widgets, JSON, log files, and any
+        non-Rich output channel.  Equivalent to ``display_plain``.
+        """
         return self.value.upper()
 
     @property
+    def display_plain(self) -> str:
+        """Alias for ``.plain`` — plain uppercase trust tier name.
+
+        Prefer this alias over ``.plain`` when the intent is display
+        (vs. equality checks) to make the rendering path explicit.
+        """
+        return self.plain
+
+    @property
     def label(self) -> str:
-        """Rich markup label — for CLI console output only."""
+        """Rich markup label — for CLI ``console.print()`` **only**.
+
+        Do **not** pass this to Discord, TUI widgets, JSON, or any other
+        channel that does not interpret Rich markup.  Use ``.plain`` instead.
+        Equivalent to ``display_rich``.
+        """
         colours = {
             TrustLevel.SAFE: "[green]SAFE[/green]",
             TrustLevel.GUARDED: "[yellow]GUARDED[/yellow]",
             TrustLevel.CRITICAL: "[red]CRITICAL[/red]",
         }
         return colours[self]
+
+    @property
+    def display_rich(self) -> str:
+        """Alias for ``.label`` — Rich markup trust tier name.
+
+        Prefer this alias over ``.label`` when the intent is display
+        (vs. equality checks) to make the rendering path explicit.
+        Only valid for Rich ``console.print()`` in CLI/Terminal contexts.
+        """
+        return self.label
 
 
 @dataclass

--- a/tests/test_event_consumer_map.py
+++ b/tests/test_event_consumer_map.py
@@ -1,0 +1,222 @@
+"""
+Event Consumer Map Completeness Tests (Issue #146)
+===================================================
+
+Verifies that:
+
+1. Every event type exported from ``loom.core.events.__all__`` is documented
+   in the Consumer Map table inside the module docstring — so the table never
+   drifts out of sync when a new event is added.
+
+2. ``EventConsumer`` protocol is importable and has the four required handler
+   stubs as protocol methods.
+
+3. ``TrustLevel`` display properties work correctly and are idempotent
+   (Issue #148).
+
+These are **static / unit-level** tests — no agent session is started.
+"""
+
+import inspect
+import re
+from typing import get_type_hints
+
+import pytest
+
+import loom.core.events as events_module
+from loom.core.events import (
+    EventConsumer,
+    TextChunk,
+    ToolBegin,
+    ToolEnd,
+    TurnDone,
+)
+from loom.core.harness.permissions import TrustLevel
+
+
+# ---------------------------------------------------------------------------
+# Issue #146 — Consumer Map completeness
+# ---------------------------------------------------------------------------
+
+# Events that intentionally do NOT appear in the Consumer Map table because
+# they are view-model helpers, not stream events.  Update this set if new
+# non-event exports are added to __all__.
+_NON_EVENT_EXPORTS: frozenset[str] = frozenset(
+    {
+        "EventConsumer",
+        "ExecutionEnvelopeView",
+        "ExecutionNodeView",
+        "GrantSummary",
+    }
+)
+
+
+def _consumer_map_event_names() -> set[str]:
+    """Parse the event names from the Consumer Map table in events.py docstring."""
+    doc = events_module.__doc__ or ""
+    # Match lines like: | TextChunk           |  ✓  |  ✓  |    ✓    |   YES    |
+    # Capture the first cell (event name), stripping whitespace.
+    pattern = re.compile(r"^\|\s+(\w+)\s+\|", re.MULTILINE)
+    return {m.group(1) for m in pattern.finditer(doc)}
+
+
+def test_all_stream_events_in_consumer_map():
+    """Every event in __all__ (except view-model helpers) must appear in the Consumer Map.
+
+    When you add a new event type to loom/core/events.py, you MUST:
+      1. Add it to ``__all__``
+      2. Add it to the Consumer Map table in the module docstring
+      3. Add ``Producers:`` / ``Consumers:`` to its class docstring
+
+    If this test fails, you have added a new event to ``__all__`` without
+    updating the Consumer Map.  Update the table in the module docstring.
+    """
+    all_exports = set(events_module.__all__)
+    stream_events = all_exports - _NON_EVENT_EXPORTS
+
+    map_entries = _consumer_map_event_names()
+
+    missing = stream_events - map_entries
+    assert not missing, (
+        f"The following event(s) are exported in __all__ but missing from the "
+        f"Consumer Map table in loom/core/events.py:\n\n"
+        + "\n".join(f"  - {name}" for name in sorted(missing))
+        + "\n\nAdd each missing event to the table and add Producers:/Consumers: "
+        "to its class docstring."
+    )
+
+
+def test_consumer_map_has_no_unknown_events():
+    """The Consumer Map must not reference event names that don't exist in __all__.
+
+    This catches typos and stale entries after event renames.
+    """
+    all_exports = set(events_module.__all__)
+    map_entries = _consumer_map_event_names()
+
+    unknown = map_entries - all_exports
+    # Remove header row artefacts that the regex might capture
+    unknown.discard("Event")
+    assert not unknown, (
+        f"The following name(s) appear in the Consumer Map table but are NOT "
+        f"in __all__:\n\n"
+        + "\n".join(f"  - {name}" for name in sorted(unknown))
+        + "\n\nEither remove the stale row from the Consumer Map table or add "
+        "the missing export to __all__."
+    )
+
+
+def test_event_consumer_protocol_is_importable():
+    """EventConsumer must be importable from loom.core.events."""
+    assert EventConsumer is not None
+
+
+def test_event_consumer_protocol_has_required_methods():
+    """EventConsumer protocol must expose the four required handler stubs."""
+    required = {"on_text_chunk", "on_tool_begin", "on_tool_end", "on_turn_done"}
+    protocol_methods = {
+        name
+        for name, member in inspect.getmembers(EventConsumer)
+        if not name.startswith("_")
+        and callable(getattr(EventConsumer, name, None))
+    }
+    missing = required - protocol_methods
+    assert not missing, (
+        f"EventConsumer protocol is missing required method(s): "
+        f"{sorted(missing)}.  Add them to the Protocol definition."
+    )
+
+
+def test_event_consumer_in_all():
+    """EventConsumer must be exported via __all__ so static analysers see it."""
+    assert "EventConsumer" in events_module.__all__
+
+
+# ---------------------------------------------------------------------------
+# Issue #146 — event class docstrings have Producers / Consumers sections
+# ---------------------------------------------------------------------------
+
+# Required events must document both sections; optional events should too
+# but we only enforce it on the four required ones.
+_REQUIRED_EVENTS = (TextChunk, ToolBegin, ToolEnd, TurnDone)
+
+
+@pytest.mark.parametrize("event_cls", _REQUIRED_EVENTS, ids=lambda c: c.__name__)
+def test_required_event_has_producers_section(event_cls):
+    """Required events must document their Producers in the class docstring."""
+    doc = event_cls.__doc__ or ""
+    assert "Producers:" in doc, (
+        f"{event_cls.__name__} docstring is missing a 'Producers:' section. "
+        "Add it to describe which session code yields this event."
+    )
+
+
+@pytest.mark.parametrize("event_cls", _REQUIRED_EVENTS, ids=lambda c: c.__name__)
+def test_required_event_has_consumers_section(event_cls):
+    """Required events must document their Consumers in the class docstring."""
+    doc = event_cls.__doc__ or ""
+    assert "Consumers:" in doc, (
+        f"{event_cls.__name__} docstring is missing a 'Consumers:' section. "
+        "Add it to describe which platforms handle this event."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #148 — TrustLevel display properties
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("level", list(TrustLevel))
+def test_trust_level_plain_is_uppercase(level):
+    """TrustLevel.plain must return uppercase ASCII with no markup."""
+    result = level.plain
+    assert result == result.upper(), f"{level}.plain is not uppercase: {result!r}"
+    assert "[" not in result, (
+        f"{level}.plain must not contain Rich markup, got: {result!r}"
+    )
+
+
+@pytest.mark.parametrize("level", list(TrustLevel))
+def test_trust_level_display_plain_equals_plain(level):
+    """display_plain must be identical to plain (alias contract)."""
+    assert level.display_plain == level.plain, (
+        f"{level}.display_plain != {level}.plain — alias is broken"
+    )
+
+
+@pytest.mark.parametrize("level", list(TrustLevel))
+def test_trust_level_label_contains_markup(level):
+    """TrustLevel.label must contain Rich markup tags."""
+    result = level.label
+    assert "[" in result and "]" in result, (
+        f"{level}.label should contain Rich markup, got: {result!r}"
+    )
+
+
+@pytest.mark.parametrize("level", list(TrustLevel))
+def test_trust_level_display_rich_equals_label(level):
+    """display_rich must be identical to label (alias contract)."""
+    assert level.display_rich == level.label, (
+        f"{level}.display_rich != {level}.label — alias is broken"
+    )
+
+
+@pytest.mark.parametrize("level", list(TrustLevel))
+def test_trust_level_plain_not_equal_label(level):
+    """plain and label must differ — plain must never contain Rich markup."""
+    assert level.plain != level.label, (
+        f"{level}.plain and .label are identical — likely a broken alias"
+    )
+
+
+def test_trust_level_plain_values():
+    """Spot-check the exact plain string values."""
+    assert TrustLevel.SAFE.plain == "SAFE"
+    assert TrustLevel.GUARDED.plain == "GUARDED"
+    assert TrustLevel.CRITICAL.plain == "CRITICAL"
+
+
+def test_trust_level_display_plain_values():
+    """display_plain values must match plain exactly."""
+    assert TrustLevel.SAFE.display_plain == "SAFE"
+    assert TrustLevel.GUARDED.display_plain == "GUARDED"
+    assert TrustLevel.CRITICAL.display_plain == "CRITICAL"


### PR DESCRIPTION
## Summary

Addresses **Issue #146** (static event contracts) and **Issue #148** (TrustLevel display guidance) in a single PR — both are `arch`-class improvements to static analysability with **zero runtime behaviour changes**.

---

## Issue #146 — Static Contracts for Harness Event Consumers

**Background:** graphify analysis found 14 event types in `loom/core/events.py` with almost no static dependency edges to their consumers in CLI, TUI, and Discord.

### Changes — `loom/core/events.py`

- **Consumer Map table** added to the module docstring: single authoritative reference listing every event × platform (producer, consumer, required/optional).
- **`Producers:` / `Consumers:` sections** added to every event class docstring, making the event-flow traceable by static analysis tools.
- **`EventConsumer` Protocol** added — four required handler stubs (`on_text_chunk`, `on_tool_begin`, `on_tool_end`, `on_turn_done`). Platform dispatch loops do not need to subclass it; it exists purely for pyright / graphify coverage verification.
- `EventConsumer` exported in `__all__`.

---

## Issue #148 — Centralise TrustLevel Display Rules

**Background:** `TrustLevel.plain` (plain ASCII) vs `TrustLevel.label` (Rich markup) were being used inconsistently. Passing `.label` to Discord renders raw `[green]SAFE[/green]` as literal text.

### Changes — `loom/core/harness/permissions.py`

- **Expanded `TrustLevel` class docstring** with a dedicated *Display methods* section that makes the channel restrictions unambiguous.
- **`display_plain` alias property** — use for Discord, TUI labels, JSON, log files, and all non-Rich channels.
- **`display_rich` alias property** — use **only** for `console.print()` in CLI/Terminal contexts.
- Existing `.plain` and `.label` are preserved unchanged (100% backward compatible).

---

## Tests — `tests/test_event_consumer_map.py` (new, 30 tests)

| Test group | Count | What it guards |
|---|---|---|
| Consumer Map completeness | 2 | Every `__all__` stream event ↔ Consumer Map (bidirectional) |
| EventConsumer Protocol | 3 | Importable, has required stubs, in `__all__` |
| Event docstring coverage | 8 | Four required events have `Producers:` and `Consumers:` sections |
| TrustLevel display | 17 | plain/label values, alias contracts, no markup leak into plain |

---

## Verification

- **30/30 new tests pass**
- **1000/1000 existing tests pass** — zero regression
- No runtime behaviour changed in any execution path

Closes #146
Closes #148