### PR TITLE
feat(observability): preserve framework signals — error_context, middleware_trace, mutator failure record (#212)

### DIFF
--- a/loom/core/cognition/skill_mutator.py
+++ b/loom/core/cognition/skill_mutator.py
@@ -27,6 +27,7 @@ PR 2 scope
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -148,6 +149,11 @@ class SkillMutator:
         self._min_suggestions = min_suggestions
         self._max_body_chars = max_body_chars
         self._fast_track_threshold = fast_track_threshold
+        # Issue #212: signal-preserving record of the most recent LLM
+        # failure so the session can surface mutator silence instead of
+        # swallowing it. Each entry: {path, skill, error, error_type,
+        # timestamp}. ``None`` means no failure observed yet.
+        self.last_failure: dict | None = None
 
     # ------------------------------------------------------------------
     # Public
@@ -202,7 +208,21 @@ class SkillMutator:
             )
             raw = (response.text or "").strip()
         except Exception as exc:
-            logger.debug("SkillMutator LLM call failed: %s", exc)
+            # Issue #212: silent LLM failures masked the entire skill
+            # evolution loop. Bump to WARNING with full traceback, and
+            # record on the mutator so callers (session, telemetry) can
+            # see *why* a candidate was not produced.
+            logger.warning(
+                "SkillMutator LLM call failed (skill=%s): %s",
+                parent.name, exc, exc_info=True,
+            )
+            self.last_failure = {
+                "path": "propose_candidate",
+                "skill": parent.name,
+                "error": str(exc),
+                "error_type": type(exc).__name__,
+                "timestamp": time.time(),
+            }
             return None
 
         new_body = _strip_fencing(raw)
@@ -282,7 +302,19 @@ class SkillMutator:
             )
             raw = (response.text or "").strip()
         except Exception as exc:
-            logger.debug("from_batch_diagnostic LLM call failed: %s", exc)
+            # Issue #212: see propose_candidate above — record so the
+            # silence is observable.
+            logger.warning(
+                "from_batch_diagnostic LLM call failed (skill=%s): %s",
+                parent.name, exc, exc_info=True,
+            )
+            self.last_failure = {
+                "path": "from_batch_diagnostic",
+                "skill": parent.name,
+                "error": str(exc),
+                "error_type": type(exc).__name__,
+                "timestamp": time.time(),
+            }
             return None
 
         new_body = _strip_fencing(raw)

--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -12,6 +12,7 @@ Execution order (outermost → innermost):
 import asyncio
 import logging
 import time
+import traceback
 import uuid
 
 _log = logging.getLogger(__name__)
@@ -86,9 +87,35 @@ class ToolResult:
     failure_type: str | None = None   # one of FAILURE_TYPES when success=False
     duration_ms: float = 0.0
     metadata: dict[str, Any] = field(default_factory=dict)
+    # Issue #212: full diagnostic context for tool/middleware exceptions.
+    # ``error`` stays a single line for the agent's prompt; ``error_context``
+    # carries the full traceback (or other structured detail) for telemetry,
+    # forensics, and post-mortem inspection. Always None on success.
+    error_context: str | None = None
 
 
 ToolHandler = Callable[[ToolCall], Awaitable[ToolResult]]
+
+
+# ---------------------------------------------------------------------------
+# Issue #212: middleware signal preservation helpers
+# ---------------------------------------------------------------------------
+
+_TRACE_KEY = "middleware_trace"
+
+
+def _trace_middleware(
+    call: ToolCall, name: str, decision: str, **extra: Any,
+) -> None:
+    """Append a structured decision entry to ``call.metadata['middleware_trace']``.
+
+    Each entry is a small dict so the agent (and post-mortem tooling) can
+    answer "which middleware acted on this call, in what order, with what
+    outcome" without cross-referencing logs and ActionRecords. Cheap by
+    design — one list append per decision point.
+    """
+    trace = call.metadata.setdefault(_TRACE_KEY, [])
+    trace.append({"middleware": name, "decision": decision, **extra})
 
 # ---------------------------------------------------------------------------
 # Middleware base
@@ -236,7 +263,11 @@ class JITRetrievalMiddleware(Middleware):
         except Exception as exc:
             _log.warning(
                 "JIT spill to scratchpad failed for %r: %s — keeping inline.",
-                call.tool_name, exc,
+                call.tool_name, exc, exc_info=True,
+            )
+            _trace_middleware(
+                call, "JITRetrieval", "spill-failed",
+                reason=str(exc), error_context=traceback.format_exc(),
             )
             return result
 
@@ -271,6 +302,7 @@ class JITRetrievalMiddleware(Middleware):
             failure_type=result.failure_type,
             duration_ms=result.duration_ms,
             metadata=new_metadata,
+            error_context=result.error_context,
         )
 
 
@@ -555,6 +587,14 @@ class BlastRadiusMiddleware(Middleware):
         if ctx is not None:
             ctx.authorization_result = result
             ctx.authorization_reason = reason
+        # Issue #212: surface authorization decisions in middleware_trace
+        # so an agent inspecting a denied result can see "BlastRadius said
+        # X because Y" without cross-referencing the lifecycle ActionRecord.
+        _trace_middleware(
+            call, "BlastRadius",
+            "authorize" if result else "deny",
+            reason=reason,
+        )
 
     async def _enter_awaiting_confirm(self, call: ToolCall) -> None:
         """Transition ActionRecord to AWAITING_CONFIRM before prompting user (#109)."""
@@ -633,7 +673,11 @@ class BlastRadiusMiddleware(Middleware):
         except Exception as exc:
             _log.warning(
                 "scope_resolver for %r raised: %s — falling back to legacy",
-                call.tool_name, exc,
+                call.tool_name, exc, exc_info=True,
+            )
+            _trace_middleware(
+                call, "BlastRadius", "scope-resolver-raised",
+                reason=str(exc), error_context=traceback.format_exc(),
             )
             return self._FALLBACK_TO_LEGACY
 
@@ -941,7 +985,12 @@ class LifecycleGateMiddleware(Middleware):
             except Exception as exc:
                 _log.warning(
                     "precondition_check[%d] for %r raised: %s — treating as failed",
-                    i, call.tool_name, exc,
+                    i, call.tool_name, exc, exc_info=True,
+                )
+                _trace_middleware(
+                    call, "LifecycleGate", "precondition-raised",
+                    check_index=i, reason=str(exc),
+                    error_context=traceback.format_exc(),
                 )
                 passed = False
 
@@ -976,6 +1025,10 @@ class LifecycleGateMiddleware(Middleware):
                     )
                 error_text = "\n".join(error_lines)
 
+                _trace_middleware(
+                    call, "LifecycleGate", "precondition-failed",
+                    check_index=i, reason=desc, owner_skill=owner_skill,
+                )
                 await ctx.transition(
                     ActionState.ABORTED,
                     reason=f"Precondition failed: {desc}",
@@ -1030,19 +1083,31 @@ class LifecycleGateMiddleware(Middleware):
                 if exc is not None:
                     # Tool raised instead of returning ToolResult — convert and
                     # continue through OBSERVED so MEMORIALIZED always fires.
+                    tb = "".join(traceback.format_exception(
+                        type(exc), exc, exc.__traceback__,
+                    ))
                     _log.warning(
                         "tool %r raised during abort-raced execution: %s",
-                        call.tool_name, exc,
+                        call.tool_name, exc, exc_info=exc,
+                    )
+                    _trace_middleware(
+                        call, "LifecycleGate", "tool-raised",
+                        reason=str(exc), error_context=tb,
                     )
                     result = ToolResult(
                         call_id=call.id, tool_name=call.tool_name,
                         success=False, error=str(exc),
                         failure_type="execution_error",
+                        error_context=tb,
                     )
                 else:
                     result = exec_task.result()
             else:
                 # Abort signal fired during execution
+                _trace_middleware(
+                    call, "LifecycleGate", "aborted-during-execution",
+                    reason="abort signal during execution",
+                )
                 await ctx.transition(
                     ActionState.ABORTED,
                     reason="abort signal during execution",
@@ -1061,13 +1126,20 @@ class LifecycleGateMiddleware(Middleware):
             except Exception as exc:
                 # Tool raised instead of returning ToolResult — convert and
                 # continue through OBSERVED so MEMORIALIZED always fires.
+                tb = traceback.format_exc()
                 _log.warning(
                     "tool %r raised during execution: %s", call.tool_name, exc,
+                    exc_info=True,
+                )
+                _trace_middleware(
+                    call, "LifecycleGate", "tool-raised",
+                    reason=str(exc), error_context=tb,
                 )
                 result = ToolResult(
                     call_id=call.id, tool_name=call.tool_name,
                     success=False, error=str(exc),
                     failure_type="execution_error",
+                    error_context=tb,
                 )
 
         # ── OBSERVED — executor returned ──────────────────────────────
@@ -1285,7 +1357,12 @@ class LifecycleMiddleware(Middleware):
             except Exception as _val_exc:
                 _log.warning(
                     "post_validator for %r raised unexpectedly: %s — treating as passed",
-                    call.tool_name, _val_exc,
+                    call.tool_name, _val_exc, exc_info=True,
+                )
+                _trace_middleware(
+                    call, "Lifecycle", "post-validator-raised",
+                    reason=str(_val_exc),
+                    error_context=traceback.format_exc(),
                 )
                 raw_verdict = True
 
@@ -1316,11 +1393,21 @@ class LifecycleMiddleware(Middleware):
                         rb_result = await rollback_fn(call, result)
                         record.rollback_result = rb_result
                     except Exception as exc:
+                        tb = traceback.format_exc()
+                        _log.warning(
+                            "rollback_fn for %r raised: %s",
+                            call.tool_name, exc, exc_info=True,
+                        )
+                        _trace_middleware(
+                            call, "Lifecycle", "rollback-raised",
+                            reason=str(exc), error_context=tb,
+                        )
                         record.rollback_result = ToolResult(
                             call_id=call.id,
                             tool_name=call.tool_name,
                             success=False,
                             error=f"Rollback failed: {exc}",
+                            error_context=tb,
                         )
                     await ctx.transition(ActionState.REVERTED)
                     # Rolled-back result — still a semantic failure at heart.

--- a/tests/test_signal_preservation.py
+++ b/tests/test_signal_preservation.py
@@ -1,0 +1,311 @@
+"""
+Issue #212: framework signal preservation.
+
+These tests pin the contract that any place where the harness used to
+swallow a signal (tool exception, middleware decision, mutator LLM
+failure) now produces structured, queryable output.
+
+Scope of this file matches the three actionable items left in #212
+after #196/#197/#205 closed the rest:
+
+* ``ToolResult.error_context`` — full traceback for tool/middleware
+  exceptions, separate from the single-line ``error`` shown to the agent.
+* ``call.metadata["middleware_trace"]`` — append-only list of
+  ``{middleware, decision, …}`` entries so a denied/raised result can be
+  attributed to the middleware that produced the verdict.
+* ``SkillMutator.last_failure`` — non-None record of the most recent
+  silent LLM failure so the skill-evolution loop is no longer invisible.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from loom.core.harness.lifecycle import ActionState
+from loom.core.harness.middleware import (
+    BlastRadiusMiddleware,
+    LifecycleGateMiddleware,
+    LifecycleMiddleware,
+    MiddlewarePipeline,
+    ToolCall,
+    ToolResult,
+)
+from loom.core.harness.permissions import PermissionContext, TrustLevel
+from loom.core.harness.registry import ToolDefinition, ToolRegistry
+from loom.core.harness.validation import SchemaValidationMiddleware
+
+
+# ---------------------------------------------------------------------------
+# Helpers — pared-down versions of the test_lifecycle.py fixtures
+# ---------------------------------------------------------------------------
+
+def _registry(*tools: ToolDefinition) -> ToolRegistry:
+    reg = ToolRegistry()
+    for t in tools:
+        reg.register(t)
+    return reg
+
+
+def _call(tool_name: str, trust_level: TrustLevel = TrustLevel.SAFE) -> ToolCall:
+    return ToolCall(
+        tool_name=tool_name,
+        args={},
+        trust_level=trust_level,
+        session_id="t",
+    )
+
+
+async def _ok(call: ToolCall) -> ToolResult:
+    return ToolResult(
+        call_id=call.id, tool_name=call.tool_name,
+        success=True, output="ok",
+    )
+
+
+def _pipeline(registry: ToolRegistry, perm: PermissionContext | None = None) -> MiddlewarePipeline:
+    perm = perm or PermissionContext(session_id="t")
+    return MiddlewarePipeline([
+        LifecycleMiddleware(registry=registry),
+        SchemaValidationMiddleware(registry=registry),
+        BlastRadiusMiddleware(perm_ctx=perm, confirm_fn=AsyncMock(return_value=True)),
+        LifecycleGateMiddleware(registry=registry),
+    ])
+
+
+# ---------------------------------------------------------------------------
+# #2 — ToolResult.error_context
+# ---------------------------------------------------------------------------
+
+class TestToolResultErrorContext:
+    def test_default_is_none(self) -> None:
+        """Successful results carry no error_context."""
+        r = ToolResult(call_id="c", tool_name="t", success=True, output="x")
+        assert r.error_context is None
+
+    @pytest.mark.asyncio
+    async def test_tool_raise_populates_error_context(self) -> None:
+        """When a tool handler raises, the harness must surface the full
+        traceback in ``error_context`` (not just ``str(exc)`` in ``error``)."""
+        async def boom(call: ToolCall) -> ToolResult:
+            raise RuntimeError("kaboom from tool")
+
+        tool = ToolDefinition(
+            name="bomb", description="",
+            input_schema={}, executor=boom,
+            trust_level=TrustLevel.SAFE,
+        )
+        result = await _pipeline(_registry(tool)).execute(_call("bomb"), boom)
+
+        assert not result.success
+        assert result.failure_type == "execution_error"
+        # The user-facing ``error`` stays compact …
+        assert result.error == "kaboom from tool"
+        # … while ``error_context`` carries the full traceback so
+        # forensics / telemetry can reconstruct the call site.
+        assert result.error_context is not None
+        assert "Traceback" in result.error_context
+        assert "kaboom from tool" in result.error_context
+        # The frame for ``boom`` itself must show up so debugging is real.
+        assert "boom" in result.error_context
+
+    @pytest.mark.asyncio
+    async def test_error_context_survives_jit_spill(self) -> None:
+        """JIT spilling rewrites ``output`` but must not drop
+        ``error_context`` from the wrapped result."""
+        from loom.core.harness.middleware import JITRetrievalMiddleware
+
+        class _Pad:
+            def __init__(self) -> None:
+                self.store: dict[str, str] = {}
+            def write(self, ref: str, value: str) -> None:
+                self.store[ref] = value
+
+        pad = _Pad()
+        jit = JITRetrievalMiddleware(
+            scratchpad=pad, registry=ToolRegistry(), threshold_chars=10,
+        )
+
+        # Use a failure ToolResult with a large output AND error_context
+        # to verify JIT preserves the latter.
+        big_out = "x" * 200
+        async def handler(_: ToolCall) -> ToolResult:
+            return ToolResult(
+                call_id="c", tool_name="t", success=False,
+                output=big_out, error="failed",
+                error_context="Traceback (...): ...",
+            )
+
+        pipeline = MiddlewarePipeline([jit])
+        result = await pipeline.execute(_call("t"), handler)
+
+        # JIT replaced ``output`` with a placeholder …
+        assert result.output != big_out
+        # … but error_context survived intact.
+        assert result.error_context == "Traceback (...): ..."
+
+
+# ---------------------------------------------------------------------------
+# #6 — middleware_trace
+# ---------------------------------------------------------------------------
+
+class TestMiddlewareTrace:
+    @pytest.mark.asyncio
+    async def test_authorize_recorded(self) -> None:
+        """A pre-authorized SAFE tool produces a BlastRadius authorize entry."""
+        tool = ToolDefinition(
+            name="ok", description="",
+            input_schema={}, executor=_ok,
+            trust_level=TrustLevel.SAFE,
+        )
+        call = _call("ok")
+        await _pipeline(_registry(tool)).execute(call, _ok)
+
+        trace = call.metadata.get("middleware_trace", [])
+        decisions = [(e["middleware"], e["decision"]) for e in trace]
+        assert ("BlastRadius", "authorize") in decisions
+
+    @pytest.mark.asyncio
+    async def test_tool_raised_recorded(self) -> None:
+        """A handler that raises must show up in middleware_trace as
+        ``LifecycleGate / tool-raised`` with reason + error_context."""
+        async def boom(call: ToolCall) -> ToolResult:
+            raise ValueError("trace-me")
+
+        tool = ToolDefinition(
+            name="bomb", description="",
+            input_schema={}, executor=boom,
+            trust_level=TrustLevel.SAFE,
+        )
+        call = _call("bomb")
+        await _pipeline(_registry(tool)).execute(call, boom)
+
+        trace = call.metadata.get("middleware_trace", [])
+        raised = [
+            e for e in trace
+            if e["middleware"] == "LifecycleGate"
+            and e["decision"] == "tool-raised"
+        ]
+        assert len(raised) == 1
+        assert raised[0]["reason"] == "trace-me"
+        assert "Traceback" in raised[0]["error_context"]
+
+    @pytest.mark.asyncio
+    async def test_precondition_failure_recorded(self) -> None:
+        """A failing precondition produces a ``precondition-failed`` trace
+        entry that names which check (by index) failed."""
+        async def always_false(_: ToolCall) -> bool:
+            return False
+
+        tool = ToolDefinition(
+            name="gated", description="",
+            input_schema={}, executor=_ok,
+            trust_level=TrustLevel.SAFE,
+            preconditions=["must be true"],
+            precondition_checks=[always_false],
+        )
+        call = _call("gated")
+        await _pipeline(_registry(tool)).execute(call, _ok)
+
+        trace = call.metadata.get("middleware_trace", [])
+        fails = [
+            e for e in trace
+            if e["middleware"] == "LifecycleGate"
+            and e["decision"] == "precondition-failed"
+        ]
+        assert len(fails) == 1
+        assert fails[0]["check_index"] == 0
+        assert fails[0]["reason"] == "must be true"
+
+    @pytest.mark.asyncio
+    async def test_trace_is_ordered(self) -> None:
+        """Trace order matches execution order: BlastRadius authorizes
+        before LifecycleGate fires the tool."""
+        async def boom(call: ToolCall) -> ToolResult:
+            raise RuntimeError("x")
+
+        tool = ToolDefinition(
+            name="bomb", description="",
+            input_schema={}, executor=boom,
+            trust_level=TrustLevel.SAFE,
+        )
+        call = _call("bomb")
+        await _pipeline(_registry(tool)).execute(call, boom)
+
+        trace = call.metadata.get("middleware_trace", [])
+        decisions = [(e["middleware"], e["decision"]) for e in trace]
+        # Authorize must precede tool-raised.
+        i_auth = decisions.index(("BlastRadius", "authorize"))
+        i_raise = decisions.index(("LifecycleGate", "tool-raised"))
+        assert i_auth < i_raise
+
+
+# ---------------------------------------------------------------------------
+# #4 — SkillMutator.last_failure
+# ---------------------------------------------------------------------------
+
+class TestSkillMutatorLastFailure:
+    def test_default_is_none(self) -> None:
+        from loom.core.cognition.skill_mutator import SkillMutator
+        m = SkillMutator(router=AsyncMock(), model="x", enabled=True)
+        assert m.last_failure is None
+
+    @pytest.mark.asyncio
+    async def test_propose_candidate_records_llm_failure(self) -> None:
+        """When the LLM call raises inside ``propose_candidate`` the mutator
+        must (a) still return ``None`` (non-fatal contract preserved) and
+        (b) populate ``last_failure`` so the session can see the silence."""
+        from loom.core.cognition.skill_mutator import SkillMutator
+
+        router = AsyncMock()
+        router.chat.side_effect = RuntimeError("provider 503")
+
+        m = SkillMutator(router=router, model="x", enabled=True, min_suggestions=1)
+
+        parent = SimpleNamespace(name="test-skill", body="# Skill\nbody text", version="v1")
+        diagnostic = SimpleNamespace(
+            mutation_suggestions=["do X"],
+            instructions_violated=[],
+            failure_patterns=[],
+            quality_score=2.0,
+        )
+
+        result = await m.propose_candidate(parent, diagnostic, session_id="s")
+
+        assert result is None
+        assert m.last_failure is not None
+        assert m.last_failure["path"] == "propose_candidate"
+        assert m.last_failure["skill"] == "test-skill"
+        assert m.last_failure["error_type"] == "RuntimeError"
+        assert "503" in m.last_failure["error"]
+        assert isinstance(m.last_failure["timestamp"], float)
+
+    @pytest.mark.asyncio
+    async def test_from_batch_diagnostic_records_llm_failure(self) -> None:
+        """Same contract for the batch path."""
+        from loom.core.cognition.skill_mutator import SkillMutator
+
+        router = AsyncMock()
+        router.chat.side_effect = TimeoutError("router timeout")
+
+        m = SkillMutator(router=router, model="x", enabled=True)
+
+        parent = SimpleNamespace(name="batch-skill", body="# Skill\nbody", version="v1")
+        batch = SimpleNamespace(
+            aggregated_suggestions=["s"],
+            aggregated_violations=[],
+            aggregated_failures=[],
+            improvement=0.05,
+            diagnostics=[],
+        )
+
+        result = await m.from_batch_diagnostic(parent, batch, session_id="s")
+
+        assert result is None
+        assert m.last_failure is not None
+        assert m.last_failure["path"] == "from_batch_diagnostic"
+        assert m.last_failure["skill"] == "batch-skill"
+        assert m.last_failure["error_type"] == "TimeoutError"


### PR DESCRIPTION
Closes part of #212. Companion PR for #213 (Startup Diagnostic Suite) will follow on top.

## Summary

Three actionable signal-loss points from #212. The other three points listed in the issue are already covered on master, so this PR does not close #212 — sets the foundation #213 needs to land on.

| # | Item | Status before | Status after |
|---|------|---------------|--------------|
| 1 | Python stderr 消失 | already merged via `stderr=STDOUT` (cli/tools.py:717,:783) + `_verify_run_bash` python_traceback signal | unchanged |
| 2 | Tool exception → only `error` string | only `str(exc)` survived; `_log.warning("…: %s", exc)` had no `exc_info` | **`ToolResult.error_context: str \| None`** populated with `traceback.format_exc()` at every conversion site; logs now use `exc_info=True` |
| 3 | Shell stderr 混合不一致 | already consistent (both subprocess paths merge stderr) | unchanged |
| 4 | SkillMutator silent | both code paths only `logger.debug("…: %s", exc)` | **`SkillMutator.last_failure`** records `{path, skill, error, error_type, timestamp}`; logs bumped to `WARNING` with `exc_info=True` |
| 5 | jobs_cancel reason | already exposed via `_fmt_job` | unchanged |
| 6 | Middleware execution trace | scattered across `call.metadata` + `ActionRecord`, no flat list | **`call.metadata[\"middleware_trace\"]`** = ordered list of `{middleware, decision, …}` entries |

## Implementation

- `loom/core/harness/middleware.py`
  - `ToolResult` gains `error_context: str | None = None`
  - `_trace_middleware(call, name, decision, **extra)` helper
  - Trace points wired at: BlastRadius authorize/deny + scope-resolver-raised; LifecycleGate precondition-failed / precondition-raised / tool-raised (both abort-raced and direct paths) / aborted-during-execution; outer Lifecycle post-validator-raised / rollback-raised; JITRetrieval spill-failed
  - All five `except Exception as exc:` branches that build a failure `ToolResult` now include `error_context=traceback.format_exc()` and log with `exc_info=True`
  - JIT result reconstruction propagates `error_context` so spilled failures keep their traceback
- `loom/core/cognition/skill_mutator.py`
  - `self.last_failure: dict | None = None` instance attribute (default None)
  - Both `propose_candidate` and `from_batch_diagnostic` exception handlers populate it and bump log level

## Test plan

- [x] `pytest tests/test_signal_preservation.py` — 10 new cases:
  - `error_context` default None on success / populated on tool raise / survives JIT spill
  - `middleware_trace` records BlastRadius authorize / LifecycleGate tool-raised + precondition-failed / order matches execution order
  - `SkillMutator.last_failure` default None / captured on `propose_candidate` LLM failure / captured on `from_batch_diagnostic` LLM failure
- [x] Full suite: 1122 passed (1112 baseline + 10 new), 1 pre-existing version-mismatch deselected.

## Follow-ups

- **#213 Startup Diagnostic Suite** depends on the structured observability surface this PR ships — that's the next PR.
- Tier-3 (threshold-triggered alerts) from #212 is intentionally out of scope here; that's a new feature on top of these signals, not foundational infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)