### PR TITLE
fix(telemetry): filter tool events from compression yield denominator (#173)

### DIFF
--- a/loom/core/infra/telemetry.py
+++ b/loom/core/infra/telemetry.py
@@ -233,6 +233,11 @@ class MemoryCompressionDimension(DimensionTracker):
 
     Backed by the soft-delete landed in #158 — when yield is low, operators
     know the raw episodic trace is still on disk and can be re-mined.
+
+    Tool-event entries (``tool_call`` / ``tool_result``) are excluded from
+    the yield denominator (#173): they record operational side-effects, not
+    knowledge, so a low facts/entries ratio on a tool-heavy session is
+    semantically correct and shouldn't fire an anomaly.
     """
 
     name = "memory_compression"
@@ -244,28 +249,38 @@ class MemoryCompressionDimension(DimensionTracker):
     def __init__(self) -> None:
         self._runs: int = 0
         self._entries_total: int = 0
+        self._tool_events_total: int = 0
         self._facts_total: int = 0
         # Window of recent yield ratios for anomaly detection
         self._recent_yields: list[float] = []
         self._last_at: str | None = None
+        # Runs that had no knowledge entries after filtering — tracked for
+        # visibility but excluded from the anomaly window.
+        self._skipped_runs: int = 0
 
-    def record(self, *, entries: int, facts: int) -> None:
+    def record(self, *, entries: int, facts: int, tool_events: int = 0) -> None:
         self._runs += 1
         self._entries_total += entries
+        self._tool_events_total += tool_events
         self._facts_total += facts
-        if entries > 0:
-            self._recent_yields.append(facts / entries)
+        knowledge_entries = entries - tool_events
+        if knowledge_entries > 0:
+            self._recent_yields.append(facts / knowledge_entries)
             # Keep the window bounded — rolling average over last 10 runs
             if len(self._recent_yields) > 10:
                 self._recent_yields.pop(0)
+        else:
+            self._skipped_runs += 1
         self._last_at = datetime.now(UTC).isoformat()
 
     @property
+    def knowledge_entries_total(self) -> int:
+        return max(self._entries_total - self._tool_events_total, 0)
+
+    @property
     def overall_yield(self) -> float:
-        return (
-            self._facts_total / self._entries_total
-            if self._entries_total > 0 else 0.0
-        )
+        denom = self.knowledge_entries_total
+        return self._facts_total / denom if denom > 0 else 0.0
 
     @property
     def recent_yield(self) -> float:
@@ -278,9 +293,12 @@ class MemoryCompressionDimension(DimensionTracker):
         return {
             "runs": self._runs,
             "entries_total": self._entries_total,
+            "tool_events_total": self._tool_events_total,
+            "knowledge_entries_total": self.knowledge_entries_total,
             "facts_total": self._facts_total,
             "overall_yield": round(self.overall_yield, 3),
             "recent_yields": [round(y, 3) for y in self._recent_yields],
+            "skipped_runs": self._skipped_runs,
             "last_at": self._last_at,
         }
 
@@ -289,7 +307,7 @@ class MemoryCompressionDimension(DimensionTracker):
             return "compress: (not run)"
         return (
             f"compress:{self.overall_yield:.0%} yield "
-            f"({self._facts_total}/{self._entries_total}, n={self._runs})"
+            f"({self._facts_total}/{self.knowledge_entries_total}, n={self._runs})"
         )
 
     def render_detail(self) -> str:
@@ -299,12 +317,18 @@ class MemoryCompressionDimension(DimensionTracker):
             "## memory_compression",
             f"- runs: {self._runs}",
             f"- entries processed: {self._entries_total}",
+            f"- tool events filtered: {self._tool_events_total}",
+            f"- knowledge entries: {self.knowledge_entries_total}",
             f"- facts extracted: {self._facts_total}",
             f"- overall yield: {self.overall_yield:.2%}",
             f"- recent yield (last {len(self._recent_yields)} runs): "
             f"{self.recent_yield:.2%}",
         ]
-        if self.recent_yield < self.LOW_YIELD_THRESHOLD and self._runs >= self.MIN_RUNS_FOR_ANOMALY:
+        if self._skipped_runs:
+            lines.append(
+                f"- runs skipped (tool-only, no knowledge entries): {self._skipped_runs}"
+            )
+        if self.has_anomaly():
             lines.append(
                 "- ⚠ yield is low — LLM extractor may be missing content. "
                 "Original entries are soft-deleted (#158) and remain on disk "
@@ -314,7 +338,7 @@ class MemoryCompressionDimension(DimensionTracker):
 
     def has_anomaly(self) -> bool:
         return (
-            self._runs >= self.MIN_RUNS_FOR_ANOMALY
+            len(self._recent_yields) >= self.MIN_RUNS_FOR_ANOMALY
             and self.recent_yield < self.LOW_YIELD_THRESHOLD
         )
 

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -202,10 +202,21 @@ async def compress_session(
 
     # Issue #142: record the yield ratio so a silently degrading extractor
     # (facts << entries) surfaces as an anomaly on the next turn boundary.
+    # Issue #173: exclude tool_call/tool_result entries from the denominator —
+    # they describe operations, not knowledge, so their inclusion produced a
+    # permanent false-positive low-yield alert on tool-heavy sessions.
     if telemetry is not None:
         dim = telemetry.get("memory_compression")
         if dim is not None:
-            dim.record(entries=len(entries), facts=len(facts))
+            tool_events = sum(
+                1 for e in entries
+                if e.event_type in ("tool_call", "tool_result")
+            )
+            dim.record(
+                entries=len(entries),
+                facts=len(facts),
+                tool_events=tool_events,
+            )
             telemetry.mark_dirty()
 
     return len(facts)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -118,6 +118,32 @@ def test_memory_compression_rolling_window_bounded():
     assert len(dim._recent_yields) == 10
 
 
+def test_memory_compression_tool_events_excluded_from_denominator():
+    """Issue #173: tool_call/tool_result entries don't count as knowledge input.
+
+    A session with 18 tool events and 2 message entries yielding 1 fact should
+    score as 1/2 = 50% yield, not 1/20 = 5%.
+    """
+    dim = MemoryCompressionDimension()
+    dim.record(entries=20, facts=1, tool_events=18)
+    snap = dim.snapshot()
+    assert snap["entries_total"] == 20
+    assert snap["tool_events_total"] == 18
+    assert snap["knowledge_entries_total"] == 2
+    assert abs(snap["overall_yield"] - 0.5) < 0.01
+
+
+def test_memory_compression_tool_only_runs_skip_anomaly_window():
+    """Tool-only runs (no knowledge entries) must not poison the yield window
+    or trip the anomaly detector — this was the #173 false positive."""
+    dim = MemoryCompressionDimension()
+    for _ in range(5):
+        dim.record(entries=15, facts=0, tool_events=15)
+    assert dim.has_anomaly() is False
+    assert dim.snapshot()["skipped_runs"] == 5
+    assert dim._recent_yields == []
+
+
 # ---------------------------------------------------------------------------
 # ContextLayoutDimension
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `MemoryCompressionDimension` now excludes `tool_call` / `tool_result` entries from the yield denominator — they describe operations, not knowledge, and were driving the false-positive low-yield alert on every tool-heavy session
- Runs that contain only tool events (no knowledge entries to extract from) are skipped from the anomaly window rather than poisoning it with spurious 0% yields
- `compress_session()` now counts tool events from the batch and passes them through to `dim.record()`
- Snapshot / detail rendering expose `tool_events_total`, `knowledge_entries_total`, and `skipped_runs` so operators can still see what was filtered

## Why not just raise the threshold?
Raising `LOW_YIELD_THRESHOLD` below 5% would silence the signal even for genuinely degrading extractors on knowledge sessions. The root cause was a semantic mismatch — tool events are operational, not knowledge input — so filtering them out at the denominator is the honest fix.

## Test plan
- [x] `pytest tests/test_telemetry.py` — 20 passed, new cases cover (a) denominator excluding tool events, (b) tool-only runs skipping the anomaly window
- [x] `pytest tests/` — full suite 972 passed
- [x] Backward-compatible signature: `record(entries=, facts=)` still works with `tool_events` defaulting to 0

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)