### PR TITLE
fix(cognition): configurable per-model output_max_tokens (#181)

### DIFF
--- a/loom.toml.example
+++ b/loom.toml.example
@@ -39,6 +39,19 @@ personality = ""
 default_model = "claude-sonnet-4-6"
 max_tokens    = 8096
 
+# Output-token cap for the main stream_turn() LLM call. Different providers
+# have wildly different ceilings — MiniMax-M2.7 supports ~64K, Claude Sonnet
+# 4.6 supports ~64K, small local models often 4-8K. Set a conservative
+# session-wide default and override per-model below.
+output_max_tokens = 32768
+
+# Per-model overrides (table key = exact model name). Entries here win over
+# the default above. Unknown models fall through to output_max_tokens.
+[cognition.output_max_tokens_overrides]
+"MiniMax-M2.7"       = 65536
+"claude-sonnet-4-6"  = 65536
+"claude-opus-4-7"    = 32768
+
 # ─────────────────────────────────────────────
 # Local providers
 # ─────────────────────────────────────────────

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -246,6 +246,35 @@ def _load_loom_config() -> dict:
     return {}
 
 
+# Issue #181: per-model output cap. Different providers have very different
+# output ceilings (MiniMax-M2.7 ~64K, Claude Sonnet 4.6 ~64K, smaller local
+# models often 4-8K) so a single hardcoded value was either wasteful or
+# clipping long tool-loop turns. Resolved once at session start.
+_DEFAULT_OUTPUT_MAX_TOKENS = 8192
+
+
+def _resolve_output_max_tokens(cfg: dict, model: str) -> int:
+    """Return the output-token cap for *model* from ``[cognition]``.
+
+    Precedence: ``[cognition.output_max_tokens_overrides][<model>]`` →
+    ``[cognition].output_max_tokens`` → ``_DEFAULT_OUTPUT_MAX_TOKENS``.
+    """
+    cog = cfg.get("cognition", {}) or {}
+    overrides = cog.get("output_max_tokens_overrides", {}) or {}
+    if model in overrides:
+        try:
+            return int(overrides[model])
+        except (TypeError, ValueError):
+            pass
+    default = cog.get("output_max_tokens")
+    if default is not None:
+        try:
+            return int(default)
+        except (TypeError, ValueError):
+            pass
+    return _DEFAULT_OUTPUT_MAX_TOKENS
+
+
 def _load_env(project_root: Path | None = None) -> dict[str, str]:
     """Load .env from project root or current directory."""
     search = [
@@ -465,6 +494,9 @@ class LoomSession:
         self._episodic_compress_threshold: int = (
             config.get("memory", {}).get("episodic_compress_threshold", 30)
         )
+        # Issue #181: cache the whole config so ``output_max_tokens`` resolves
+        # cheaply on every LLM call, and responds live to ``set_model``.
+        self._loom_config: dict = config
         system_prompt = self._stack.load()
 
         # Inject workspace context into system prompt
@@ -1353,7 +1385,9 @@ class LoomSession:
                 model=self.model,
                 messages=self.messages,
                 tools=tools,
-                max_tokens=8096,
+                max_tokens=_resolve_output_max_tokens(
+                    self._loom_config, self.model,
+                ),
                 abort_signal=abort_signal,
             ):
                 if final is None:
@@ -2975,6 +3009,7 @@ __all__ = [
     "_load_loom_config",
     "_load_env",
     "_parse_skill_frontmatter",
+    "_resolve_output_max_tokens",
     "COMPRESS_PROMPT",
     "COMPACT_PROMPT",
 ]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -189,6 +189,48 @@ class TestConfigPathResolution:
         assert isinstance(result, dict)
 
 
+class TestOutputMaxTokensResolution:
+    """Issue #181: per-model output cap resolution."""
+
+    def test_falls_back_to_hardcoded_default_on_empty_config(self):
+        from loom.core.session import _resolve_output_max_tokens
+        assert _resolve_output_max_tokens({}, "claude-sonnet-4-6") == 8192
+
+    def test_uses_cognition_default_when_no_override(self):
+        from loom.core.session import _resolve_output_max_tokens
+        cfg = {"cognition": {"output_max_tokens": 32768}}
+        assert _resolve_output_max_tokens(cfg, "MiniMax-M2.7") == 32768
+
+    def test_per_model_override_wins_over_default(self):
+        from loom.core.session import _resolve_output_max_tokens
+        cfg = {
+            "cognition": {
+                "output_max_tokens": 8192,
+                "output_max_tokens_overrides": {
+                    "MiniMax-M2.7": 65536,
+                    "claude-sonnet-4-6": 32768,
+                },
+            }
+        }
+        assert _resolve_output_max_tokens(cfg, "MiniMax-M2.7") == 65536
+        assert _resolve_output_max_tokens(cfg, "claude-sonnet-4-6") == 32768
+        # unknown model → fall through to default
+        assert _resolve_output_max_tokens(cfg, "gpt-5") == 8192
+
+    def test_invalid_values_fall_back_gracefully(self):
+        from loom.core.session import _resolve_output_max_tokens
+        cfg = {
+            "cognition": {
+                "output_max_tokens": "not-a-number",
+                "output_max_tokens_overrides": {
+                    "claude-sonnet-4-6": "also-bad",
+                },
+            }
+        }
+        # both invalid → hardcoded default
+        assert _resolve_output_max_tokens(cfg, "claude-sonnet-4-6") == 8192
+
+
 class TestParallelDispatch:
     @pytest.mark.asyncio
     async def test_dispatch_parallel_uses_current_task_graph_api_and_preserves_order(self):


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `max_tokens=8096` in `stream_turn()` with a resolved per-model cap
- New `[cognition].output_max_tokens` for the session default and `[cognition.output_max_tokens_overrides]` for per-model overrides
- Resolution lives in `_resolve_output_max_tokens(cfg, model)` — pure dict lookup, cheap enough to call per LLM turn so `set_model()` takes effect immediately
- Config cached on `LoomSession` at `__init__` so we don't re-read `loom.toml` on the hot path
- `loom.toml.example` updated with sensible defaults (MiniMax-M2.7 / claude-sonnet-4-6 at 64K, opus-4-7 at 32K)

## Why not tie this to `ContextBudget`?
The issue's proposed \"use remaining budget as soft cap\" mixes two dimensions: `ContextBudget.total_tokens = 204_800` is the **input context budget** (drives compression threshold), while `max_tokens` is the **output cap**. Model families have different input/output ceilings and shouldn't share a single knob.

## Out of scope
Kept the scope tight to the main `stream_turn()` call. The other small `max_tokens` values (1024 for compression, 2048 for dream / smart-compact) are deliberate bounds on background tasks and remain unchanged.

## Test plan
- [x] `pytest tests/test_session.py` — 23 passed, new `TestOutputMaxTokensResolution` covers: default fallback, per-model override, unknown model fall-through, invalid-type graceful fallback
- [x] `pytest tests/` — full suite 974 passed
- [x] Backwards compatible: existing `loom.toml` files without the new keys silently fall back to 8192

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)