### PR TITLE
feat(subagent): result_write slot + wrap-up reminder for reliability (#225)

### DIFF
--- a/loom/__init__.py
+++ b/loom/__init__.py
@@ -1,6 +1,6 @@
 """Loom — Harness-first, memory-native, self-directing agent framework."""
 
-__version__ = "0.2.5.1"
+__version__ = "0.3.5.0"
 
 from loom.extensibility.adapter import AdapterRegistry as _AdapterRegistry
 from loom.extensibility.plugin import LoomPlugin, PluginRegistry as _PluginRegistry

--- a/loom/core/agent/subagent.py
+++ b/loom/core/agent/subagent.py
@@ -61,6 +61,11 @@ class SubAgentResult:
     failure_code: str | None = None
     recovery_suggestion: str | None = None
     error_context: dict[str, Any] = field(default_factory=dict)
+    # Issue #225: best-effort result the sub-agent explicitly committed via
+    # ``result_write``. Survives both end_turn and max_turns paths so the
+    # parent never gets an empty hand even when the sub-agent runs out of
+    # turns. None ⇒ sub-agent never called result_write.
+    result_slot: str | None = None
 
 
 async def run_subagent(
@@ -118,6 +123,53 @@ async def run_subagent(
         if config.allowed_tools is None and tool.trust_level != TrustLevel.SAFE:
             continue
         child_registry.register(tool)
+
+    # ── result_write — issue #225 ────────────────────────────────────────────
+    # Always-available tool that lets the sub-agent rewrite its best-effort
+    # result every turn. The slot is captured below as a closure cell so both
+    # end_turn and max_turns paths can read it. Registered AFTER the parent
+    # registry filtering so allowed_tools does not gate it.
+    _result_slot_cell: dict[str, str | None] = {"value": None}
+
+    async def _result_write(call: ToolCall) -> ToolResult:
+        content = call.args.get("content")
+        if not isinstance(content, str):
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False,
+                error="'content' must be a string",
+                failure_type="validation_error",
+            )
+        _result_slot_cell["value"] = content
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=True,
+            output=f"[result slot updated, {len(content)} chars]",
+        )
+
+    child_registry.register(ToolDefinition(
+        name="result_write",
+        description=(
+            "Overwrite your best-effort task result. Each call replaces the slot "
+            "entirely — there is no append. The parent agent receives the latest "
+            "slot content even if you run out of turns, so write incrementally: "
+            "save what you have at every meaningful checkpoint, refine on the "
+            "next turn. Empty / never-called slot ⇒ parent gets your end_turn "
+            "text on success or nothing on max_turns."
+        ),
+        trust_level=TrustLevel.SAFE,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "description": "Best-effort result so far. Replaces any prior slot.",
+                },
+            },
+            "required": ["content"],
+        },
+        executor=_result_write,
+    ))
 
     # Wrap memorize so writes are tagged with this agent's provenance
     _orig_memorize = child_registry.get("memorize")
@@ -198,8 +250,18 @@ async def run_subagent(
     system_prompt = (
         f"You are a sub-agent (id: {agent_id}) spawned by a parent agent.\n"
         f"Your workspace is: {workspace}\n"
+        f"You have a budget of {config.max_turns} turn(s).\n"
         f"Complete the following task and respond with a clear, concise result.\n"
         f"Do not ask clarifying questions — work with what you have.\n"
+        f"\n"
+        f"IMPORTANT — result_write contract:\n"
+        f"At every meaningful checkpoint, call `result_write(content=...)` "
+        f"to commit your best-effort result so far. The slot is overwrite-only "
+        f"(each call replaces the previous content). Whatever is in the slot "
+        f"when you exit — whether you reach end_turn naturally or run out of "
+        f"turns — is what the parent agent receives. Treat it as your hand-off "
+        f"buffer: write something useful early, refine it as you go.\n"
+        f"\n"
         f"Available tools: {', '.join(child_registry._tools.keys()) or 'none'}."
     )
     messages: list[dict[str, Any]] = [
@@ -220,6 +282,8 @@ async def run_subagent(
     consecutive_failure_tool: str | None = None
     consecutive_failure_count = 0
     max_consecutive_failures = 0
+    # Issue #225: idempotency for the wrap-up reminder injected near max_turns.
+    wrapup_warned = False
 
     # ── Agent loop ────────────────────────────────────────────────────────────
     while turns_used < config.max_turns:
@@ -264,6 +328,10 @@ async def run_subagent(
                     b.get("text", "") for b in raw_content
                     if isinstance(b, dict) and b.get("type") == "text"
                 )
+            # Issue #225: result_slot is the explicit best-effort the sub-agent
+            # committed; prefer it over end_turn free text when both exist.
+            if _result_slot_cell["value"]:
+                final_output = _result_slot_cell["value"]
             break
 
         if response.stop_reason == "tool_use":
@@ -311,8 +379,32 @@ async def run_subagent(
                 messages.append(
                     router.format_tool_result(config.model, tu.id, tool_output, result.success)
                 )
+
+            # Issue #225: wrap-up reminder. When two turns remain, force the
+            # sub-agent to commit a result and end_turn rather than burn the
+            # last slot on a fresh tool chain. Idempotent — fires once.
+            turns_remaining = config.max_turns - turns_used
+            if (
+                turns_remaining == 2
+                and config.max_turns >= 3
+                and not wrapup_warned
+            ):
+                messages.append({
+                    "role": "user",
+                    "content": (
+                        "<system-reminder>\n"
+                        "You have 2 turns left. On your next turn, call "
+                        "`result_write(content=...)` with your best-effort "
+                        "result so far, then end_turn. Do not start new long "
+                        "tool chains — wrap up.\n"
+                        "</system-reminder>"
+                    ),
+                })
+                wrapup_warned = True
         else:
             break
+
+    result_slot_value = _result_slot_cell["value"]
 
     if turns_used >= config.max_turns and not final_output:
         partial = assistant_text_trail.strip()
@@ -338,10 +430,14 @@ async def run_subagent(
             failure_code=failure_code,
             recovery_suggestion=recovery_suggestion,
             error_context=error_context,
+            result_slot=result_slot_value,
         )
+        # Issue #225: surface the explicit slot as the failure's output so the
+        # parent never sees an empty hand. success stays False — end_turn is
+        # the only honest "done" signal — but the work isn't lost.
         return SubAgentResult(
             success=False,
-            output="",
+            output=result_slot_value or "",
             agent_id=agent_id,
             turns_used=turns_used,
             tool_calls=total_tool_calls,
@@ -352,6 +448,7 @@ async def run_subagent(
             failure_code=failure_code,
             recovery_suggestion=recovery_suggestion,
             error_context=error_context,
+            result_slot=result_slot_value,
         )
 
     return SubAgentResult(
@@ -360,6 +457,7 @@ async def run_subagent(
         agent_id=agent_id,
         turns_used=turns_used,
         tool_calls=total_tool_calls,
+        result_slot=result_slot_value,
     )
 
 
@@ -409,6 +507,7 @@ def _write_failure_scratchpad(
     failure_code: str | None = None,
     recovery_suggestion: str | None = None,
     error_context: dict[str, Any] | None = None,
+    result_slot: str | None = None,
 ) -> None:
     """Write sub-agent failure context to scratchpad if available.
 
@@ -431,6 +530,7 @@ def _write_failure_scratchpad(
         "failure_code": failure_code,
         "recovery_suggestion": recovery_suggestion,
         "error_context": error_context or {},
+        "result_slot": result_slot,
     }
     try:
         scratchpad.write(ref, json.dumps(payload, ensure_ascii=False, indent=2))

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -2475,13 +2475,30 @@ def make_spawn_agent_tool(parent_session: Any) -> "ToolDefinition":
                 )
             if result.recovery_suggestion:
                 parts.append(f"hint: {result.recovery_suggestion}")
+            # Issue #225: if the sub-agent committed a best-effort result via
+            # result_write, surface it inline so the parent can act on it
+            # without a follow-up scratchpad_read. Truncate aggressively —
+            # full content stays in the scratchpad payload.
+            if result.result_slot:
+                slot_preview = result.result_slot
+                if len(slot_preview) > 800:
+                    slot_preview = slot_preview[:800] + " […truncated]"
+                parts.append(f"result_slot: {slot_preview}")
             parts.append(
                 f"Full failure context at scratchpad ref: subagent_failure:{result.agent_id} "
                 f"(read via scratchpad_read)."
             )
+            metadata = {
+                "subagent_agent_id": result.agent_id,
+                "subagent_turns_used": result.turns_used,
+                "subagent_tool_calls": result.tool_calls,
+                "subagent_failure_code": result.failure_code or "",
+                "subagent_has_result_slot": bool(result.result_slot),
+            }
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
                               success=False, error=" | ".join(parts),
-                              failure_type="execution_error")
+                              failure_type="execution_error",
+                              metadata=metadata)
 
     return ToolDefinition(
         name="spawn_agent",

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -523,6 +523,44 @@ class TestSubAgentFailureCodes:
         assert result.error_context["max_consecutive_failures"] == 2
         assert result.error_context["stuck_tool"] is None
 
+    async def test_result_slot_in_scratchpad_payload(
+        self,
+        semantic: SemanticMemory,
+        episodic: EpisodicMemory,
+        procedural: ProceduralMemory,
+        tmp_path: Path,
+    ) -> None:
+        """Issue #225: failure scratchpad payload carries the result_slot field."""
+        registry = ToolRegistry()
+        registry.register(_make_failing_tool())
+        router = _FakeRouter([
+            _tool_use_response("c1", "trying"),
+        ])
+        scratchpad = Scratchpad()
+
+        result = await run_subagent(
+            SubAgentConfig(
+                task="Task.",
+                model="gpt-test",
+                allowed_tools=["always_fail"],
+                max_turns=1,
+                agent_id="sub-slotpad",
+            ),
+            router=router,
+            episodic=episodic,
+            semantic=semantic,
+            procedural=procedural,
+            tool_registry=registry,
+            parent_session_id="parent-1",
+            workspace=tmp_path,
+            scratchpad=scratchpad,
+        )
+
+        payload = json.loads(scratchpad.read(f"subagent_failure:{result.agent_id}"))
+        # Field exists; None because result_write was never called.
+        assert "result_slot" in payload
+        assert payload["result_slot"] is None
+
     async def test_failure_code_in_scratchpad_payload(
         self,
         semantic: SemanticMemory,
@@ -563,3 +601,317 @@ class TestSubAgentFailureCodes:
         assert "always_fail" in payload["recovery_suggestion"]
         assert payload["error_context"]["stuck_tool"] == "always_fail"
         assert payload["error_context"]["max_consecutive_failures"] == 3
+
+
+# ── result_write slot — issue #225 ──────────────────────────────────────────
+
+
+def _result_write_response(call_id: str, content: str) -> LLMResponse:
+    """Assistant calls result_write(content=...) — registered by run_subagent."""
+    return LLMResponse(
+        text=None,
+        tool_uses=[ToolUse(id=call_id, name="result_write", args={"content": content})],
+        stop_reason="tool_use",
+        raw_message={
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use", "id": call_id,
+                    "name": "result_write", "input": {"content": content},
+                },
+            ],
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": "result_write",
+                        "arguments": json.dumps({"content": content}),
+                    },
+                }
+            ],
+        },
+    )
+
+
+def _end_turn_response(text: str) -> LLMResponse:
+    return LLMResponse(
+        text=text,
+        tool_uses=[],
+        stop_reason="end_turn",
+        raw_message={"role": "assistant", "content": text},
+    )
+
+
+class TestResultWriteSlot:
+    """Issue #225: best-effort result slot survives both termination paths."""
+
+    async def test_slot_overrides_end_turn_text_on_success(
+        self,
+        semantic: SemanticMemory,
+        episodic: EpisodicMemory,
+        procedural: ProceduralMemory,
+        tmp_path: Path,
+    ) -> None:
+        """When sub-agent committed a slot, it takes precedence over end_turn text.
+
+        The slot is the explicit hand-off; end_turn text is incidental closing
+        chatter. Parent should see the slot.
+        """
+        registry = ToolRegistry()
+        router = _FakeRouter([
+            _result_write_response("c1", "structured result payload"),
+            _end_turn_response("ok, done."),
+        ])
+
+        result = await run_subagent(
+            SubAgentConfig(
+                task="Produce a result.",
+                model="gpt-test",
+                allowed_tools=[],
+                max_turns=5,
+                agent_id="sub-slot-success",
+            ),
+            router=router,
+            episodic=episodic,
+            semantic=semantic,
+            procedural=procedural,
+            tool_registry=registry,
+            parent_session_id="parent-1",
+            workspace=tmp_path,
+        )
+
+        assert result.success is True
+        assert result.result_slot == "structured result payload"
+        assert result.output == "structured result payload"
+
+    async def test_slot_falls_back_to_end_turn_text_when_unset(
+        self,
+        semantic: SemanticMemory,
+        episodic: EpisodicMemory,
+        procedural: ProceduralMemory,
+        tmp_path: Path,
+    ) -> None:
+        """No result_write call ⇒ end_turn text is the output (legacy contract)."""
+        registry = ToolRegistry()
+        router = _FakeRouter([_end_turn_response("done")])
+
+        result = await run_subagent(
+            SubAgentConfig(
+                task="Trivial.",
+                model="gpt-test",
+                allowed_tools=[],
+                max_turns=3,
+                agent_id="sub-no-slot",
+            ),
+            router=router,
+            episodic=episodic,
+            semantic=semantic,
+            procedural=procedural,
+            tool_registry=registry,
+            parent_session_id="parent-1",
+            workspace=tmp_path,
+        )
+
+        assert result.success is True
+        assert result.result_slot is None
+        assert result.output == "done"
+
+    async def test_slot_survives_max_turns_failure(
+        self,
+        semantic: SemanticMemory,
+        episodic: EpisodicMemory,
+        procedural: ProceduralMemory,
+        tmp_path: Path,
+    ) -> None:
+        """The big #225 win: slot is non-empty even though success=False.
+
+        Sub-agent commits a checkpoint, then keeps spinning, then runs out of
+        turns. Parent gets the checkpoint as output instead of an empty hand.
+        """
+        registry = ToolRegistry()
+        registry.register(_make_failing_tool())
+        router = _FakeRouter([
+            _result_write_response("c1", "checkpoint A: 3/5 done"),
+            _tool_use_response("c2", "trying to finish"),
+        ])
+        scratchpad = Scratchpad()
+
+        result = await run_subagent(
+            SubAgentConfig(
+                task="Do five things.",
+                model="gpt-test",
+                allowed_tools=["always_fail"],
+                max_turns=2,
+                agent_id="sub-slot-maxturns",
+            ),
+            router=router,
+            episodic=episodic,
+            semantic=semantic,
+            procedural=procedural,
+            tool_registry=registry,
+            parent_session_id="parent-1",
+            workspace=tmp_path,
+            scratchpad=scratchpad,
+        )
+
+        assert result.success is False
+        assert result.result_slot == "checkpoint A: 3/5 done"
+        # The key contract: output is non-empty on max_turns when slot was set.
+        assert result.output == "checkpoint A: 3/5 done"
+        # And the scratchpad payload carries it for full audit.
+        payload = json.loads(scratchpad.read(f"subagent_failure:sub-slot-maxturns"))
+        assert payload["result_slot"] == "checkpoint A: 3/5 done"
+
+    async def test_slot_overwrites_on_repeated_writes(
+        self,
+        semantic: SemanticMemory,
+        episodic: EpisodicMemory,
+        procedural: ProceduralMemory,
+        tmp_path: Path,
+    ) -> None:
+        """Each result_write replaces the slot — last write wins."""
+        registry = ToolRegistry()
+        router = _FakeRouter([
+            _result_write_response("c1", "version 1"),
+            _result_write_response("c2", "version 2 — refined"),
+            _end_turn_response("done"),
+        ])
+
+        result = await run_subagent(
+            SubAgentConfig(
+                task="x",
+                model="gpt-test",
+                allowed_tools=[],
+                max_turns=5,
+                agent_id="sub-overwrite",
+            ),
+            router=router,
+            episodic=episodic,
+            semantic=semantic,
+            procedural=procedural,
+            tool_registry=registry,
+            parent_session_id="parent-1",
+            workspace=tmp_path,
+        )
+
+        assert result.result_slot == "version 2 — refined"
+        assert result.output == "version 2 — refined"
+
+
+class TestWrapupReminder:
+    """Issue #225: harness injects a wrap-up reminder when 2 turns remain."""
+
+    async def test_reminder_injected_when_two_turns_left(
+        self,
+        semantic: SemanticMemory,
+        episodic: EpisodicMemory,
+        procedural: ProceduralMemory,
+        tmp_path: Path,
+    ) -> None:
+        """With max_turns=4, after turn 2 (turns_remaining=2) reminder fires.
+
+        We verify by spying on the messages list — the test router records
+        the messages it received on each call.
+        """
+        registry = ToolRegistry()
+        registry.register(_make_failing_tool())
+
+        seen_messages: list[list[dict]] = []
+
+        class _SpyRouter(_FakeRouter):
+            async def stream_chat(self, model, messages, tools=None, max_tokens=8096):
+                seen_messages.append([dict(m) for m in messages])
+                async for chunk, final in super().stream_chat(model, messages, tools, max_tokens):
+                    yield chunk, final
+
+        router = _SpyRouter([
+            _tool_use_response("c1", "turn 1"),
+            _tool_use_response("c2", "turn 2"),
+            _tool_use_response("c3", "turn 3"),
+            _tool_use_response("c4", "turn 4"),
+        ])
+
+        await run_subagent(
+            SubAgentConfig(
+                task="x",
+                model="gpt-test",
+                allowed_tools=["always_fail"],
+                max_turns=4,
+                agent_id="sub-wrap",
+            ),
+            router=router,
+            episodic=episodic,
+            semantic=semantic,
+            procedural=procedural,
+            tool_registry=registry,
+            parent_session_id="parent-1",
+            workspace=tmp_path,
+        )
+
+        # The reminder is appended after the tool_use of turn 2 (turns_used==2,
+        # remaining==2), so the 3rd LLM call should see it in its messages.
+        third_call = seen_messages[2]
+        reminder_present = any(
+            isinstance(m.get("content"), str) and "2 turns left" in m["content"]
+            for m in third_call
+        )
+        assert reminder_present, "wrap-up reminder should be injected before turn 3"
+
+        # And it should fire only once — turn 4's messages should still contain
+        # exactly one such reminder.
+        fourth_call = seen_messages[3]
+        count = sum(
+            1 for m in fourth_call
+            if isinstance(m.get("content"), str) and "2 turns left" in m["content"]
+        )
+        assert count == 1, f"reminder should be idempotent; saw {count}"
+
+    async def test_reminder_skipped_when_max_turns_below_three(
+        self,
+        semantic: SemanticMemory,
+        episodic: EpisodicMemory,
+        procedural: ProceduralMemory,
+        tmp_path: Path,
+    ) -> None:
+        """max_turns=2 gives no useful 'wrap up' window — reminder must not fire."""
+        registry = ToolRegistry()
+        registry.register(_make_failing_tool())
+
+        seen_messages: list[list[dict]] = []
+
+        class _SpyRouter(_FakeRouter):
+            async def stream_chat(self, model, messages, tools=None, max_tokens=8096):
+                seen_messages.append([dict(m) for m in messages])
+                async for chunk, final in super().stream_chat(model, messages, tools, max_tokens):
+                    yield chunk, final
+
+        router = _SpyRouter([
+            _tool_use_response("c1", "turn 1"),
+            _tool_use_response("c2", "turn 2"),
+        ])
+
+        await run_subagent(
+            SubAgentConfig(
+                task="x",
+                model="gpt-test",
+                allowed_tools=["always_fail"],
+                max_turns=2,
+                agent_id="sub-wrap-short",
+            ),
+            router=router,
+            episodic=episodic,
+            semantic=semantic,
+            procedural=procedural,
+            tool_registry=registry,
+            parent_session_id="parent-1",
+            workspace=tmp_path,
+        )
+
+        # No call should have seen the reminder.
+        for msgs in seen_messages:
+            for m in msgs:
+                assert not (
+                    isinstance(m.get("content"), str)
+                    and "2 turns left" in m["content"]
+                ), "no reminder expected when max_turns < 3"


### PR DESCRIPTION
Closes #225.

## Reframing

The original issue proposed merging the sub-agent's scratchpad into the parent's namespace on failure, on the assumption that intermediate work was being lost to a session-scoped clear. After reading the architecture (`subagent.py` shares `parent_session._scratchpad` and `_jobstore`; nothing is per-session-scoped; teardown only happens on parent `session.stop()`), the real gap turned out to be different: **the sub-agent's `final_output` is only filled at `end_turn`, and on `max_turns` the parent gets an empty string**. Async job refs survive fine — the lost work was the sub-agent's own conclusions.

So this PR fixes the structural cause (sub-agent unreliability when it runs out of turns) rather than the proposed workaround (post-hoc scratchpad merge).

## What changes

### 1. `result_write` slot

Sub-agent gets an always-available `result_write(content=...)` tool, registered in `child_registry` after `allowed_tools` filtering so it's available even when the parent passes a tight whitelist. The slot is **overwrite-only** — each call replaces the prior content.

- end_turn + non-empty slot → output = slot (explicit hand-off wins)
- end_turn + empty slot → output = end_turn text (legacy)
- max_turns + non-empty slot → \`output = slot\`, \`success=False\` (end_turn is the only honest 'done' signal, but parent isn't empty-handed)
- max_turns + empty slot → output = '' (existing behavior)

The slot also lands in the failure scratchpad payload (\`result_slot\` field) and inline in spawn_agent's error string (truncated to 800 chars) so the parent can act without a follow-up \`scratchpad_read\`.

### 2. Wrap-up reminder

When 2 turns remain (and \`max_turns >= 3\`), the harness injects a one-shot \`<system-reminder>\` user message telling the sub-agent to commit a result and \`end_turn\`. Idempotent. Skipped for short \`max_turns\` where the warning window isn't useful.

### 3. System prompt

Sub-agent's system prompt now explains the result_write contract: write incrementally at every meaningful checkpoint, refine on the next turn — don't wait until end_turn.

### Use-case guidance (Agent.md)

A small section was added to the local \`Agent.md\` covering when to use \`spawn_agent\` (context isolation) vs not (fan-out → use async tools + Scratchpad). \`Agent.md\` is gitignored as a user-personal file, so it's not part of this PR's diff — it's a local-only artifact mirroring the saved feedback.

## Files

- \`loom/core/agent/subagent.py\` — register \`result_write\`, track slot, prefer slot over end_turn text, wrap-up reminder injection, slot in SubAgentResult + scratchpad payload, system prompt guidance
- \`loom/platform/cli/tools.py\` — surface \`result_slot\` inline (truncated) in spawn_agent's failure error string + metadata
- \`tests/test_subagent.py\` — 7 new tests across two new test classes

## Test plan

- [x] Existing 8 \`test_subagent.py\` tests unchanged and pass — backward compatible
- [x] 7 new tests for slot semantics + reminder behavior
- [x] Full suite: 1172 passed (1 unrelated pre-existing version-string mismatch deselected)
- [ ] Manual: spawn a sub-agent with max_turns=4 doing real work, verify wrap-up reminder lands and slot survives a forced timeout

## Notes for review

- The defensive \`isinstance(content, str)\` check in \`_result_write\` is unreachable through the normal pipeline (SchemaValidationMiddleware coerces ints to strings before the executor runs). Kept as belt-and-suspenders rather than tested through-the-pipe — testing it would require bypassing the validation layer, which is the wrong shape of test.
- The wrap-up reminder fires on \`turns_remaining == 2\` specifically (not \`<= 2\`) because it should land **before** the second-to-last turn fires, not after. The idempotency flag protects against accidental re-injection if the loop structure changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)