### PR TITLE
feat(tasklist): collapse 5 task_* tools into single task_write (#205)

### DIFF
--- a/doc/17-Task-Engine.md
+++ b/doc/17-Task-Engine.md
@@ -1,19 +1,42 @@
 # Task Engine — TaskList
 
-> 架構演進（#153 / v0.3.2.1）：Task Engine 自 v0.3.2 的 DAG 執行層退回到「認知外骨骼」定位。主 agent 自己讀清單、自己決定順序、自己動手；harness 不再做拓撲排序，也不再驅動節點執行。先前 TaskGraph 的 `compile()` / `TaskScheduler` / `ExecutionPlan` 已全數移除（參見 #152 autonomy stall 根因分析）。
+> 架構演進：
+> - v0.3.2（#128）：DAG 執行層，後因從未被接線而退回（#152 stall 根因）
+> - v0.3.2.1（#153）：5 個 task_* 工具的「認知外骨骼」
+> - v0.3.3（#205）：收斂為單一 `task_write`，廢除 `task_done` 的「動詞」語意造成的假完成幻覺
+>
+> 本文件描述 v0.3.3。先前版本見 git history。
 
 ---
 
-## 為什麼不再需要 DAG 執行層？
+## 為什麼從 5 個工具收斂成 1 個？
+
+`task_done(node_id, result=...)` 的「動詞」語意是 issue #205 觀察到的失敗根源：
+
+- 呼叫它感覺像是「向框架回報完成」
+- 即使 result 是空的、artifact 不存在，呼叫這個動作本身就帶著「往前推進」的儀式感
+- 在 7+ 節點的長任務裡，agent 心裡想的是「讓框架前進」而不是「確認產出真的存在」
+- **儀式感 = 認知置換的源頭**
+
+對照 Claude Code 的 `TodoWrite`：沒有 `done` 動詞，agent **重寫整張清單**把那一格從 `pending` 改成 `completed`。改的是自己桌上的便利貼，沒有對象、沒有觀眾、沒有儀式感——所以也沒有「報告了 = 做了」的幻覺。
+
+同時：
+- `result` 欄位徹底消失 → 所有產出**強制走檔案**（`write_file` → `tmp/*.md`）
+- `depends_on` + `ready_nodes` 拿掉 → 順序由 agent 自己讀清單決定
+- artifact 驗證問題（issue #205 P0）**結構上不可能發生**——因為清單根本不存產出
+
+---
+
+## 為什麼也不再需要 DAG 執行層？
 
 實戰觀察：agent 在面對複雜任務時，本來就會自然形成「先做 A、拿 A 結果再做 B」的線性推理。原本的 DAG 結構試圖把這條線性推理「編譯」成分層並行的執行計畫，但：
 
 1. 主 agent 面對圖結構時變成**動口不動手**的協調者——規劃完之後反而不自己執行（#152 的 `graph 66859851` 就是這個模式，4 個 L0 節點全部 stall）
-2. 真正的並行需求是 **IO 層**的（同時抓 4 個 URL），不是**推理層**的——推理一但並行就失去跨節點的累積上下文
-3. DAG 的 `compile()` / `scheduler.asyncio.gather()` 在 v0.3.2 實際上**從未被接線**——2000 行代碼供著一個沒被觸發的執行框架
+2. 真正的並行需求是 **IO 層**的（同時抓 4 個 URL），不是**推理層**的——推理一旦並行就失去跨節點的累積上下文
+3. DAG 的 `compile()` / `scheduler.asyncio.gather()` 在 v0.3.2 實際上**從未被接線**
 
 結論：
-- **推理層**改用 TaskList（本文件）——平坦清單、agent 自己驅動
+- **推理層**用 TaskList（本文件）——平坦清單、agent 自己驅動
 - **IO 層**用 JobStore + Scratchpad（見 [18-Task-Scheduler.md](18-Task-Scheduler.md)）——`async_mode=True` 下放並行到 tool layer
 
 ---
@@ -28,19 +51,12 @@ class TaskNode:
     id: str
     content: str
     status: TaskStatus = TaskStatus.PENDING
-    depends_on: list[str] = field(default_factory=list)  # documentation only
-    result: str | None = None
-    result_summary: str | None = None
-    error: str | None = None
-    metadata: dict[str, Any] = field(default_factory=dict)
 
     @property
-    def is_done(self) -> bool: ...
-    @property
-    def is_active(self) -> bool: ...
-    def complete(self, result: str | None = None) -> None: ...
-    def fail(self, error: str) -> None: ...
+    def is_active(self) -> bool: ...   # PENDING or IN_PROGRESS
 ```
+
+只有 `id`、`content`、`status`。沒有 `result`、沒有 `depends_on`、沒有 `error`、沒有 `metadata`。
 
 ### TaskStatus
 
@@ -49,55 +65,60 @@ class TaskStatus(Enum):
     PENDING     = "pending"
     IN_PROGRESS = "in_progress"
     COMPLETED   = "completed"
-    FAILED      = "failed"
 ```
 
-`SKIPPED` 隨 DAG 執行層一併移除——agent 自主決定是否跳過，透過 `task_done(error=...)` 顯式記錄即可。
+`FAILED` 也拿掉了——放棄就把 status 設 `completed` 並在 content 註明 `[放棄] 原因`。失敗與成功是 agent 決策範疇，不是框架狀態。
 
 ### TaskList
 
 ```python
 class TaskList:
-    def add(self, node_id: str, content: str,
-            depends_on: list[str] | None = None,
-            metadata: dict | None = None) -> TaskNode: ...
-    def remove(self, node_id: str) -> None: ...      # 僅限 PENDING 節點
-    def update(self, node_id: str, ...) -> TaskNode: ...  # 僅限 PENDING 節點
-    def get(self, node_id: str) -> TaskNode | None: ...
+    def replace(self, todos: list[dict]) -> None:
+        """Replace entire list. todos = [{id, content, status?}]."""
 
     @property
     def nodes(self) -> list[TaskNode]: ...
-    def pending(self) -> list[TaskNode]: ...
     def active(self) -> list[TaskNode]: ...
-    def ready(self) -> list[TaskNode]: ...   # depends_on 全 COMPLETED 的 PENDING
-    def validate(self) -> None: ...          # DFS 三色 cycle detection
     def status_summary(self) -> dict: ...
 ```
 
-**關鍵設計**：
-- `depends_on` 僅為**文件**——agent 自己閱讀並判斷順序，harness 不據此排程
-- `ready()` 是方便 agent 查詢的**視圖**，非排程指令；agent 可自由跳過依賴
-- `validate()` 仍做 DFS cycle detection——環是 plan bug，即使依賴是 advisory 也應抓出來
-- `update()` / `remove()` 只能作用在 `PENDING` 節點——已啟動/完成節點不允許修改歷史
+只有 replace 語意——沒有 add / remove / update / get_ready。每次 agent 想改就傳完整意圖狀態，框架負責 mirror。
 
 ---
 
 ## 工作流程（agent 視角）
 
-```
-1. task_plan     — 建立清單（開始一個複雜任務前）
-2. task_status   — 隨時查清單狀態、反漂移
-3. task_modify   — 計畫需調整時增刪改未啟動節點
-4. 逐節點執行（直接用其他 tools，不派給 sub-agent）
-5. task_done     — 每完成一個節點：傳 result 或 error
-6. task_read     — 需要上游完整結果時按需取用（Pull Model）
+```python
+# 1. 開始任務 — 建立清單
+task_write(todos=[
+    {"id": "research", "content": "蒐集論文", "status": "pending"},
+    {"id": "draft",    "content": "寫初稿到 tmp/draft.md", "status": "pending"},
+    {"id": "audit",    "content": "審核", "status": "pending"},
+])
+
+# 2. 開始第一個節點 — 重寫清單把 status 改 in_progress
+task_write(todos=[
+    {"id": "research", "content": "...", "status": "in_progress"},
+    {"id": "draft",    "content": "...", "status": "pending"},
+    {"id": "audit",    "content": "...", "status": "pending"},
+])
+
+# 3. 完成 research、產出寫到 tmp/ — 重寫清單
+write_file("tmp/research_summary.md", findings)   # 產出 → 磁碟
+task_write(todos=[
+    {"id": "research", "content": "...", "status": "completed"},
+    {"id": "draft",    "content": "...", "status": "in_progress"},
+    {"id": "audit",    "content": "...", "status": "pending"},
+])
+
+# ... 一直到全部 completed
 ```
 
-**無 `next_ready` 自動推進**——agent 自己看 `ready()` 決定下一步。
+**沒有 `next_ready` 自動推進**——agent 自己看清單決定下一步。
 
 ---
 
-## Pre-Final-Response Self-Check（stream_turn hook）
+## Pre-Final-Response Self-Check（stream_turn middleware）
 
 防止 agent 做到一半靜默結束回應：
 
@@ -110,32 +131,40 @@ if has_active_nodes():
 
 觸發時機：`response.stop_reason == "end_turn"` 且 TaskList 仍有 PENDING / IN_PROGRESS 節點。注入一次後設 flag，同 turn 內不重複。
 
-Agent 收到 reminder 的三條出路：
-1. 繼續執行下一個節點
-2. `task_done(node_id=..., error="原因")` 明確標記放棄
-3. 如果真的已完成，用 `task_done(result=...)` 補上——然後自然 end_turn
+Agent 收到 reminder 的兩條出路：
+1. 繼續執行未完成的節點
+2. 用 `task_write` 重寫清單，把放棄的節點 status 改 `completed` 並在 content 註明放棄原因
 
 ---
 
-## Result 硬截斷
+## File-as-State
 
-`task_done(result=...)` 超過 `HARD_RESULT_CAP = 5000` chars 會在 Manager 層截斷並附通知，引導 agent 改用 `write_file` 把大型產出寫到磁碟、TaskList 只存摘要與路徑。
+TaskList 只記「我有沒有忘記做這步」，**從來不存產出**。所有實際資料都走檔案：
 
-**為什麼硬截斷而不自動進 Scratchpad？** — Scratchpad 是 IO 過程產物的暫存區；`task_done` 的 result 屬於 agent 的**最終交付**，應該顯式決定去處（磁碟、記憶系統、或壓在摘要裡），而不是偷偷寄放。
+```python
+# ✅ 正確
+write_file("tmp/dim_a.md", report_body)
+task_write(todos=[..., {"id": "dim_a", "content": "...", "status": "completed"}, ...])
+
+# ❌ 錯誤（無欄位可塞）
+task_write(todos=[..., {"id": "dim_a", "content": report_body, "status": "completed"}, ...])
+```
+
+跨節點傳資料就用約定好的檔名（`tmp/dim_a.md` → 下游 `read_file` 取回）。中斷恢復也很自然：檔案存在就是「做過了」，檔案不存在就是「還沒做」，TaskList 的 status 只是輔助提示。
 
 ---
 
-## 與 #128 / v0.3.2 TaskGraph 的差異
+## 與先前版本的差異
 
-| 項目 | v0.3.2 TaskGraph | v0.3.2.1 TaskList |
-|------|------------------|-------------------|
-| 結構 | DAG with compile() | 平坦清單 |
-| `depends_on` | 驅動排程 | 僅文件 |
-| 並行執行 | levels + asyncio.gather | 無（並行下放到 async_jobs） |
-| 跨 session 持久化 | `~/.loom/task_graphs/` | 無（交給記憶系統） |
-| 結果溢出 | `~/.loom/artifacts/` | Scratchpad（見 #18） |
-| SKIPPED 狀態 | 有 | 無（改用 `task_done(error=)`） |
-| Tool API | 相同 5 個 | 相同 5 個（無 breaking change） |
+| 項目 | v0.3.2 TaskGraph (#128) | v0.3.2.1 TaskList (#153) | v0.3.3 task_write (#205) |
+|------|-------------------------|--------------------------|--------------------------|
+| 結構 | DAG with compile() | 平坦清單 + depends_on | 平坦清單 |
+| `depends_on` | 驅動排程 | 僅文件 + ready() 視圖 | 不存在 |
+| `result` 欄位 | 有，溢出到 artifacts/ | 有，5000 char 截斷 | **不存在** |
+| `task_done` | 有 | 有（含 verifier） | **不存在** |
+| 並行執行 | levels + asyncio.gather | 無 | 無 |
+| Tool 數量 | 5 個 | 5 個 | **1 個（task_write）** |
+| 狀態載體 | TaskGraph + artifacts/ | TaskList + result 欄位 | **檔案系統（tmp/）** |
 
 ---
 
@@ -143,9 +172,11 @@ Agent 收到 reminder 的三條出路：
 
 | 檔案 | 職責 |
 |------|------|
-| `loom/core/tasks/tasklist.py` | `TaskNode` / `TaskStatus` / `TaskList` 資料結構 |
-| `loom/core/tasks/manager.py` | `TaskListManager` — tool 呼叫邊界、result 截斷、self-check message |
+| `loom/core/tasks/tasklist.py` | `TaskNode` / `TaskStatus` / `TaskList` 資料結構（~100 行） |
+| `loom/core/tasks/manager.py` | `TaskListManager` — write 邊界、self-check message（~80 行） |
+| `loom/platform/cli/tools.py` | `make_task_write_tool` — 唯一的 tool factory |
 | `skills/task_list/SKILL.md` | Agent 可見的 Tier-1 skill genome |
 
 相關文件：
 - [18-Task-Scheduler.md](18-Task-Scheduler.md) — Async Jobs（JobStore + Scratchpad），IO 並行層
+- Issue #205 — 收斂的根因分析與設計討論

--- a/doc/18-Task-Scheduler.md
+++ b/doc/18-Task-Scheduler.md
@@ -96,7 +96,7 @@ class Scratchpad:
     def __contains__(self, ref: str) -> bool: ...
 ```
 
-`section` 支援 `"head"` / `"tail"` / `"N-M"` / 關鍵字（grep 語義）——與 `task_read` 一致，避免 agent 每次都讀完整 blob。
+`section` 支援 `"head"` / `"tail"` / `"N-M"` / 關鍵字（grep 語義），避免 agent 每次都讀完整 blob。
 
 `max_bytes` 在 section filter 之**前**截斷原始 bytes，超過時附加 `[scratchpad_read: output truncated at N bytes]`。預設 200_000 bytes。
 
@@ -132,7 +132,7 @@ run_bash(command=..., async_mode=True)
 | `jobs_status(job_id)` | 單個 job 的完整狀態（含 elapsed、args、error） |
 | `jobs_await(job_ids, timeout)` | 等到全部 terminal 或 timeout。**不 raise**——回傳 `{timeout_hit, finished, still_running}` 讓 agent 自己決定 cancel 或再等 |
 | `jobs_cancel(job_id, reason)` | `reason` 必填——schema 層就擋掉沒帶理由的呼叫 |
-| `scratchpad_read(ref?, section?, max_bytes?)` | 省略 `ref` 時列出可用 refs；`section` 與 `task_read` 同義 |
+| `scratchpad_read(ref?, section?, max_bytes?)` | 省略 `ref` 時列出可用 refs；`section` 支援 `head`/`tail`/`N-M`/keyword |
 
 所有這 5 個工具 trust level 都是 `SAFE`——純讀操作，不需要確認。
 

--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -184,7 +184,7 @@ class JITRetrievalMiddleware(Middleware):
     inspects.
 
     **Opt-out**: tools whose entire purpose is returning content the agent
-    needs inline (``task_read``, ``scratchpad_read``, ``list_dir``, etc.)
+    needs inline (``scratchpad_read``, ``list_dir``, ``task_write`` etc.)
     should set ``ToolDefinition.inline_only=True`` to bypass spill.
 
     **Async-mode passthrough**: when ``result.metadata["async"] is True``

--- a/loom/core/harness/registry.py
+++ b/loom/core/harness/registry.py
@@ -88,10 +88,9 @@ class ToolDefinition:
     to scratchpad regardless of size (Issue #197).
 
     Set this for tools whose purpose is already to return content the agent
-    needs inline — spilling defeats the point. Examples: ``task_read``
-    (already a deliberate retrieval), ``scratchpad_read`` (paradoxical to
-    re-spill), ``list_dir`` (always small), ``memorize`` / ``task_done``
-    (structured short responses).
+    needs inline — spilling defeats the point. Examples: ``scratchpad_read``
+    (paradoxical to re-spill), ``list_dir`` (always small), ``memorize`` /
+    ``task_write`` (structured short responses).
     """
 
     # --- Scope-aware permission (Issue #45 Phase A) ---

--- a/loom/core/jobs/scratchpad.py
+++ b/loom/core/jobs/scratchpad.py
@@ -79,7 +79,7 @@ class Scratchpad:
 
 
 def _apply_section(text: str, section: str) -> str:
-    """Apply a section filter matching task_read semantics.
+    """Apply a section filter on text content.
 
     Supported:
       - "head"     → first 50 lines

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1001,23 +1001,15 @@ class LoomSession:
         # Register sub-agent tool (Phase 5E)
         self.registry.register(make_spawn_agent_tool(self))
 
-        # Issue #153: Agent-driven TaskList tools (cognitive checklist for the
-        # main agent). Cross-session continuity is handled by the memory system,
-        # not the TaskList itself — each session starts with a clean list.
+        # Issue #205: Single-tool TaskList (cognitive checklist for the main
+        # agent). Replaced the 5-tool surface (#153) with one task_write —
+        # see loom/platform/cli/tools.py for the rationale. Cross-session
+        # continuity is handled by the memory system, not the TaskList itself;
+        # each session starts with a clean list.
         from loom.core.tasks.manager import TaskListManager
-        from loom.platform.cli.tools import (
-            make_task_plan_tool,
-            make_task_status_tool,
-            make_task_modify_tool,
-            make_task_done_tool,
-            make_task_read_tool,
-        )
+        from loom.platform.cli.tools import make_task_write_tool
         self._tasklist_manager = TaskListManager(session_id=self.session_id)
-        self.registry.register(make_task_plan_tool(self._tasklist_manager))
-        self.registry.register(make_task_status_tool(self._tasklist_manager))
-        self.registry.register(make_task_modify_tool(self._tasklist_manager))
-        self.registry.register(make_task_done_tool(self._tasklist_manager))
-        self.registry.register(make_task_read_tool(self._tasklist_manager))
+        self.registry.register(make_task_write_tool(self._tasklist_manager))
 
         # Issue #154: async job inspection tools. The JobStore + Scratchpad
         # themselves are created in __init__ so run_bash/fetch_url can close
@@ -1395,9 +1387,10 @@ class LoomSession:
         _MAX_STREAM_RETRIES = 2  # auto-retry up to 2 times on response=None
         _stop_reason = "complete"  # tracks why the loop exits
 
-        # Issue #153: TaskList self-check. On end_turn we inject a reminder
+        # Issue #205: TaskList self-check. On end_turn we inject a reminder
         # at most once per stream_turn if the list still has active nodes,
-        # nudging the agent to either continue executing or mark abandonment.
+        # nudging the agent to either continue executing or rewrite the list
+        # to mark abandonment.
         _tasklist_selfcheck_done = False
         # Issue #154: Jobs status injection, also at most once per stream_turn.
         # Reports newly-finished and still-running background jobs so the
@@ -1577,7 +1570,7 @@ class LoomSession:
             ))
 
             if response.stop_reason == "end_turn":
-                # Issue #153: Pre-final-response self-check. If the TaskList
+                # Issue #205: Pre-final-response self-check. If the TaskList
                 # has pending/in-progress nodes and we haven't already nudged
                 # this turn, inject a reminder and loop back into the model.
                 # This catches the autonomy stall mode where an agent creates

--- a/loom/core/tasks/manager.py
+++ b/loom/core/tasks/manager.py
@@ -1,30 +1,19 @@
 """
-TaskListManager — session-scoped wrapper around a single active TaskList.
+TaskListManager — session-scoped wrapper around the active TaskList.
 
-Provides the narrow API used by the task_* tools and the pre-final-response
-self-check middleware. No persistence, no artifact overflow, no graph-state
-lifecycle — see Issue #153 for the rationale behind removing those.
-
-Long-result storage (overflow) will return in Issue #154 via the Scratchpad.
-Until then, results larger than HARD_RESULT_CAP are hard-truncated.
+After Issue #205 collapse: this is a thin wrapper that exposes only what
+the single ``task_write`` tool and the turn-boundary self-check middleware
+need. No result storage, no overflow handling, no per-node lifecycle —
+those concepts went away with ``task_done``.
 """
 
 from __future__ import annotations
 
-import logging
-from typing import Any
-
-from .tasklist import TaskList, TaskNode, TaskStatus
-
-logger = logging.getLogger(__name__)
-
-SHORT_THRESHOLD = 500
-MEDIUM_THRESHOLD = 5000
-HARD_RESULT_CAP = 5000
+from .tasklist import TaskList
 
 
 class TaskListManager:
-    """Session-scoped manager for a single active TaskList."""
+    """Session-scoped wrapper for one TaskList."""
 
     def __init__(self, session_id: str) -> None:
         self.session_id = session_id
@@ -41,192 +30,31 @@ class TaskListManager:
     def has_active_nodes(self) -> bool:
         return self._list is not None and bool(self._list.active())
 
-    # ── List construction ──────────────────────────────────────────────
+    def write(self, todos: list[dict]) -> dict:
+        """Replace the entire list with the agent-provided todos.
 
-    def create_list(self, tasks: list[dict[str, Any]]) -> TaskList:
-        """Build a fresh TaskList from agent-provided task specs.
-
-        If a prior list exists but all its nodes are done, it is replaced.
-        If it still has active nodes, creation fails — agent must abandon
-        or finish first.
+        Empty list clears the active TaskList. Returns the new status
+        summary so the tool layer can echo it back to the agent.
         """
-        if self._list is not None:
-            if all(n.is_done for n in self._list.nodes):
-                self._list = None
-            else:
-                raise ValueError(
-                    "A task list already exists with active nodes. "
-                    "Use task_modify to adjust, or mark unfinished nodes "
-                    "with task_done(error=...) first."
-                )
-
+        if not todos:
+            self._list = None
+            return {"total": 0, "by_status": {}, "todos": []}
         lst = TaskList()
-        seen: set[str] = set()
-        for spec in tasks:
-            tid = spec["id"]
-            if tid in seen:
-                raise ValueError(f"Duplicate task ID: '{tid}'")
-            seen.add(tid)
-
-        for spec in tasks:
-            lst.add(
-                node_id=spec["id"],
-                content=spec["content"],
-                depends_on=spec.get("depends_on", []),
-            )
-        lst.validate()
-
+        lst.replace(todos)
         self._list = lst
-        return lst
+        return lst.status_summary()
 
-    # ── List mutation ──────────────────────────────────────────────────
-
-    def add_nodes(self, tasks: list[dict[str, Any]]) -> list[TaskNode]:
-        self._require_list()
-        added: list[TaskNode] = []
-        for spec in tasks:
-            node = self._list.add(
-                node_id=spec["id"],
-                content=spec["content"],
-                depends_on=spec.get("depends_on", []),
-            )
-            added.append(node)
-        self._list.validate()
-        return added
-
-    def remove_nodes(self, node_ids: list[str]) -> None:
-        self._require_list()
-        for nid in node_ids:
-            self._list.remove(nid)
-
-    def update_nodes(self, updates: list[dict[str, Any]]) -> list[TaskNode]:
-        self._require_list()
-        updated: list[TaskNode] = []
-        for spec in updates:
-            node = self._list.update(
-                node_id=spec["id"],
-                content=spec.get("content"),
-                depends_on=spec.get("depends_on"),
-            )
-            updated.append(node)
-        if any(spec.get("depends_on") is not None for spec in updates):
-            self._list.validate()
-        return updated
-
-    # ── Execution support ──────────────────────────────────────────────
-
-    def get_ready_nodes(self) -> list[TaskNode]:
-        self._require_list()
-        return self._list.ready()
-
-    def mark_in_progress(self, node_id: str) -> TaskNode:
-        self._require_list()
-        node = self._list.get(node_id)
-        if node is None:
-            raise ValueError(f"Node '{node_id}' not found")
-        if node.status != TaskStatus.PENDING:
-            raise ValueError(
-                f"Cannot start node '{node_id}' with status {node.status.value} "
-                f"— only PENDING nodes can be started"
-            )
-        node.status = TaskStatus.IN_PROGRESS
-        return node
-
-    def mark_completed(self, node_id: str, result: str) -> TaskNode:
-        """Mark a node as completed. Long results are hard-truncated.
-
-        Issue #154 will reintroduce Scratchpad-backed overflow so that long
-        results don't lose information. For now the safe default is truncate
-        plus a clear notice, and the agent is nudged to write files directly.
-        """
-        self._require_list()
-        node = self._list.get(node_id)
-        if node is None:
-            raise ValueError(f"Node '{node_id}' not found")
-
-        original_len = len(result)
-        if original_len > HARD_RESULT_CAP:
-            truncated = result[:HARD_RESULT_CAP]
-            truncated += (
-                f"\n\n[TaskList: result hard-truncated at {HARD_RESULT_CAP} chars "
-                f"— original was {original_len} chars. For long outputs, write to "
-                f"a file via write_file and record only the path/summary here. "
-                f"Scratchpad-backed overflow is tracked in Issue #154.]"
-            )
-            node.complete(truncated)
-        else:
-            node.complete(result)
-
-        node.result_summary = self._generate_summary(result, node_id=node_id)
-        return node
-
-    def mark_failed(self, node_id: str, error: str) -> TaskNode:
-        self._require_list()
-        node = self._list.get(node_id)
-        if node is None:
-            raise ValueError(f"Node '{node_id}' not found")
-        node.fail(error)
-        return node
-
-    def get_node_result(self, node_id: str, section: str | None = None) -> str | None:
-        """Return the full result of a completed node (pull model)."""
-        self._require_list()
-        node = self._list.get(node_id)
-        if node is None:
-            raise ValueError(f"Node '{node_id}' not found")
-        if node.status != TaskStatus.COMPLETED:
-            return None
-        result = node.result
-        if result is None:
-            return None
-        if section is None:
-            return result
-        return self._apply_section_filter(result, section)
-
-    def build_node_context(self, node: TaskNode) -> str:
-        """Build an injection string summarising prior-node results for the agent.
-
-        Returned to the agent via task_done's response so it can include upstream
-        context when executing a downstream node. Pull model: the agent sees the
-        summary plus a hint to call task_read for full details.
-        """
-        self._require_list()
-        parts = [f"You are executing task node [{node.id}]: {node.content}"]
-
-        for dep_id in node.depends_on:
-            dep = self._list.get(dep_id)
-            if dep is None or dep.status != TaskStatus.COMPLETED:
-                continue
-            result_len = len(dep.result) if dep.result else 0
-            summary = dep.result_summary or "(no summary)"
-            parts.append(
-                f"\nPrior task [{dep.id}] ({dep.content[:60]}) completed.\n"
-                f"Result summary: {summary}\n"
-                f"(full result: ~{result_len} chars"
-                f" — use task_read(node_id='{dep.id}') to inspect,"
-                f" supports section='head'/'tail'/'10-50'/keyword)"
-            )
-
-        return "\n".join(parts)
-
-    # ── Status / query ─────────────────────────────────────────────────
-
-    def status(self) -> dict[str, Any]:
-        self._require_list()
+    def status(self) -> dict:
+        if self._list is None:
+            return {"total": 0, "by_status": {}, "todos": []}
         return self._list.status_summary()
-
-    def abandon(self) -> None:
-        """Discard the current list. No cleanup beyond dropping the reference."""
-        self._list = None
-
-    # ── Self-check (Issue #153) ────────────────────────────────────────
 
     def build_self_check_message(self) -> str | None:
         """Build a pre-final-response reminder when active nodes remain.
 
         Returns None if there is no list or all nodes are done. Otherwise
         returns a reminder the session inserts as a system-style nudge so
-        the agent either continues or explicitly marks abandonment.
+        the agent either continues or rewrites the list to mark closure.
         """
         if self._list is None:
             return None
@@ -235,71 +63,16 @@ class TaskListManager:
             return None
 
         lines = [
-            f"[TaskList self-check] You still have {len(active)} unfinished node(s):",
+            f"[TaskList self-check] You still have {len(active)} unfinished todo(s):",
         ]
         for n in active:
-            deps = f" (deps: {', '.join(n.depends_on)})" if n.depends_on else ""
-            lines.append(
-                f"  - [{n.id}] {n.content[:80]} — {n.status.value}{deps}"
-            )
+            lines.append(f"  - [{n.id}] {n.content[:80]} — {n.status.value}")
         lines.append("")
         lines.append(
-            "If you intend to finish the task, continue executing the remaining "
-            "nodes now. If the task is no longer viable, mark each unfinished "
-            "node via task_done(node_id=..., error=\"reason\") so the abandonment "
-            "reason is preserved. Do not end this turn silently with work still "
-            "pending."
+            "Either continue executing now, or — if the work is no longer "
+            "viable — call task_write again with the full updated list, "
+            "marking the abandoned items as 'completed' with the reason "
+            "stated in their content. Do not end this turn silently with "
+            "todos still pending."
         )
         return "\n".join(lines)
-
-    # ── Helpers ────────────────────────────────────────────────────────
-
-    @staticmethod
-    def _apply_section_filter(text: str, section: str) -> str:
-        try:
-            lines = text.splitlines(keepends=True)
-            if section == "head":
-                return "".join(lines[:200])
-            if section == "tail":
-                return "".join(lines[-200:])
-            if "-" in section:
-                parts = section.split("-", 1)
-                try:
-                    start = max(1, int(parts[0])) - 1
-                    end = int(parts[1])
-                    return "".join(lines[start:end])
-                except (ValueError, IndexError):
-                    pass
-            matched = [ln for ln in lines if section.lower() in ln.lower()]
-            if matched:
-                return "".join(matched)
-            return f"(no lines matching '{section}')"
-        except Exception as exc:
-            return f"(section filter error: {exc})"
-
-    def _require_list(self) -> None:
-        if self._list is None:
-            raise ValueError("No active task list. Use task_plan to create one.")
-
-    @staticmethod
-    def _generate_summary(result: str, node_id: str = "") -> str:
-        if not result:
-            return "(empty result)"
-        length = len(result)
-        if length <= SHORT_THRESHOLD:
-            return result
-        read_hint = (
-            f"\nFull result ({length} chars) available — "
-            f"use task_read(node_id='{node_id}') to retrieve, "
-            f"supports section='head'/'tail'/'10-50'/keyword"
-        ) if node_id else f"\n... ({length} chars total, use task_read for full result)"
-        if length <= MEDIUM_THRESHOLD:
-            return result[:400] + read_hint
-        head = result[:300]
-        tail = result[-200:]
-        return (
-            f"{head}\n"
-            f"... ({length} chars total) ...\n"
-            f"{tail}"
-            f"{read_hint}"
-        )

--- a/loom/core/tasks/tasklist.py
+++ b/loom/core/tasks/tasklist.py
@@ -1,28 +1,32 @@
 """
-TaskList — an agent's cognitive checklist for multi-step work.
+TaskList — the agent's cognitive checklist for multi-step work.
 
-Each node represents one task with a status and optional textual dependencies.
-Dependencies (`depends_on`) are metadata for the agent's own reference — they
-do NOT drive execution. The main agent executes nodes itself, one turn at a
-time, using task_* tools to track progress and self-check before finishing.
+Each node is just an id, a one-line content, and a status. There are no
+result fields, no dependencies, no readiness computation. The whole list
+is replaced atomically each time the agent calls ``task_write`` — the
+act of marking a node ``completed`` is editing the data structure, not
+calling a "done" verb. This avoids the cognitive substitution where
+``task_done(...)`` feels like reporting progress to the framework even
+when no artifact exists (Issue #205).
 
-Design origin: Issue #153. Supersedes the TaskGraph execution framework from
-#128 / #150, whose compile()/scheduler/asyncio.gather path was never wired up
-and caused silent stalls under autonomy (e.g. graph 66859851, 2026-04-17).
+All real outputs go to disk via ``write_file``. The TaskList tracks only
+"have I forgotten this step?", never "what did this step produce?".
+
+Design origin: Issue #153 introduced the agent-driven model. Issue #205
+collapsed it further to a single ``task_write`` tool after observing
+``task_done`` was the source of false-completion failures.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
-from typing import Any
 
 
 class TaskStatus(Enum):
     PENDING = "pending"
     IN_PROGRESS = "in_progress"
     COMPLETED = "completed"
-    FAILED = "failed"
 
 
 @dataclass
@@ -30,172 +34,69 @@ class TaskNode:
     id: str
     content: str
     status: TaskStatus = TaskStatus.PENDING
-    depends_on: list[str] = field(default_factory=list)
-    result: str | None = None
-    result_summary: str | None = None
-    error: str | None = None
-    metadata: dict[str, Any] = field(default_factory=dict)
-
-    @property
-    def is_done(self) -> bool:
-        return self.status in (TaskStatus.COMPLETED, TaskStatus.FAILED)
 
     @property
     def is_active(self) -> bool:
         return self.status in (TaskStatus.PENDING, TaskStatus.IN_PROGRESS)
 
-    def complete(self, result: str | None = None) -> None:
-        self.status = TaskStatus.COMPLETED
-        self.result = result
-
-    def fail(self, error: str) -> None:
-        self.status = TaskStatus.FAILED
-        self.error = error
-
 
 class TaskList:
-    """Ordered collection of task nodes with textual dependencies.
+    """Ordered collection of task nodes — a sticky-note board, nothing more.
 
-    Dependencies do not participate in execution — they are documentation for
-    the agent's own reference. There is no compiler, no scheduler, no graph
-    topology; the agent reads the list and decides what to do next.
+    Replace-style: the agent submits the full intended state every time;
+    the list mirrors what was submitted. No partial mutations, no per-node
+    APIs, no execution scheduling.
     """
 
     def __init__(self) -> None:
         self._nodes: dict[str, TaskNode] = {}
 
-    def add(
-        self,
-        node_id: str,
-        content: str,
-        depends_on: list[str] | None = None,
-        metadata: dict[str, Any] | None = None,
-    ) -> TaskNode:
-        if node_id in self._nodes:
-            raise ValueError(f"Node ID '{node_id}' already exists")
-        node = TaskNode(
-            id=node_id,
-            content=content,
-            depends_on=list(depends_on or []),
-            metadata=dict(metadata or {}),
-        )
-        self._nodes[node_id] = node
-        return node
+    def replace(self, todos: list[dict]) -> None:
+        """Replace the entire list with the agent-provided todos.
 
-    def remove(self, node_id: str) -> None:
-        node = self._nodes.get(node_id)
-        if node is None:
-            raise ValueError(f"Node '{node_id}' not found")
-        if node.status != TaskStatus.PENDING:
-            raise ValueError(
-                f"Cannot remove node '{node_id}' with status {node.status.value} "
-                f"— only PENDING nodes can be removed"
-            )
-        del self._nodes[node_id]
-        for n in self._nodes.values():
-            if node_id in n.depends_on:
-                n.depends_on.remove(node_id)
-
-    def update(
-        self,
-        node_id: str,
-        content: str | None = None,
-        depends_on: list[str] | None = None,
-    ) -> TaskNode:
-        node = self._nodes.get(node_id)
-        if node is None:
-            raise ValueError(f"Node '{node_id}' not found")
-        if node.status != TaskStatus.PENDING:
-            raise ValueError(
-                f"Cannot update node '{node_id}' with status {node.status.value} "
-                f"— only PENDING nodes can be updated"
-            )
-        if content is not None:
-            node.content = content
-        if depends_on is not None:
-            for dep in depends_on:
-                if dep not in self._nodes:
-                    raise ValueError(f"Dependency '{dep}' not found in list")
-            node.depends_on = list(depends_on)
-        return node
-
-    def get(self, node_id: str) -> TaskNode | None:
-        return self._nodes.get(node_id)
+        Each todo is ``{"id", "content", "status"}``. Order is preserved
+        from the input. Validates: non-empty unique ids, non-empty content,
+        recognised status values.
+        """
+        seen: set[str] = set()
+        new_nodes: dict[str, TaskNode] = {}
+        for i, spec in enumerate(todos):
+            tid = (spec.get("id") or "").strip()
+            content = (spec.get("content") or "").strip()
+            status_str = (spec.get("status") or "pending").strip().lower()
+            if not tid:
+                raise ValueError(f"todo at index {i} is missing 'id'")
+            if not content:
+                raise ValueError(f"todo {tid!r} is missing 'content'")
+            if tid in seen:
+                raise ValueError(f"duplicate id {tid!r}")
+            seen.add(tid)
+            try:
+                status = TaskStatus(status_str)
+            except ValueError:
+                raise ValueError(
+                    f"todo {tid!r} has unknown status {status_str!r} "
+                    f"(expected one of: pending, in_progress, completed)"
+                ) from None
+            new_nodes[tid] = TaskNode(id=tid, content=content, status=status)
+        self._nodes = new_nodes
 
     @property
     def nodes(self) -> list[TaskNode]:
         return list(self._nodes.values())
 
-    def pending(self) -> list[TaskNode]:
-        return [n for n in self._nodes.values() if n.status == TaskStatus.PENDING]
-
     def active(self) -> list[TaskNode]:
         return [n for n in self._nodes.values() if n.is_active]
 
-    def ready(self) -> list[TaskNode]:
-        """PENDING nodes whose `depends_on` are all COMPLETED.
-
-        Convenience view for the agent. Since dependencies are advisory,
-        the agent may still choose to execute out of order.
-        """
-        out: list[TaskNode] = []
-        for n in self._nodes.values():
-            if n.status != TaskStatus.PENDING:
-                continue
-            deps_met = all(
-                (dep := self._nodes.get(d)) is not None
-                and dep.status == TaskStatus.COMPLETED
-                for d in n.depends_on
-            )
-            if deps_met:
-                out.append(n)
-        return out
-
-    def validate(self) -> None:
-        """Check that all depends_on references resolve and no cycles exist.
-
-        Cycles are a plan bug even when dependencies are advisory — catching
-        them prevents the agent silently assuming A needs B and B needs A.
-        """
-        for n in self._nodes.values():
-            for dep in n.depends_on:
-                if dep not in self._nodes:
-                    raise ValueError(
-                        f"Node '{n.id}' depends on unknown node '{dep}'"
-                    )
-        WHITE, GRAY, BLACK = 0, 1, 2
-        color = {nid: WHITE for nid in self._nodes}
-
-        def visit(nid: str, chain: list[str]) -> None:
-            if color[nid] == GRAY:
-                cycle = " -> ".join(chain + [nid])
-                raise ValueError(f"Cycle detected in task dependencies: {cycle}")
-            if color[nid] == BLACK:
-                return
-            color[nid] = GRAY
-            for dep in self._nodes[nid].depends_on:
-                visit(dep, chain + [nid])
-            color[nid] = BLACK
-
-        for nid in list(self._nodes):
-            visit(nid, [])
-
-    def status_summary(self) -> dict[str, Any]:
+    def status_summary(self) -> dict:
         by_status: dict[str, list[str]] = {}
         for n in self._nodes.values():
             by_status.setdefault(n.status.value, []).append(n.id)
         return {
-            "total_nodes": len(self._nodes),
+            "total": len(self._nodes),
             "by_status": by_status,
-            "nodes": [
-                {
-                    "id": n.id,
-                    "content": n.content[:80],
-                    "status": n.status.value,
-                    "depends_on": n.depends_on,
-                    **({"result_summary": n.result_summary} if n.result_summary else {}),
-                    **({"error": n.error} if n.error else {}),
-                }
+            "todos": [
+                {"id": n.id, "content": n.content, "status": n.status.value}
                 for n in self._nodes.values()
             ],
         }

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -2533,461 +2533,92 @@ def make_spawn_agent_tool(parent_session: Any) -> "ToolDefinition":
 # read_file / write_file / list_dir are registered via make_filesystem_tools(workspace).
 
 
-# ── Issue #153: Agent-driven TaskList tools ────────────────────────────────
+# ── Issue #205: Single-tool TaskList — task_write replaces 5 tools ─────────
+#
+# Replaces task_plan / task_status / task_modify / task_done / task_read.
+# Rationale: task_done was a "verb" — calling it felt like reporting progress
+# to the framework, even when no artifact existed. The cognitive substitution
+# (call → "I'm done") was the root cause of false-completion failures in long
+# multi-step tasks. task_write is an "edit" — agent rewrites the whole list,
+# changing status fields. No verb, no ceremony, no illusion of being tracked.
+#
+# All real outputs go to disk via write_file; the TaskList only tracks
+# "have I forgotten this step?".
 
-def make_task_plan_tool(manager: "TaskListManager") -> ToolDefinition:
-    """Create the task_plan tool for building a TaskList from agent specs."""
+def make_task_write_tool(manager: "TaskListManager") -> ToolDefinition:
+    """Create the task_write tool — replace-the-whole-list semantics."""
 
-    async def _task_plan(call: ToolCall) -> ToolResult:
-        tasks = call.args.get("tasks", [])
-        if not tasks:
+    async def _task_write(call: ToolCall) -> ToolResult:
+        todos = call.args.get("todos")
+        if todos is None or not isinstance(todos, list):
             return ToolResult(
                 call_id=call.id, tool_name=call.tool_name,
-                success=False, error="'tasks' list is required and must not be empty",
+                success=False, error="'todos' is required and must be a list",
             )
-        for i, t in enumerate(tasks):
-            if not t.get("id") or not t.get("content"):
-                return ToolResult(
-                    call_id=call.id, tool_name=call.tool_name,
-                    success=False,
-                    error=f"Task at index {i} missing required 'id' or 'content'",
-                )
         try:
-            tasklist = manager.create_list(tasks)
-            summary = tasklist.status_summary()
-            return ToolResult(
-                call_id=call.id, tool_name=call.tool_name,
-                success=True,
-                output=json.dumps({
-                    "status": "tasklist_created",
-                    "total_nodes": summary["total_nodes"],
-                    "ready_nodes": [n.id for n in manager.get_ready_nodes()],
-                }, ensure_ascii=False),
-            )
+            summary = manager.write(todos)
         except ValueError as exc:
             return ToolResult(
                 call_id=call.id, tool_name=call.tool_name,
                 success=False, error=str(exc),
             )
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=True,
+            output=json.dumps(summary, ensure_ascii=False),
+        )
 
     return ToolDefinition(
-        name="task_plan",
+        name="task_write",
         description=(
-            "Build a TaskList for complex multi-step work — a checklist the "
-            "main agent maintains for itself to plan, track, and self-check "
-            "progress. Each task becomes a node with optional `depends_on` "
-            "references (dependencies are documentation only; you execute "
-            "the nodes yourself one at a time). Use this when the current "
-            "goal requires multiple coordinated steps."
+            "Maintain your todo list for multi-step work. Pass the FULL "
+            "intended list every time — this replaces the previous list. "
+            "Each todo is {id, content, status} where status is "
+            "'pending' | 'in_progress' | 'completed'. To 'complete' a "
+            "step, rewrite the list with that item's status changed.\n\n"
+            "This is your sticky-note board — a reminder of what's left, "
+            "not a state container. Real outputs (reports, code, data) "
+            "MUST go to files via write_file. The todo list never holds "
+            "the result itself, only the fact that the step exists.\n\n"
+            "Use it when a goal has 3+ coordinated steps and forgetting "
+            "one would be costly. Skip it for trivial single-turn work. "
+            "Pass an empty list to clear."
         ),
         trust_level=TrustLevel.SAFE,
         capabilities=ToolCapability.NONE,
         input_schema={
             "type": "object",
             "properties": {
-                "tasks": {
+                "todos": {
                     "type": "array",
-                    "description": "List of tasks with dependencies",
+                    "description": "Full intended todo list. Replaces any prior list.",
                     "items": {
                         "type": "object",
                         "properties": {
                             "id": {
                                 "type": "string",
-                                "description": "Short unique ID for this task (e.g. 'a', 'analyze', 'step1')",
+                                "description": "Short unique id (e.g. 'research', 'draft', 'audit').",
                             },
                             "content": {
                                 "type": "string",
-                                "description": "Clear description of what this task should accomplish (becomes the turn prompt)",
+                                "description": "One-line description of the step.",
                             },
-                            "depends_on": {
-                                "type": "array",
-                                "items": {"type": "string"},
-                                "description": "IDs of tasks that must complete before this one starts",
+                            "status": {
+                                "type": "string",
+                                "enum": ["pending", "in_progress", "completed"],
+                                "description": "Current status. Defaults to 'pending'.",
                             },
                         },
                         "required": ["id", "content"],
                     },
                 },
             },
-            "required": ["tasks"],
+            "required": ["todos"],
         },
-        executor=_task_plan,
+        executor=_task_write,
         tags=["task", "planning"],
         impact_scope="agent",
-    )
-
-
-def make_task_status_tool(manager: "TaskListManager") -> ToolDefinition:
-    """Create the task_status tool for querying the current TaskList state."""
-
-    async def _task_status(call: ToolCall) -> ToolResult:
-        if not manager.has_list:
-            return ToolResult(
-                call_id=call.id, tool_name=call.tool_name,
-                success=True, output="No active task list.",
-            )
-        try:
-            summary = manager.status()
-            return ToolResult(
-                call_id=call.id, tool_name=call.tool_name,
-                success=True,
-                output=json.dumps(summary, ensure_ascii=False),
-            )
-        except Exception as exc:
-            return ToolResult(
-                call_id=call.id, tool_name=call.tool_name,
-                success=False, error=str(exc),
-            )
-
-    return ToolDefinition(
-        name="task_status",
-        description=(
-            "Check the current state of the active TaskList. "
-            "Shows each node's status (pending/in_progress/completed/failed), "
-            "dependencies, and result summaries for completed nodes."
-        ),
-        trust_level=TrustLevel.SAFE,
-        capabilities=ToolCapability.NONE,
-        input_schema={"type": "object", "properties": {}},
-        executor=_task_status,
-        tags=["task", "status"],
-        impact_scope="agent",
-    )
-
-
-def make_task_modify_tool(manager: "TaskListManager") -> ToolDefinition:
-    """Create the task_modify tool for mutating the active TaskList."""
-
-    async def _task_modify(call: ToolCall) -> ToolResult:
-        if not manager.has_list:
-            return ToolResult(
-                call_id=call.id, tool_name=call.tool_name,
-                success=False, error="No active task list. Use task_plan first.",
-            )
-        errors: list[str] = []
-        changes: list[str] = []
-
-        # Add new nodes
-        add_specs = call.args.get("add", [])
-        if add_specs:
-            try:
-                added = manager.add_nodes(add_specs)
-                changes.append(f"Added {len(added)} node(s): {[n.id for n in added]}")
-            except Exception as exc:
-                errors.append(f"add: {exc}")
-
-        # Remove nodes
-        remove_ids = call.args.get("remove", [])
-        if remove_ids:
-            try:
-                manager.remove_nodes(remove_ids)
-                changes.append(f"Removed {len(remove_ids)} node(s): {remove_ids}")
-            except Exception as exc:
-                errors.append(f"remove: {exc}")
-
-        # Update nodes
-        update_specs = call.args.get("update", [])
-        if update_specs:
-            try:
-                updated = manager.update_nodes(update_specs)
-                changes.append(f"Updated {len(updated)} node(s): {[n.id for n in updated]}")
-            except Exception as exc:
-                errors.append(f"update: {exc}")
-
-        if errors and not changes:
-            return ToolResult(
-                call_id=call.id, tool_name=call.tool_name,
-                success=False, error="; ".join(errors),
-            )
-
-        summary = manager.status()
-        output = {
-            "changes": changes,
-            "ready_nodes": [n.id for n in manager.get_ready_nodes()],
-            "graph": summary,
-        }
-        if errors:
-            output["partial_errors"] = errors
-        return ToolResult(
-            call_id=call.id, tool_name=call.tool_name,
-            success=True,
-            output=json.dumps(output, ensure_ascii=False),
-        )
-
-    return ToolDefinition(
-        name="task_modify",
-        description=(
-            "Modify the active TaskList: add new nodes, remove pending nodes, "
-            "or update content/dependencies of pending nodes. "
-            "Only PENDING nodes can be removed or updated."
-        ),
-        trust_level=TrustLevel.SAFE,
-        capabilities=ToolCapability.MUTATES,
-        input_schema={
-            "type": "object",
-            "properties": {
-                "add": {
-                    "type": "array",
-                    "description": "New tasks to add (same format as task_plan)",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "id": {"type": "string"},
-                            "content": {"type": "string"},
-                            "depends_on": {
-                                "type": "array",
-                                "items": {"type": "string"},
-                            },
-                        },
-                        "required": ["id", "content"],
-                    },
-                },
-                "remove": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                    "description": "IDs of pending nodes to remove",
-                },
-                "update": {
-                    "type": "array",
-                    "description": "Pending nodes to update",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "id": {"type": "string"},
-                            "content": {"type": "string"},
-                            "depends_on": {
-                                "type": "array",
-                                "items": {"type": "string"},
-                            },
-                        },
-                        "required": ["id"],
-                    },
-                },
-            },
-        },
-        executor=_task_modify,
-        tags=["task", "modify"],
-        impact_scope="agent",
-    )
-
-
-def make_task_done_tool(manager: "TaskListManager") -> ToolDefinition:
-    """Create the task_done tool for marking nodes completed or failed."""
-    from loom.core.tasks.tasklist import TaskStatus
-    from loom.core.tasks.manager import SHORT_THRESHOLD
-
-    async def _verify_task_done(call: ToolCall, result: ToolResult) -> VerifierResult:
-        """State-desync check (Issue #196 Phase 1, PR #198 review).
-
-        task_done is TaskList's most trusted invariant — it asserts a node
-        reached a terminal state. If the executor reports success but the
-        TaskList internal state disagrees, every downstream decision drifts.
-
-        This validator reads back the node status to confirm the claim.
-        """
-        node_id = call.args.get("node_id", "").strip()
-        if not node_id or manager.tasklist is None:
-            return VerifierResult(passed=True)
-        try:
-            node = manager.tasklist.get(node_id)
-        except Exception as exc:
-            # Don't block on validator infra failure — downgrade to pass.
-            _log.warning("task_done validator lookup failed: %s", exc)
-            return VerifierResult(passed=True)
-        if node is None:
-            return VerifierResult(
-                passed=False,
-                reason=f"task_done reported success but node {node_id!r} "
-                       f"no longer exists in the TaskList.",
-                signal="task_node_missing",
-            )
-        error_text = call.args.get("error")
-        expected_status = TaskStatus.FAILED if error_text else TaskStatus.COMPLETED
-        if node.status != expected_status:
-            return VerifierResult(
-                passed=False,
-                reason=(
-                    f"task_done reported success but node {node_id!r} status "
-                    f"is {node.status.value!r}, expected {expected_status.value!r}."
-                ),
-                signal="task_state_desync",
-            )
-        return VerifierResult(passed=True)
-
-    async def _task_done(call: ToolCall) -> ToolResult:
-        node_id = call.args.get("node_id", "").strip()
-        if not node_id:
-            return ToolResult(
-                call_id=call.id, tool_name=call.tool_name,
-                success=False, error="'node_id' is required",
-            )
-        result_text = call.args.get("result", "").strip()
-        error_text = call.args.get("error")
-        failed = bool(error_text)
-
-        try:
-            node_obj = manager.tasklist.get(node_id) if manager.tasklist else None
-            if node_obj and node_obj.status == TaskStatus.PENDING:
-                manager.mark_in_progress(node_id)
-
-            if failed:
-                node = manager.mark_failed(node_id, error_text)
-                status = manager.status()
-                return ToolResult(
-                    call_id=call.id, tool_name=call.tool_name,
-                    success=True,
-                    output=json.dumps({
-                        "action": "node_failed",
-                        "node_id": node.id,
-                        "error": error_text,
-                        "tasklist": status,
-                        "hint": "Decide: retry (task_modify to update node), skip downstream, or abandon the list.",
-                    }, ensure_ascii=False),
-                )
-            if not result_text:
-                return ToolResult(
-                    call_id=call.id, tool_name=call.tool_name,
-                    success=False,
-                    error="'result' is required when completing a node (summarize what you accomplished)",
-                )
-            node = manager.mark_completed(node_id, result_text)
-            ready = manager.get_ready_nodes()
-            status = manager.status()
-
-            ready_with_context = []
-            for rn in ready:
-                ctx = manager.build_node_context(rn)
-                ready_with_context.append({
-                    "node_id": rn.id,
-                    "content": rn.content,
-                    "context": ctx,
-                })
-
-            result_info: dict[str, Any] = {
-                "action": "node_completed",
-                "node_id": node.id,
-                "result_summary": node.result_summary,
-                "ready_nodes": ready_with_context,
-                "tasklist": status,
-            }
-            result_len = len(result_text)
-            if result_len > SHORT_THRESHOLD:
-                result_info["full_result_chars"] = result_len
-                result_info["retrieval_hint"] = (
-                    f"task_read(node_id='{node_id}') for full {result_len}-char result "
-                    f"(supports section='head'/'tail'/'N-M'/keyword)"
-                )
-
-            return ToolResult(
-                call_id=call.id, tool_name=call.tool_name,
-                success=True,
-                output=json.dumps(result_info, ensure_ascii=False),
-            )
-        except ValueError as exc:
-            return ToolResult(
-                call_id=call.id, tool_name=call.tool_name,
-                success=False, error=str(exc),
-            )
-
-    return ToolDefinition(
-        name="task_done",
-        description=(
-            "Mark a task node as completed (with result) or failed (with error). "
-            "On completion, returns which nodes are now ready plus their upstream "
-            "context (pull-model summaries). On failure, returns the TaskList "
-            "state so you can decide how to proceed. Always call this after "
-            "finishing a node so the TaskList stays accurate for self-check."
-        ),
-        trust_level=TrustLevel.SAFE,
-        capabilities=ToolCapability.MUTATES,
-        input_schema={
-            "type": "object",
-            "properties": {
-                "node_id": {
-                    "type": "string",
-                    "description": "ID of the node to mark",
-                },
-                "result": {
-                    "type": "string",
-                    "description": "Summary of what was accomplished (required for completion)",
-                },
-                "error": {
-                    "type": "string",
-                    "description": "Error description (provide this instead of result to mark as failed)",
-                },
-            },
-            "required": ["node_id"],
-        },
-        executor=_task_done,
-        tags=["task", "done"],
-        impact_scope="agent",
-        post_validator=_verify_task_done,
         inline_only=True,  # Output is a structured status JSON; #197
-    )
-
-
-def make_task_read_tool(manager: "TaskListManager") -> ToolDefinition:
-    """Create the task_read tool for pulling full node results."""
-
-    async def _task_read(call: ToolCall) -> ToolResult:
-        node_id = call.args.get("node_id", "").strip()
-        if not node_id:
-            return ToolResult(
-                call_id=call.id, tool_name=call.tool_name,
-                success=False, error="'node_id' is required",
-            )
-        section = call.args.get("section")
-        try:
-            result = manager.get_node_result(node_id, section=section)
-            if result is None:
-                node = manager.tasklist.get(node_id) if manager.tasklist else None
-                status = node.status.value if node else "not found"
-                return ToolResult(
-                    call_id=call.id, tool_name=call.tool_name,
-                    success=False,
-                    error=f"Node '{node_id}' has no result (status: {status})",
-                )
-            return ToolResult(
-                call_id=call.id, tool_name=call.tool_name,
-                success=True, output=result,
-            )
-        except ValueError as exc:
-            return ToolResult(
-                call_id=call.id, tool_name=call.tool_name,
-                success=False, error=str(exc),
-            )
-
-    return ToolDefinition(
-        name="task_read",
-        description=(
-            "Read the full result of a completed task node. "
-            "Use this when the result summary (shown in task_status) "
-            "is insufficient and you need the complete output. "
-            "For large results, use section to read specific parts."
-        ),
-        trust_level=TrustLevel.SAFE,
-        capabilities=ToolCapability.NONE,
-        input_schema={
-            "type": "object",
-            "properties": {
-                "node_id": {
-                    "type": "string",
-                    "description": "ID of the completed node to read",
-                },
-                "section": {
-                    "type": "string",
-                    "description": (
-                        "Optional filter: 'head' (first 200 lines), 'tail' (last 200 lines), "
-                        "'10-50' (line range), or a keyword to grep for matching lines"
-                    ),
-                },
-            },
-            "required": ["node_id"],
-        },
-        executor=_task_read,
-        tags=["task", "read"],
-        impact_scope="agent",
-        inline_only=True,  # Purpose IS to surface content; spilling defeats it; #197
     )
 
 

--- a/skills/task_list/SKILL.md
+++ b/skills/task_list/SKILL.md
@@ -41,6 +41,12 @@ task_write(todos=[
 - **沒有 result 欄位**：所有實際產出走 `write_file` 寫到磁碟
 - **沒有 depends_on**：順序由你自己讀清單決定
 
+## 紀律：`in_progress` 要主動更新
+
+**開始做一個節點前**，先 `task_write` 把它的 status 從 `pending` 改成 `in_progress`；**做完後**再次 `task_write` 改成 `completed`。框架不會自動推進——這份「自己決定走到哪」的責任感是這個設計的核心精神。
+
+忘了更新也不會壞事，只是節點會留在 `pending`，self-check 會在 turn 結束前 nudge 你。但養成「開始前 → in_progress、做完 → completed」的習慣，看清單時才能立刻知道現在停在哪一步。
+
 ## When to use it
 
 - 多步驟任務（3+ 協調步驟），忘了哪步代價很大

--- a/skills/task_list/SKILL.md
+++ b/skills/task_list/SKILL.md
@@ -1,44 +1,123 @@
 ---
 name: task_list
-description: Multi-step task planning and tracking for the main agent. Use task_plan when a goal needs multiple coordinated steps.
+description: Multi-step todo tracking for the main agent. Use task_write when a goal has 3+ coordinated steps and forgetting one would be costly.
 tags: [core, planning, tracking]
 ---
 
-# TaskList — Core Planning Tool
+# task_write — Your Sticky-Note Board
 
-TaskList is a **cognitive exoskeleton** for the main agent — a checklist you maintain yourself to stay on track during complex multi-step tasks. It is NOT a sub-agent scheduler.
+`task_write` is a **cognitive checklist** for the main agent — a reminder of what's left, not a state container. You rewrite the whole list every time you want to update it.
+
+## Mental Model
+
+```
+┌─────────────────────────────┐
+│ [x] research                │  ← 已完成
+│ [x] dim_a                   │
+│ [→] draft                   │  ← 正在做
+│ [ ] audit                   │  ← 還沒做
+│ [ ] commit                  │
+└─────────────────────────────┘
+```
+
+- 它**不會推著你前進**
+- 它**讓你不會忘記做到哪裡**
+- 每個 turn 開始前掃一眼，知道現在在哪
+- 完成一項就**重寫整張清單**，把那一項的 status 改成 `completed`
+
+## Single Tool
+
+```python
+task_write(todos=[
+    {"id": "research", "content": "蒐集 X 領域論文", "status": "completed"},
+    {"id": "draft",    "content": "撰寫初稿到 tmp/draft.md", "status": "in_progress"},
+    {"id": "audit",    "content": "審稿", "status": "pending"},
+    {"id": "commit",   "content": "寫入磁碟並更新記憶", "status": "pending"},
+])
+```
+
+- **Replace 整張清單**：每次呼叫都傳完整意圖狀態，會覆蓋掉上一份
+- **status enum**：`pending` / `in_progress` / `completed`（可省略，預設 `pending`）
+- **沒有 result 欄位**：所有實際產出走 `write_file` 寫到磁碟
+- **沒有 depends_on**：順序由你自己讀清單決定
 
 ## When to use it
 
-Use `task_plan` when you face a goal that requires more than 2–3 tool calls with dependencies between steps. Examples:
-- A multi-file refactor with a known sequence
-- A research task with distinct analysis phases
-- Any task where forgetting a sub-step would be costly
+- 多步驟任務（3+ 協調步驟），忘了哪步代價很大
+- 跨 turn 追蹤進度
+- 研究 / 寫作 / 重構等需要多階段的工作
 
-**Do NOT use it** for simple one-off actions.
+## When NOT to use it
 
-## Tool Chain
+- 單次就能做完的事
+- 純對話 / 解釋
+- 太瑣碎、追蹤反而加負擔
 
-| Tool | Purpose |
-|------|---------|
-| `task_plan` | Create the list with task nodes |
-| `task_status` | Check current state (who's pending/done/failed) |
-| `task_modify` | Add/remove/update nodes mid-flight |
-| `task_done` | Mark a node completed (with result) or failed (with error) |
-| `task_read` | Pull full result of a completed node (supports section=head/tail/N-M/keyword) |
+## 為什麼沒有 task_done
 
-## Important Rules
+舊版有 `task_done(node_id, result=...)`。這個工具的「動詞」性質造成了**認知置換**：呼叫它感覺像是「向框架回報完成」，即使 result 是空的、檔案根本不存在，agent 心裡也會覺得「我推進了一步」。在長任務裡這個錯覺累積成 issue #205 觀察到的「全部 completed 但報告從未存在」。
 
-- **`depends_on` is documentation only** — harness does not schedule based on it. You read it and decide the order.
-- **Result size limit: 5000 chars** — if your output is longer, write it to a file first and put only the path/summary in the result.
-- **Pre-final-response self-check** — if you try to end your turn with pending nodes, the system will inject a reminder. You must either continue executing or call `task_done(node_id=..., error="reason")` to explicitly abandon.
-- **One agent turn ≈ one node** — do not try to finish 3 nodes in a single assistant message.
-- **If the task is no longer viable**: call `task_done(node_id=..., error="reason")` for each pending node. Do not silently leave work undone.
+`task_write` 是個編輯動作，不是回報動詞。你改的是自己桌上的便利貼，沒有對象、沒有觀眾、沒有儀式感——所以也沒有「報告了 = 做了」的幻覺。
 
-## Result Truncation
+## 真正的產出在哪
 
-When `task_done(result=...)` exceeds 5000 chars, it is hard-truncated. The system adds a notice pointing to the file path — write long outputs to disk and record only the path in the result.
+**所有產出都寫檔案**，TaskList 只記「我有沒有忘記做這步」：
 
-## Abandoning the Whole List
+```python
+# ✅ 正確流程
+write_file("tmp/draft.md", draft_content)        # 產出 → 磁碟
+task_write(todos=[                               # 更新清單
+    ...,
+    {"id": "draft", "content": "...", "status": "completed"},
+    ...,
+])
 
-Currently there is no `task_abandon` tool. To abandon: call `task_done(node_id=..., error="reason")` for each active node. Follow-up Issue #154 may add a dedicated abandon tool.
+# ❌ 錯誤
+task_write(todos=[
+    {"id": "draft", "content": "draft 內容: ...", "status": "completed"},
+    # ← 試圖把產出塞進 content，這違反設計
+])
+```
+
+跨步驟需要傳資料？用約定好的檔名：
+```python
+# step A 寫
+write_file("tmp/research_summary.md", findings)
+
+# step B 讀
+content = read_file("tmp/research_summary.md")
+```
+
+## Pre-final-response self-check
+
+Turn 結束前若你還有 `pending` / `in_progress` 的 todo，框架會注入 reminder 強迫再跑一輪。要結束的話兩條路：
+- 把剩下的事做完
+- 用 `task_write` 重寫清單，把放棄的項目 status 改成 `completed`，並在 content 註明放棄原因
+
+不要靜默結束 turn 留著未完成的事。
+
+## 範例：研究流程
+
+```python
+# 開始時
+task_write(todos=[
+    {"id": "scope",    "content": "與 user 確認研究範圍", "status": "in_progress"},
+    {"id": "dim_a",    "content": "維度 A：寫到 tmp/dim_a.md", "status": "pending"},
+    {"id": "dim_b",    "content": "維度 B：寫到 tmp/dim_b.md", "status": "pending"},
+    {"id": "synth",    "content": "綜合 dim_a + dim_b → tmp/report.md", "status": "pending"},
+    {"id": "commit",   "content": "報告寫入最終位置 + 更新記憶", "status": "pending"},
+])
+
+# scope 完成後
+task_write(todos=[
+    {"id": "scope",    "content": "...", "status": "completed"},
+    {"id": "dim_a",    "content": "...", "status": "in_progress"},
+    {"id": "dim_b",    "content": "...", "status": "pending"},
+    {"id": "synth",    "content": "...", "status": "pending"},
+    {"id": "commit",   "content": "...", "status": "pending"},
+])
+
+# ... 一直 replace 整張到全部 completed
+```
+
+清空清單：`task_write(todos=[])`。


### PR DESCRIPTION
Closes #205.

## Summary

`task_done` 的「動詞」語意造成認知置換 —— 呼叫它感覺像是「向框架回報完成」，即使 `result` 是空的、artifact 不存在。在 7+ 節點的長任務裡，agent 心裡想的是「讓框架前進」而不是「確認產出真的存在」，造成 issue #205 觀察到的「全部 completed 但報告從未存在」失敗。

把 5 個工具（`task_plan` / `task_status` / `task_modify` / `task_done` / `task_read`）收斂成單一的 `task_write` —— agent 重寫整張清單來改變狀態，沒有動詞、沒有儀式感。模型同 Claude Code 的 `TodoWrite`：完成是編輯資料結構，不是呼叫「我做完了」API。

## Design discussion

完整設計討論見 [issue #205 comment](https://github.com/Dakai666/Loom/issues/205#issuecomment-4318620016)。核心論點：
- `task_done` 不只是「沒驗證 artifact」的問題，動詞語意本身就是認知置換源頭
- `result` 欄位徹底消失 → 所有產出**強制走檔案**（`write_file` → `tmp/*.md`）
- artifact 驗證問題（issue #205 P0）**結構上不可能發生**——TaskList 不再代表產出
- `depends_on` + `ready_nodes` 拿掉 → 順序由 agent 自己讀清單決定
- 「框架幫我算下一個」的便利感從一開始就是幻覺源頭，稀釋了「我自己是執行主體」的責任感

## Changes

| 檔案 | 動作 |
|------|------|
| `loom/core/tasks/tasklist.py` | 砍 `result`/`result_summary`/`error`/`depends_on`/`ready()`，留 `id`/`content`/`status`（200→100 行）|
| `loom/core/tasks/manager.py` | 305→80 行：只留 `write()`、`status()`、`has_active_nodes()`、`build_self_check_message()` |
| `loom/platform/cli/tools.py` | 刪 5 個 `make_task_*_tool` + `_verify_task_done` post-validator；新增 `make_task_write_tool`（淨 -380 行）|
| `loom/core/session.py` | 註冊改成單一 `make_task_write_tool`，self-check 訊息文字更新 |
| `loom/core/harness/{registry,middleware}.py`, `loom/core/jobs/scratchpad.py` | 註解清掉 `task_done`/`task_read` 的 spill 排除與 section 引用 |
| `skills/task_list/SKILL.md` | 重寫成單一工具 + file-as-state 的小抄文件 |
| `doc/17-Task-Engine.md` | 重寫為 v0.3.3，包含演進史與設計理由 |
| `doc/18-Task-Scheduler.md` | 移除對 `task_read` 的交叉引用 |

**Self-check middleware** 沿用現有 turn-boundary 機制（`session.py:1580+`，end_turn 條件成立時注入 system reminder），只更新訊息文字指向 `task_write`。

## What you lose

- `depends_on` + `ready_nodes` 自動算下一個節點的「便利感」——但這份便利從一開始就是幻覺的來源，讓 agent 變成動口不動手的協調者
- 跨節點傳資料的 `task_read(summary) + read_file(artifact)` 雙軌——統一收斂為「約定 `tmp/foo.md` 路徑 + read_file」
- `FAILED` 狀態——放棄就把 status 設 `completed` 並在 content 註明 `[放棄] 原因`

## What you gain

- 「假完成」結構上不可能發生（TaskList 不存產出）
- 單一工具，文件大幅簡化
- 認知模型直觀：便利貼牆，自己重寫，沒有對象

## Test plan

- [x] Tests pass：`python -m pytest tests/` → 1075/1076（lone failure 是 pre-existing pyproject version mismatch，與本 PR 無關）
- [x] `tests/test_tasklist.py` 重寫，覆蓋新 API（24 tests）
- [x] `tests/test_tool_verifiers.py` 移除 `task_done` verifier 測試（已刪）
- [x] `tests/test_jit_retrieval.py` 把 `task_read` 範例改為 `task_write`
- [ ] Manual smoke：`loom chat` 跑一個多步驟任務驗證 task_write + self-check 行為
- [ ] Manual：deep_researcher 技能在新 API 下跑一輪研究（local-only skill）

## Notes

- 沒有做 backwards-compat shim：CLAUDE.md 沒提需要，且符合「砍乾淨」精神
- `tests/` 與 `skills/deep_researcher/` 都在 .gitignore 內，本地驗證但不在 PR 範圍
- pre-existing pyproject.toml version bump（0.2.5.1 → 0.3.5.0）造成的 1 個 metadata test failure 不在本 PR 範圍

🤖 Generated with [Claude Code](https://claude.com/claude-code)