### PR TITLE
feat(context): JIT retrieval — auto-spill large tool outputs to scratchpad (#197 Phase 1)

### DIFF
--- a/loom.toml.example
+++ b/loom.toml.example
@@ -246,6 +246,41 @@ internal = "UTC"
 default_trust_level = "guarded"   # "safe" | "guarded" | "critical"
 require_audit_log   = true
 
+# ── Context management (Issue #197) ──────────────────────────────────────────
+#
+# Just-in-time retrieval: when a tool's output exceeds this token budget,
+# the harness automatically writes the full content to the session
+# scratchpad and replaces the inline output with a structured reference.
+# The agent can then either re-call the tool for fresh data or read the
+# scratchpad ref for cached content.
+#
+# Tokens are estimated as len(output) // 4 (≈ char-to-token ratio for most
+# real-world tool outputs). Rough estimate is sufficient — a 30% error has
+# no practical effect on whether content is spilled.
+#
+# Tools whose purpose is content retrieval (task_read, scratchpad_read,
+# list_dir, memorize, task_done) are marked inline_only and bypass JIT.
+#
+# Recommended values:
+#   2000 (default) — most tool outputs stay inline; large fetches/reads spill
+#    500           — aggressive spilling for very long sessions
+#       0           — disables JIT entirely
+jit_spill_threshold_tokens = 2000
+
+# ── Observation masking (Issue #197 Phase 2 — currently a no-op) ─────────────
+#
+# Eventually: fold tool outputs older than N turns into placeholders.
+# The mechanism uses scratchpad as the persistence layer, so masked
+# entries are never lost — only their inline visibility changes.
+#
+# Active research data (fetched articles, search results in synthesis)
+# is automatically protected because JIT already wrote it to scratchpad;
+# masking just hides the inline view, not the source of truth.
+#
+# 7 = balance between noise reduction and avoiding over-eager folding.
+# Set to 0 to disable when masking ships.
+mask_age_turns = 7
+
 # When true, confines run_bash to the workspace root (cwd=workspace).
 # File I/O tools (read_file, write_file, list_dir) always enforce workspace
 # boundaries regardless of this setting.

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -265,7 +265,7 @@ require_audit_log   = true
 #   2000 (default) — most tool outputs stay inline; large fetches/reads spill
 #    500           — aggressive spilling for very long sessions
 #       0           — disables JIT entirely
-jit_spill_threshold_tokens = 2000
+jit_spill_threshold_tokens = 2000  # internally × 4 → 8000-char threshold
 
 # ── Observation masking (Issue #197 Phase 2 — currently a no-op) ─────────────
 #
@@ -277,9 +277,12 @@ jit_spill_threshold_tokens = 2000
 # is automatically protected because JIT already wrote it to scratchpad;
 # masking just hides the inline view, not the source of truth.
 #
-# 7 = balance between noise reduction and avoiding over-eager folding.
-# Set to 0 to disable when masking ships.
-mask_age_turns = 7
+# Tuning note: deep-research tasks (multi-step fetch_url / web_search
+# collection followed by synthesis) routinely keep tool outputs relevant
+# for 15+ turns. 20 errs on the side of preserving research context;
+# operational tasks (debug loops, file edits) tolerate lower values like
+# 7-10. Set to 0 to disable when masking ships.
+mask_age_turns = 20
 
 # When true, confines run_bash to the workspace root (cwd=workspace).
 # File I/O tools (read_file, write_file, list_dir) always enforce workspace

--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -168,6 +168,112 @@ class LogMiddleware(Middleware):
         return result
 
 
+class JITRetrievalMiddleware(Middleware):
+    """Just-in-time spill of large tool outputs to scratchpad (Issue #197).
+
+    When a tool produces output larger than ``threshold_chars``, this
+    middleware writes the full output to the session scratchpad and
+    replaces ``result.output`` with a structured placeholder pointing at
+    the scratchpad ref. The model sees a compact reference instead of the
+    raw payload, recovering token budget for synthesis-heavy turns.
+
+    **Placement**: must wrap LifecycleMiddleware on the outside so that
+    ``post_validator`` callbacks still see the full output for heuristic
+    inspection (Python tracebacks, pytest summaries, etc.). JIT spills only
+    affect what flows out to the message history, never what the verifier
+    inspects.
+
+    **Opt-out**: tools whose entire purpose is returning content the agent
+    needs inline (``task_read``, ``scratchpad_read``, ``list_dir``, etc.)
+    should set ``ToolDefinition.inline_only=True`` to bypass spill.
+
+    **Async-mode passthrough**: when ``result.metadata["async"] is True``
+    the tool already returned a job handle and the body is destined for
+    scratchpad through its own job pipeline — JIT skips to avoid double
+    indirection.
+
+    **Threshold**: configured in chars (~tokens × 4). Defaults to 8000
+    chars (~2000 tokens) if not specified.
+    """
+
+    DEFAULT_THRESHOLD_CHARS = 8000
+
+    def __init__(
+        self,
+        scratchpad: Any,
+        registry: Any,
+        threshold_chars: int = DEFAULT_THRESHOLD_CHARS,
+    ) -> None:
+        self._scratchpad = scratchpad
+        self._registry = registry
+        self._threshold_chars = max(0, threshold_chars)
+
+    async def process(self, call: ToolCall, next: ToolHandler) -> ToolResult:
+        result = await next(call)
+
+        if self._threshold_chars <= 0 or self._scratchpad is None:
+            return result
+        if (result.metadata or {}).get("async") is True:
+            return result
+
+        tool_def = None
+        if self._registry is not None:
+            tool_def = self._registry.get(call.tool_name)
+        if tool_def is not None and getattr(tool_def, "inline_only", False):
+            return result
+
+        output_str = "" if result.output is None else str(result.output)
+        size = len(output_str)
+        if size <= self._threshold_chars:
+            return result
+
+        # Generate a stable, agent-readable ref. uuid suffix avoids
+        # collisions across tools that produce many outputs in a turn.
+        short_id = uuid.uuid4().hex[:6]
+        ref = f"auto_{call.tool_name}_{short_id}"
+        try:
+            self._scratchpad.write(ref, output_str)
+        except Exception as exc:
+            _log.warning(
+                "JIT spill to scratchpad failed for %r: %s — keeping inline.",
+                call.tool_name, exc,
+            )
+            return result
+
+        # Build a placeholder that gives the model two retrieval paths and
+        # explicit signals for fresh-vs-cached semantics. Designed to be
+        # parseable: every line uses the format expected by docs / tests,
+        # and the structured info lives in metadata as well.
+        placeholder = (
+            f"[tool output spilled to scratchpad — {size} chars]\n"
+            f"  tool: {call.tool_name}\n"
+            f"  ref:  scratchpad:{ref}\n"
+            f"  size: {size} chars (~{size // 4} tokens)\n"
+            f"\n"
+            f"  Read with scratchpad_read(ref='{ref}') for cached content,\n"
+            f"  or re-call {call.tool_name} for fresh data.\n"
+            f"  Agent: prefer cached for immutable resources (web pages,\n"
+            f"  static files); re-call for state that may have changed."
+        )
+
+        new_metadata = {
+            **(result.metadata or {}),
+            "jit_spilled": True,
+            "jit_ref": ref,
+            "jit_original_size": size,
+        }
+        return ToolResult(
+            call_id=result.call_id,
+            tool_name=result.tool_name,
+            success=result.success,
+            output=placeholder,
+            error=result.error,
+            failure_type=result.failure_type,
+            duration_ms=result.duration_ms,
+            metadata=new_metadata,
+        )
+
+
 class TraceMiddleware(Middleware):
     """
     Measures wall-clock execution time and fires an async callback after

--- a/loom/core/harness/registry.py
+++ b/loom/core/harness/registry.py
@@ -82,6 +82,18 @@ class ToolDefinition:
     Values: "filesystem", "shell", "network", "memory", "agent", "general".
     """
 
+    inline_only: bool = False
+    """
+    If True, ``JITRetrievalMiddleware`` will not spill this tool's output
+    to scratchpad regardless of size (Issue #197).
+
+    Set this for tools whose purpose is already to return content the agent
+    needs inline — spilling defeats the point. Examples: ``task_read``
+    (already a deliberate retrieval), ``scratchpad_read`` (paradoxical to
+    re-spill), ``list_dir`` (always small), ``memorize`` / ``task_done``
+    (structured short responses).
+    """
+
     # --- Scope-aware permission (Issue #45 Phase A) ---
     scope_descriptions: list[str] = field(default_factory=list)
     """

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -73,6 +73,7 @@ from loom.core.events import (
 from loom.core.harness.lifecycle import ActionRecord, ExecutionEnvelope, LIFECYCLE_CTX_KEY
 from loom.core.harness.middleware import (
     BlastRadiusMiddleware,
+    JITRetrievalMiddleware,
     LifecycleGateMiddleware,
     LifecycleMiddleware,
     MiddlewarePipeline,
@@ -531,8 +532,14 @@ class LoomSession:
         # Registry — run_bash + workspace-aware filesystem tools
         # NOTE: tool factories are lazy-imported from loom.platform.cli.tools.
         # This coupling will be resolved when tools migrate to loom.core.tools.
-        _strict_sandbox: bool = config.get("harness", {}).get("strict_sandbox", False)
+        _harness_cfg = config.get("harness", {})
+        _strict_sandbox: bool = _harness_cfg.get("strict_sandbox", False)
         self._strict_sandbox = _strict_sandbox
+        # Issue #197: JIT spill threshold for tool outputs. Tokens × 4 ≈
+        # chars; 2000 tokens ≈ 8000 chars is conservative — most tool
+        # outputs stay inline. 0 disables spilling entirely.
+        _jit_tokens: int = int(_harness_cfg.get("jit_spill_threshold_tokens", 2000))
+        self._jit_threshold_chars = max(0, _jit_tokens) * 4
         self.registry = ToolRegistry()
         # Issue #154: JobStore + Scratchpad must exist before tools that may
         # submit to them (run_bash, fetch_url). Session-scoped, in-memory,
@@ -1058,8 +1065,17 @@ class LoomSession:
             make_exec_escape_fn(self.workspace) if self._strict_sandbox else None
         )
 
+        # Issue #197: JIT must wrap LifecycleMiddleware on the outside so
+        # post_validators still see the full output for heuristic checks
+        # (run_bash traceback detection, etc.). JIT only mutates what
+        # propagates out to the message history.
         self._pipeline = MiddlewarePipeline(
             [
+                JITRetrievalMiddleware(
+                    scratchpad=self._scratchpad,
+                    registry=self.registry,
+                    threshold_chars=self._jit_threshold_chars,
+                ),
                 LifecycleMiddleware(
                     registry=self.registry,
                     on_lifecycle=self._on_lifecycle,

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -474,6 +474,7 @@ def make_filesystem_tools(workspace: Path) -> list["ToolDefinition"]:
             executor=_list_dir,
             tags=["filesystem", "read"],
             impact_scope="filesystem",
+            inline_only=True,  # Output is structured + always small; #197
         ),
     ]
 
@@ -993,6 +994,7 @@ def make_memorize_tool(memory: "MemoryFacade") -> ToolDefinition:
         impact_scope="memory",
         rollback_fn=_memorize_rollback,
         post_validator=_verify_memorize,
+        inline_only=True,  # Returns short structured ack; #197
     )
 
 
@@ -2920,6 +2922,7 @@ def make_task_done_tool(manager: "TaskListManager") -> ToolDefinition:
         tags=["task", "done"],
         impact_scope="agent",
         post_validator=_verify_task_done,
+        inline_only=True,  # Output is a structured status JSON; #197
     )
 
 
@@ -2984,6 +2987,7 @@ def make_task_read_tool(manager: "TaskListManager") -> ToolDefinition:
         executor=_task_read,
         tags=["task", "read"],
         impact_scope="agent",
+        inline_only=True,  # Purpose IS to surface content; spilling defeats it; #197
     )
 
 
@@ -3246,4 +3250,5 @@ def make_scratchpad_read_tool(scratchpad: Any) -> ToolDefinition:
         executor=_scratchpad_read,
         tags=["jobs", "scratchpad"],
         impact_scope="agent",
+        inline_only=True,  # Re-spilling scratchpad reads is paradoxical; #197
     )

--- a/tests/test_jit_retrieval.py
+++ b/tests/test_jit_retrieval.py
@@ -1,0 +1,273 @@
+"""
+Tests for JITRetrievalMiddleware (Issue #197 Phase 1).
+
+The middleware spills large tool outputs to scratchpad and replaces the
+inline output with a structured placeholder. These tests cover the
+threshold logic, opt-out via inline_only, async-mode passthrough,
+graceful degradation on scratchpad failures, and placeholder shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from loom.core.harness.middleware import (
+    JITRetrievalMiddleware,
+    MiddlewarePipeline,
+    ToolCall,
+    ToolResult,
+)
+from loom.core.harness.permissions import TrustLevel
+from loom.core.harness.registry import ToolDefinition, ToolRegistry
+from loom.core.jobs.scratchpad import Scratchpad
+
+
+def _call(tool_name: str = "fetch_url") -> ToolCall:
+    return ToolCall(
+        id="c1", tool_name=tool_name, args={},
+        trust_level=TrustLevel.SAFE, session_id="s",
+    )
+
+
+def _make_registry(*tools: ToolDefinition) -> ToolRegistry:
+    reg = ToolRegistry()
+    for t in tools:
+        reg.register(t)
+    return reg
+
+
+def _make_tool(name: str, *, inline_only: bool = False) -> ToolDefinition:
+    async def _executor(call: ToolCall) -> ToolResult:
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=True, output="placeholder — overridden in tests",
+        )
+    return ToolDefinition(
+        name=name, description="", input_schema={},
+        executor=_executor, trust_level=TrustLevel.SAFE,
+        inline_only=inline_only,
+    )
+
+
+async def _run(jit: JITRetrievalMiddleware, call: ToolCall, output: str = "",
+               *, success: bool = True, metadata: dict | None = None) -> ToolResult:
+    """Drive jit.process with an inner handler returning a fixed result."""
+    async def _inner(c: ToolCall) -> ToolResult:
+        return ToolResult(
+            call_id=c.id, tool_name=c.tool_name,
+            success=success, output=output, metadata=metadata or {},
+        )
+    return await jit.process(call, _inner)
+
+
+class TestJITRetrievalThreshold:
+    """Threshold logic — spill above, inline below."""
+
+    async def test_output_below_threshold_stays_inline(self) -> None:
+        scratchpad = Scratchpad()
+        registry = _make_registry(_make_tool("fetch_url"))
+        jit = JITRetrievalMiddleware(scratchpad, registry, threshold_chars=100)
+
+        result = await _run(jit, _call("fetch_url"), output="x" * 50)
+
+        assert result.output == "x" * 50
+        assert "jit_spilled" not in result.metadata
+        assert scratchpad.list_refs() == []
+
+    async def test_output_above_threshold_spills_to_scratchpad(self) -> None:
+        scratchpad = Scratchpad()
+        registry = _make_registry(_make_tool("fetch_url"))
+        jit = JITRetrievalMiddleware(scratchpad, registry, threshold_chars=100)
+
+        big_output = "y" * 5000
+        result = await _run(jit, _call("fetch_url"), output=big_output)
+
+        # Inline output is the placeholder, not the original content
+        assert "spilled to scratchpad" in result.output
+        assert "fetch_url" in result.output
+        assert "5000 chars" in result.output
+
+        # Scratchpad has the original content under the metadata's ref
+        assert result.metadata["jit_spilled"] is True
+        ref = result.metadata["jit_ref"]
+        assert ref.startswith("auto_fetch_url_")
+        assert scratchpad.read(ref) == big_output
+
+    async def test_threshold_at_exact_boundary(self) -> None:
+        """Output equal to threshold stays inline (>, not >=)."""
+        scratchpad = Scratchpad()
+        registry = _make_registry(_make_tool("fetch_url"))
+        jit = JITRetrievalMiddleware(scratchpad, registry, threshold_chars=100)
+
+        result = await _run(jit, _call("fetch_url"), output="z" * 100)
+
+        assert result.output == "z" * 100
+        assert "jit_spilled" not in result.metadata
+
+    async def test_threshold_zero_disables_spilling(self) -> None:
+        scratchpad = Scratchpad()
+        registry = _make_registry(_make_tool("fetch_url"))
+        jit = JITRetrievalMiddleware(scratchpad, registry, threshold_chars=0)
+
+        big_output = "y" * 100_000
+        result = await _run(jit, _call("fetch_url"), output=big_output)
+
+        assert result.output == big_output
+        assert scratchpad.list_refs() == []
+
+
+class TestJITInlineOnlyOptOut:
+    """Tools marked inline_only=True bypass JIT regardless of size."""
+
+    async def test_inline_only_tool_never_spills(self) -> None:
+        scratchpad = Scratchpad()
+        registry = _make_registry(_make_tool("task_read", inline_only=True))
+        jit = JITRetrievalMiddleware(scratchpad, registry, threshold_chars=100)
+
+        big_output = "important content " * 1000  # well past threshold
+        result = await _run(jit, _call("task_read"), output=big_output)
+
+        assert result.output == big_output
+        assert "jit_spilled" not in result.metadata
+        assert scratchpad.list_refs() == []
+
+    async def test_unknown_tool_still_spills(self) -> None:
+        """If the tool isn't in the registry, default to spilling — better
+        to spill an unknown than silently bloat context."""
+        scratchpad = Scratchpad()
+        registry = _make_registry()  # empty
+        jit = JITRetrievalMiddleware(scratchpad, registry, threshold_chars=100)
+
+        big_output = "?" * 5000
+        result = await _run(jit, _call("mystery_tool"), output=big_output)
+
+        assert result.metadata["jit_spilled"] is True
+
+
+class TestJITAsyncModePassthrough:
+    """Tools that already returned a job_id (async_mode=True) should not be
+    re-spilled — the body is destined for scratchpad through its own path."""
+
+    async def test_async_mode_result_skips_spill(self) -> None:
+        scratchpad = Scratchpad()
+        registry = _make_registry(_make_tool("fetch_url"))
+        jit = JITRetrievalMiddleware(scratchpad, registry, threshold_chars=100)
+
+        # Job submission output is short anyway, but use a long one to
+        # prove the metadata flag — not size — is what skips JIT.
+        long_msg = "Submitted as job_xyz. " * 100
+        result = await _run(
+            jit, _call("fetch_url"), output=long_msg,
+            metadata={"job_id": "job_xyz", "async": True},
+        )
+
+        assert result.output == long_msg
+        assert "jit_spilled" not in result.metadata
+        assert result.metadata.get("async") is True
+
+
+class TestJITFailureBehavior:
+    """Failed tool results: spill on size, like successful ones (consistency)."""
+
+    async def test_failed_result_with_large_error_output_spills(self) -> None:
+        scratchpad = Scratchpad()
+        registry = _make_registry(_make_tool("run_bash"))
+        jit = JITRetrievalMiddleware(scratchpad, registry, threshold_chars=100)
+
+        big_error_output = "stderr line\n" * 1000
+        result = await _run(
+            jit, _call("run_bash"), output=big_error_output, success=False,
+        )
+
+        assert result.success is False
+        assert "spilled to scratchpad" in result.output
+        assert result.metadata["jit_spilled"] is True
+
+    async def test_scratchpad_write_failure_keeps_inline(self) -> None:
+        """Graceful degradation: if scratchpad.write raises, log a warning
+        and return the original result unchanged. JIT must never fail the
+        underlying tool call."""
+
+        class _FailingScratchpad:
+            def write(self, ref, content):
+                raise RuntimeError("disk full")
+
+            def read(self, ref):
+                raise KeyError(ref)
+
+            def list_refs(self):
+                return []
+
+        registry = _make_registry(_make_tool("fetch_url"))
+        jit = JITRetrievalMiddleware(_FailingScratchpad(), registry, threshold_chars=100)
+
+        big_output = "y" * 5000
+        result = await _run(jit, _call("fetch_url"), output=big_output)
+
+        # Original content preserved; no spill metadata claims
+        assert result.output == big_output
+        assert "jit_spilled" not in result.metadata
+
+
+class TestJITPlaceholderShape:
+    """Placeholder text is the agent's only signal of what was spilled —
+    its structure must communicate retrieval paths clearly."""
+
+    async def test_placeholder_contains_tool_name_size_and_ref(self) -> None:
+        scratchpad = Scratchpad()
+        registry = _make_registry(_make_tool("fetch_url"))
+        jit = JITRetrievalMiddleware(scratchpad, registry, threshold_chars=100)
+
+        result = await _run(jit, _call("fetch_url"), output="z" * 5000)
+
+        placeholder = result.output
+        ref = result.metadata["jit_ref"]
+        assert "fetch_url" in placeholder
+        assert ref in placeholder
+        assert "5000 chars" in placeholder
+
+    async def test_placeholder_offers_both_retrieval_paths(self) -> None:
+        """Cached (scratchpad_read) AND fresh (re-call tool) — agent should
+        understand both options without parsing prose."""
+        scratchpad = Scratchpad()
+        registry = _make_registry(_make_tool("fetch_url"))
+        jit = JITRetrievalMiddleware(scratchpad, registry, threshold_chars=100)
+
+        result = await _run(jit, _call("fetch_url"), output="z" * 5000)
+
+        placeholder = result.output
+        assert "scratchpad_read" in placeholder
+        assert "fresh" in placeholder.lower()  # re-call hint
+
+    async def test_metadata_carries_structured_jit_info(self) -> None:
+        """Telemetry / future learning loops parse metadata, not the
+        placeholder text — pin the metadata shape."""
+        scratchpad = Scratchpad()
+        registry = _make_registry(_make_tool("fetch_url"))
+        jit = JITRetrievalMiddleware(scratchpad, registry, threshold_chars=100)
+
+        result = await _run(jit, _call("fetch_url"), output="z" * 5000)
+
+        meta = result.metadata
+        assert meta["jit_spilled"] is True
+        assert meta["jit_ref"].startswith("auto_fetch_url_")
+        assert meta["jit_original_size"] == 5000
+
+
+class TestJITRefUniqueness:
+    """Many spills in a turn must not collide on ref names."""
+
+    async def test_multiple_spills_get_distinct_refs(self) -> None:
+        scratchpad = Scratchpad()
+        registry = _make_registry(_make_tool("fetch_url"))
+        jit = JITRetrievalMiddleware(scratchpad, registry, threshold_chars=100)
+
+        refs = set()
+        for i in range(10):
+            result = await _run(
+                jit, _call("fetch_url"), output=f"content {i} " + "x" * 200,
+            )
+            refs.add(result.metadata["jit_ref"])
+
+        assert len(refs) == 10
+        assert len(scratchpad.list_refs()) == 10


### PR DESCRIPTION
## Summary

#197 Phase 1. Long sessions hit the "Lost in the Middle" 30% degradation curve when large tool outputs (file reads, fetched articles, search results) accumulate in conversation history. JIT spills them to the session scratchpad and replaces inline output with a structured ref.

## Why JIT first, masking second

JIT guarantees **data persistence** — full content stays in scratchpad, accessible via \`scratchpad_read\` or by re-calling the tool. Masking (Phase 2) is a read-time token optimization layered on top.

The user's framing during design was load-bearing here:

> 面對研究任務的時候,如何把大量資料還在資料收集與整合階段時,不會直接丟失這才是問題點

Without JIT, masking would risk folding away research data still being synthesized. **With JIT, masking is safe** — it only changes inline visibility; the source-of-truth lives in scratchpad regardless.

## Placement decision (load-bearing)

JIT must sit **outside** \`LifecycleMiddleware\`, not inside. Reason: \`post_validator\` callbacks (e.g. \`_verify_run_bash\` heuristic detection of pytest failures, Python tracebacks) inspect raw output. If JIT spilled before validation, every validator would see only the placeholder. The pipeline order is now:

\`\`\`
JITRetrievalMiddleware    ← spills on the way OUT
  → LifecycleMiddleware (post_validator sees full output)
    → TraceMiddleware
    → ... (rest unchanged)
\`\`\`

## Configuration

\`loom.toml.example\` adds two knobs in \`[harness]\`:

| Setting | Default | Status |
|---|---|---|
| \`jit_spill_threshold_tokens\` | 2000 | Active in this PR |
| \`mask_age_turns\` | 7 | Phase 2 placeholder (no-op) |

\`mask_age_turns\` ships now as documentation — telegraphs the design direction so users see both knobs at once instead of being surprised by Phase 2.

## inline_only opt-out

Five tools bypass JIT regardless of size:

| Tool | Why opt-out |
|---|---|
| \`task_read\` | Purpose IS to surface content; spilling defeats it |
| \`scratchpad_read\` | Re-spilling scratchpad reads is paradoxical |
| \`list_dir\` | Always small, structured |
| \`memorize\` | Returns short structured ack |
| \`task_done\` | Returns structured status JSON |

Unknown tools (not in registry) default to spilling — better to spill an unknown than silently bloat context.

## Placeholder design

The agent's only signal of what was spilled. Designed for clarity:

\`\`\`
[tool output spilled to scratchpad — 12450 chars]
  tool: fetch_url
  ref:  scratchpad:auto_fetch_url_a3f7
  size: 12450 chars (~3112 tokens)

  Read with scratchpad_read(ref='auto_fetch_url_a3f7') for cached content,
  or re-call fetch_url for fresh data.
  Agent: prefer cached for immutable resources (web pages,
  static files); re-call for state that may have changed.
\`\`\`

Both retrieval paths exposed; cached-vs-fresh semantics explicit so research tasks (cached is fine) and state-checking tasks (re-call) get the right hint.

## Test plan

13 new tests, suite total 1086 (was 1073):

- [x] Threshold above/below/exact-boundary/zero behaviors
- [x] \`inline_only=True\` tool never spills
- [x] Unknown tools default to spill
- [x] Async-mode results skip spilling (have own pipeline)
- [x] Failed results with large error output also spill (consistency)
- [x] Scratchpad write failure → graceful degradation, log warning, keep inline
- [x] Placeholder contains tool name, size, ref
- [x] Placeholder offers both \`scratchpad_read\` AND re-call paths
- [x] Metadata pins \`jit_spilled\` / \`jit_ref\` / \`jit_original_size\`
- [x] Multiple spills in one turn get distinct refs (uuid suffix)

## Phase 2 follow-up

Observation masking (folding turn-old entries) will land in a separate PR. Now that JIT is in place, masking can be confident it's an optimization layer — never a data-loss risk. The \`mask_age_turns\` config knob is already documented but inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)