### PR TITLE
feat(verifiers): fetch_url HTTP 2xx silent-failure detector (#199)

### DIFF
--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -2100,6 +2100,19 @@ async def _verify_fetch_url(call: ToolCall, result: ToolResult) -> VerifierResul
     Non-HTML responses (JSON APIs, plain text) are passed through unchecked
     — the "short body" heuristic only fires on HTML, since API responses
     can legitimately be very short.
+
+    Signals emitted (PR #202 review):
+      - ``html_error_page``: title matches a canonical error/challenge
+        pattern. Strong signal — usually means retry the URL or accept
+        the resource is unavailable.
+      - ``thin_html_content``: HTML page has a title but cleaned body is
+        nearly empty. Often a JS-rendered SPA (use a headless browser
+        instead) or a stripped error template (escalate as html_error_page
+        if title is unhelpful).
+
+    These signal tags are stable strings — telemetry consumers and any
+    future learning loop (#200) can dispatch on them without parsing
+    ``reason``.
     """
     # Async mode returns a job_id header, not content; no verification.
     if (result.metadata or {}).get("async") is True:
@@ -2133,6 +2146,12 @@ async def _verify_fetch_url(call: ToolCall, result: ToolResult) -> VerifierResul
     # SPA serving content via JS (captured as empty after script stripping)
     # or a minimalist error page. Either way, the agent didn't receive
     # usable content.
+    #
+    # Threshold note: 100 chars is conservative — any real article body
+    # after script/style/nav stripping reliably exceeds this. If a future
+    # site is observed under 100 chars legitimately, either narrow by
+    # domain heuristic or expose this as a per-tool config knob; do not
+    # raise the global floor without telemetry support.
     if len(body.strip()) < 100:
         return VerifierResult(
             passed=False,

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -2058,6 +2058,95 @@ def sanitize_untrusted_text(text: str) -> str:
     return f"<untrusted_external_content>\n{safe_text}\n</untrusted_external_content>"
 
 
+# ── fetch_url semantic verification (Issue #199) ───────────────────────────
+# Wrapper applied by sanitize_untrusted_text() — validator peels it off
+# before inspecting content.
+_SANITIZE_OPEN = "<untrusted_external_content>\n"
+_SANITIZE_CLOSE = "\n</untrusted_external_content>"
+
+# Error-page title patterns. Calibrated to match canonical server/CDN
+# error page titles without false-positiving on legitimate articles that
+# happen to discuss error codes. Key trick: require the canonical
+# "{code} {message}" pairing or exact-match short strings — an article
+# titled "404 Error Handling in HTTP" won't match "404 Not Found".
+_ERROR_PAGE_TITLE_PATTERNS = [
+    re.compile(
+        r"^\s*[45]\d{2}\s+(Not Found|Forbidden|Unauthorized|Internal Server Error|"
+        r"Service Unavailable|Bad Gateway|Gateway Timeout|Bad Request)",
+        re.IGNORECASE,
+    ),
+    re.compile(r"^\s*Page Not Found\s*$", re.IGNORECASE),
+    re.compile(r"^\s*Not Found\s*$", re.IGNORECASE),
+    re.compile(r"^\s*Access Denied", re.IGNORECASE),
+    re.compile(r"^\s*Forbidden\s*$", re.IGNORECASE),
+    re.compile(r"^\s*Unauthorized\s*$", re.IGNORECASE),
+    # Cloudflare / bot-wall challenge pages
+    re.compile(r"^\s*Just a moment", re.IGNORECASE),
+    re.compile(r"^\s*Attention Required", re.IGNORECASE),
+    re.compile(r"^\s*Please verify you are", re.IGNORECASE),
+]
+
+
+async def _verify_fetch_url(call: ToolCall, result: ToolResult) -> VerifierResult:
+    """Detect HTTP-2xx silent failures from fetch_url (Issue #199).
+
+    fetch_url's executor already calls raise_for_status(), so non-2xx is
+    handled by the tool itself. What slips through: 200 responses that are
+    actually error-page templates, CDN challenge pages, or suspiciously
+    thin cleaned content. This validator inspects the Title-prefixed HTML
+    output format produced by _html_to_text and flags known error-page
+    shapes.
+
+    Non-HTML responses (JSON APIs, plain text) are passed through unchecked
+    — the "short body" heuristic only fires on HTML, since API responses
+    can legitimately be very short.
+    """
+    # Async mode returns a job_id header, not content; no verification.
+    if (result.metadata or {}).get("async") is True:
+        return VerifierResult(passed=True)
+
+    output = str(result.output or "")
+    if not output:
+        return VerifierResult(passed=True)
+
+    # Peel the sanitize_untrusted_text wrapper if present.
+    content = output
+    if content.startswith(_SANITIZE_OPEN) and content.endswith(_SANITIZE_CLOSE):
+        content = content[len(_SANITIZE_OPEN):-len(_SANITIZE_CLOSE)]
+
+    # Non-HTML fetches have no "Title: " prefix — skip body/title heuristics.
+    if not content.startswith("Title: "):
+        return VerifierResult(passed=True)
+
+    first_line, _, body = content.partition("\n\n")
+    title = first_line[len("Title: "):].strip()
+
+    for pattern in _ERROR_PAGE_TITLE_PATTERNS:
+        if pattern.match(title):
+            return VerifierResult(
+                passed=False,
+                reason=f"HTTP 2xx but page title indicates error: {title!r}",
+                signal="html_error_page",
+            )
+
+    # HTML page with a title but almost no cleaned body → typically an
+    # SPA serving content via JS (captured as empty after script stripping)
+    # or a minimalist error page. Either way, the agent didn't receive
+    # usable content.
+    if len(body.strip()) < 100:
+        return VerifierResult(
+            passed=False,
+            reason=(
+                f"HTML body is only {len(body.strip())} chars after cleaning — "
+                f"likely a challenge/captcha page, JS-rendered SPA, or "
+                f"stripped error template."
+            ),
+            signal="thin_html_content",
+        )
+
+    return VerifierResult(passed=True)
+
+
 def make_fetch_url_tool(
     jobstore: Any = None,
     scratchpad: Any = None,
@@ -2146,6 +2235,7 @@ def make_fetch_url_tool(
         impact_scope="network",
         scope_descriptions=["connects to the requested URL domain"],
         scope_resolver=_fetch_url_resolver,
+        post_validator=_verify_fetch_url,
     )
 
 

--- a/tests/test_tool_verifiers.py
+++ b/tests/test_tool_verifiers.py
@@ -22,11 +22,13 @@ from loom.core.memory.search import MemorySearch
 from loom.core.memory.semantic import SemanticMemory
 from loom.core.memory.store import SQLiteStore
 from loom.platform.cli.tools import (
+    _verify_fetch_url,
     _verify_run_bash,
     _verify_spawn_agent,
     make_filesystem_tools,
     make_memorize_tool,
     make_task_done_tool,
+    sanitize_untrusted_text,
 )
 
 
@@ -411,6 +413,169 @@ class TestTaskDoneVerifier:
         assert verdict.passed is False
         assert verdict.signal == "task_state_desync"
         assert "pending" in (verdict.reason or "").lower()
+
+
+def _fetch_url_output(title: str, body: str) -> str:
+    """Build an output string shaped like fetch_url's HTML path:
+    sanitize_untrusted_text(f"Title: {title}\\n\\n{body}")."""
+    raw = f"Title: {title}\n\n{body}" if title else body
+    return sanitize_untrusted_text(raw)
+
+
+class TestFetchUrlVerifier:
+    """fetch_url post_validator catches HTTP-2xx silent failures —
+    error-page templates, CDN challenges, thin SPA responses (Issue #199)."""
+
+    async def test_passes_on_normal_article(self) -> None:
+        """Happy path: proper article with title + substantial body."""
+        output = _fetch_url_output(
+            "Introduction to Python Generators",
+            "Python generators are a powerful feature that let you iterate "
+            "over potentially large datasets without loading them all into "
+            "memory. They use the yield keyword to produce values lazily, "
+            "pausing execution between each call. This is especially useful "
+            "when processing files or streams.",
+        )
+        result = ToolResult(
+            call_id="c1", tool_name="fetch_url",
+            success=True, output=output,
+        )
+        verdict = await _verify_fetch_url(
+            _call("fetch_url", url="https://example.com/py"), result,
+        )
+        assert verdict.passed is True
+
+    async def test_passes_on_json_response(self) -> None:
+        """Non-HTML responses (no 'Title:' prefix) are never flagged as
+        thin/error — a JSON API returning {\"status\":\"ok\"} is legit."""
+        output = sanitize_untrusted_text('{"status":"ok"}')
+        result = ToolResult(
+            call_id="c1", tool_name="fetch_url",
+            success=True, output=output,
+        )
+        verdict = await _verify_fetch_url(
+            _call("fetch_url", url="https://api.example.com/status"), result,
+        )
+        assert verdict.passed is True
+
+    async def test_fails_on_404_error_page(self) -> None:
+        output = _fetch_url_output("404 Not Found", "The page you requested does not exist.")
+        result = ToolResult(
+            call_id="c1", tool_name="fetch_url",
+            success=True, output=output,
+        )
+        verdict = await _verify_fetch_url(
+            _call("fetch_url", url="https://example.com/missing"), result,
+        )
+        assert verdict.passed is False
+        assert verdict.signal == "html_error_page"
+        assert "404 Not Found" in (verdict.reason or "")
+
+    async def test_fails_on_access_denied_title(self) -> None:
+        output = _fetch_url_output(
+            "Access Denied",
+            "You do not have permission to view this resource. " * 5,
+        )
+        result = ToolResult(
+            call_id="c1", tool_name="fetch_url",
+            success=True, output=output,
+        )
+        verdict = await _verify_fetch_url(
+            _call("fetch_url", url="https://example.com/secret"), result,
+        )
+        assert verdict.passed is False
+        assert verdict.signal == "html_error_page"
+
+    async def test_fails_on_cloudflare_challenge(self) -> None:
+        output = _fetch_url_output(
+            "Just a moment...",
+            "Please wait while we verify your browser.",
+        )
+        result = ToolResult(
+            call_id="c1", tool_name="fetch_url",
+            success=True, output=output,
+        )
+        verdict = await _verify_fetch_url(
+            _call("fetch_url", url="https://protected.example.com"), result,
+        )
+        assert verdict.passed is False
+        assert verdict.signal == "html_error_page"
+
+    async def test_passes_on_article_about_error_codes(self) -> None:
+        """False-positive guard: an article titled '404 Error Handling in HTTP'
+        must NOT match '404 Not Found' pattern — the regex requires a specific
+        canonical status-code phrase."""
+        output = _fetch_url_output(
+            "404 Error Handling in HTTP — Best Practices",
+            "When building web applications, handling 404 errors gracefully "
+            "is important. This article explores the different strategies "
+            "for returning useful responses when a resource is not found. "
+            "We'll cover both server-side redirects and client-side fallbacks.",
+        )
+        result = ToolResult(
+            call_id="c1", tool_name="fetch_url",
+            success=True, output=output,
+        )
+        verdict = await _verify_fetch_url(
+            _call("fetch_url", url="https://blog.example.com/http-404"), result,
+        )
+        assert verdict.passed is True
+
+    async def test_passes_on_article_about_not_found_topic(self) -> None:
+        """False-positive guard: 'Not Found: How to Handle Missing Resources'
+        doesn't match because the pattern requires EXACT 'Not Found' title."""
+        output = _fetch_url_output(
+            "Not Found: How to Handle Missing Resources in REST APIs",
+            "A common pattern in REST API design is returning 404 for missing "
+            "resources. This post covers the nuances of when to use 404 vs "
+            "other status codes. We'll examine real-world examples from "
+            "several popular APIs.",
+        )
+        result = ToolResult(
+            call_id="c1", tool_name="fetch_url",
+            success=True, output=output,
+        )
+        verdict = await _verify_fetch_url(
+            _call("fetch_url", url="https://blog.example.com/rest"), result,
+        )
+        assert verdict.passed is True
+
+    async def test_fails_on_thin_html_content(self) -> None:
+        """JS-heavy SPA or minimalist error page: title present but cleaned
+        body is nearly empty."""
+        output = _fetch_url_output("My SPA", "Loading...")  # 10 chars
+        result = ToolResult(
+            call_id="c1", tool_name="fetch_url",
+            success=True, output=output,
+        )
+        verdict = await _verify_fetch_url(
+            _call("fetch_url", url="https://spa.example.com"), result,
+        )
+        assert verdict.passed is False
+        assert verdict.signal == "thin_html_content"
+
+    async def test_skips_async_mode_results(self) -> None:
+        """async_mode returns a job_id — no content to verify yet."""
+        result = ToolResult(
+            call_id="c1", tool_name="fetch_url",
+            success=True,
+            output="Submitted as job_xyz. Poll with jobs_status or jobs_await.",
+            metadata={"job_id": "job_xyz", "async": True},
+        )
+        verdict = await _verify_fetch_url(
+            _call("fetch_url", url="https://big.example.com"), result,
+        )
+        assert verdict.passed is True
+
+    async def test_skips_empty_output(self) -> None:
+        result = ToolResult(
+            call_id="c1", tool_name="fetch_url",
+            success=True, output="",
+        )
+        verdict = await _verify_fetch_url(
+            _call("fetch_url", url="https://example.com"), result,
+        )
+        assert verdict.passed is True
 
 
 class TestMemorizeDoubleFailureEdgeCase:


### PR DESCRIPTION
## Summary

Closes #199. fetch_url's executor already handles non-2xx via \`raise_for_status()\`, but 200 responses that are actually error-page templates (404 pages, Cloudflare challenges, CDN blocks) slip through as \`success=True\`. This validator catches the common cases.

## Two design decisions from investigating the existing path

### 1. fetch_url's output is NOT raw HTML

Loom pre-processes HTML via \`_html_to_text\` into \`Title: {title}\\n\\n{body}\`. The reviewer's suggested \`"<html" in output\` heuristic from #199's issue description doesn't apply. Switched to **title-pattern matching**, which is more precise anyway — most error pages have distinctive titles.

### 2. Output is sanitized-wrapped

\`sanitize_untrusted_text\` wraps in \`<untrusted_external_content>\` tags and replaces inner \`<>\` with full-width equivalents. Validator peels the wrapper before inspection.

## Three failure classes caught

| Signal | Trigger | Example |
|---|---|---|
| \`html_error_page\` | Title matches canonical error pattern | \`\"404 Not Found\"\`, \`\"Access Denied\"\`, \`\"Just a moment...\"\` (Cloudflare) |
| \`thin_html_content\` | HTML title present, body cleaned to <100 chars | JS-rendered SPA, stripped error template |
| *(pass)* | Non-HTML responses, async job results, empty output | JSON API \`{\"status\":\"ok\"}\`, job submission |

## False-positive design

The core risk: an article legitimately discussing HTTP errors (e.g. \`\"404 Error Handling in HTTP\"\`) shouldn't match. Tackled via **anchored regex requiring canonical status-code phrasing**:

\`\`\`python
re.compile(
    r\"^\\s*[45]\\d{2}\\s+(Not Found|Forbidden|Unauthorized|...\"
    ...
)
\`\`\`

- \`\"404 Not Found\"\` → **matches** (canonical error page)
- \`\"404 Error Handling in HTTP\"\` → **doesn't match** (no canonical message)
- \`\"Not Found\"\` (exact) → **matches** (anchored with \`\$\`)
- \`\"Not Found: How to Handle Missing Resources\"\` → **doesn't match** (not exact)

Three FP-guard tests explicitly cover these scenarios.

## Test plan

- [x] Happy path (article with proper content) passes
- [x] JSON API response passes (no Title: prefix)
- [x] 404 Not Found fails (html_error_page)
- [x] Access Denied title fails
- [x] Cloudflare 'Just a moment' fails
- [x] Article about 404 errors passes (FP guard)
- [x] \"Not Found: ...\" article passes (FP guard for exact-match)
- [x] Thin SPA content fails (thin_html_content)
- [x] Async-mode results skip verification
- [x] Empty output skips verification
- [x] Full suite: 1073 tests pass (was 1063, +10)

## Follow-up

Patterns can evolve as we see real failures in telemetry — the \`signal\` field (\`html_error_page\` vs \`thin_html_content\`) separates categories so future #200-style learning loops can adjust per-signal thresholds without touching the other path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)