### PR TITLE
fix(subagent): surface failure context via SubAgentResult + scratchpad ref (#192)

### DIFF
--- a/loom/core/agent/subagent.py
+++ b/loom/core/agent/subagent.py
@@ -49,6 +49,12 @@ class SubAgentResult:
     turns_used: int
     tool_calls: int
     error: str | None = None
+    # Failure context (Issue #192 P0) — populated when success=False so the
+    # parent agent can diagnose without re-running. Scratchpad ref
+    # "subagent_failure:<agent_id>" holds the full structured trace.
+    last_tool_name: str | None = None
+    last_tool_error: str | None = None
+    partial_output: str | None = None
 
 
 async def run_subagent(
@@ -62,6 +68,7 @@ async def run_subagent(
     parent_session_id: str,
     workspace: Any,              # pathlib.Path
     parent_grants: "list[Any] | None" = None,
+    scratchpad: Any = None,
 ) -> SubAgentResult:
     """
     Run a sub-agent to completion and return a SubAgentResult.
@@ -198,6 +205,9 @@ async def run_subagent(
     turns_used = 0
     total_tool_calls = 0
     final_output = ""
+    last_tool_name: str | None = None
+    last_tool_error: str | None = None
+    assistant_text_trail = ""  # Accumulated free text from assistant turns (for partial_output)
 
     # ── Agent loop ────────────────────────────────────────────────────────────
     while turns_used < config.max_turns:
@@ -218,14 +228,28 @@ async def run_subagent(
 
         messages.append(response.raw_message)
 
+        # Accumulate free text from this assistant message (even during tool_use
+        # turns it may contain a preamble). Used to populate partial_output on
+        # failure so the parent sees what the agent was thinking.
+        raw = response.raw_message
+        raw_content = raw.get("content")
+        if isinstance(raw_content, str):
+            if raw_content:
+                assistant_text_trail += raw_content + "\n"
+        elif isinstance(raw_content, list):
+            for block in raw_content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text = block.get("text", "")
+                    if text:
+                        assistant_text_trail += text + "\n"
+
         if response.stop_reason == "end_turn":
             turns_used += 1
-            raw = response.raw_message
-            if isinstance(raw.get("content"), str):
-                final_output = raw["content"]
-            elif isinstance(raw.get("content"), list):
+            if isinstance(raw_content, str):
+                final_output = raw_content
+            elif isinstance(raw_content, list):
                 final_output = " ".join(
-                    b.get("text", "") for b in raw["content"]
+                    b.get("text", "") for b in raw_content
                     if isinstance(b, dict) and b.get("type") == "text"
                 )
             break
@@ -257,6 +281,9 @@ async def run_subagent(
                     result.duration_ms = (time.monotonic() - ts) * 1000
 
                 tool_output = str(result.output) if result.success else (result.error or "")
+                if not result.success:
+                    last_tool_name = tu.name
+                    last_tool_error = result.error or tool_output or "(no error message)"
                 messages.append(
                     router.format_tool_result(config.model, tu.id, tool_output, result.success)
                 )
@@ -264,13 +291,24 @@ async def run_subagent(
             break
 
     if turns_used >= config.max_turns and not final_output:
+        partial = assistant_text_trail.strip()
+        partial_output = partial[-2000:] if partial else None
+        error_msg = f"Sub-agent reached max_turns limit ({config.max_turns}) without completing."
+        _write_failure_scratchpad(
+            scratchpad, agent_id, turns_used, total_tool_calls,
+            config.max_turns, last_tool_name, last_tool_error,
+            partial_output, error_msg,
+        )
         return SubAgentResult(
             success=False,
             output="",
             agent_id=agent_id,
             turns_used=turns_used,
             tool_calls=total_tool_calls,
-            error=f"Sub-agent reached max_turns limit ({config.max_turns}) without completing.",
+            error=error_msg,
+            last_tool_name=last_tool_name,
+            last_tool_error=last_tool_error,
+            partial_output=partial_output,
         )
 
     return SubAgentResult(
@@ -280,3 +318,41 @@ async def run_subagent(
         turns_used=turns_used,
         tool_calls=total_tool_calls,
     )
+
+
+def _write_failure_scratchpad(
+    scratchpad: Any,
+    agent_id: str,
+    turns_used: int,
+    tool_calls: int,
+    max_turns: int,
+    last_tool_name: str | None,
+    last_tool_error: str | None,
+    partial_output: str | None,
+    error: str,
+) -> None:
+    """Write sub-agent failure context to scratchpad if available.
+
+    Ref format: ``subagent_failure:<agent_id>``. Parent agent can read via
+    scratchpad_read to recover partial context when spawn_agent returns an
+    error. Silent no-op if no scratchpad is provided.
+    """
+    if scratchpad is None:
+        return
+    import json
+    ref = f"subagent_failure:{agent_id}"
+    payload = {
+        "agent_id": agent_id,
+        "turns_used": turns_used,
+        "tool_calls": tool_calls,
+        "max_turns": max_turns,
+        "last_tool_name": last_tool_name,
+        "last_tool_error": last_tool_error,
+        "partial_output": partial_output,
+        "error": error,
+    }
+    try:
+        scratchpad.write(ref, json.dumps(payload, ensure_ascii=False, indent=2))
+    except Exception:
+        # Scratchpad write must never mask the real failure — swallow.
+        pass

--- a/loom/core/agent/subagent.py
+++ b/loom/core/agent/subagent.py
@@ -14,6 +14,7 @@ Design principles:
 
 from __future__ import annotations
 
+import json
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -339,7 +340,6 @@ def _write_failure_scratchpad(
     """
     if scratchpad is None:
         return
-    import json
     ref = f"subagent_failure:{agent_id}"
     payload = {
         "agent_id": agent_id,

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -2122,6 +2122,7 @@ def make_spawn_agent_tool(parent_session: Any) -> "ToolDefinition":
                 parent_session_id=parent_session.session_id,
                 workspace=parent_session.workspace,
                 parent_grants=parent_session.perm.grants,
+                scratchpad=getattr(parent_session, "_scratchpad", None),
             )
         except Exception as exc:
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
@@ -2136,8 +2137,20 @@ def make_spawn_agent_tool(parent_session: Any) -> "ToolDefinition":
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
                               success=True, output=header + result.output)
         else:
+            # Issue #192 P0: attach failure context hint so the parent can
+            # decide whether to read the scratchpad ref for full diagnostics.
+            parts = [result.error or "Sub-agent failed"]
+            if result.last_tool_name:
+                parts.append(
+                    f"last_tool={result.last_tool_name}"
+                    + (f" error={result.last_tool_error!r}" if result.last_tool_error else "")
+                )
+            parts.append(
+                f"Full failure context at scratchpad ref: subagent_failure:{result.agent_id} "
+                f"(read via scratchpad_read)."
+            )
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
-                              success=False, error=result.error or "Sub-agent failed",
+                              success=False, error=" | ".join(parts),
                               failure_type="execution_error")
 
     return ToolDefinition(

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest_asyncio
 
 from loom.core.agent.subagent import SubAgentConfig, run_subagent
 from loom.core.cognition.providers import LLMResponse, ToolUse
-from loom.core.harness.registry import ToolRegistry
+from loom.core.harness.permissions import ToolCapability, TrustLevel
+from loom.core.harness.middleware import ToolCall, ToolResult
+from loom.core.harness.registry import ToolDefinition, ToolRegistry
+from loom.core.jobs.scratchpad import Scratchpad
 from loom.core.memory.episodic import EpisodicMemory
 from loom.core.memory.facade import MemoryFacade
 from loom.core.memory.procedural import ProceduralMemory
@@ -134,3 +138,193 @@ class TestSubAgentMemorize:
         entry = await semantic.get("project:fact")
         assert entry is not None
         assert entry.source == "agent:sub-123"
+
+
+def _make_failing_tool() -> ToolDefinition:
+    """A SAFE tool that always fails — used to simulate tool errors in the loop."""
+
+    async def _always_fail(call: ToolCall) -> ToolResult:
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=False, error="simulated failure for test",
+            failure_type="execution_error",
+        )
+
+    return ToolDefinition(
+        name="always_fail",
+        description="Test tool that always fails.",
+        trust_level=TrustLevel.SAFE,
+        capabilities=ToolCapability(0),
+        input_schema={"type": "object", "properties": {}},
+        executor=_always_fail,
+        tags=["test"],
+    )
+
+
+def _tool_use_response(tool_id: str, preamble_text: str) -> LLMResponse:
+    """Assistant emits a short free-text preamble then calls always_fail."""
+    return LLMResponse(
+        text=None,
+        tool_uses=[ToolUse(id=tool_id, name="always_fail", args={})],
+        stop_reason="tool_use",
+        raw_message={
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": preamble_text},
+                {"type": "tool_use", "id": tool_id, "name": "always_fail", "input": {}},
+            ],
+            "tool_calls": [
+                {
+                    "id": tool_id,
+                    "type": "function",
+                    "function": {"name": "always_fail", "arguments": "{}"},
+                }
+            ],
+        },
+    )
+
+
+class TestSubAgentFailureContext:
+    """Regression tests for Issue #192 P0 — failure context + scratchpad."""
+
+    async def test_max_turns_failure_populates_context_and_scratchpad(
+        self,
+        semantic: SemanticMemory,
+        episodic: EpisodicMemory,
+        procedural: ProceduralMemory,
+        tmp_path: Path,
+    ) -> None:
+        registry = ToolRegistry()
+        registry.register(_make_failing_tool())
+
+        # Two tool_use turns — both call the failing tool. max_turns=2 means the
+        # loop exits via the max_turns branch, not end_turn.
+        router = _FakeRouter([
+            _tool_use_response("call_1", "first attempt: trying to resolve X"),
+            _tool_use_response("call_2", "second attempt: retrying with different approach"),
+        ])
+
+        scratchpad = Scratchpad()
+
+        result = await run_subagent(
+            SubAgentConfig(
+                task="Do the impossible.",
+                model="gpt-test",
+                allowed_tools=["always_fail"],
+                max_turns=2,
+                agent_id="sub-fail",
+            ),
+            router=router,
+            episodic=episodic,
+            semantic=semantic,
+            procedural=procedural,
+            tool_registry=registry,
+            parent_session_id="parent-1",
+            workspace=tmp_path,
+            scratchpad=scratchpad,
+        )
+
+        # SubAgentResult carries structured failure context
+        assert result.success is False
+        assert result.turns_used == 2
+        assert result.tool_calls == 2
+        assert result.last_tool_name == "always_fail"
+        assert result.last_tool_error == "simulated failure for test"
+        assert result.partial_output is not None
+        assert "first attempt" in result.partial_output
+        assert "second attempt" in result.partial_output
+        assert "max_turns limit" in (result.error or "")
+
+        # Scratchpad ref populated with full structured payload
+        ref = "subagent_failure:sub-fail"
+        assert ref in scratchpad
+        payload = json.loads(scratchpad.read(ref))
+        assert payload["agent_id"] == "sub-fail"
+        assert payload["turns_used"] == 2
+        assert payload["tool_calls"] == 2
+        assert payload["max_turns"] == 2
+        assert payload["last_tool_name"] == "always_fail"
+        assert payload["last_tool_error"] == "simulated failure for test"
+        assert "second attempt" in (payload["partial_output"] or "")
+
+    async def test_success_path_leaves_failure_fields_none(
+        self,
+        semantic: SemanticMemory,
+        episodic: EpisodicMemory,
+        procedural: ProceduralMemory,
+        tmp_path: Path,
+    ) -> None:
+        """Successful sub-agent does not populate failure context or scratchpad."""
+        registry = ToolRegistry()
+        router = _FakeRouter([
+            LLMResponse(
+                text="done",
+                tool_uses=[],
+                stop_reason="end_turn",
+                raw_message={"role": "assistant", "content": "done"},
+            ),
+        ])
+        scratchpad = Scratchpad()
+
+        result = await run_subagent(
+            SubAgentConfig(
+                task="Trivial task.",
+                model="gpt-test",
+                allowed_tools=[],
+                max_turns=5,
+                agent_id="sub-ok",
+            ),
+            router=router,
+            episodic=episodic,
+            semantic=semantic,
+            procedural=procedural,
+            tool_registry=registry,
+            parent_session_id="parent-1",
+            workspace=tmp_path,
+            scratchpad=scratchpad,
+        )
+
+        assert result.success is True
+        assert result.output == "done"
+        assert result.last_tool_name is None
+        assert result.last_tool_error is None
+        assert result.partial_output is None
+        assert scratchpad.list_refs() == []
+
+    async def test_failure_without_scratchpad_still_populates_result(
+        self,
+        semantic: SemanticMemory,
+        episodic: EpisodicMemory,
+        procedural: ProceduralMemory,
+        tmp_path: Path,
+    ) -> None:
+        """When no scratchpad is provided, failure context must still be on the result."""
+        registry = ToolRegistry()
+        registry.register(_make_failing_tool())
+        router = _FakeRouter([
+            _tool_use_response("call_1", "only attempt"),
+        ])
+
+        result = await run_subagent(
+            SubAgentConfig(
+                task="Task without scratchpad.",
+                model="gpt-test",
+                allowed_tools=["always_fail"],
+                max_turns=1,
+                agent_id="sub-no-pad",
+            ),
+            router=router,
+            episodic=episodic,
+            semantic=semantic,
+            procedural=procedural,
+            tool_registry=registry,
+            parent_session_id="parent-1",
+            workspace=tmp_path,
+            # scratchpad omitted
+        )
+
+        assert result.success is False
+        assert result.last_tool_name == "always_fail"
+        assert result.last_tool_error == "simulated failure for test"
+        assert result.partial_output is not None
+        assert "only attempt" in result.partial_output


### PR DESCRIPTION
## Summary

Closes the "failure context evaporates" gap from #192. When a sub-agent hits `max_turns`, the parent previously saw only a one-line error and an empty output — 30–40 tool calls of intermediate state were unrecoverable.

P0 scope (P1/P2 tracked in #193):

- `SubAgentResult` gains `last_tool_name` / `last_tool_error` / `partial_output`
- `run_subagent` tracks the last failed tool + accumulates assistant free-text (trimmed to 2000 chars)
- On failure, writes a structured JSON payload to scratchpad ref `subagent_failure:<agent_id>`
- `spawn_agent` passes the parent session's scratchpad and appends the ref hint + last-tool summary to the error string

## Why this shape

- **Structured fields on the result** — parents can check `result.last_tool_error` directly, no string parsing.
- **Scratchpad as the full-context store** — keeps the tool result terse while giving the parent an explicit opt-in for the full diagnostic via `scratchpad_read`. Aligns with how `run_bash --async_mode` and `fetch_url` already use scratchpad.
- **No behavior change on the success path** — existing tests continue to pass unchanged; new fields default to `None`.
- **Backwards compatible** — `scratchpad` is an optional keyword arg on `run_subagent`; callers without a scratchpad still get the structured fields on `SubAgentResult`.

## Test plan

- [x] Existing `test_memorize_retags_source_with_agent_id` still green
- [x] `test_max_turns_failure_populates_context_and_scratchpad` — full P0 path: verifies all three result fields, scratchpad ref contents, and partial_output preserves text from every assistant turn
- [x] `test_success_path_leaves_failure_fields_none` — success path does not populate failure fields or scratchpad
- [x] `test_failure_without_scratchpad_still_populates_result` — graceful degradation when scratchpad is omitted
- [x] Full suite: 1030 tests pass (+3 new)

## Follow-up

- #193 — P1: structured `failure_code`, `recovery_suggestion` heuristics, `error_context` dict
- P2 (streaming chunks every N turns, early-exit on approaching max_turns) scoped but not prioritized

🤖 Generated with [Claude Code](https://claude.com/claude-code)