### PR TITLE
feat(subagent): structured failure_code + recovery hints on max_turns (#193)

### DIFF
--- a/loom/core/agent/subagent.py
+++ b/loom/core/agent/subagent.py
@@ -56,6 +56,11 @@ class SubAgentResult:
     last_tool_name: str | None = None
     last_tool_error: str | None = None
     partial_output: str | None = None
+    # Structured failure classification (Issue #193 P1) — lets the parent
+    # switch on failure_code instead of parsing error strings.
+    failure_code: str | None = None
+    recovery_suggestion: str | None = None
+    error_context: dict[str, Any] = field(default_factory=dict)
 
 
 async def run_subagent(
@@ -209,6 +214,12 @@ async def run_subagent(
     last_tool_name: str | None = None
     last_tool_error: str | None = None
     assistant_text_trail = ""  # Accumulated free text from assistant turns (for partial_output)
+    # Issue #193 P1: per-tool failure stats + longest consecutive-failure streak
+    # for the same tool (resets on success or when a different tool is called).
+    tool_failure_counts: dict[str, int] = {}
+    consecutive_failure_tool: str | None = None
+    consecutive_failure_count = 0
+    max_consecutive_failures = 0
 
     # ── Agent loop ────────────────────────────────────────────────────────────
     while turns_used < config.max_turns:
@@ -285,6 +296,18 @@ async def run_subagent(
                 if not result.success:
                     last_tool_name = tu.name
                     last_tool_error = result.error or tool_output or "(no error message)"
+                    tool_failure_counts[tu.name] = tool_failure_counts.get(tu.name, 0) + 1
+                    if consecutive_failure_tool == tu.name:
+                        consecutive_failure_count += 1
+                    else:
+                        consecutive_failure_tool = tu.name
+                        consecutive_failure_count = 1
+                    if consecutive_failure_count > max_consecutive_failures:
+                        max_consecutive_failures = consecutive_failure_count
+                else:
+                    # Reset the streak on any success
+                    consecutive_failure_tool = None
+                    consecutive_failure_count = 0
                 messages.append(
                     router.format_tool_result(config.model, tu.id, tool_output, result.success)
                 )
@@ -294,11 +317,27 @@ async def run_subagent(
     if turns_used >= config.max_turns and not final_output:
         partial = assistant_text_trail.strip()
         partial_output = partial[-2000:] if partial else None
+        stuck_tool = (
+            consecutive_failure_tool if max_consecutive_failures >= 3 else None
+        )
+        failure_code, recovery_suggestion = _classify_failure(
+            partial_output=partial_output,
+            stuck_tool=stuck_tool,
+            stuck_count=max_consecutive_failures,
+        )
+        error_context = {
+            "tool_failure_counts": dict(tool_failure_counts),
+            "max_consecutive_failures": max_consecutive_failures,
+            "stuck_tool": stuck_tool,
+        }
         error_msg = f"Sub-agent reached max_turns limit ({config.max_turns}) without completing."
         _write_failure_scratchpad(
             scratchpad, agent_id, turns_used, total_tool_calls,
             config.max_turns, last_tool_name, last_tool_error,
             partial_output, error_msg,
+            failure_code=failure_code,
+            recovery_suggestion=recovery_suggestion,
+            error_context=error_context,
         )
         return SubAgentResult(
             success=False,
@@ -310,6 +349,9 @@ async def run_subagent(
             last_tool_name=last_tool_name,
             last_tool_error=last_tool_error,
             partial_output=partial_output,
+            failure_code=failure_code,
+            recovery_suggestion=recovery_suggestion,
+            error_context=error_context,
         )
 
     return SubAgentResult(
@@ -318,6 +360,38 @@ async def run_subagent(
         agent_id=agent_id,
         turns_used=turns_used,
         tool_calls=total_tool_calls,
+    )
+
+
+def _classify_failure(
+    *,
+    partial_output: str | None,
+    stuck_tool: str | None,
+    stuck_count: int,
+) -> tuple[str, str]:
+    """Classify a max_turns failure into a code + one-line recovery suggestion.
+
+    Priority: tool_loop (a clear repeating pattern) > partial (task making
+    progress but ran out of room) > no_progress (empty trail, likely
+    infeasible). The three codes are a deliberately small vocabulary so
+    parent agents can reliably switch on them (Issue #193 P1).
+    """
+    if stuck_tool is not None:
+        return (
+            "tool_loop",
+            f"Sub-agent called '{stuck_tool}' {stuck_count} times consecutively without "
+            f"success — try alternative tools or give more explicit task guidance.",
+        )
+    if partial_output:
+        return (
+            "max_turns_partial",
+            "Partial result captured in scratchpad — consider resuming with a narrower "
+            "scope or a higher max_turns.",
+        )
+    return (
+        "max_turns_no_progress",
+        "No progress detected — task may be infeasible with given tools; consider "
+        "splitting the task or expanding allowed_tools.",
     )
 
 
@@ -331,6 +405,10 @@ def _write_failure_scratchpad(
     last_tool_error: str | None,
     partial_output: str | None,
     error: str,
+    *,
+    failure_code: str | None = None,
+    recovery_suggestion: str | None = None,
+    error_context: dict[str, Any] | None = None,
 ) -> None:
     """Write sub-agent failure context to scratchpad if available.
 
@@ -350,6 +428,9 @@ def _write_failure_scratchpad(
         "last_tool_error": last_tool_error,
         "partial_output": partial_output,
         "error": error,
+        "failure_code": failure_code,
+        "recovery_suggestion": recovery_suggestion,
+        "error_context": error_context or {},
     }
     try:
         scratchpad.write(ref, json.dumps(payload, ensure_ascii=False, indent=2))

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -2137,14 +2137,18 @@ def make_spawn_agent_tool(parent_session: Any) -> "ToolDefinition":
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
                               success=True, output=header + result.output)
         else:
-            # Issue #192 P0: attach failure context hint so the parent can
-            # decide whether to read the scratchpad ref for full diagnostics.
-            parts = [result.error or "Sub-agent failed"]
+            # Issue #192 P0 / #193 P1: attach failure context, code, and
+            # recovery hint so the parent can choose a next action without
+            # parsing strings. Full trace at scratchpad_read(subagent_failure:...).
+            prefix = f"[{result.failure_code}] " if result.failure_code else ""
+            parts = [prefix + (result.error or "Sub-agent failed")]
             if result.last_tool_name:
                 parts.append(
                     f"last_tool={result.last_tool_name}"
                     + (f" error={result.last_tool_error!r}" if result.last_tool_error else "")
                 )
+            if result.recovery_suggestion:
+                parts.append(f"hint: {result.recovery_suggestion}")
             parts.append(
                 f"Full failure context at scratchpad ref: subagent_failure:{result.agent_id} "
                 f"(read via scratchpad_read)."

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -328,3 +328,236 @@ class TestSubAgentFailureContext:
         assert result.last_tool_error == "simulated failure for test"
         assert result.partial_output is not None
         assert "only attempt" in result.partial_output
+
+
+def _make_named_failing_tool(name: str) -> ToolDefinition:
+    """Like _make_failing_tool but with a configurable name (for tool_loop tests)."""
+
+    async def _always_fail(call: ToolCall) -> ToolResult:
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=False, error=f"{name} simulated failure",
+            failure_type="execution_error",
+        )
+
+    return ToolDefinition(
+        name=name,
+        description=f"Test tool {name} that always fails.",
+        trust_level=TrustLevel.SAFE,
+        capabilities=ToolCapability(0),
+        input_schema={"type": "object", "properties": {}},
+        executor=_always_fail,
+        tags=["test"],
+    )
+
+
+def _tool_use_response_for(tool_name: str, call_id: str, preamble_text: str) -> LLMResponse:
+    """Variant of _tool_use_response that targets a specific tool name."""
+    return LLMResponse(
+        text=None,
+        tool_uses=[ToolUse(id=call_id, name=tool_name, args={})],
+        stop_reason="tool_use",
+        raw_message={
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": preamble_text},
+                {"type": "tool_use", "id": call_id, "name": tool_name, "input": {}},
+            ],
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": tool_name, "arguments": "{}"},
+                }
+            ],
+        },
+    )
+
+
+def _tool_use_response_no_text(call_id: str) -> LLMResponse:
+    """Tool call with no free-text preamble — used for no_progress classification."""
+    return LLMResponse(
+        text=None,
+        tool_uses=[ToolUse(id=call_id, name="always_fail", args={})],
+        stop_reason="tool_use",
+        raw_message={
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "id": call_id, "name": "always_fail", "input": {}},
+            ],
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": "always_fail", "arguments": "{}"},
+                }
+            ],
+        },
+    )
+
+
+class TestSubAgentFailureCodes:
+    """Regression tests for Issue #193 P1 — failure_code / recovery_suggestion / error_context."""
+
+    async def test_tool_loop_detected_on_three_consecutive_same_tool_failures(
+        self,
+        semantic: SemanticMemory,
+        episodic: EpisodicMemory,
+        procedural: ProceduralMemory,
+        tmp_path: Path,
+    ) -> None:
+        registry = ToolRegistry()
+        registry.register(_make_failing_tool())
+        router = _FakeRouter([
+            _tool_use_response("c1", "try 1"),
+            _tool_use_response("c2", "try 2"),
+            _tool_use_response("c3", "try 3"),
+        ])
+
+        result = await run_subagent(
+            SubAgentConfig(
+                task="Task.",
+                model="gpt-test",
+                allowed_tools=["always_fail"],
+                max_turns=3,
+                agent_id="sub-loop",
+            ),
+            router=router,
+            episodic=episodic,
+            semantic=semantic,
+            procedural=procedural,
+            tool_registry=registry,
+            parent_session_id="parent-1",
+            workspace=tmp_path,
+        )
+
+        assert result.success is False
+        assert result.failure_code == "tool_loop"
+        assert "always_fail" in (result.recovery_suggestion or "")
+        assert result.error_context["stuck_tool"] == "always_fail"
+        assert result.error_context["max_consecutive_failures"] == 3
+        assert result.error_context["tool_failure_counts"] == {"always_fail": 3}
+
+    async def test_max_turns_partial_when_failures_not_consecutive(
+        self,
+        semantic: SemanticMemory,
+        episodic: EpisodicMemory,
+        procedural: ProceduralMemory,
+        tmp_path: Path,
+    ) -> None:
+        """Alternating failures across two tools → no single tool stuck, partial output present."""
+        registry = ToolRegistry()
+        registry.register(_make_named_failing_tool("tool_a"))
+        registry.register(_make_named_failing_tool("tool_b"))
+        router = _FakeRouter([
+            _tool_use_response_for("tool_a", "c1", "trying A"),
+            _tool_use_response_for("tool_b", "c2", "trying B"),
+        ])
+
+        result = await run_subagent(
+            SubAgentConfig(
+                task="Task.",
+                model="gpt-test",
+                allowed_tools=["tool_a", "tool_b"],
+                max_turns=2,
+                agent_id="sub-partial",
+            ),
+            router=router,
+            episodic=episodic,
+            semantic=semantic,
+            procedural=procedural,
+            tool_registry=registry,
+            parent_session_id="parent-1",
+            workspace=tmp_path,
+        )
+
+        assert result.success is False
+        assert result.failure_code == "max_turns_partial"
+        assert result.partial_output is not None
+        assert "trying A" in result.partial_output
+        assert "trying B" in result.partial_output
+        assert result.error_context["stuck_tool"] is None
+        assert result.error_context["max_consecutive_failures"] == 1
+        assert result.error_context["tool_failure_counts"] == {"tool_a": 1, "tool_b": 1}
+        assert "narrower scope" in (result.recovery_suggestion or "")
+
+    async def test_max_turns_no_progress_when_no_text_captured(
+        self,
+        semantic: SemanticMemory,
+        episodic: EpisodicMemory,
+        procedural: ProceduralMemory,
+        tmp_path: Path,
+    ) -> None:
+        """Tool calls with no free-text preamble → partial_output empty → no_progress code."""
+        registry = ToolRegistry()
+        registry.register(_make_failing_tool())
+        router = _FakeRouter([
+            _tool_use_response_no_text("c1"),
+            _tool_use_response_no_text("c2"),
+        ])
+
+        result = await run_subagent(
+            SubAgentConfig(
+                task="Task.",
+                model="gpt-test",
+                allowed_tools=["always_fail"],
+                max_turns=2,
+                agent_id="sub-noprogress",
+            ),
+            router=router,
+            episodic=episodic,
+            semantic=semantic,
+            procedural=procedural,
+            tool_registry=registry,
+            parent_session_id="parent-1",
+            workspace=tmp_path,
+        )
+
+        assert result.success is False
+        assert result.partial_output is None
+        # Two consecutive same-tool failures is < 3 → not tool_loop; empty partial → no_progress.
+        assert result.failure_code == "max_turns_no_progress"
+        assert "infeasible" in (result.recovery_suggestion or "")
+        assert result.error_context["max_consecutive_failures"] == 2
+        assert result.error_context["stuck_tool"] is None
+
+    async def test_failure_code_in_scratchpad_payload(
+        self,
+        semantic: SemanticMemory,
+        episodic: EpisodicMemory,
+        procedural: ProceduralMemory,
+        tmp_path: Path,
+    ) -> None:
+        """Scratchpad JSON must include the new P1 fields alongside P0 context."""
+        registry = ToolRegistry()
+        registry.register(_make_failing_tool())
+        router = _FakeRouter([
+            _tool_use_response("c1", "a"),
+            _tool_use_response("c2", "b"),
+            _tool_use_response("c3", "c"),
+        ])
+        scratchpad = Scratchpad()
+
+        result = await run_subagent(
+            SubAgentConfig(
+                task="Task.",
+                model="gpt-test",
+                allowed_tools=["always_fail"],
+                max_turns=3,
+                agent_id="sub-sp",
+            ),
+            router=router,
+            episodic=episodic,
+            semantic=semantic,
+            procedural=procedural,
+            tool_registry=registry,
+            parent_session_id="parent-1",
+            workspace=tmp_path,
+            scratchpad=scratchpad,
+        )
+
+        payload = json.loads(scratchpad.read(f"subagent_failure:{result.agent_id}"))
+        assert payload["failure_code"] == "tool_loop"
+        assert "always_fail" in payload["recovery_suggestion"]
+        assert payload["error_context"]["stuck_tool"] == "always_fail"
+        assert payload["error_context"]["max_consecutive_failures"] == 3

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -432,11 +432,12 @@ class TestSubAgentFailureCodes:
         )
 
         assert result.success is False
+        # Verify the causal signals first, then the classification derived from them.
+        assert result.error_context["tool_failure_counts"] == {"always_fail": 3}
+        assert result.error_context["max_consecutive_failures"] == 3
+        assert result.error_context["stuck_tool"] == "always_fail"
         assert result.failure_code == "tool_loop"
         assert "always_fail" in (result.recovery_suggestion or "")
-        assert result.error_context["stuck_tool"] == "always_fail"
-        assert result.error_context["max_consecutive_failures"] == 3
-        assert result.error_context["tool_failure_counts"] == {"always_fail": 3}
 
     async def test_max_turns_partial_when_failures_not_consecutive(
         self,
@@ -472,13 +473,14 @@ class TestSubAgentFailureCodes:
         )
 
         assert result.success is False
-        assert result.failure_code == "max_turns_partial"
+        # Verify the causal signals first, then the classification derived from them.
         assert result.partial_output is not None
         assert "trying A" in result.partial_output
         assert "trying B" in result.partial_output
-        assert result.error_context["stuck_tool"] is None
-        assert result.error_context["max_consecutive_failures"] == 1
         assert result.error_context["tool_failure_counts"] == {"tool_a": 1, "tool_b": 1}
+        assert result.error_context["max_consecutive_failures"] == 1
+        assert result.error_context["stuck_tool"] is None
+        assert result.failure_code == "max_turns_partial"
         assert "narrower scope" in (result.recovery_suggestion or "")
 
     async def test_max_turns_no_progress_when_no_text_captured(


### PR DESCRIPTION
## Summary

Closes #193. Builds on #192 P0 — now that failure context survives the spawn_agent boundary, parents can also switch on a compact failure vocabulary instead of parsing error strings.

Three optional fields on `SubAgentResult`:

- `failure_code` — one of `tool_loop`, `max_turns_partial`, `max_turns_no_progress`
- `recovery_suggestion` — one-line next-action hint derived from the code
- `error_context` — `{tool_failure_counts, max_consecutive_failures, stuck_tool}`

## Classification rationale

Priority is **most specific signal first**:

1. `tool_loop` — same tool failed ≥3 times consecutively. This is the clearest "the agent is stuck" signal and overrides partial/no-progress because even if some text was captured, the underlying pathology is different.
2. `max_turns_partial` — ran out of turns with `partial_output` captured. The task was making progress; resuming with narrower scope or higher `max_turns` is reasonable.
3. `max_turns_no_progress` — ran out of turns with no assistant text at all. Likely infeasible or missing tools.

Deliberately small vocabulary — I'd rather parents can reliably `switch` on three codes than juggle a dozen near-overlapping ones.

## Tracking logic

`run_subagent` keeps two per-loop accumulators:

- `tool_failure_counts: dict[str, int]` — raw count per tool
- A consecutive-failure counter (`consecutive_failure_tool` / `consecutive_failure_count`) that **resets on any tool success or tool switch**, plus `max_consecutive_failures` tracking the longest streak

The streak-reset-on-success is important: a tool that fails, recovers, then fails again should not be marked as stuck.

## spawn_agent error string

Now reads:

```
[tool_loop] Sub-agent reached max_turns limit (3) without completing. |
  last_tool=always_fail error='simulated failure for test' |
  hint: Sub-agent called 'always_fail' 3 times consecutively without success — try alternative tools... |
  Full failure context at scratchpad ref: subagent_failure:sub-xyz (read via scratchpad_read).
```

Parents can grep for `[tool_loop]` / `[max_turns_partial]` / `[max_turns_no_progress]` in logs or strings.

## Test plan

- [x] Existing 4 subagent tests still pass (backward compat)
- [x] `test_tool_loop_detected_on_three_consecutive_same_tool_failures` — 3 consecutive same-tool failures → `tool_loop`, stuck_tool populated
- [x] `test_max_turns_partial_when_failures_not_consecutive` — alternating failures across two tools → `max_turns_partial`, stuck_tool=None
- [x] `test_max_turns_no_progress_when_no_text_captured` — tool calls without text preamble, <3 consecutive → `max_turns_no_progress`
- [x] `test_failure_code_in_scratchpad_payload` — scratchpad JSON carries all three new fields alongside P0 context
- [x] Full suite: 1034 tests pass (+4 new)

## Out of scope (P2)

Streaming intermediate chunks every N turns and early-exit near max_turns remain unimplemented — tracked as future items in #193. This PR focuses on classification & diagnostics, which deliver most of the parent-agent recovery value without touching the lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)