### PR TITLE
fix(harness): enforce skill lifecycle invariant + agent recovery hints (#184)

### DIFF
--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -778,8 +778,12 @@ class LifecycleGateMiddleware(Middleware):
     LifecycleMiddleware), this middleware is a transparent pass-through.
     """
 
-    def __init__(self, registry: Any) -> None:
+    def __init__(self, registry: Any, skill_check_manager: Any = None) -> None:
         self._registry = registry
+        # Optional: used to attribute precondition failures back to the
+        # skill that mounted the check, so the error message can tell the
+        # agent how to self-recover (unload_skill / load different skill).
+        self._skill_check_manager = skill_check_manager
 
     async def process(self, call: ToolCall, next: ToolHandler) -> ToolResult:
         from .lifecycle import LIFECYCLE_CTX_KEY, ActionState
@@ -824,6 +828,31 @@ class LifecycleGateMiddleware(Middleware):
                     if i < len(precondition_descs)
                     else f"precondition_check[{i}]"
                 )
+
+                # Attribute the failing check back to the skill that mounted
+                # it, so the agent can self-recover without bubbling to user.
+                owner_skill = None
+                if self._skill_check_manager is not None:
+                    try:
+                        owner_skill = self._skill_check_manager.owner_of(check)
+                    except Exception:
+                        owner_skill = None
+
+                error_lines = [f"Precondition failed: {desc}"]
+                if owner_skill is not None:
+                    error_lines.append(
+                        f"This check was mounted by skill '{owner_skill}'."
+                    )
+                    error_lines.append(
+                        "Recovery: if this skill's guard is not relevant to "
+                        "your current task, call "
+                        f"unload_skill(name=\"{owner_skill}\") to lift it; "
+                        "otherwise adjust the command to satisfy the check. "
+                        "This is recoverable — do not ask the user unless "
+                        "the intent itself is ambiguous."
+                    )
+                error_text = "\n".join(error_lines)
+
                 await ctx.transition(
                     ActionState.ABORTED,
                     reason=f"Precondition failed: {desc}",
@@ -832,7 +861,7 @@ class LifecycleGateMiddleware(Middleware):
                     call_id=call.id,
                     tool_name=call.tool_name,
                     success=False,
-                    error=f"Precondition failed: {desc}",
+                    error=error_text,
                     failure_type="execution_error",
                 )
                 record.result = result

--- a/loom/core/harness/skill_checks.py
+++ b/loom/core/harness/skill_checks.py
@@ -134,6 +134,34 @@ class SkillCheckManager:
     # Mount / Unmount
     # ------------------------------------------------------------------
 
+    def activate(self, skill_name: str, keep_existing: bool = False) -> None:
+        """
+        Declare *skill_name* as the active skill.
+
+        This is a pure lifecycle event — it does NOT mount any checks, but
+        it DOES auto-unmount the previous active skill's checks (unless
+        ``keep_existing=True``).  Call this on every ``load_skill`` event,
+        including skills that declare no precondition checks, so the
+        harness invariant holds: ``active_skill`` always reflects the most
+        recently loaded skill, and stale checks from a prior skill never
+        linger across a skill transition.
+
+        Idempotent: re-activating the currently active skill is a no-op.
+        """
+        if skill_name == self._active_skill:
+            return
+        if not keep_existing and self._active_skill is not None:
+            self.unmount(self._active_skill)
+        self._active_skill = skill_name
+
+    def owner_of(self, check_fn: Callable) -> str | None:
+        """Return the skill name that mounted *check_fn*, or None."""
+        for skill, checks in self._mounted.items():
+            for mc in checks:
+                if mc.check_fn is check_fn:
+                    return skill
+        return None
+
     def mount(
         self,
         skill_name: str,

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1074,7 +1074,10 @@ class LoomSession:
                     exec_escape_fn=_exec_escape_fn,
                     registry=self.registry,
                 ),
-                LifecycleGateMiddleware(registry=self.registry),
+                LifecycleGateMiddleware(
+                    registry=self.registry,
+                    skill_check_manager=self._skill_check_manager,
+                ),
             ]
         )
 

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -1203,7 +1203,15 @@ def make_load_skill_tool(
         keep_existing: bool = False,
     ) -> list[str]:
         """Resolve and mount precondition checks for a skill. Returns descriptions."""
-        if manager is None or not skill.precondition_check_refs:
+        if manager is None:
+            return []
+
+        # Harness invariant: every load_skill is a lifecycle event for the
+        # manager, even when the new skill declares no checks.  Without this,
+        # a skill with no checks would leave the previous skill's checks
+        # stranded on tool definitions (Issue #184).
+        if not skill.precondition_check_refs:
+            manager.activate(name, keep_existing=keep_existing)
             return []
 
         from loom.core.harness.skill_checks import SkillPreconditionRef, SkillCheckManager

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -402,6 +402,87 @@ class TestPreconditionGates:
         assert "Precondition failed" in result.error
 
     @pytest.mark.asyncio
+    async def test_precondition_failure_includes_skill_recovery_hint(self):
+        """
+        Issue #184: when a precondition is mounted by a skill, the failure
+        message must tell the agent who mounted it and how to self-recover.
+        """
+        from loom.core.harness.skill_checks import (
+            SkillCheckManager,
+            SkillPreconditionRef,
+        )
+
+        async def failing_check(call):
+            return False
+
+        tool = ToolDefinition(
+            name="run_bash", description="",
+            input_schema={}, executor=_echo_handler,
+            trust_level=TrustLevel.SAFE,
+        )
+        reg = _make_registry(tool)
+
+        # Mount the check through a real SkillCheckManager so owner_of()
+        # can attribute the failure back to the skill.
+        manager = SkillCheckManager(reg)
+        refs = [SkillPreconditionRef(
+            ref="checks.only_pet_script",
+            applies_to=["run_bash"],
+            description="only pet.py allowed",
+        )]
+        manager.mount("pet-cat", refs, {"checks.only_pet_script": failing_check})
+
+        perm = PermissionContext(session_id="test-session")
+        pipeline = MiddlewarePipeline([
+            LifecycleMiddleware(registry=reg),
+            SchemaValidationMiddleware(registry=reg),
+            BlastRadiusMiddleware(
+                perm_ctx=perm, confirm_fn=AsyncMock(return_value=True),
+            ),
+            LifecycleGateMiddleware(
+                registry=reg, skill_check_manager=manager,
+            ),
+        ])
+        call = _make_call("run_bash")
+
+        result = await pipeline.execute(call, _echo_handler)
+
+        assert not result.success
+        assert "Precondition failed" in result.error
+        # Owner skill must be named so the agent can act on it
+        assert "pet-cat" in result.error
+        # Recovery path must be spelled out, not hinted at
+        assert "unload_skill" in result.error
+        # The failure must be marked as recoverable at the agent layer
+        assert "recoverable" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_precondition_failure_without_manager_is_plain(self):
+        """
+        Backward compat: if no skill_check_manager is wired (e.g. sub-agent
+        pipeline), the error stays the simple legacy form.
+        """
+        async def failing_check(call):
+            return False
+
+        tool = ToolDefinition(
+            name="run_bash", description="",
+            input_schema={}, executor=_echo_handler,
+            trust_level=TrustLevel.SAFE,
+            preconditions=["some guard"],
+            precondition_checks=[failing_check],
+        )
+        reg = _make_registry(tool)
+        pipeline = _build_pipeline(reg)  # no skill_check_manager
+        call = _make_call("run_bash")
+
+        result = await pipeline.execute(call, _echo_handler)
+        assert not result.success
+        assert "Precondition failed" in result.error
+        # No recovery hint when we can't attribute
+        assert "unload_skill" not in result.error
+
+    @pytest.mark.asyncio
     async def test_all_preconditions_pass_proceeds(self):
         """All preconditions pass → tool executes normally."""
         async def ok_check(call):

--- a/tests/test_skill_checks.py
+++ b/tests/test_skill_checks.py
@@ -267,6 +267,127 @@ class TestSkillCheckManagerAutoUnmount:
 
 
 # ---------------------------------------------------------------------------
+# Harness invariant: activate() as pure lifecycle event  (Issue #184)
+# ---------------------------------------------------------------------------
+
+
+class TestSkillCheckManagerActivate:
+    """
+    The harness must maintain the invariant: ``active_skill`` always
+    reflects the most recently loaded skill, even when that skill declares
+    no precondition checks.  Without this, loading a skill-with-checks
+    followed by a skill-without-checks leaves the first skill's checks
+    stranded on tool definitions.
+    """
+
+    def test_activate_without_checks_unmounts_prior(self):
+        """
+        Issue #184 core bug: load_skill(skill_a_with_checks) →
+        load_skill(skill_b_no_checks) must clear skill_a's checks.
+        """
+        registry = _make_registry_with_tools("run_bash")
+        manager = SkillCheckManager(registry)
+
+        refs_a = [SkillPreconditionRef(
+            ref="checks.fn_a",
+            applies_to=["run_bash"],
+            description="Check from A",
+        )]
+
+        manager.mount("skill_a", refs_a, {"checks.fn_a": _always_pass})
+        assert len(registry.get("run_bash").precondition_checks) == 1
+        assert manager.active_skill == "skill_a"
+
+        # skill_b declares no precondition_checks → activate() is the only
+        # signal the manager receives.  It must still clear skill_a.
+        manager.activate("skill_b")
+
+        assert len(registry.get("run_bash").precondition_checks) == 0
+        assert manager.active_skill == "skill_b"
+        assert manager.mounted_skills() == []
+
+    def test_activate_same_skill_is_noop(self):
+        registry = _make_registry_with_tools("run_bash")
+        manager = SkillCheckManager(registry)
+
+        refs = [SkillPreconditionRef(
+            ref="checks.fn",
+            applies_to=["run_bash"],
+            description="Check",
+        )]
+        manager.mount("skill_a", refs, {"checks.fn": _always_pass})
+
+        # Re-activating the currently active skill must not clear its checks
+        manager.activate("skill_a")
+
+        assert len(registry.get("run_bash").precondition_checks) == 1
+        assert manager.active_skill == "skill_a"
+
+    def test_activate_keep_existing(self):
+        registry = _make_registry_with_tools("run_bash")
+        manager = SkillCheckManager(registry)
+
+        refs_a = [SkillPreconditionRef(
+            ref="checks.fn_a",
+            applies_to=["run_bash"],
+            description="A",
+        )]
+        manager.mount("skill_a", refs_a, {"checks.fn_a": _always_pass})
+
+        manager.activate("skill_b", keep_existing=True)
+
+        # skill_a's checks remain; only active_skill pointer moves
+        assert len(registry.get("run_bash").precondition_checks) == 1
+        assert manager.active_skill == "skill_b"
+        assert "skill_a" in manager.mounted_skills()
+
+    def test_activate_from_empty(self):
+        registry = _make_registry_with_tools("run_bash")
+        manager = SkillCheckManager(registry)
+
+        assert manager.active_skill is None
+        manager.activate("skill_a")
+        assert manager.active_skill == "skill_a"
+
+
+class TestSkillCheckManagerOwnerOf:
+    """Reverse lookup: which skill mounted a given check function."""
+
+    def test_owner_of_mounted_check(self):
+        registry = _make_registry_with_tools("run_bash")
+        manager = SkillCheckManager(registry)
+
+        refs = [SkillPreconditionRef(
+            ref="checks.fn",
+            applies_to=["run_bash"],
+            description="Check",
+        )]
+        manager.mount("pet-cat", refs, {"checks.fn": _always_fail})
+
+        assert manager.owner_of(_always_fail) == "pet-cat"
+
+    def test_owner_of_unknown_check(self):
+        registry = _make_registry_with_tools("run_bash")
+        manager = SkillCheckManager(registry)
+
+        assert manager.owner_of(_always_pass) is None
+
+    def test_owner_of_after_unmount(self):
+        registry = _make_registry_with_tools("run_bash")
+        manager = SkillCheckManager(registry)
+
+        refs = [SkillPreconditionRef(
+            ref="checks.fn",
+            applies_to=["run_bash"],
+            description="Check",
+        )]
+        manager.mount("skill_a", refs, {"checks.fn": _always_fail})
+        manager.unmount("skill_a")
+
+        assert manager.owner_of(_always_fail) is None
+
+
+# ---------------------------------------------------------------------------
 # Callable resolution
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #184.

## 站位
不把這當成 pet-cat 單一技能的問題，修在 harness 層。Harness 必須保證 skill lifecycle 的不變量，不能靠每個技能各自守規矩。錯誤要引導 agent 自行復原，不要把 recoverable 的狀況拋給使用者。

## 被打破的不變量
> `SkillCheckManager.active_skill` 必須永遠反映最近載入的技能，前一個技能的 checks 不應該跨越 skill transition 殘留在 tool definition 上。

## Root Cause
`loom/platform/cli/tools.py:_mount_skill_checks` 在新技能沒宣告 `precondition_checks` 時提早 return，**跳過了 `SkillCheckManager.mount()`** —— 而 auto-unmount 的邏輯只有在 `mount()` 裡會觸發。

實際觸發場景：
1. `load_skill(pet-cat)` → mount `restrict_to_pet_script` 到 `run_bash`
2. `load_skill(task_list)`（沒宣告 checks）→ `_mount_skill_checks` 提早 return → pet-cat 的 guard **繼續掛著**
3. 後續任何非 pet.py 的 shell 指令都被 pet-cat guard 擋下

## Summary
- **`SkillCheckManager.activate(skill_name)`** — 新的純 lifecycle event API。`load_skill` 現在在每次技能切換時都呼叫，不論新技能有沒有 check，`active_skill` 指針永遠跟著最後一次 `load_skill` 走，前任技能的 check 保證清掉。
- **`SkillCheckManager.owner_of(check_fn)`** — 反向查詢，讓 harness 可以把失敗的 check 歸因到哪個技能。
- **`LifecycleGateMiddleware`** 接受 optional `skill_check_manager`。precondition 擋下時，error 變成給 agent 看的 recovery 指引：
  - 標明是哪個技能掛的 check
  - 明確告訴 agent 下一步：`unload_skill(name=\"<skill>\")`
  - 標註「recoverable — do not ask the user unless intent itself is ambiguous」
- `LoomSession.start()` 把既有的 `_skill_check_manager` 注入 `LifecycleGateMiddleware`。Sub-agent 流程沒動（繼續 pass None → legacy error）。

## 設計原則
| 層 | 責任 |
|----|------|
| Harness invariant | `activate()` 守住 skill lifecycle 一致性，不依賴技能宣告 |
| Agent self-recovery | precondition 失敗訊息裡直接告訴 LLM 下一步可以做什麼 |
| User notification | 只有首次 mount 信任授權這類重大決策才通知 user，routine guard 踩到不打擾 |

## Test plan
- [x] `TestSkillCheckManagerActivate` — 三個新測試覆蓋 activate 的 lifecycle、idempotency、keep_existing 語意
- [x] `TestSkillCheckManagerOwnerOf` — 三個測試覆蓋 owner 反查的 happy path、unknown fn、unmount 後
- [x] `TestPreconditionGates.test_precondition_failure_includes_skill_recovery_hint` — error 帶 skill 名稱 + `unload_skill` + `recoverable`
- [x] `TestPreconditionGates.test_precondition_failure_without_manager_is_plain` — 向後相容：manager=None 時回到 legacy error 格式
- [x] 全 test suite 1015 tests 全綠

## Out of scope
- pet-cat guard 的文件描述修正（Issue #184 Solution A）：本 PR 修了底層不變量，讓 guard stranding 不會再發生；文件本身若要描述 guard 語意可另開一個小 PR 處理，不綁在這次核心修法裡
- Skill mount approval UX 的其他優化

🤖 Generated with [Claude Code](https://claude.com/claude-code)