### PR TITLE
fix(session): enforce tool_use ↔ tool_result adjacency in sanitize (#218 Tier 1)

### DIFF
--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -2565,6 +2565,44 @@ class LoomSession:
             keep2.append(msg)
         self.messages = keep2
 
+        # Pass 4 (Issue #218): enforce tool_use ↔ tool_result adjacency.
+        # Anthropic API requires every assistant tool_use to be immediately
+        # followed by a user message containing the matching tool_result.
+        # Out-of-order pairs (both exist but separated by other messages) trigger
+        # 2013 even though Pass 2/3 are happy. Producer: a long-running tool
+        # subprocess kept running past a user interrupt / abort and its late
+        # result was appended after subsequent turns had already advanced.
+        # Repair strategy: index every tool result by tool_call_id, then re-emit
+        # canonical messages with each assistant's results pulled adjacent.
+        result_by_id: dict[str, dict] = {}
+        for msg in self.messages:
+            if msg.get("role") == "tool":
+                tid = msg.get("tool_call_id")
+                if tid:
+                    result_by_id[tid] = msg
+
+        emitted_result_ids: set[str] = set()
+        keep3: list[dict] = []
+        for msg in self.messages:
+            role = msg.get("role")
+            if role == "tool":
+                if msg.get("tool_call_id") in emitted_result_ids:
+                    continue  # already emitted adjacent to its assistant
+                # Result reached here without being emitted means its assistant
+                # has no tool_call referencing it — Pass 3 should have caught
+                # this, drop defensively.
+                continue
+            if role == "assistant" and msg.get("tool_calls"):
+                keep3.append(msg)
+                for tc in msg["tool_calls"]:
+                    tid = tc.get("id")
+                    if tid and tid in result_by_id and tid not in emitted_result_ids:
+                        keep3.append(result_by_id[tid])
+                        emitted_result_ids.add(tid)
+                continue
+            keep3.append(msg)
+        self.messages = keep3
+
     def _telemetry_record_tool(
         self,
         tool_name: str,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -560,3 +560,100 @@ class TestStreamTurnLock:
         session._turn_lock.release()
         with contextlib.suppress(BaseException):
             await task
+
+
+class TestSanitizeHistoryAdjacency:
+    """Pass 4 (Issue #218): tool_use ↔ tool_result adjacency repair.
+
+    Anthropic API rejects (2013) any assistant tool_use not immediately
+    followed by its tool_result. Pass 2/3 only check existence anywhere;
+    Pass 4 enforces position so out-of-order pairs (e.g. late subprocess
+    completion appended after subsequent turns) are repaired.
+    """
+
+    def _call(self, cid: str, name: str = "run_bash") -> dict:
+        return {
+            "id": cid,
+            "type": "function",
+            "function": {"name": name, "arguments": "{}"},
+        }
+
+    def _asst(self, cids: list[str]) -> dict:
+        return {"role": "assistant", "content": "", "tool_calls": [self._call(c) for c in cids]}
+
+    def _tool(self, cid: str, content: str = "ok") -> dict:
+        return {"role": "tool", "tool_call_id": cid, "content": content}
+
+    def _from_loom_session(self, messages: list[dict]) -> list[dict]:
+        from loom.core.session import LoomSession
+        fake = SimpleNamespace()
+        fake.messages = [dict(m) for m in messages]
+        LoomSession._sanitize_history(fake)
+        return fake.messages
+
+    def test_late_arriving_tool_result_is_pulled_adjacent(self):
+        # Producer: user interrupted while T1 was running; harness ran T2/T3;
+        # T1's late result was appended after T3.
+        msgs = [
+            {"role": "user", "content": "go"},
+            self._asst(["T1"]),
+            {"role": "user", "content": "interrupt"},
+            self._asst(["T2"]),
+            self._tool("T2"),
+            self._asst(["T3"]),
+            self._tool("T3"),
+            self._tool("T1"),  # ← late
+        ]
+        out = self._from_loom_session(msgs)
+        # Each assistant tool_call must be immediately followed by its result.
+        for i, m in enumerate(out):
+            if m.get("role") == "assistant" and m.get("tool_calls"):
+                cids = [tc["id"] for tc in m["tool_calls"]]
+                followers = out[i+1 : i+1+len(cids)]
+                follower_ids = [f.get("tool_call_id") for f in followers]
+                assert set(follower_ids) == set(cids), \
+                    f"assistant {cids} not immediately followed by results, got {follower_ids}"
+
+    def test_two_consecutive_assistants_repaired(self):
+        # Producer (no user interrupt): cancel/timeout left T1 dispatched but
+        # not awaited; harness moved to T2; T1's late result arrived after T2.
+        msgs = [
+            {"role": "user", "content": "go"},
+            self._asst(["T1"]),
+            self._asst(["T2"]),     # back-to-back assistants
+            self._tool("T2"),
+            self._tool("T1"),       # late
+        ]
+        out = self._from_loom_session(msgs)
+        # No two assistants with tool_calls may be adjacent.
+        for i in range(len(out) - 1):
+            a, b = out[i], out[i+1]
+            if a.get("role") == "assistant" and a.get("tool_calls"):
+                assert b.get("role") == "tool", \
+                    f"assistant tool_call at {i} followed by {b.get('role')}, not tool"
+
+    def test_well_formed_history_unchanged(self):
+        msgs = [
+            {"role": "user", "content": "go"},
+            self._asst(["T1"]),
+            self._tool("T1"),
+            self._asst(["T2"]),
+            self._tool("T2"),
+        ]
+        out = self._from_loom_session(msgs)
+        assert out == msgs
+
+    def test_orphan_pairs_still_dropped(self):
+        # Pass 2/3 invariants must still hold after Pass 4.
+        msgs = [
+            {"role": "user", "content": "go"},
+            self._asst(["T1"]),  # no result anywhere
+            {"role": "user", "content": "next"},
+            self._tool("T2"),    # no call anywhere
+        ]
+        out = self._from_loom_session(msgs)
+        roles = [(m.get("role"), m.get("tool_call_id") or
+                  [tc["id"] for tc in m.get("tool_calls", [])] or m.get("content"))
+                 for m in out]
+        # Both orphans gone; only the two user messages remain.
+        assert all(m.get("role") == "user" for m in out), roles


### PR DESCRIPTION
## Summary
- Tier 1 stop-bleed for #218. Adds Pass 4 to `_sanitize_history()`: re-emits canonical messages with each assistant's tool results pulled adjacent in call order, repairing histories where a late subprocess completion was appended after subsequent turns had advanced.
- Pass 2/3 only check existence anywhere; Anthropic API requires strict position. The new pass closes that gap and rescues already-corrupted on-disk sessions on next load.
- 4 new regression tests (`TestSanitizeHistoryAdjacency`).

## Validation
- Real snapshot `~/.loom/debug/llm_failure_20260426T212645_719061.json`: 40 wire mismatches → 0; all 466 canonical messages preserved.
- Full suite: 1147 passed (one pre-existing failure in `test_package_version_matches_pyproject` unrelated to this change, deselected).

## Test plan
- [x] Unit: out-of-order pair (user-interrupt mode) is repaired
- [x] Unit: two consecutive assistants (no interrupt) is repaired
- [x] Unit: well-formed history is unchanged
- [x] Unit: orphan pairs from Pass 2/3 still get dropped
- [ ] Manual: load a known-broken session via `loom chat --resume <id>` and confirm next turn no longer 2013s

## Follow-ups (tracked in #218)
- Tier 2: kill in-flight tool subprocess on abort/interrupt so late results never reach `self.messages`
- Tier 3: single-source append discipline + persist `_emit_turn`/`_tool_name` to `session_log.metadata`

🤖 Generated with [Claude Code](https://claude.com/claude-code)