### PR TITLE
fix(session): capture _turn_index eagerly in fire-and-forget _log_message (#218 Tier 2)

### DIFF
--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1178,7 +1178,7 @@ class LoomSession:
         """
         now_str = user_timestamp()
         self.messages.append({"role": "user", "content": f"[{now_str}]\n{message}"})
-        asyncio.ensure_future(self._log_message("user", message))
+        asyncio.ensure_future(self._log_message("user", message, turn_index=self._turn_index))
         self.resume()
 
     def cancel(self) -> None:
@@ -1418,7 +1418,7 @@ class LoomSession:
             now_str = user_timestamp()
             annotated = f"[{now_str}]\n{user_input}"
             self.messages.append({"role": "user", "content": annotated})
-            asyncio.ensure_future(self._log_message("user", annotated))
+            asyncio.ensure_future(self._log_message("user", annotated, turn_index=self._turn_index))
 
             # Issue #196 Phase 2: drain any async judge verdicts produced after
             # the previous turn ended. Inject as separate <system-reminder>
@@ -1661,6 +1661,7 @@ class LoomSession:
                     _content_text,
                     {"format": "raw_message"},
                     raw_json=_raw_json_str,
+                    turn_index=self._turn_index,
                 ))
 
                 if response.stop_reason == "end_turn":
@@ -1835,6 +1836,7 @@ class LoomSession:
                             asyncio.ensure_future(self._log_message(
                                 "tool", tool_output[:500],
                                 {"tool_call_id": tu.id, "tool_name": tu.name},
+                                turn_index=self._turn_index,
                             ))
                     else:
                         # Sequential: single tool, or needs interactive confirmation.
@@ -1915,6 +1917,7 @@ class LoomSession:
                             asyncio.ensure_future(self._log_message(
                                 "tool", tool_output[:500],
                                 {"tool_call_id": tu.id, "tool_name": tu.name},
+                                turn_index=self._turn_index,
                             ))
 
                     # ── Issue #106: Envelope completed ─────────────────────────
@@ -2628,13 +2631,24 @@ class LoomSession:
 
     async def _log_message(
         self, role: str, content: str, metadata: dict | None = None,
-        raw_json: str | None = None,
+        raw_json: str | None = None, turn_index: int | None = None,
     ) -> None:
-        """Fire-and-forget session_log write. Exceptions are swallowed inside log_message."""
+        """Fire-and-forget session_log write. Exceptions are swallowed inside log_message.
+
+        Issue #218: ``turn_index`` is captured eagerly at the call site and
+        passed through, NOT read lazily from ``self._turn_index`` here.
+        Callers schedule this via ``asyncio.ensure_future`` so the body runs
+        an unknown number of event-loop ticks later — by then stream_turn
+        may have advanced ``_turn_index``, which would persist this row with
+        the wrong turn and reorder it on reload (root cause of #218 wire
+        2013 errors). When ``turn_index`` is omitted we fall back to the
+        live value for backwards compatibility.
+        """
         if self._session_log is None:
             return
+        ti = turn_index if turn_index is not None else self._turn_index
         await self._session_log.log_message(
-            self.session_id, self._turn_index, role, content, metadata or {},
+            self.session_id, ti, role, content, metadata or {},
             raw_json=raw_json,
         )
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -657,3 +657,53 @@ class TestSanitizeHistoryAdjacency:
                  for m in out]
         # Both orphans gone; only the two user messages remain.
         assert all(m.get("role") == "user" for m in out), roles
+
+
+class TestLogMessageTurnIndexCapture:
+    """Issue #218 Tier 2: _log_message must persist with the turn_index that
+    was current at *schedule* time, not at *run* time. Otherwise stream_turn
+    advancing _turn_index between an `ensure_future(_log_message(...))` call
+    and the task actually running mis-tags the row, which on reload reorders
+    the message via `ORDER BY turn_index ASC, id ASC` and breaks the
+    tool_use ↔ tool_result adjacency invariant.
+    """
+
+    async def test_explicit_turn_index_overrides_live_value(self):
+        from loom.core.session import LoomSession
+
+        captured: list[int] = []
+
+        class FakeLog:
+            async def log_message(self, session_id, turn_index, role,
+                                  content, metadata, raw_json=None):
+                captured.append(turn_index)
+
+        fake = SimpleNamespace()
+        fake._session_log = FakeLog()
+        fake._turn_index = 99  # simulate stream_turn having advanced
+        fake.session_id = "s1"
+
+        # Caller scheduled this when _turn_index was 7 — the row must persist
+        # at 7, not 99.
+        await LoomSession._log_message(
+            fake, "tool", "result", {"tool_call_id": "T1"}, turn_index=7,
+        )
+        assert captured == [7]
+
+    async def test_no_explicit_value_falls_back_to_live(self):
+        from loom.core.session import LoomSession
+
+        captured: list[int] = []
+
+        class FakeLog:
+            async def log_message(self, session_id, turn_index, role,
+                                  content, metadata, raw_json=None):
+                captured.append(turn_index)
+
+        fake = SimpleNamespace()
+        fake._session_log = FakeLog()
+        fake._turn_index = 12
+        fake.session_id = "s1"
+
+        await LoomSession._log_message(fake, "user", "hi")
+        assert captured == [12]


### PR DESCRIPTION
## Summary
- Real producer of #218 wire 2013s. `_log_message` is fire-and-forget; the awaited body read `self._turn_index` lazily, so when stream_turn advanced the index between scheduling and execution, the tool row was persisted with the wrong turn. On reload, `ORDER BY turn_index ASC, id ASC` reordered the message and broke `tool_use ↔ tool_result` adjacency.
- Add `turn_index` kwarg captured eagerly at every call site (5 places); fallback to live value when omitted for backwards compatibility.
- 2 new tests in `TestLogMessageTurnIndexCapture`.

(Re-targeted to master after #220 was merged. Original PR #221 was auto-closed when its base branch was deleted by squash-merge of #220.)

## Why this not just kill-the-subprocess (the original Tier 2 plan)

The snapshot pattern (cf[244] tool result landing 12 messages past its tool_use) cannot be produced by an orphaned subprocess: cancellation propagating through `_dispatch` raises `CancelledError`, which short-circuits the `messages.append` at session.py:1834/1914 — no row is appended at all. The only path that could persist a row at the wrong logical position is the fire-and-forget log scheduling, which is exactly what this fix targets.

Subprocess-kill hygiene is now tracked in #222.

## Validation
- `tests/test_session.py::TestLogMessageTurnIndexCapture` — 2 new tests
- `tests/test_session.py::TestSanitizeHistoryAdjacency` — Tier 1 still green
- Full suite: 1149 passed (1 pre-existing version-mismatch failure deselected)

## Test plan
- [x] Unit: explicit `turn_index` kwarg overrides live `self._turn_index`
- [x] Unit: omitted `turn_index` falls back to live value
- [ ] Manual: long-running run_bash + Discord interrupt → next turn does not 2013, and on session resume new tool_use/tool_result rows are correctly ordered

🤖 Generated with [Claude Code](https://claude.com/claude-code)