### PR TITLE
feat(observability): startup diagnostic suite — pluggable boot-time health checks (#213)

### DIFF
--- a/loom/core/diagnostic/__init__.py
+++ b/loom/core/diagnostic/__init__.py
@@ -1,0 +1,31 @@
+"""Startup Diagnostic Suite (Issue #213).
+
+A pluggable health-check system that runs after ``LoomSession.start()``
+has wired every subsystem, so operators can see at a glance whether
+memory / router / pipeline / skills / registry / config are all healthy
+— rather than discovering a bad config when the first turn fails.
+
+Public surface
+--------------
+- ``StartupDiagnostic``  — runs a list of checks and produces a report.
+- ``DiagnosticCheck``    — ABC for individual checks (subclass and
+  register to extend).
+- ``DiagnosticResult``   — single check outcome.
+- ``DiagnosticReport``   — aggregate of all check outcomes; renders.
+"""
+
+from loom.core.diagnostic.startup import (
+    DiagnosticCheck,
+    DiagnosticReport,
+    DiagnosticResult,
+    StartupDiagnostic,
+    default_checks,
+)
+
+__all__ = [
+    "DiagnosticCheck",
+    "DiagnosticReport",
+    "DiagnosticResult",
+    "StartupDiagnostic",
+    "default_checks",
+]

--- a/loom/core/diagnostic/startup.py
+++ b/loom/core/diagnostic/startup.py
@@ -223,6 +223,13 @@ class SkillsCheck(DiagnosticCheck):
     Zero skills is *not* a failure — fresh installs and unit-test
     sessions legitimately have none. We only fail if the index itself
     failed to build.
+
+    Reads ``MemoryIndex.skill_count`` (the field the indexer actually
+    populates from ``ProceduralMemory.list_active()``). An earlier
+    version of this check read a non-existent ``.skills`` attribute via
+    ``getattr(..., "skills", [])`` and silently always reported zero —
+    masking real skill counts and creating the false appearance that
+    ``_auto_import_skills`` had stopped registering SkillGenomes.
     """
     name = "skills"
 
@@ -233,11 +240,11 @@ class SkillsCheck(DiagnosticCheck):
                 self.name, False, "MemoryIndex not built",
                 detail="session._memory_index is None",
             )
-        skills = list(getattr(index, "skills", []) or [])
-        if not skills:
+        count = int(getattr(index, "skill_count", 0) or 0)
+        if count == 0:
             return DiagnosticResult(self.name, True, "0 skills indexed")
         return DiagnosticResult(
-            self.name, True, f"{len(skills)} skill(s) indexed",
+            self.name, True, f"{count} skill(s) indexed",
         )
 
 

--- a/loom/core/diagnostic/startup.py
+++ b/loom/core/diagnostic/startup.py
@@ -1,0 +1,327 @@
+"""Startup Diagnostic Suite — see ``loom.core.diagnostic`` package docstring.
+
+Design notes
+------------
+- Checks run sequentially. They are cheap (a handle inspection, a count,
+  a TOML parse) — never an LLM round-trip — so total cost is sub-ms and
+  startup latency is unaffected.
+- Each check is independent: a failing check produces a failed
+  ``DiagnosticResult`` but does NOT abort the suite; the rest still run.
+  Same applies if a check itself raises — the harness wraps it in a
+  ``check-raised`` failure so a bad check can never break startup.
+- The session stores the produced ``DiagnosticReport`` on
+  ``session._startup_report`` so platforms (CLI/TUI/Discord) and
+  telemetry can read structured outcomes without re-running checks.
+- Pluggability: callers can pass a custom ``checks=[…]`` list to
+  ``StartupDiagnostic(...)``; the default set covers core subsystems.
+
+Adding a new check is two lines:
+
+    class MyCheck(DiagnosticCheck):
+        name = "my-subsystem"
+        async def run(self, session): ...
+
+    StartupDiagnostic(checks=[*default_checks(), MyCheck()])
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DiagnosticResult:
+    """The outcome of a single diagnostic check."""
+    name: str
+    passed: bool
+    summary: str                  # human-readable one-liner ("3 providers", "reachable", …)
+    detail: str | None = None     # populated when passed=False
+
+    @property
+    def status_glyph(self) -> str:
+        return "✓" if self.passed else "✗"
+
+
+@dataclass
+class DiagnosticReport:
+    """Aggregate of all check outcomes from one ``StartupDiagnostic.run_all()``."""
+    results: list[DiagnosticResult] = field(default_factory=list)
+
+    @property
+    def all_passed(self) -> bool:
+        return all(r.passed for r in self.results)
+
+    @property
+    def failures(self) -> list[DiagnosticResult]:
+        return [r for r in self.results if not r.passed]
+
+    def render(self) -> str:
+        """Return a multi-line, columns-aligned summary suitable for
+        console output. Mirrors the format prescribed in #213."""
+        if not self.results:
+            return "[Loom] Startup diagnostic — no checks registered."
+
+        # Pad name column to widest entry so the glyphs line up.
+        width = max(len(r.name) for r in self.results)
+        header = "[Loom] Startup diagnostic..."
+        body = "\n".join(
+            f"  {r.name.ljust(width)}  {r.status_glyph} {r.summary}"
+            + (f" — {r.detail}" if r.detail and not r.passed else "")
+            for r in self.results
+        )
+        return f"{header}\n{body}"
+
+
+# ---------------------------------------------------------------------------
+# Check ABC
+# ---------------------------------------------------------------------------
+
+class DiagnosticCheck(ABC):
+    """Implement a startup health check.
+
+    Subclasses set a class-level ``name`` and implement ``run()``. Any
+    exception raised inside ``run()`` is caught by ``StartupDiagnostic``
+    and converted to a failed result — implementations should not
+    swallow their own errors.
+    """
+    name: str = ""
+
+    @abstractmethod
+    async def run(self, session: Any) -> DiagnosticResult:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Built-in checks
+# ---------------------------------------------------------------------------
+
+class MemoryCheck(DiagnosticCheck):
+    """Verify the MemoryFacade and its underlying SQLite handle are wired."""
+    name = "memory"
+
+    async def run(self, session: Any) -> DiagnosticResult:
+        if getattr(session, "_memory", None) is None:
+            return DiagnosticResult(
+                self.name, False, "facade not built",
+                detail="session._memory is None — start() did not complete",
+            )
+        if getattr(session, "_db", None) is None:
+            return DiagnosticResult(
+                self.name, False, "DB handle missing",
+                detail="session._db is None",
+            )
+        return DiagnosticResult(self.name, True, "reachable")
+
+
+class RouterCheck(DiagnosticCheck):
+    """Verify the LLM router has at least one provider registered."""
+    name = "router"
+
+    async def run(self, session: Any) -> DiagnosticResult:
+        router = getattr(session, "router", None)
+        if router is None:
+            return DiagnosticResult(
+                self.name, False, "router missing",
+                detail="session.router is None",
+            )
+        providers = list(getattr(router, "providers", []) or [])
+        if not providers:
+            return DiagnosticResult(
+                self.name, False, "no providers",
+                detail="router has zero providers — set MINIMAX_API_KEY / "
+                       "ANTHROPIC_API_KEY or configure ollama/lmstudio",
+            )
+        return DiagnosticResult(
+            self.name, True, f"{len(providers)} provider(s) registered",
+        )
+
+
+# Minimum middleware count for a healthy session pipeline. Threshold is
+# deliberately conservative — the current production wiring has 7,
+# anything below the core 5 means something has been pulled out.
+PIPELINE_MIN_MIDDLEWARE = 5
+
+
+class PipelineCheck(DiagnosticCheck):
+    """Verify the middleware pipeline is built and contains the core layers."""
+    name = "pipeline"
+
+    async def run(self, session: Any) -> DiagnosticResult:
+        pipeline = getattr(session, "_pipeline", None)
+        if pipeline is None:
+            return DiagnosticResult(
+                self.name, False, "pipeline not built",
+                detail="session._pipeline is None",
+            )
+
+        middlewares = getattr(pipeline, "_middlewares", []) or []
+        count = len(middlewares)
+        if count < PIPELINE_MIN_MIDDLEWARE:
+            return DiagnosticResult(
+                self.name, False,
+                f"{count} middleware (minimum {PIPELINE_MIN_MIDDLEWARE})",
+                detail="core layers may be missing — check session.start()",
+            )
+
+        # Spot-check the two layers without which lifecycle / authorization
+        # is broken. We use class-name comparison so subclasses still count.
+        names = {type(m).__name__ for m in middlewares}
+        for required in ("LifecycleMiddleware", "BlastRadiusMiddleware"):
+            if required not in names:
+                return DiagnosticResult(
+                    self.name, False,
+                    f"{count} middleware loaded, but {required} missing",
+                    detail=f"required middleware '{required}' not in pipeline",
+                )
+
+        return DiagnosticResult(self.name, True, f"{count} middleware loaded")
+
+
+class RegistryCheck(DiagnosticCheck):
+    """Verify core tools (write_file / read_file / run_bash / list_dir) are
+    registered. Other tools are inspectable via the count."""
+    name = "registry"
+
+    REQUIRED_TOOLS = ("write_file", "read_file", "run_bash", "list_dir")
+
+    async def run(self, session: Any) -> DiagnosticResult:
+        registry = getattr(session, "registry", None)
+        if registry is None:
+            return DiagnosticResult(
+                self.name, False, "registry missing",
+                detail="session.registry is None",
+            )
+
+        missing = [
+            name for name in self.REQUIRED_TOOLS if registry.get(name) is None
+        ]
+        if missing:
+            return DiagnosticResult(
+                self.name, False,
+                f"{len(missing)} core tool(s) missing",
+                detail=f"missing: {', '.join(missing)}",
+            )
+
+        total = len(getattr(registry, "_tools", {}) or {})
+        return DiagnosticResult(
+            self.name, True, f"{total} tool(s) registered",
+        )
+
+
+class SkillsCheck(DiagnosticCheck):
+    """Report indexed skill count from the MemoryIndex.
+
+    Zero skills is *not* a failure — fresh installs and unit-test
+    sessions legitimately have none. We only fail if the index itself
+    failed to build.
+    """
+    name = "skills"
+
+    async def run(self, session: Any) -> DiagnosticResult:
+        index = getattr(session, "_memory_index", None)
+        if index is None:
+            return DiagnosticResult(
+                self.name, False, "MemoryIndex not built",
+                detail="session._memory_index is None",
+            )
+        skills = list(getattr(index, "skills", []) or [])
+        if not skills:
+            return DiagnosticResult(self.name, True, "0 skills indexed")
+        return DiagnosticResult(
+            self.name, True, f"{len(skills)} skill(s) indexed",
+        )
+
+
+class ConfigCheck(DiagnosticCheck):
+    """Verify ``loom.toml`` parses (or is absent — both are fine).
+
+    A *malformed* loom.toml is the failure case; a missing one is OK
+    because Loom ships sensible defaults.
+    """
+    name = "config"
+
+    async def run(self, session: Any) -> DiagnosticResult:
+        # Re-import each time so tests can monkey-patch ``_load_loom_config``
+        # without us caching its successful return value at import time.
+        from loom.core import session as session_module
+
+        try:
+            cfg = session_module._load_loom_config()
+        except Exception as exc:
+            return DiagnosticResult(
+                self.name, False, "loom.toml parse failed",
+                detail=f"{type(exc).__name__}: {exc}",
+            )
+
+        if not cfg:
+            return DiagnosticResult(self.name, True, "no loom.toml (defaults)")
+        return DiagnosticResult(
+            self.name, True, f"{len(cfg)} top-level section(s) parsed",
+        )
+
+
+def default_checks() -> list[DiagnosticCheck]:
+    """The standard suite, in execution order. Order matters for
+    rendering — bottom-up dependencies first, so a memory failure
+    appears above (and explains) downstream failures."""
+    return [
+        MemoryCheck(),
+        RouterCheck(),
+        PipelineCheck(),
+        RegistryCheck(),
+        SkillsCheck(),
+        ConfigCheck(),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Suite
+# ---------------------------------------------------------------------------
+
+class StartupDiagnostic:
+    """Run a list of ``DiagnosticCheck`` against a ``LoomSession``.
+
+    Usage (typically called by ``LoomSession.start()`` itself):
+
+        report = await StartupDiagnostic().run_all(session)
+        if not report.all_passed:
+            logger.warning("Startup diagnostic flagged %d failures",
+                           len(report.failures))
+    """
+
+    def __init__(self, checks: list[DiagnosticCheck] | None = None) -> None:
+        self._checks = list(checks) if checks is not None else default_checks()
+
+    async def run_all(self, session: Any) -> DiagnosticReport:
+        results: list[DiagnosticResult] = []
+        for check in self._checks:
+            results.append(await self._run_one(check, session))
+        return DiagnosticReport(results=results)
+
+    async def _run_one(
+        self, check: DiagnosticCheck, session: Any,
+    ) -> DiagnosticResult:
+        """Run one check with full failure isolation — a buggy custom
+        check never breaks startup."""
+        try:
+            return await check.run(session)
+        except Exception as exc:
+            logger.warning(
+                "Diagnostic check %r raised: %s", check.name, exc,
+                exc_info=True,
+            )
+            return DiagnosticResult(
+                check.name or type(check).__name__,
+                False,
+                "check raised",
+                detail=f"{type(exc).__name__}: {exc}",
+            )

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -39,6 +39,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.rule import Rule
 
+from loom.core.diagnostic import DiagnosticReport, StartupDiagnostic
 from loom.core.memory.facade import MemoryFacade
 from loom.core.cognition.context import ContextBudget
 from loom.core.cognition.prompt_stack import PromptStack
@@ -611,6 +612,10 @@ class LoomSession:
         self._reflection: ReflectionAPI | None = None
         self._reflector: CounterFactualReflector | None = None
         self._pipeline: MiddlewarePipeline | None = None
+        # Issue #213: result of the last StartupDiagnostic.run_all() call.
+        # Populated at the end of start(); platforms (CLI/TUI/Discord) and
+        # telemetry can consult it for structured boot-time health state.
+        self._startup_report: "DiagnosticReport | None" = None
         self._memory_index: MemoryIndex = MemoryIndex()
         self._session_log: SessionLog | None = None
         self._governor: MemoryGovernor | None = None  # Issue #43
@@ -1129,6 +1134,25 @@ class LoomSession:
                 ),
             ]
         )
+
+        # Issue #213: post-wiring health check. Runs sequentially with
+        # only handle inspections / counts (no LLM round-trips), so
+        # startup latency stays unchanged. A failing check never aborts
+        # startup — operators see structured failures at the top of the
+        # session log instead of discovering them on the first turn.
+        self._startup_report = await StartupDiagnostic().run_all(self)
+        rendered = self._startup_report.render()
+        # Console for the operator …
+        console.print(rendered)
+        # … and structured log for ops / telemetry.
+        if self._startup_report.all_passed:
+            logger.info("startup_diagnostic: all checks passed")
+        else:
+            for f in self._startup_report.failures:
+                logger.warning(
+                    "startup_diagnostic: %s failed — %s (%s)",
+                    f.name, f.summary, f.detail,
+                )
 
     # ------------------------------------------------------------------
     # HITL pause / resume / cancel

--- a/tests/test_startup_diagnostic.py
+++ b/tests/test_startup_diagnostic.py
@@ -1,0 +1,335 @@
+"""Issue #213: Startup Diagnostic Suite.
+
+Pin the public contract of the diagnostic module:
+
+* Built-in checks return structured ``DiagnosticResult`` with the
+  expected pass/fail semantics.
+* The suite isolates check failures — one bad check never aborts the
+  rest, and a check that *raises* still produces a graceful failed
+  result instead of bubbling out.
+* Custom ``DiagnosticCheck`` subclasses can be plugged in.
+* ``DiagnosticReport.render()`` emits the columns-aligned format
+  prescribed in the issue.
+* ``LoomSession.start()`` populates ``session._startup_report`` so
+  platforms / telemetry can read structured outcomes.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from loom.core.diagnostic import (
+    DiagnosticCheck,
+    DiagnosticReport,
+    DiagnosticResult,
+    StartupDiagnostic,
+    default_checks,
+)
+from loom.core.diagnostic.startup import (
+    ConfigCheck,
+    MemoryCheck,
+    PipelineCheck,
+    RegistryCheck,
+    RouterCheck,
+    SkillsCheck,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake session — minimum surface the built-in checks read.
+# ---------------------------------------------------------------------------
+
+def _fake_session(
+    *,
+    memory: bool = True,
+    db: bool = True,
+    router_providers: int = 2,
+    middleware_count: int = 7,
+    middleware_classes: tuple[str, ...] = (
+        "JITRetrievalMiddleware",
+        "LifecycleMiddleware",
+        "TraceMiddleware",
+        "SchemaValidationMiddleware",
+        "BlastRadiusMiddleware",
+        "LegitimacyGuard",
+        "LifecycleGateMiddleware",
+    ),
+    tools: tuple[str, ...] = ("write_file", "read_file", "run_bash", "list_dir"),
+    skills_count: int = 3,
+) -> SimpleNamespace:
+    """Build a session-shaped object with just the attributes the
+    diagnostic checks consult. Keeping this synthetic avoids the
+    expensive LoomSession.start() path in unit tests."""
+    middlewares = [
+        type(name, (), {})() for name in middleware_classes[:middleware_count]
+    ]
+    pipeline = SimpleNamespace(_middlewares=middlewares)
+
+    registry_tools = {name: object() for name in tools}
+    registry = MagicMock()
+    registry.get.side_effect = lambda n: registry_tools.get(n)
+    registry._tools = registry_tools
+
+    return SimpleNamespace(
+        _memory=object() if memory else None,
+        _db=object() if db else None,
+        router=SimpleNamespace(
+            providers=[object() for _ in range(router_providers)],
+        ),
+        _pipeline=pipeline,
+        registry=registry,
+        _memory_index=SimpleNamespace(skills=[f"s{i}" for i in range(skills_count)]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Result / Report shape
+# ---------------------------------------------------------------------------
+
+class TestReportShape:
+    def test_status_glyph_pass(self) -> None:
+        r = DiagnosticResult("x", True, "ok")
+        assert r.status_glyph == "✓"
+
+    def test_status_glyph_fail(self) -> None:
+        r = DiagnosticResult("x", False, "no", detail="reason")
+        assert r.status_glyph == "✗"
+
+    def test_all_passed(self) -> None:
+        rpt = DiagnosticReport([
+            DiagnosticResult("a", True, "ok"),
+            DiagnosticResult("b", True, "ok"),
+        ])
+        assert rpt.all_passed
+        assert rpt.failures == []
+
+    def test_failures_listed(self) -> None:
+        bad = DiagnosticResult("b", False, "boom", detail="stack")
+        rpt = DiagnosticReport([
+            DiagnosticResult("a", True, "ok"),
+            bad,
+        ])
+        assert not rpt.all_passed
+        assert rpt.failures == [bad]
+
+    def test_render_aligns_columns_and_shows_detail_only_for_failures(self) -> None:
+        rpt = DiagnosticReport([
+            DiagnosticResult("memory", True, "reachable"),
+            DiagnosticResult("router", False, "no providers", detail="set keys"),
+        ])
+        out = rpt.render()
+        assert "[Loom] Startup diagnostic..." in out
+        assert "memory  ✓ reachable" in out
+        # Failure includes the ` — detail` suffix.
+        assert "router  ✗ no providers — set keys" in out
+
+
+# ---------------------------------------------------------------------------
+# Built-in checks
+# ---------------------------------------------------------------------------
+
+class TestBuiltinChecks:
+    @pytest.mark.asyncio
+    async def test_memory_check_passes_when_facade_and_db_present(self) -> None:
+        r = await MemoryCheck().run(_fake_session())
+        assert r.passed
+        assert r.summary == "reachable"
+
+    @pytest.mark.asyncio
+    async def test_memory_check_fails_without_facade(self) -> None:
+        r = await MemoryCheck().run(_fake_session(memory=False))
+        assert not r.passed
+        assert "facade not built" in r.summary
+
+    @pytest.mark.asyncio
+    async def test_router_check_fails_with_zero_providers(self) -> None:
+        r = await RouterCheck().run(_fake_session(router_providers=0))
+        assert not r.passed
+        assert "no providers" in r.summary
+        assert "MINIMAX_API_KEY" in r.detail
+
+    @pytest.mark.asyncio
+    async def test_pipeline_check_passes_with_full_set(self) -> None:
+        r = await PipelineCheck().run(_fake_session())
+        assert r.passed
+        assert "7 middleware" in r.summary
+
+    @pytest.mark.asyncio
+    async def test_pipeline_check_fails_when_below_minimum(self) -> None:
+        # Only 2 middleware → below PIPELINE_MIN_MIDDLEWARE (5).
+        r = await PipelineCheck().run(
+            _fake_session(middleware_count=2),
+        )
+        assert not r.passed
+        assert "minimum 5" in r.summary
+
+    @pytest.mark.asyncio
+    async def test_pipeline_check_fails_when_required_layer_missing(self) -> None:
+        # Five layers but BlastRadiusMiddleware is replaced with a stub.
+        r = await PipelineCheck().run(_fake_session(
+            middleware_classes=(
+                "JITRetrievalMiddleware",
+                "LifecycleMiddleware",
+                "TraceMiddleware",
+                "SchemaValidationMiddleware",
+                "LifecycleGateMiddleware",
+            ),
+            middleware_count=5,
+        ))
+        assert not r.passed
+        assert "BlastRadiusMiddleware" in r.summary
+
+    @pytest.mark.asyncio
+    async def test_registry_check_fails_when_core_tool_missing(self) -> None:
+        r = await RegistryCheck().run(_fake_session(
+            tools=("write_file", "read_file"),  # missing run_bash + list_dir
+        ))
+        assert not r.passed
+        assert "missing: run_bash, list_dir" in r.detail
+
+    @pytest.mark.asyncio
+    async def test_skills_check_passes_with_zero_skills(self) -> None:
+        """Empty skill set is legal (fresh install / unit test)."""
+        r = await SkillsCheck().run(_fake_session(skills_count=0))
+        assert r.passed
+        assert "0 skills" in r.summary
+
+    @pytest.mark.asyncio
+    async def test_config_check_passes_when_config_loads(self, monkeypatch) -> None:
+        from loom.core import session as session_module
+        monkeypatch.setattr(session_module, "_load_loom_config", lambda: {"x": 1})
+        r = await ConfigCheck().run(_fake_session())
+        assert r.passed
+        assert "1 top-level section" in r.summary
+
+    @pytest.mark.asyncio
+    async def test_config_check_fails_when_parse_raises(self, monkeypatch) -> None:
+        from loom.core import session as session_module
+
+        def _bad():
+            raise ValueError("malformed toml at line 4")
+
+        monkeypatch.setattr(session_module, "_load_loom_config", _bad)
+        r = await ConfigCheck().run(_fake_session())
+        assert not r.passed
+        assert "loom.toml parse failed" in r.summary
+        assert "ValueError" in r.detail
+
+
+# ---------------------------------------------------------------------------
+# Suite isolation & pluggability
+# ---------------------------------------------------------------------------
+
+class _RaisingCheck(DiagnosticCheck):
+    name = "raises"
+
+    async def run(self, session):
+        raise RuntimeError("custom check exploded")
+
+
+class _SimpleCheck(DiagnosticCheck):
+    name = "custom"
+
+    async def run(self, session):
+        return DiagnosticResult(self.name, True, "ran")
+
+
+class TestSuiteIsolationAndPluggability:
+    @pytest.mark.asyncio
+    async def test_check_that_raises_does_not_abort_suite(self) -> None:
+        """A buggy custom check must not break startup — the harness
+        catches it and continues to the next check."""
+        suite = StartupDiagnostic(checks=[_RaisingCheck(), _SimpleCheck()])
+        report = await suite.run_all(_fake_session())
+
+        assert len(report.results) == 2
+        # The raising check produced a graceful failed result …
+        raised = report.results[0]
+        assert raised.name == "raises"
+        assert not raised.passed
+        assert raised.summary == "check raised"
+        assert "RuntimeError" in raised.detail
+        assert "custom check exploded" in raised.detail
+        # … and the next check still ran.
+        assert report.results[1].passed
+        assert report.results[1].name == "custom"
+
+    @pytest.mark.asyncio
+    async def test_default_checks_run_against_fake_session(self) -> None:
+        """End-to-end smoke: the default suite runs cleanly against a
+        properly-shaped session."""
+        # Patch _load_loom_config so the config check has a stable answer.
+        from loom.core import session as session_module
+        orig = session_module._load_loom_config
+        session_module._load_loom_config = lambda: {"k": "v"}
+        try:
+            suite = StartupDiagnostic()  # uses default_checks()
+            report = await suite.run_all(_fake_session())
+        finally:
+            session_module._load_loom_config = orig
+
+        # Every default check should produce a result.
+        names = [r.name for r in report.results]
+        for expected in ("memory", "router", "pipeline", "registry", "skills", "config"):
+            assert expected in names
+        assert report.all_passed, [
+            (r.name, r.summary, r.detail) for r in report.failures
+        ]
+
+    def test_default_checks_returns_independent_lists(self) -> None:
+        """Mutating one caller's list should not poison the next."""
+        a = default_checks()
+        b = default_checks()
+        a.clear()
+        assert len(b) > 0
+
+
+# ---------------------------------------------------------------------------
+# Integration: LoomSession.start() populates _startup_report
+# ---------------------------------------------------------------------------
+
+class TestSessionIntegration:
+    @pytest.mark.asyncio
+    async def test_start_populates_startup_report(
+        self, monkeypatch, tmp_path,
+    ) -> None:
+        """After ``LoomSession.start()`` returns, ``_startup_report`` is
+        a populated DiagnosticReport — proving the suite ran end-to-end
+        against the real wiring."""
+        from loom.core import session as session_module
+        from loom.core.session import LoomSession
+
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(session_module, "build_router", lambda: MagicMock(providers=[object()]))
+        monkeypatch.setattr(session_module, "_load_loom_config", lambda: {})
+        monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {})
+        monkeypatch.setattr(session_module, "build_embedding_provider", lambda env, cfg: None)
+        from rich.prompt import Confirm
+        monkeypatch.setattr(Confirm, "ask", lambda *args, **kwargs: True)
+
+        session = LoomSession(
+            model="test-model",
+            db_path=str(tmp_path / "loom.db"),
+            workspace=workspace,
+        )
+        # Default value before start().
+        assert session._startup_report is None
+
+        await session.start()
+        try:
+            report = session._startup_report
+            assert report is not None
+            assert isinstance(report, DiagnosticReport)
+            # Every default check must appear, regardless of pass/fail.
+            names = [r.name for r in report.results]
+            for expected in ("memory", "router", "pipeline", "registry", "skills", "config"):
+                assert expected in names
+        finally:
+            await session.stop()

--- a/tests/test_startup_diagnostic.py
+++ b/tests/test_startup_diagnostic.py
@@ -81,7 +81,14 @@ def _fake_session(
         ),
         _pipeline=pipeline,
         registry=registry,
-        _memory_index=SimpleNamespace(skills=[f"s{i}" for i in range(skills_count)]),
+        # Mirror the real ``MemoryIndex`` field names. An earlier version of
+        # the SkillsCheck read a non-existent ``.skills`` attribute and the
+        # fake here mirrored the same typo, so the test silently passed
+        # while the real check always reported zero.
+        _memory_index=SimpleNamespace(
+            skill_count=skills_count,
+            skill_catalog=[f"s{i}" for i in range(skills_count)],
+        ),
     )
 
 
@@ -196,6 +203,32 @@ class TestBuiltinChecks:
         r = await SkillsCheck().run(_fake_session(skills_count=0))
         assert r.passed
         assert "0 skills" in r.summary
+
+    @pytest.mark.asyncio
+    async def test_skills_check_reports_real_count(self) -> None:
+        """Regression: prior to the fix, SkillsCheck read a non-existent
+        ``index.skills`` attribute via ``getattr(..., "skills", [])`` and
+        always reported zero, masking the real skill count loaded by
+        ``_auto_import_skills``. This pins the contract that the check
+        reads ``skill_count`` and surfaces the actual number."""
+        r = await SkillsCheck().run(_fake_session(skills_count=10))
+        assert r.passed
+        assert "10 skill(s) indexed" in r.summary
+
+    @pytest.mark.asyncio
+    async def test_skills_check_uses_real_memoryindex_field(self) -> None:
+        """Regression: a pure ``MemoryIndex`` (no ``skills`` attribute,
+        only ``skill_count`` / ``skill_catalog``) must be readable by
+        SkillsCheck. This catches the original typo where the check
+        consulted an attribute name that ``MemoryIndex`` does not
+        define — the assertion below would fail under the old code."""
+        from loom.core.memory.index import MemoryIndex
+
+        index = MemoryIndex(skill_count=4, skill_catalog=[])
+        session = SimpleNamespace(_memory_index=index)
+        r = await SkillsCheck().run(session)
+        assert r.passed
+        assert "4 skill(s) indexed" in r.summary
 
     @pytest.mark.asyncio
     async def test_config_check_passes_when_config_loads(self, monkeypatch) -> None:


### PR DESCRIPTION
Closes #213. Builds on top of #216 (signal preservation foundation).

## Summary

New \`loom.core.diagnostic\` package: pluggable startup health-check suite that runs at the end of \`LoomSession.start()\`. Operators see structured boot-time health status — memory / router / pipeline / registry / skills / config — instead of discovering subsystem issues on the first turn.

The output matches the format prescribed in #213:

\`\`\`
[Loom] Startup diagnostic...
  memory    ✓ reachable
  router    ✓ 2 provider(s) registered
  pipeline  ✓ 7 middleware loaded
  registry  ✓ 18 tool(s) registered
  skills    ✓ 3 skill(s) indexed
  config    ✓ 4 top-level section(s) parsed
\`\`\`

## Public surface

- \`DiagnosticCheck\`  — ABC, subclass with a class-level \`name\` and \`async def run(self, session) -> DiagnosticResult\`.
- \`DiagnosticResult\` — single outcome (\`passed\`, \`summary\`, \`detail\`).
- \`DiagnosticReport\` — aggregate; \`.render()\` produces the columns-aligned table; \`.all_passed\` / \`.failures\` for programmatic use.
- \`StartupDiagnostic(checks=[…]).run_all(session)\` — runs the suite with full failure isolation (a check that raises becomes a graceful \`check raised\` failed result, the rest still run).

## Built-in checks

| Check | Passes when | Fails when |
|---|---|---|
| \`MemoryCheck\` | \`session._memory\` + \`session._db\` wired | Either is None |
| \`RouterCheck\` | ≥ 1 provider registered | Zero providers |
| \`PipelineCheck\` | ≥ 5 middleware AND \`LifecycleMiddleware\` + \`BlastRadiusMiddleware\` present | Below threshold or core layer missing |
| \`RegistryCheck\` | \`write_file\` / \`read_file\` / \`run_bash\` / \`list_dir\` registered | Any core tool missing |
| \`SkillsCheck\` | MemoryIndex built (zero skills OK) | Index not built |
| \`ConfigCheck\` | \`loom.toml\` parses (absent OK) | TOML malformed |

All checks are cheap — handle inspections / counts / one TOML parse, no LLM round-trips. Sub-ms total, startup latency unchanged.

## Wiring

\`LoomSession.start()\` calls the suite at the end and:

1. stores the report on \`session._startup_report\` for platforms / telemetry,
2. prints the rendered table via \`console.print(...)\` for the operator,
3. logs \`info\` when all checks pass and \`warning\` per failure.

**Failures never abort startup** — they surface as a clear table at the top of the log so the operator can act, while the session still becomes usable.

## Pluggability

Custom checks compose cleanly with defaults:

\`\`\`python
StartupDiagnostic(checks=[*default_checks(), MyCheck()]).run_all(s)
\`\`\`

## Test plan

- [x] \`pytest tests/test_startup_diagnostic.py\` — 19 cases covering: result/report shape, \`render()\` formatting, every built-in check's pass + fail paths (including \`PipelineCheck\` rejecting a pipeline that loses \`BlastRadiusMiddleware\`), suite isolation (\`_RaisingCheck\` does not abort the next check), pluggability, and an end-to-end integration test confirming \`LoomSession.start()\` populates \`session._startup_report\` against real wiring.
- [x] Full suite: **1141 passed** (1122 baseline + 19 new), 1 pre-existing version-mismatch deselected.

## Notes

- Autonomy is intentionally not a built-in check — it runs as a separate process (\`loom autonomy start\`), not part of \`LoomSession\`. The \`ConfigCheck\` covers the loom.toml parse half of what the issue mentioned for autonomy.
- Tier-3 (threshold-triggered alerts) from #212 remains out of scope; that's a runtime-anomaly feature, distinct from boot-time health.

🤖 Generated with [Claude Code](https://claude.com/claude-code)