### PR TITLE
fix(cognition): refine judge gate to structural signals (#226)

### DIFF
--- a/loom/core/cognition/judge.py
+++ b/loom/core/cognition/judge.py
@@ -97,6 +97,28 @@ def is_high_stakes(envelopes: list["ExecutionEnvelopeView"]) -> bool:
     return False
 
 
+# ── Trace anomaly detection ────────────────────────────────────────────────
+
+# Non-success terminal states. Anything in here means a tool didn't reach
+# its happy-path conclusion — the kind of trace the judge has a real shot
+# at catching a say-do gap against.
+_TROUBLED_STATES: frozenset[str] = frozenset({
+    "denied",      # blocked by trust/scope/legitimacy
+    "aborted",     # cancelled mid-flight
+    "timed_out",   # blew the budget
+    "reverted",    # rolled back after the fact
+})
+
+
+def has_trace_anomaly(envelopes: list["ExecutionEnvelopeView"]) -> bool:
+    """True iff any node ended in a non-success terminal state."""
+    for env in envelopes:
+        for node in env.nodes:
+            if node.state in _TROUBLED_STATES:
+                return True
+    return False
+
+
 # ── Gate predicate ─────────────────────────────────────────────────────────
 
 
@@ -106,21 +128,32 @@ def gate_should_fire(
 ) -> bool:
     """Pure predicate — do we have enough signal to even run a judge?
 
+    Two structural triggers, no broad text-heuristic fallback:
+
+    - **High-stakes external action** (push / merge / release / CRITICAL
+      trust): always fire, regardless of claim. Externally visible
+      effects must be verified.
+    - **Trace anomaly + completion claim**: any node ended in a non-success
+      terminal state (denied / aborted / timed_out / reverted) AND the
+      agent's final text claims completion. Classic say-do gap.
+
+    Notably absent: bare ``MUTATES + claim``. Loom marks almost every
+    useful tool MUTATES (read_file, run_bash, write_file…), and agents
+    routinely close turns with "完成" / "done", so that combination
+    triggered on virtually every successful turn — pure noise. See
+    issue #226.
+
     Lifted out of the dispatcher so the caller can decide whether to spend
-    the per-turn idempotency token *before* committing it. Without this
-    split, a stream_turn that goes (text-only end_turn → reminder loop →
-    tool_use with MUTATES → end_turn with claim) burns its judge slot on
-    the first end_turn and silently skips the real completion.
+    the per-turn idempotency token *before* committing it (regression
+    guard for the iter-1-burns-the-slot bug).
     """
     if not envelopes:
         return False
-    mutated = any(
-        "MUTATES" in (n.capabilities or [])
-        for env in envelopes for n in env.nodes
-    )
-    if not mutated:
-        return False
-    return claims_completion(final_text)
+    if is_high_stakes(envelopes):
+        return True
+    if has_trace_anomaly(envelopes) and claims_completion(final_text):
+        return True
+    return False
 
 
 # ── Digest construction ────────────────────────────────────────────────────

--- a/loom/core/cognition/judge.py
+++ b/loom/core/cognition/judge.py
@@ -102,12 +102,36 @@ def is_high_stakes(envelopes: list["ExecutionEnvelopeView"]) -> bool:
 # Non-success terminal states. Anything in here means a tool didn't reach
 # its happy-path conclusion — the kind of trace the judge has a real shot
 # at catching a say-do gap against.
+#
+# Source of truth: ``loom.core.harness.lifecycle._FAILURE_STATES``. Mirrored
+# here as plain strings to keep cognition free of a harness import; the
+# module-level assertion below catches drift if a new failure state ever
+# lands without being reflected here.
 _TROUBLED_STATES: frozenset[str] = frozenset({
     "denied",      # blocked by trust/scope/legitimacy
     "aborted",     # cancelled mid-flight
     "timed_out",   # blew the budget
     "reverted",    # rolled back after the fact
 })
+
+
+def _assert_in_sync_with_lifecycle() -> None:
+    """Drift guard — fails import if lifecycle adds a failure state we miss.
+
+    Cheap one-shot at module load. If this ever trips, either add the new
+    state to ``_TROUBLED_STATES`` or, if it shouldn't trigger the judge,
+    document the exception explicitly here.
+    """
+    from loom.core.harness.lifecycle import _FAILURE_STATES  # local: avoid hot-path
+    canonical = {s.value for s in _FAILURE_STATES}
+    missing = canonical - _TROUBLED_STATES
+    assert not missing, (
+        f"judge._TROUBLED_STATES out of sync with lifecycle._FAILURE_STATES; "
+        f"missing: {sorted(missing)}"
+    )
+
+
+_assert_in_sync_with_lifecycle()
 
 
 def has_trace_anomaly(envelopes: list["ExecutionEnvelopeView"]) -> bool:
@@ -312,6 +336,28 @@ async def run_judge(
             reason="judge call failed; treat as no-signal",
             error=f"{type(exc).__name__}: {exc}",
         )
+
+
+# ── Dispatch policy ────────────────────────────────────────────────────────
+
+
+def should_inject_reminder(verdict: JudgeVerdict) -> bool:
+    """Should this verdict become a ``<system-reminder>`` for the agent?
+
+    Two filters:
+
+    - ``verdict.error`` set → judge itself failed (empty / malformed /
+      network). Surface in telemetry only; never push the judge's own
+      malfunction back at the agent as homework. (Issue #226.)
+    - Verdict is ``pass`` → silent by design. Avoids self-congratulatory
+      noise on every successful turn.
+
+    Centralised so sync (``_maybe_run_judge``) and async
+    (``_run_judge_async``) dispatch paths can't drift apart.
+    """
+    if verdict.error:
+        return False
+    return verdict.verdict in (VERDICT_FAIL, VERDICT_UNCERTAIN)
 
 
 # ── Reminder formatting ────────────────────────────────────────────────────

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -47,14 +47,12 @@ from loom.core.cognition.providers import AnthropicProvider
 from loom.core.cognition.counter_factual import CounterFactualReflector
 from loom.core.cognition.judge import (
     JudgeVerdict,
-    VERDICT_FAIL,
-    VERDICT_PASS,
-    VERDICT_UNCERTAIN,
     build_trace_digest,
     format_verdict_reminder,
     gate_should_fire,
     is_high_stakes,
     run_judge,
+    should_inject_reminder,
 )
 from loom.core.cognition.reflection import ReflectionAPI
 from loom.core.cognition.router import LLMRouter
@@ -2126,12 +2124,7 @@ class LoomSession:
         if is_high_stakes(envelopes):
             verdict = await run_judge(self.router, self.model, digest)
             self._record_verdict_telemetry(verdict, sync=True)
-            if verdict.error:
-                # Judge itself failed (empty / malformed / network) —
-                # don't promote that into agent-facing noise. Telemetry
-                # already captured it. See issue #226.
-                return None
-            if verdict.verdict in (VERDICT_FAIL, VERDICT_UNCERTAIN):
+            if should_inject_reminder(verdict):
                 return format_verdict_reminder(verdict)
             return None
 
@@ -2147,10 +2140,7 @@ class LoomSession:
     async def _run_judge_async(self, digest: str) -> None:
         verdict = await run_judge(self.router, self.model, digest)
         self._record_verdict_telemetry(verdict, sync=False)
-        if verdict.error:
-            # Judge itself failed — telemetry only, no reminder. See #226.
-            return
-        if verdict.verdict in (VERDICT_FAIL, VERDICT_UNCERTAIN):
+        if should_inject_reminder(verdict):
             self._pending_verdicts.append(format_verdict_reminder(verdict))
 
     def _record_verdict_telemetry(self, verdict: "JudgeVerdict", *, sync: bool) -> None:

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -2126,6 +2126,11 @@ class LoomSession:
         if is_high_stakes(envelopes):
             verdict = await run_judge(self.router, self.model, digest)
             self._record_verdict_telemetry(verdict, sync=True)
+            if verdict.error:
+                # Judge itself failed (empty / malformed / network) —
+                # don't promote that into agent-facing noise. Telemetry
+                # already captured it. See issue #226.
+                return None
             if verdict.verdict in (VERDICT_FAIL, VERDICT_UNCERTAIN):
                 return format_verdict_reminder(verdict)
             return None
@@ -2142,6 +2147,9 @@ class LoomSession:
     async def _run_judge_async(self, digest: str) -> None:
         verdict = await run_judge(self.router, self.model, digest)
         self._record_verdict_telemetry(verdict, sync=False)
+        if verdict.error:
+            # Judge itself failed — telemetry only, no reminder. See #226.
+            return
         if verdict.verdict in (VERDICT_FAIL, VERDICT_UNCERTAIN):
             self._pending_verdicts.append(format_verdict_reminder(verdict))
 

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -15,6 +15,7 @@ from loom.core.cognition.judge import (
     has_trace_anomaly,
     is_high_stakes,
     parse_verdict,
+    should_inject_reminder,
 )
 from loom.core.events import ExecutionEnvelopeView, ExecutionNodeView
 
@@ -285,6 +286,77 @@ class TestVerdictParsing:
     def test_case_insensitive(self):
         v = parse_verdict("verdict: PASS — looks good.")
         assert v.verdict == VERDICT_PASS
+
+
+# ── dispatch policy ─────────────────────────────────────────────────────────
+
+
+class TestShouldInjectReminder:
+    """The single predicate both sync + async dispatch paths consult.
+
+    Centralises the #226 fix: judge self-failures (verdict.error set) must
+    NOT be promoted to agent-facing reminders, regardless of what verdict
+    string parse_verdict happened to assign as a fallback.
+    """
+
+    def test_pass_is_silent(self):
+        v = JudgeVerdict(verdict=VERDICT_PASS, reason="all good")
+        assert not should_inject_reminder(v)
+
+    def test_fail_injects(self):
+        v = JudgeVerdict(verdict=VERDICT_FAIL, reason="say-do gap")
+        assert should_inject_reminder(v)
+
+    def test_uncertain_injects(self):
+        v = JudgeVerdict(verdict=VERDICT_UNCERTAIN, reason="ambiguous trace")
+        assert should_inject_reminder(v)
+
+    def test_error_swallows_uncertain(self):
+        # The exact #226 noise case: judge model returned empty → parse_verdict
+        # produced uncertain + error="empty_response". Must NOT inject.
+        v = JudgeVerdict(
+            verdict=VERDICT_UNCERTAIN,
+            reason="judge returned empty response",
+            error="empty_response",
+        )
+        assert not should_inject_reminder(v)
+
+    def test_error_swallows_fail(self):
+        # Defensive: even if a malformed-fallback path lands on `fail`, an
+        # error-tagged verdict still represents judge malfunction, not agent
+        # gap. Don't promote it.
+        v = JudgeVerdict(
+            verdict=VERDICT_FAIL,
+            reason="...",
+            error="malformed_verdict",
+        )
+        assert not should_inject_reminder(v)
+
+    def test_error_swallows_pass_too(self):
+        # Vacuously true (pass already silent) but locks the contract: the
+        # error gate runs first, independent of the verdict string.
+        v = JudgeVerdict(verdict=VERDICT_PASS, reason="x", error="boom")
+        assert not should_inject_reminder(v)
+
+
+# ── lifecycle drift guard ───────────────────────────────────────────────────
+
+
+def test_troubled_states_match_lifecycle_failure_states():
+    """If lifecycle adds a new failure state, this test breaks loud.
+
+    The judge module also asserts this at import time, but we duplicate the
+    check at test time so a CI failure points at this exact concern rather
+    than a generic ImportError.
+    """
+    from loom.core.cognition.judge import _TROUBLED_STATES
+    from loom.core.harness.lifecycle import _FAILURE_STATES
+
+    canonical = {s.value for s in _FAILURE_STATES}
+    assert canonical == _TROUBLED_STATES, (
+        f"lifecycle._FAILURE_STATES={canonical} drifted from "
+        f"judge._TROUBLED_STATES={_TROUBLED_STATES}"
+    )
 
 
 # ── reminder formatting ─────────────────────────────────────────────────────

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -12,6 +12,7 @@ from loom.core.cognition.judge import (
     claims_completion,
     format_verdict_reminder,
     gate_should_fire,
+    has_trace_anomaly,
     is_high_stakes,
     parse_verdict,
 )
@@ -53,10 +54,16 @@ class TestClaimsCompletion:
 # ── high-stakes detection ───────────────────────────────────────────────────
 
 
-def _node(name: str, *, trust: str = "GUARDED", capabilities=None) -> ExecutionNodeView:
+def _node(
+    name: str,
+    *,
+    trust: str = "GUARDED",
+    capabilities=None,
+    state: str = "memorialized",
+) -> ExecutionNodeView:
     return ExecutionNodeView(
         node_id="n1", call_id="c1", action_id="n1",
-        tool_name=name, level=0, state="memorialized",
+        tool_name=name, level=0, state=state,
         trust_level=trust, capabilities=list(capabilities or []),
     )
 
@@ -89,36 +96,98 @@ class TestHighStakes:
 # ── gate predicate ──────────────────────────────────────────────────────────
 
 
+class TestHasTraceAnomaly:
+    def test_all_success_is_clean(self):
+        env = _envelope(
+            _node("write_file", capabilities=["MUTATES"]),
+            _node("run_bash", capabilities=["EXEC", "MUTATES"]),
+        )
+        assert not has_trace_anomaly([env])
+
+    def test_denied_node_is_anomaly(self):
+        env = _envelope(_node("write_file", state="denied"))
+        assert has_trace_anomaly([env])
+
+    def test_timed_out_node_is_anomaly(self):
+        env = _envelope(_node("run_bash", state="timed_out"))
+        assert has_trace_anomaly([env])
+
+    def test_aborted_node_is_anomaly(self):
+        env = _envelope(_node("run_bash", state="aborted"))
+        assert has_trace_anomaly([env])
+
+    def test_reverted_node_is_anomaly(self):
+        env = _envelope(_node("write_file", state="reverted"))
+        assert has_trace_anomaly([env])
+
+    def test_one_bad_among_many_good(self):
+        envs = [
+            _envelope(_node("read_file")),
+            _envelope(_node("run_bash", state="timed_out")),
+            _envelope(_node("write_file")),
+        ]
+        assert has_trace_anomaly(envs)
+
+    def test_empty_envelopes(self):
+        assert not has_trace_anomaly([])
+
+
 class TestGateShouldFire:
     """Pure-predicate regression tests.
 
-    The bug this guards against: in v1 the dispatcher set
-    ``_judge_done = True`` before checking the gate, so a stream_turn that
-    went (text-only end_turn → reminder loop → tool_use w/ MUTATES →
-    end_turn w/ claim) would burn its judge token on the first end_turn
-    and silently skip the real completion. Splitting the gate out as a
-    pure predicate lets the caller decide when to commit the token.
+    Two structural triggers (issue #226):
+    - is_high_stakes(envelopes) → fire (claim irrelevant)
+    - has_trace_anomaly(envelopes) AND claims_completion(text) → fire
+
+    Bare ``MUTATES + claim`` is intentionally NOT a trigger — that
+    combination was the noise source the issue called out.
+
+    Also guards the legacy iter-1-burns-the-slot bug: the gate is pure,
+    so the dispatcher only commits the per-turn token when this returns
+    True, allowing a late-appearing MUTATES tool to still be judged.
     """
 
     def test_no_envelopes_skips(self):
         assert not gate_should_fire([], "完成 ✅")
 
-    def test_envelopes_without_mutates_skip(self):
-        # Read-only investigation — agent says "完成" after grepping.
+    def test_clean_run_with_completion_claim_skips(self):
+        # The #226 noise case: read_file + completion text and nothing went
+        # wrong. Should NOT fire.
         env = _envelope(_node("read_file", capabilities=["READ_PROBE"]))
         assert not gate_should_fire([env], "看完了，沒問題 ✅")
 
-    def test_mutates_without_completion_claim_skips(self):
-        # Agent ran write_file then asked user a question.
+    def test_clean_mutates_with_claim_skips(self):
+        # The other half of the noise case: a successful MUTATES write
+        # plus completion text. Old gate fired here; new gate doesn't.
         env = _envelope(_node("write_file", capabilities=["MUTATES"]))
-        assert not gate_should_fire([env], "寫好初稿了，想再聽你的意見再下一步")
+        assert not gate_should_fire([env], "技能 v1.1 已收斂 ✅")
 
-    def test_mutates_plus_claim_fires(self):
-        env = _envelope(_node("write_file", capabilities=["MUTATES"]))
-        assert gate_should_fire([env], "技能 v1.1 已收斂 ✅")
+    def test_anomaly_without_claim_skips(self):
+        # Tool failed but the agent didn't claim done — agent is presumably
+        # already going to retry / report. Don't add a judge layer.
+        env = _envelope(_node("write_file", state="denied"))
+        assert not gate_should_fire([env], "權限不夠，幫我加 scope 後我再試一次")
 
-    def test_regression_late_appearing_mutates_still_judged(self):
-        """Iter 1 of a stream_turn had no MUTATES; later iters added them.
+    def test_anomaly_plus_claim_fires(self):
+        # The classic say-do gap: tool denied/timed_out but agent says done.
+        env = _envelope(_node("write_file", state="denied"))
+        assert gate_should_fire([env], "已寫入 ✅")
+
+    def test_high_stakes_always_fires_no_claim_needed(self):
+        # External-effect tools must be verified regardless of phrasing.
+        env = _envelope(_node("git_push"))
+        assert gate_should_fire([env], "推上去看看")
+
+    def test_high_stakes_fires_even_without_anomaly(self):
+        env = _envelope(_node("gh_pr_merge"))
+        assert gate_should_fire([env], "merge")
+
+    def test_critical_trust_fires(self):
+        env = _envelope(_node("custom_tool", trust="CRITICAL"))
+        assert gate_should_fire([env], "ok")
+
+    def test_regression_late_appearing_signal_still_judged(self):
+        """Iter-1-burns-the-slot regression guard.
 
         With the v1 buggy dispatcher this returned True at iter 1 (claim
         present, no envelopes ⇒ False) and False at iter 3 because the
@@ -126,30 +195,10 @@ class TestGateShouldFire:
         the caller only commits the token when the gate actually returns
         True — so iter 3 fires correctly.
         """
-        # Iter 1 simulation: no envelopes yet, agent text claims completion.
-        # (Imagine the agent said "我先看一下 ✅" prematurely.)
         assert not gate_should_fire([], "我先看一下 ✅")
 
-        # Iter 3 simulation: by now a write_file has run and the agent's
-        # final claim refers to the actual work.
-        env = _envelope(_node("write_file", capabilities=["MUTATES"]))
-        assert gate_should_fire([env], "已修正 race condition ✅")
-
-    def test_multiple_envelopes_one_with_mutates_fires(self):
-        envs = [
-            _envelope(_node("read_file", capabilities=["READ_PROBE"])),
-            _envelope(_node("run_bash", capabilities=["EXEC", "MUTATES"])),
-        ]
-        assert gate_should_fire(envs, "搞定")
-
-    def test_capabilities_none_treated_as_no_mutates(self):
-        n = ExecutionNodeView(
-            node_id="n1", call_id="c1", action_id="n1",
-            tool_name="custom", level=0, state="memorialized",
-            trust_level="GUARDED", capabilities=[],
-        )
-        env = _envelope(n)
-        assert not gate_should_fire([env], "完成")
+        env = _envelope(_node("git_push"))
+        assert gate_should_fire([env], "已 push ✅")
 
 
 # ── trace digest ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #226.

## Problem

The turn-boundary judge (issue #196 Phase 2) was firing on virtually every successful turn. Two layered bugs:

1. **Gate too broad**: `MUTATES + completion-claim` matched nearly every useful turn. Loom marks `read_file` / `run_bash` / `write_file` all as `MUTATES`, and agents habitually close turns with "完成" / "done". Result: judge fires on routine summaries.
2. **Judge self-failure becomes agent noise**: when the judge model returned empty / malformed / network-errored, `parse_verdict()` made it `uncertain` with `error` set — and the dispatcher then injected that as a `<system-reminder>` for the agent to react to. The judge's own failure became the agent's homework.

Concrete trace from 2026-04-27 (per #226): YouTube transcription turn → text-only summary → judge fired → judge returned empty → uncertain verdict landed in the next turn alongside actual work.

## Approach

Replace the broad text-heuristic gate with **two structural triggers**, no LLM-output regex beyond the existing legacy completion-claim detector:

- **High-stakes external action** (`git_push` / `gh_pr_merge` / `gh_release_create` / `gh_issue_close` / `CRITICAL` trust) → always fire, regardless of claim. Externally visible effects must be verified.
- **Trace anomaly + completion claim**: any node ended in a non-success terminal state (`denied` / `aborted` / `timed_out` / `reverted`) AND the agent's final text claims completion. Classic say-do gap — exactly the case the judge can catch with high signal.

Bare `MUTATES + claim` is removed entirely.

Discussed and rejected an additional "Layer C" of regex-detecting quantitative claims (`抓了 X 篇`) — regex on LLM output drifts as model phrasing shifts; structural signals only.

Independently, `_maybe_run_judge` and `_run_judge_async` now check `verdict.error` first: judge self-failures are recorded in telemetry only, never injected into the agent's context.

## Files

- `loom/core/cognition/judge.py` — new `has_trace_anomaly()` helper; rewrite `gate_should_fire()` with the two structural triggers; updated docstring explains why bare `MUTATES + claim` was dropped.
- `loom/core/session.py` — both judge dispatch paths now swallow `verdict.error` cases (telemetry-only, no reminder).
- `tests/test_judge.py` — new `TestHasTraceAnomaly` class; `TestGateShouldFire` rewritten: noise cases (clean MUTATES+claim, clean read_file+claim) now assert skip; new fires for high-stakes-no-claim, anomaly+claim, CRITICAL trust; iter-1-burns-the-slot regression guard updated to use a high-stakes signal.

## Test plan

- [x] `pytest tests/test_judge.py` — 39/39 pass
- [x] full suite `pytest tests/` — 1090 pass (1 unrelated pre-existing version-string mismatch deselected)
- [ ] Run `loom chat` for one transcribe-style turn and verify no judge reminder lands next turn
- [ ] Run a turn with an intentionally `denied` tool followed by a "已完成" claim and verify judge does fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)