### PR TITLE
feat(context): observation masking — fold stale tool outputs to scratchpad refs (#197 Phase 2)

### DIFF
--- a/loom.toml.example
+++ b/loom.toml.example
@@ -267,21 +267,24 @@ require_audit_log   = true
 #       0           — disables JIT entirely
 jit_spill_threshold_tokens = 2000  # internally × 4 → 8000-char threshold
 
-# ── Observation masking (Issue #197 Phase 2 — currently a no-op) ─────────────
+# ── Observation masking (Issue #197 Phase 2) ─────────────────────────────────
 #
-# Eventually: fold tool outputs older than N turns into placeholders.
-# The mechanism uses scratchpad as the persistence layer, so masked
-# entries are never lost — only their inline visibility changes.
+# At the start of each turn, fold tool outputs older than N turns into
+# scratchpad references when the same tool has been called more recently
+# (supersession). Masked entries are never lost — full content stays in
+# scratchpad, accessible via scratchpad_read or by re-calling the tool.
 #
-# Active research data (fetched articles, search results in synthesis)
-# is automatically protected because JIT already wrote it to scratchpad;
-# masking just hides the inline view, not the source of truth.
+# Folding triggers ONLY when both conditions hold:
+#   - age >= mask_age_turns
+#   - tool was called more recently (supersession)
+# A tool called once stays inline forever. A tool's most-recent call
+# always stays inline. Active research data is naturally preserved.
 #
-# Tuning note: deep-research tasks (multi-step fetch_url / web_search
-# collection followed by synthesis) routinely keep tool outputs relevant
-# for 15+ turns. 20 errs on the side of preserving research context;
-# operational tasks (debug loops, file edits) tolerate lower values like
-# 7-10. Set to 0 to disable when masking ships.
+# Tuning:
+#   20 (default) — deep-research tasks (multi-step fetch_url / web_search
+#                   collection feeding synthesis); errs on preserving context
+#    7-10        — operational tasks (debug loops, file edits)
+#       0        — disables masking; relies entirely on JIT for token mgmt
 mask_age_turns = 20
 
 # When true, confines run_bash to the workspace root (cwd=workspace).

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1716,7 +1716,11 @@ class LoomSession:
                         yield EnvelopeUpdated(envelope=self._build_envelope_view(_batch_t0))
                         # Issue #197 Phase 2: tag for observation masking.
                         # Underscore-prefixed keys are ignored by provider
-                        # conversion (verified for OpenAI native + Anthropic).
+                        # conversion (verified for OpenAI native + Anthropic
+                        # in providers.py — they explicitly read only role,
+                        # tool_call_id, content). If a future provider
+                        # changes that, _emit_turn / _tool_name MUST be
+                        # preserved — they're the data basis of masking.
                         _tool_msg = self.router.format_tool_result(
                             self.model, tu.id, tool_output, result.success,
                         )
@@ -2194,6 +2198,18 @@ class LoomSession:
         already in scratchpad. Masking is a token-budget optimization on
         top — it never causes data loss, only changes inline visibility.
         Scratchpad write failures gracefully degrade (keep inline).
+
+        **Scratchpad ref prefix conventions** (canonical list lives in
+        ``loom/platform/cli/tools.py:_categorize_scratchpad_refs``):
+
+        - ``auto_<tool>_<id>``          → JIT spill (Phase 1)
+        - ``masked_<tool>_<id>``        → this method (Phase 2)
+        - ``subagent_failure:<id>``     → sub-agent failure trace (#192)
+
+        Both the ``auto_`` and ``masked_`` prefixes are tool-output caches
+        an agent can read back via ``scratchpad_read``. The
+        ``scratchpad_read`` tool's listing groups refs by these prefixes so
+        the agent can scan its own folded state.
         """
         if self._mask_age_turns <= 0:
             return

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -540,6 +540,11 @@ class LoomSession:
         # outputs stay inline. 0 disables spilling entirely.
         _jit_tokens: int = int(_harness_cfg.get("jit_spill_threshold_tokens", 2000))
         self._jit_threshold_chars = max(0, _jit_tokens) * 4
+        # Issue #197 Phase 2: mask tool observations older than N turns.
+        # 20 = balance for deep-research tasks (15+ turns of fetch_url
+        # collection followed by synthesis). 0 disables masking. JIT
+        # ensures the original content is in scratchpad regardless.
+        self._mask_age_turns: int = int(_harness_cfg.get("mask_age_turns", 20))
         self.registry = ToolRegistry()
         # Issue #154: JobStore + Scratchpad must exist before tools that may
         # submit to them (run_bash, fetch_url). Session-scoped, in-memory,
@@ -1356,6 +1361,11 @@ class LoomSession:
         # (Restart or mid-turn cancel can leave the assistant message in DB without
         # a matching tool result — sanitize drops it before compaction reads history.)
         self._sanitize_history()
+        # Issue #197 Phase 2: fold stale tool observations into scratchpad
+        # refs. Runs once per turn; safe because JIT (Phase 1) already
+        # guarantees the original content lives in scratchpad before this
+        # rewrite happens.
+        self._apply_observation_masking()
 
         # Compress before the first LLM call if already over threshold.
         # (budget.used_tokens reflects the last response's actual token count,
@@ -1704,11 +1714,15 @@ class LoomSession:
                             yield self._lifecycle_events.get_nowait()
                         # Issue #106: Yield envelope update after each tool completes
                         yield EnvelopeUpdated(envelope=self._build_envelope_view(_batch_t0))
-                        self.messages.append(
-                            self.router.format_tool_result(
-                                self.model, tu.id, tool_output, result.success,
-                            )
+                        # Issue #197 Phase 2: tag for observation masking.
+                        # Underscore-prefixed keys are ignored by provider
+                        # conversion (verified for OpenAI native + Anthropic).
+                        _tool_msg = self.router.format_tool_result(
+                            self.model, tu.id, tool_output, result.success,
                         )
+                        _tool_msg["_emit_turn"] = self._turn_index
+                        _tool_msg["_tool_name"] = tu.name
+                        self.messages.append(_tool_msg)
                         asyncio.ensure_future(self._log_message(
                             "tool", tool_output[:500],
                             {"tool_call_id": tu.id, "tool_name": tu.name},
@@ -1782,11 +1796,13 @@ class LoomSession:
                             yield self._lifecycle_events.get_nowait()
                         # Issue #106: Yield envelope update after each tool completes
                         yield EnvelopeUpdated(envelope=self._build_envelope_view(_batch_t0))
-                        self.messages.append(
-                            self.router.format_tool_result(
-                                self.model, tu.id, tool_output, result.success,
-                            )
+                        # Issue #197 Phase 2: tag for observation masking.
+                        _tool_msg = self.router.format_tool_result(
+                            self.model, tu.id, tool_output, result.success,
                         )
+                        _tool_msg["_emit_turn"] = self._turn_index
+                        _tool_msg["_tool_name"] = tu.name
+                        self.messages.append(_tool_msg)
                         asyncio.ensure_future(self._log_message(
                             "tool", tool_output[:500],
                             {"tool_call_id": tu.id, "tool_name": tu.name},
@@ -2153,6 +2169,84 @@ class LoomSession:
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    def _apply_observation_masking(self) -> None:
+        """Fold stale tool observations into scratchpad references (Issue #197 Phase 2).
+
+        For each tool result message older than ``_mask_age_turns`` AND
+        superseded by a more recent call of the same tool, this method:
+
+        1. Writes the original content to scratchpad under a stable ref
+        2. Replaces the inline content with a placeholder pointing at the
+           ref, telling the agent it can read scratchpad if the data is
+           still relevant
+
+        Skipped:
+          - Already-JIT-spilled entries (already minimal — re-folding adds
+            no signal but costs a scratchpad ref)
+          - The most recent call of any given tool (the agent likely needs
+            this for continuity)
+          - Already-masked entries (idempotent)
+          - Untagged entries (e.g. from before this feature shipped, or
+            when the session was loaded from disk without the metadata)
+
+        JIT (Phase 1) is the data-persistence guarantee: large outputs are
+        already in scratchpad. Masking is a token-budget optimization on
+        top — it never causes data loss, only changes inline visibility.
+        Scratchpad write failures gracefully degrade (keep inline).
+        """
+        if self._mask_age_turns <= 0:
+            return
+
+        # First pass: index the most-recent message slot for each tool name.
+        latest_idx_per_tool: dict[str, int] = {}
+        for i, msg in enumerate(self.messages):
+            if msg.get("role") == "tool":
+                tname = msg.get("_tool_name")
+                if tname:
+                    latest_idx_per_tool[tname] = i
+
+        # Second pass: fold eligible older entries.
+        for i, msg in enumerate(self.messages):
+            if msg.get("role") != "tool":
+                continue
+            if msg.get("_masked"):
+                continue
+            emit_turn = msg.get("_emit_turn")
+            if emit_turn is None:
+                continue
+            age = self._turn_index - emit_turn
+            if age < self._mask_age_turns:
+                continue
+
+            tname = msg.get("_tool_name")
+            if tname and latest_idx_per_tool.get(tname) == i:
+                continue  # Most recent call — agent likely still using it.
+
+            content = msg.get("content", "") or ""
+            # JIT placeholder is already minimal — folding it again wastes
+            # a scratchpad ref without meaningful token savings.
+            if content.startswith("[tool output spilled to scratchpad"):
+                continue
+
+            ref = f"masked_{tname or 'tool'}_{uuid.uuid4().hex[:6]}"
+            try:
+                self._scratchpad.write(ref, content)
+            except Exception as exc:
+                logger.warning(
+                    "Observation masking failed for %r turn %d: %s — keeping inline.",
+                    tname, emit_turn, exc,
+                )
+                continue
+
+            msg["content"] = (
+                f"[observation folded — {tname or 'tool'} from {age} turns ago, "
+                f"superseded by a more recent call]\n"
+                f"  ref: scratchpad:{ref}\n"
+                f"  Read with scratchpad_read(ref='{ref}') if you still need "
+                f"the full output."
+            )
+            msg["_masked"] = True
 
     def _sanitize_history(self) -> None:
         """Remove incomplete tool_use sequences and fix malformed tool args.

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -3192,6 +3192,41 @@ def make_jobs_cancel_tool(jobstore: Any) -> ToolDefinition:
 _SCRATCHPAD_DEFAULT_MAX_BYTES = 200_000
 
 
+# ── Scratchpad ref naming convention (Issue #197 review) ───────────────────
+# Different harness mechanisms write into the same scratchpad; the prefix
+# tells you why each ref exists. Add a new prefix here when introducing a
+# new producer so scratchpad_read's listing keeps surfacing it correctly.
+#
+#   auto_<tool>_<6hex>          → JITRetrievalMiddleware (Phase 1, #197)
+#                                  Original tool output >threshold; cached
+#                                  here, agent saw a JIT placeholder.
+#   masked_<tool>_<6hex>        → _apply_observation_masking (Phase 2, #197)
+#                                  Older superseded tool call folded for
+#                                  token budget; agent saw a fold placeholder.
+#   subagent_failure:<agent_id> → run_subagent failure path (#192 P0)
+#                                  Diagnostic context from a max_turns or
+#                                  loop-detected sub-agent failure.
+#   <other>                     → ad-hoc agent or job-pipeline writes.
+def _categorize_scratchpad_refs(refs: list[str]) -> dict[str, list[str]]:
+    """Group scratchpad refs by their producer prefix."""
+    by_kind: dict[str, list[str]] = {
+        "jit_spilled": [],
+        "observation_masked": [],
+        "subagent_failure": [],
+        "other": [],
+    }
+    for ref in refs:
+        if ref.startswith("auto_"):
+            by_kind["jit_spilled"].append(ref)
+        elif ref.startswith("masked_"):
+            by_kind["observation_masked"].append(ref)
+        elif ref.startswith("subagent_failure:"):
+            by_kind["subagent_failure"].append(ref)
+        else:
+            by_kind["other"].append(ref)
+    return by_kind
+
+
 def make_scratchpad_read_tool(scratchpad: Any) -> ToolDefinition:
     """Read content from the session's Scratchpad."""
 
@@ -3199,10 +3234,20 @@ def make_scratchpad_read_tool(scratchpad: Any) -> ToolDefinition:
         ref = (call.args.get("ref") or "").strip()
         if not ref:
             refs = scratchpad.list_refs()
+            # Issue #197 Phase 2 review: categorize refs so an agent doing
+            # discovery can pick the right one without trial-and-error.
+            # ``available_refs`` stays a flat list for backward compat;
+            # ``by_kind`` is the new categorized view.
             return ToolResult(
                 call_id=call.id, tool_name=call.tool_name,
                 success=True,
-                output=json.dumps({"available_refs": refs}, indent=2),
+                output=json.dumps(
+                    {
+                        "available_refs": refs,
+                        "by_kind": _categorize_scratchpad_refs(refs),
+                    },
+                    indent=2,
+                ),
             )
         section = call.args.get("section")
         raw_max = call.args.get("max_bytes")

--- a/tests/test_jobs_tools.py
+++ b/tests/test_jobs_tools.py
@@ -223,6 +223,30 @@ class TestScratchpadTool:
         assert r.success
         payload = json.loads(r.output)
         assert payload["available_refs"] == ["a", "b"]
+        # Issue #197 Phase 2 review: discoverability — refs categorized so
+        # agent can scan its folded state without trial-and-error reads.
+        assert payload["by_kind"]["other"] == ["a", "b"]
+        assert payload["by_kind"]["jit_spilled"] == []
+        assert payload["by_kind"]["observation_masked"] == []
+        assert payload["by_kind"]["subagent_failure"] == []
+
+    async def test_list_groups_refs_by_producer_prefix(self):
+        """Refs from JIT, masking, sub-agent failure paths each land in
+        the right bucket so agents can navigate their folded state."""
+        pad = Scratchpad()
+        pad.write("auto_fetch_url_a3f7", "JIT-spilled body")
+        pad.write("masked_run_bash_b2c9", "masked older call")
+        pad.write("subagent_failure:sub-xyz", "sub-agent trace")
+        pad.write("ad_hoc_note", "agent-written")
+        tool = make_scratchpad_read_tool(pad)
+
+        r = await tool.executor(_call("scratchpad_read", {}))
+
+        payload = json.loads(r.output)
+        assert payload["by_kind"]["jit_spilled"] == ["auto_fetch_url_a3f7"]
+        assert payload["by_kind"]["observation_masked"] == ["masked_run_bash_b2c9"]
+        assert payload["by_kind"]["subagent_failure"] == ["subagent_failure:sub-xyz"]
+        assert payload["by_kind"]["other"] == ["ad_hoc_note"]
 
     async def test_missing_ref_error(self):
         pad = Scratchpad()

--- a/tests/test_observation_masking.py
+++ b/tests/test_observation_masking.py
@@ -1,0 +1,296 @@
+"""
+Tests for observation masking (Issue #197 Phase 2).
+
+Masking folds stale tool observations into scratchpad references when:
+  - The entry is older than ``_mask_age_turns`` turns
+  - The same tool has been called more recently (supersession)
+  - The entry isn't already a JIT placeholder
+  - The entry isn't already masked
+
+Tests use a duck-typed stand-in for LoomSession so the method's logic is
+exercised without bringing up a full session (DB, memory, router, etc.).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from loom.core.jobs.scratchpad import Scratchpad
+from loom.core.session import LoomSession
+
+
+def _mock_session(
+    messages: list[dict[str, Any]],
+    *,
+    turn_index: int,
+    mask_age_turns: int = 20,
+    scratchpad: Scratchpad | None = None,
+) -> SimpleNamespace:
+    """Build a minimal LoomSession stand-in with just the attrs the method reads."""
+    return SimpleNamespace(
+        messages=messages,
+        _turn_index=turn_index,
+        _scratchpad=scratchpad if scratchpad is not None else Scratchpad(),
+        _mask_age_turns=mask_age_turns,
+    )
+
+
+def _run_mask(session: SimpleNamespace) -> None:
+    """Invoke the unbound method against the mock session."""
+    LoomSession._apply_observation_masking(session)
+
+
+def _tool_msg(
+    tool_call_id: str, content: str, tool_name: str, emit_turn: int,
+    *, masked: bool = False,
+) -> dict[str, Any]:
+    msg: dict[str, Any] = {
+        "role": "tool",
+        "tool_call_id": tool_call_id,
+        "content": content,
+        "_emit_turn": emit_turn,
+        "_tool_name": tool_name,
+    }
+    if masked:
+        msg["_masked"] = True
+    return msg
+
+
+class TestMaskingTriggers:
+    """Both age AND supersession must hold for masking to fire."""
+
+    async def test_old_and_superseded_gets_folded(self) -> None:
+        """Tool called at turn 0 and again at turn 25 → first call is
+        old (age=30 > threshold 20) AND superseded → fold."""
+        scratchpad = Scratchpad()
+        messages = [
+            {"role": "user", "content": "search for X"},
+            _tool_msg("c1", "old fetch_url body — 5000 chars of HTML",
+                      "fetch_url", emit_turn=0),
+            {"role": "user", "content": "search for Y"},
+            _tool_msg("c2", "newer fetch_url body — 3000 chars",
+                      "fetch_url", emit_turn=25),
+        ]
+        session = _mock_session(messages, turn_index=30, scratchpad=scratchpad)
+
+        _run_mask(session)
+
+        # First fetch_url is masked (age=30, superseded)
+        first = messages[1]
+        assert first.get("_masked") is True
+        assert "observation folded" in first["content"]
+        assert "fetch_url from 30 turns ago" in first["content"]
+
+        # Second fetch_url survives — most recent call
+        second = messages[3]
+        assert "_masked" not in second
+        assert second["content"] == "newer fetch_url body — 3000 chars"
+
+        # Original content lives in scratchpad
+        refs = scratchpad.list_refs()
+        assert len(refs) == 1
+        assert refs[0].startswith("masked_fetch_url_")
+        assert "old fetch_url body" in scratchpad.read(refs[0])
+
+    async def test_old_but_not_superseded_preserved(self) -> None:
+        """A tool called only once stays inline regardless of age — no
+        supersession means the agent likely still needs it."""
+        scratchpad = Scratchpad()
+        messages = [
+            {"role": "user", "content": "do a thing"},
+            _tool_msg("c1", "the only fetch_url body", "fetch_url", emit_turn=0),
+            {"role": "user", "content": "follow up"},
+            _tool_msg("c2", "different tool", "list_dir", emit_turn=10),
+        ]
+        session = _mock_session(messages, turn_index=30, scratchpad=scratchpad)
+
+        _run_mask(session)
+
+        # fetch_url only called once → preserved
+        assert messages[1]["content"] == "the only fetch_url body"
+        assert "_masked" not in messages[1]
+        assert scratchpad.list_refs() == []
+
+    async def test_recent_calls_preserved_regardless_of_supersession(self) -> None:
+        """Both calls within threshold → both inline, even though one is
+        superseded by the other."""
+        scratchpad = Scratchpad()
+        messages = [
+            _tool_msg("c1", "first call", "fetch_url", emit_turn=18),
+            _tool_msg("c2", "second call", "fetch_url", emit_turn=19),
+        ]
+        session = _mock_session(messages, turn_index=20, scratchpad=scratchpad)
+
+        _run_mask(session)
+
+        assert "_masked" not in messages[0]
+        assert "_masked" not in messages[1]
+        assert scratchpad.list_refs() == []
+
+
+class TestMaskingSkipPaths:
+    """Cases where masking is the wrong move — must skip cleanly."""
+
+    async def test_disabled_when_threshold_zero(self) -> None:
+        scratchpad = Scratchpad()
+        messages = [
+            _tool_msg("c1", "ancient call", "fetch_url", emit_turn=0),
+            _tool_msg("c2", "newer call", "fetch_url", emit_turn=99),
+        ]
+        session = _mock_session(
+            messages, turn_index=100, mask_age_turns=0, scratchpad=scratchpad,
+        )
+
+        _run_mask(session)
+
+        assert "_masked" not in messages[0]
+        assert "_masked" not in messages[1]
+
+    async def test_jit_placeholder_skipped(self) -> None:
+        """Already-spilled JIT entries are minimal already — re-folding
+        them just wastes a scratchpad ref."""
+        scratchpad = Scratchpad()
+        jit_placeholder = (
+            "[tool output spilled to scratchpad — 12000 chars]\n"
+            "  tool: fetch_url\n"
+            "  ref:  scratchpad:auto_fetch_url_abc123\n"
+            "  ..."
+        )
+        messages = [
+            _tool_msg("c1", jit_placeholder, "fetch_url", emit_turn=0),
+            _tool_msg("c2", "newer call", "fetch_url", emit_turn=25),
+        ]
+        session = _mock_session(messages, turn_index=30, scratchpad=scratchpad)
+
+        _run_mask(session)
+
+        # JIT placeholder kept as-is, not re-spilled
+        assert "_masked" not in messages[0]
+        assert messages[0]["content"] == jit_placeholder
+        assert scratchpad.list_refs() == []
+
+    async def test_untagged_messages_skipped(self) -> None:
+        """Messages without _emit_turn / _tool_name (e.g. from older
+        sessions on disk) must not break masking — just skip."""
+        scratchpad = Scratchpad()
+        messages = [
+            # Untagged — no _emit_turn, no _tool_name
+            {"role": "tool", "tool_call_id": "c1", "content": "untagged"},
+            _tool_msg("c2", "tagged but only call", "fetch_url", emit_turn=0),
+        ]
+        session = _mock_session(messages, turn_index=30, scratchpad=scratchpad)
+
+        _run_mask(session)  # must not raise
+
+        assert messages[0]["content"] == "untagged"
+        # tagged but only call → preserved (not superseded)
+        assert "_masked" not in messages[1]
+
+    async def test_already_masked_idempotent(self) -> None:
+        """Running masking twice produces the same result; no double-spill."""
+        scratchpad = Scratchpad()
+        messages = [
+            _tool_msg("c1", "old", "fetch_url", emit_turn=0),
+            _tool_msg("c2", "newer", "fetch_url", emit_turn=25),
+        ]
+        session = _mock_session(messages, turn_index=30, scratchpad=scratchpad)
+
+        _run_mask(session)
+        first_pass_refs = list(scratchpad.list_refs())
+        first_pass_content = messages[0]["content"]
+
+        _run_mask(session)
+        assert list(scratchpad.list_refs()) == first_pass_refs
+        assert messages[0]["content"] == first_pass_content
+
+
+class TestMaskingPlaceholderShape:
+    """The placeholder is the agent's signal — its shape matters."""
+
+    async def test_placeholder_includes_tool_name_age_and_ref(self) -> None:
+        scratchpad = Scratchpad()
+        messages = [
+            _tool_msg("c1", "old body", "fetch_url", emit_turn=0),
+            _tool_msg("c2", "newer body", "fetch_url", emit_turn=25),
+        ]
+        session = _mock_session(messages, turn_index=30, scratchpad=scratchpad)
+
+        _run_mask(session)
+
+        placeholder = messages[0]["content"]
+        assert "fetch_url" in placeholder
+        assert "30 turns ago" in placeholder
+        assert "scratchpad_read" in placeholder
+        # Ref appears in placeholder and matches what's in scratchpad
+        ref = scratchpad.list_refs()[0]
+        assert ref in placeholder
+
+
+class TestMaskingFailureBehavior:
+    """Scratchpad write failures must not break the session."""
+
+    async def test_scratchpad_failure_keeps_inline(self) -> None:
+        class _FailingScratchpad:
+            def write(self, ref, content):
+                raise RuntimeError("disk full")
+
+            def read(self, ref):
+                raise KeyError(ref)
+
+            def list_refs(self):
+                return []
+
+        messages = [
+            _tool_msg("c1", "old body", "fetch_url", emit_turn=0),
+            _tool_msg("c2", "newer body", "fetch_url", emit_turn=25),
+        ]
+        session = _mock_session(
+            messages, turn_index=30, scratchpad=_FailingScratchpad(),
+        )
+
+        _run_mask(session)  # must not raise
+
+        # First call kept inline — masking degraded gracefully
+        assert messages[0]["content"] == "old body"
+        assert "_masked" not in messages[0]
+
+
+class TestMaskingMixedScenario:
+    """A realistic research session: many fetches, only some folded."""
+
+    async def test_research_session_folds_correctly(self) -> None:
+        """Simulates 5 fetch_url calls + 3 web_search calls across many
+        turns. Old superseded calls fold; latest of each tool stays."""
+        scratchpad = Scratchpad()
+        messages = [
+            # Turn 0–5: data collection burst
+            _tool_msg("c1", "fetch A body", "fetch_url", emit_turn=0),
+            _tool_msg("c2", "search for foo", "web_search", emit_turn=1),
+            _tool_msg("c3", "fetch B body", "fetch_url", emit_turn=2),
+            _tool_msg("c4", "search for bar", "web_search", emit_turn=3),
+            _tool_msg("c5", "fetch C body", "fetch_url", emit_turn=4),
+            # Turn 25+: synthesis phase, latest fetch
+            _tool_msg("c6", "search for baz", "web_search", emit_turn=25),
+            _tool_msg("c7", "fetch D body", "fetch_url", emit_turn=26),
+        ]
+        session = _mock_session(messages, turn_index=30, scratchpad=scratchpad)
+
+        _run_mask(session)
+
+        # First three fetch_url calls (old + superseded) → masked
+        for idx in [0, 2, 4]:
+            assert messages[idx].get("_masked") is True, f"index {idx}"
+
+        # First two web_search calls (old + superseded by c6) → masked
+        for idx in [1, 3]:
+            assert messages[idx].get("_masked") is True, f"index {idx}"
+
+        # Latest web_search and fetch_url → preserved
+        assert "_masked" not in messages[5]
+        assert "_masked" not in messages[6]
+
+        # Five entries spilled to scratchpad
+        assert len(scratchpad.list_refs()) == 5


### PR DESCRIPTION
## Summary

Closes #197 Phase 2. With JIT (Phase 1, #203) guaranteeing data persistence, this layer adds **turn-age-based folding**: old tool observations whose content has been superseded by newer calls get replaced with scratchpad refs at the start of each turn.

## Trigger condition (BOTH must hold)

1. Entry's age >= \`mask_age_turns\` (default 20)
2. Same tool has a more recent call in the history (**supersession**)

Why both? A tool called only once stays inline forever — no supersession means the agent likely still needs it. This naturally protects active research data: while an agent is still synthesizing \`fetch_url\` results, every call is still "the latest" or close to it.

## Why this is safe (revisiting Phase 1's invariant)

> 面對研究任務的時候,如何把大量資料還在資料收集與整合階段時,不會直接丟失這才是問題點

JIT already wrote the original content to scratchpad. Masking only changes the **inline visibility** in conversation history — it never causes data loss. The agent has two retrieval paths (scratchpad_read or re-call the tool) and the placeholder tells it how to use both.

## Mechanism

- **Tool result tagging** in \`stream_turn\`: every appended tool result gets \`_emit_turn\` (current \`self._turn_index\`) and \`_tool_name\`. Underscore prefix is safe — verified that both OpenAI-native and Anthropic providers ignore unknown keys during conversion.
- **\`_apply_observation_masking()\`** runs after \`_sanitize_history()\` at turn start. Two passes: index latest message slot per tool, then fold eligible older entries.
- **Folded content** → scratchpad ref \`masked_<tool>_<short_id>\`. Inline replaced with a placeholder explaining how to retrieve.
- **Skip paths**: already-masked (idempotent), already-JIT-spilled (no signal gain — placeholder is already minimal), untagged (defensive — older sessions on disk), threshold=0.
- **Graceful degradation**: scratchpad write failures logged as warning, entry kept inline. Masking must never break a session.

## Configuration

\`mask_age_turns = 20\` — tuned per #203 review feedback for deep-research tasks. Tuning notes in \`loom.toml.example\` cover both research (preserve context, 20+) and operational (fold sooner, 7-10) workflows.

## Test plan

10 new tests, suite 1096 (was 1086):

**TestMaskingTriggers** (the core 2-condition logic):
- [x] Old + superseded → folded, scratchpad has original
- [x] Old but only-call → preserved (no supersession)
- [x] Recent calls preserved regardless of supersession

**TestMaskingSkipPaths**:
- [x] \`mask_age_turns=0\` disables masking entirely
- [x] JIT placeholder skipped (already minimal)
- [x] Untagged messages skipped without raising (defensive)
- [x] Idempotent: running twice = same result, no double-spill

**TestMaskingPlaceholderShape**:
- [x] Placeholder includes tool name, age, scratchpad ref

**TestMaskingFailureBehavior**:
- [x] Scratchpad write failure → keep inline, log warning, don't crash

**TestMaskingMixedScenario**:
- [x] Realistic research session: 5 \`fetch_url\` + 3 \`web_search\` across turns; only old superseded calls fold; latest of each tool preserved

## Out of scope

- **Cross-turn task-boundary detection** (mask only when crossing a \`task_done\`) — discussed during #197 design as the "smartest" trigger but pushed to future work
- **Per-tool age overrides** (e.g. \`mask_age_turns_override_per_tag\`) — flagged in #203 review for Phase 2; left for after telemetry tells us which tools need different defaults

## Milestone

This closes the \`#197\` arc in the \`Harness Hardening\` milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)