### PR TITLE
feat: Anthropic prompt caching with cache hit % display (#224)

### DIFF
--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -322,8 +322,16 @@ class AnthropicProvider(LLMProvider):
                 for tu in tool_uses
             ]
 
-        cache_read = getattr(response.usage, "cache_read_input_tokens", 0) or 0
-        cache_creation = getattr(response.usage, "cache_creation_input_tokens", 0) or 0
+        cache_read = (
+            getattr(response.usage, "cache_read_input_tokens", 0)  # Anthropic
+            or getattr(response.usage, "prompt_cache_hit_tokens", 0)  # DeepSeek
+            or 0
+        )
+        cache_creation = (
+            getattr(response.usage, "cache_creation_input_tokens", 0)  # Anthropic
+            or getattr(response.usage, "prompt_cache_miss_tokens", 0)  # DeepSeek
+            or 0
+        )
         return LLMResponse(
             text=text,
             tool_uses=tool_uses,

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -103,6 +103,8 @@ class LLMResponse:
     stop_reason: str          # "end_turn" | "tool_use" | "max_tokens"
     input_tokens: int = 0
     output_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
     raw_message: dict[str, Any] = field(default_factory=dict)
 
 
@@ -252,7 +254,10 @@ class AnthropicProvider(LLMProvider):
             "messages": anthropic_msgs,
         }
         if system_text:
-            kwargs["system"] = system_text
+            kwargs["system"] = [
+                {"type": "text", "text": system_text,
+                 "cache_control": {"type": "ephemeral"}}
+            ]
         if tools:
             kwargs["tools"] = [
                 {"name": t["name"], "description": t.get("description", ""),
@@ -317,12 +322,16 @@ class AnthropicProvider(LLMProvider):
                 for tu in tool_uses
             ]
 
+        cache_read = getattr(response.usage, "cache_read_input_tokens", 0) or 0
+        cache_creation = getattr(response.usage, "cache_creation_input_tokens", 0) or 0
         return LLMResponse(
             text=text,
             tool_uses=tool_uses,
             stop_reason=stop_reason,
             input_tokens=response.usage.input_tokens if response.usage else 0,
             output_tokens=response.usage.output_tokens if response.usage else 0,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_creation,
             raw_message=raw_message,
         )
 

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
+import os
 import time
 import uuid
 from abc import ABC, abstractmethod
@@ -35,6 +37,8 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from .forensics import get_forensics
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -321,6 +325,20 @@ class AnthropicProvider(LLMProvider):
                 }
                 for tu in tool_uses
             ]
+
+        # Diagnostic: dump the raw usage payload when LOOM_DEBUG_USAGE=1.
+        # Cheap one-shot for verifying which cache fields the provider's wire
+        # actually returns (e.g. whether DeepSeek's /anthropic compat endpoint
+        # passes through prompt_cache_hit_tokens). Off by default.
+        if response.usage and os.environ.get("LOOM_DEBUG_USAGE") == "1":
+            try:
+                payload = response.usage.model_dump()
+            except Exception:
+                payload = {k: getattr(response.usage, k, None) for k in dir(response.usage) if not k.startswith("_")}
+            logger.warning(
+                "LOOM_DEBUG_USAGE provider=%s model=%s usage=%s",
+                self.name, self.model, json.dumps(payload, default=str),
+            )
 
         cache_read = (
             getattr(response.usage, "cache_read_input_tokens", 0)  # Anthropic

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -476,6 +476,34 @@ class AnthropicProvider(LLMProvider):
                 input_tokens = final.usage.input_tokens
                 output_tokens = final.usage.output_tokens
 
+        # Cache token extraction — must mirror _sync_chat. The original PR #229
+        # added this only to the sync path, but streaming consumers (CLI /
+        # Discord) go through stream_chat — without these the cache hit % is
+        # always 0 in the live UIs even when the wire returns cache fields.
+        cache_read = 0
+        cache_creation = 0
+        if final is not None and final.usage:
+            cache_read = (
+                getattr(final.usage, "cache_read_input_tokens", 0)
+                or getattr(final.usage, "prompt_cache_hit_tokens", 0)
+                or 0
+            )
+            cache_creation = (
+                getattr(final.usage, "cache_creation_input_tokens", 0)
+                or getattr(final.usage, "prompt_cache_miss_tokens", 0)
+                or 0
+            )
+
+            if os.environ.get("LOOM_DEBUG_USAGE") == "1":
+                try:
+                    payload = final.usage.model_dump()
+                except Exception:
+                    payload = {k: getattr(final.usage, k, None) for k in dir(final.usage) if not k.startswith("_")}
+                logger.warning(
+                    "LOOM_DEBUG_USAGE provider=%s model=%s usage=%s",
+                    self.name, self.model, json.dumps(payload, default=str),
+                )
+
         raw_message: dict[str, Any] = {"role": "assistant", "content": full_text or ""}
         if thinking_blocks:
             raw_message["_thinking_blocks"] = thinking_blocks
@@ -498,6 +526,8 @@ class AnthropicProvider(LLMProvider):
             stop_reason=stop_reason,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_creation,
             raw_message=raw_message,
         ))
 

--- a/loom/core/events.py
+++ b/loom/core/events.py
@@ -180,9 +180,10 @@ class TurnDone:
     tool_count: int
     input_tokens: int
     output_tokens: int
+    elapsed_ms: float
+    # Defaulted fields must follow non-default fields (dataclass rule).
     cache_read_input_tokens: int = 0
     cache_creation_input_tokens: int = 0
-    elapsed_ms: float
     stop_reason: str = "complete"  # "complete" | "cancelled"
 
 

--- a/loom/core/events.py
+++ b/loom/core/events.py
@@ -180,6 +180,8 @@ class TurnDone:
     tool_count: int
     input_tokens: int
     output_tokens: int
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
     elapsed_ms: float
     stop_reason: str = "complete"  # "complete" | "cancelled"
 

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1714,8 +1714,12 @@ class LoomSession:
                 self.messages.append(response.raw_message)
                 input_tokens = response.input_tokens  # report latest actual value
                 output_tokens += response.output_tokens
-                cache_read_input_tokens += getattr(response, "cache_read_input_tokens", 0) or 0
-                cache_creation_input_tokens += getattr(response, "cache_creation_input_tokens", 0) or 0
+                # Cache tokens follow the same replace semantics as input_tokens:
+                # each LLM call's usage already reflects the cumulative cached
+                # context for that call. Accumulating with += would double-count
+                # across tool-call rounds and skew the displayed hit rate.
+                cache_read_input_tokens = getattr(response, "cache_read_input_tokens", 0) or 0
+                cache_creation_input_tokens = getattr(response, "cache_creation_input_tokens", 0) or 0
 
                 # Log the full raw_message as JSON so tool_calls are preserved for resume.
                 # New path: raw_message goes into the dedicated `raw_json` column.
@@ -1842,9 +1846,9 @@ class LoomSession:
                         tool_count=tool_count,
                         input_tokens=input_tokens,
                         output_tokens=output_tokens,
+                        elapsed_ms=(time.monotonic() - t0) * 1000,
                         cache_read_input_tokens=cache_read_input_tokens,
                         cache_creation_input_tokens=cache_creation_input_tokens,
-                        elapsed_ms=(time.monotonic() - t0) * 1000,
                     )
                     return
 
@@ -2048,9 +2052,9 @@ class LoomSession:
                                 tool_count=tool_count,
                                 input_tokens=input_tokens,
                                 output_tokens=output_tokens,
-                        cache_read_input_tokens=cache_read_input_tokens,
-                        cache_creation_input_tokens=cache_creation_input_tokens,
                                 elapsed_ms=(time.monotonic() - t0) * 1000,
+                                cache_read_input_tokens=cache_read_input_tokens,
+                                cache_creation_input_tokens=cache_creation_input_tokens,
                             )
                             return
                 else:
@@ -2077,9 +2081,9 @@ class LoomSession:
                 tool_count=tool_count,
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
-                        cache_read_input_tokens=cache_read_input_tokens,
-                        cache_creation_input_tokens=cache_creation_input_tokens,
                 elapsed_ms=(time.monotonic() - t0) * 1000,
+                cache_read_input_tokens=cache_read_input_tokens,
+                cache_creation_input_tokens=cache_creation_input_tokens,
                 stop_reason=_stop_reason,
             )
         finally:

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1530,6 +1530,8 @@ class LoomSession:
             tool_count = 0
             input_tokens = 0
             output_tokens = 0
+            cache_read_input_tokens = 0
+            cache_creation_input_tokens = 0
             t0 = time.monotonic()
 
             # Think-block filter state — persists across the whole turn so multi-step
@@ -1712,6 +1714,8 @@ class LoomSession:
                 self.messages.append(response.raw_message)
                 input_tokens = response.input_tokens  # report latest actual value
                 output_tokens += response.output_tokens
+                cache_read_input_tokens += getattr(response, "cache_read_input_tokens", 0) or 0
+                cache_creation_input_tokens += getattr(response, "cache_creation_input_tokens", 0) or 0
 
                 # Log the full raw_message as JSON so tool_calls are preserved for resume.
                 # New path: raw_message goes into the dedicated `raw_json` column.
@@ -1838,6 +1842,8 @@ class LoomSession:
                         tool_count=tool_count,
                         input_tokens=input_tokens,
                         output_tokens=output_tokens,
+                        cache_read_input_tokens=cache_read_input_tokens,
+                        cache_creation_input_tokens=cache_creation_input_tokens,
                         elapsed_ms=(time.monotonic() - t0) * 1000,
                     )
                     return
@@ -2042,6 +2048,8 @@ class LoomSession:
                                 tool_count=tool_count,
                                 input_tokens=input_tokens,
                                 output_tokens=output_tokens,
+                        cache_read_input_tokens=cache_read_input_tokens,
+                        cache_creation_input_tokens=cache_creation_input_tokens,
                                 elapsed_ms=(time.monotonic() - t0) * 1000,
                             )
                             return
@@ -2069,6 +2077,8 @@ class LoomSession:
                 tool_count=tool_count,
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
+                        cache_read_input_tokens=cache_read_input_tokens,
+                        cache_creation_input_tokens=cache_creation_input_tokens,
                 elapsed_ms=(time.monotonic() - t0) * 1000,
                 stop_reason=_stop_reason,
             )

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -1210,6 +1210,8 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 clear_line()
                 if not at_line_start:
                     console.print()
+                cache_total = event.cache_read_input_tokens + event.cache_creation_input_tokens + event.input_tokens
+                cache_hit_pct = (event.cache_read_input_tokens / cache_total * 100) if cache_total > 0 else 0.0
                 elapsed = time.monotonic() - t0
                 console.print(
                     status_bar(
@@ -1218,6 +1220,7 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                         output_tokens=event.output_tokens,
                         elapsed_ms=elapsed * 1000,
                         tool_count=event.tool_count,
+                        cache_hit_pct=cache_hit_pct,
                     )
                 )
 

--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -268,6 +268,7 @@ def status_bar(
     output_tokens: int,
     elapsed_ms: float,
     tool_count: int,
+    cache_hit_pct: float = 0.0,
 ) -> Text:
     """
     Render the closing status bar after a turn completes.
@@ -284,6 +285,7 @@ def status_bar(
         f"[dim]-[/dim]"
         f"[{ctx_color}]{bar}[/{ctx_color}]"
         f"[dim] context {pct:.1f}%  |  "
+        f"cache {cache_hit_pct:.0f}%  |  " if cache_hit_pct > 0 else ""
         f"{input_tokens}in / {output_tokens}out  |  "
         f"{elapsed_ms / 1000:.1f}s  |  "
         f"{tool_count} tool{'s' if tool_count != 1 else ''}"

--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -281,11 +281,15 @@ def status_bar(
     filled = int(bar_len * context_fraction)
     bar = "#" * filled + "." * (bar_len - filled)
 
+    # Extracted into a variable: a conditional expression mid-f-string would
+    # bind to adjacent string literals via implicit concat at lex time, eating
+    # the segments on either side. See PR #229 review.
+    cache_seg = f"cache {cache_hit_pct:.0f}%  |  " if cache_hit_pct > 0 else ""
+
     return Text.from_markup(
         f"[dim]-[/dim]"
         f"[{ctx_color}]{bar}[/{ctx_color}]"
-        f"[dim] context {pct:.1f}%  |  "
-        f"cache {cache_hit_pct:.0f}%  |  " if cache_hit_pct > 0 else ""
+        f"[dim] context {pct:.1f}%  |  {cache_seg}"
         f"{input_tokens}in / {output_tokens}out  |  "
         f"{elapsed_ms / 1000:.1f}s  |  "
         f"{tool_count} tool{'s' if tool_count != 1 else ''}"

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -1047,6 +1047,13 @@ class LoomDiscordBot:
                 chunk, remaining = remaining[:_MAX_CHARS], remaining[_MAX_CHARS:]
                 await message.channel.send(chunk)
 
+        # cache_tag is consumed by both the embed footer (below) and the
+        # post-summary footer further down — compute once up front so the
+        # embed branch doesn't reference an undefined name. (PR #229 review.)
+        cache_total = _cache_read_tokens + _cache_creation_tokens + _cache_input_tokens
+        cache_hit_pct = (_cache_read_tokens / cache_total * 100) if cache_total > 0 else 0.0
+        cache_tag = f"  ·  cache {cache_hit_pct:.0f}%" if cache_hit_pct > 0 else ""
+
         # ── Turn summary (if enabled) ─────────────────────────────────────
         if self._summary_mode != "off" and _envelope_count > 0:
             # Grants info
@@ -1083,9 +1090,6 @@ class LoomDiscordBot:
                 await message.channel.send(f"-# {' · '.join(parts)}")
 
         # ── Footer: persona / context / model ────────────────────────────
-        cache_total = _cache_read_tokens + _cache_creation_tokens + _cache_input_tokens
-        cache_hit_pct = (_cache_read_tokens / cache_total * 100) if cache_total > 0 else 0.0
-        cache_tag = f"  ·  cache {cache_hit_pct:.0f}%" if cache_hit_pct > 0 else ""
         persona = session.current_personality or "default"
         pct = session.budget.usage_fraction * 100
         model = session.model

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -826,6 +826,9 @@ class LoomDiscordBot:
         _total_actions = 0
         _total_failures = 0
         _total_elapsed_ms = 0.0
+        _cache_read_tokens = 0
+        _cache_creation_tokens = 0
+        _cache_input_tokens = 0
         _had_pause = False
         _had_rollback = False
 
@@ -988,6 +991,9 @@ class LoomDiscordBot:
                         pass  # too granular for Discord display
 
                     elif isinstance(event, TurnDone):
+                        _cache_read_tokens = event.cache_read_input_tokens
+                        _cache_creation_tokens = event.cache_creation_input_tokens
+                        _cache_input_tokens = event.input_tokens
                         if event.stop_reason == "cancelled":
                             await message.channel.send(
                                 "⚠️ **Turn aborted** — too many denied authorizations. "
@@ -1065,7 +1071,7 @@ class LoomDiscordBot:
                 if _had_rollback:
                     embed.add_field(name="Rollbacks", value="Yes", inline=True)
                 embed.add_field(name="Grants", value=grants_str, inline=True)
-                embed.set_footer(text=f"{session.current_personality or 'default'}  ·  context {session.budget.usage_fraction * 100:.1f}%  ·  {session.model}")
+                embed.set_footer(text=f"{session.current_personality or 'default'}  ·  context {session.budget.usage_fraction * 100:.1f}%  ·  {session.model}{cache_tag}")
                 await message.channel.send(embed=embed)
             else:
                 # Compact one-liner
@@ -1077,13 +1083,16 @@ class LoomDiscordBot:
                 await message.channel.send(f"-# {' · '.join(parts)}")
 
         # ── Footer: persona / context / model ────────────────────────────
+        cache_total = _cache_read_tokens + _cache_creation_tokens + _cache_input_tokens
+        cache_hit_pct = (_cache_read_tokens / cache_total * 100) if cache_total > 0 else 0.0
+        cache_tag = f"  ·  cache {cache_hit_pct:.0f}%" if cache_hit_pct > 0 else ""
         persona = session.current_personality or "default"
         pct = session.budget.usage_fraction * 100
         model = session.model
         # Skip footer if detail summary already includes it
         if not (self._summary_mode == "detail" and _envelope_count > 0):
             await message.channel.send(
-                f"-# {persona}  ·  context {pct:.1f}%  ·  {model}"
+                f"-# {persona}  ·  context {pct:.1f}%{cache_tag}  ·  {model}"
             )
 
         # ── Mark done ─────────────────────────────────────────────────────

--- a/tests/test_cache_display.py
+++ b/tests/test_cache_display.py
@@ -1,0 +1,131 @@
+"""Regression tests for prompt-caching plumbing (issue #224, PR #229).
+
+The PR initially had three execution-level bugs that an import + smoke test
+would have caught immediately:
+
+1. ``TurnDone`` dataclass: defaulted cache fields placed before non-default
+   ``elapsed_ms`` ⇒ module fails to import.
+2. ``status_bar`` f-string: a mid-string ``... if cond else ""`` consumed the
+   adjacent string-literal segments via implicit concatenation, producing a
+   half-empty status bar in *both* branches.
+3. ``Discord _run_turn``: ``cache_tag`` referenced before being defined when
+   the embed (detail) summary path was taken.
+
+These tests guard the contracts that, if violated again, would re-introduce
+those failures.
+"""
+
+from __future__ import annotations
+
+from loom.core.events import TurnDone
+from loom.core.cognition.providers import LLMResponse
+from loom.platform.cli.ui import status_bar
+
+
+# ── TurnDone dataclass ──────────────────────────────────────────────────────
+
+
+class TestTurnDoneCacheFields:
+    def test_construct_with_only_required_fields(self):
+        # Defaulted cache fields must come AFTER all non-default fields, or
+        # this construction (and the import itself) blows up.
+        t = TurnDone(
+            tool_count=1,
+            input_tokens=100,
+            output_tokens=50,
+            elapsed_ms=1234.0,
+        )
+        assert t.cache_read_input_tokens == 0
+        assert t.cache_creation_input_tokens == 0
+        assert t.stop_reason == "complete"
+
+    def test_construct_with_cache_fields(self):
+        t = TurnDone(
+            tool_count=1,
+            input_tokens=100,
+            output_tokens=50,
+            elapsed_ms=1234.0,
+            cache_read_input_tokens=8000,
+            cache_creation_input_tokens=200,
+        )
+        assert t.cache_read_input_tokens == 8000
+        assert t.cache_creation_input_tokens == 200
+
+
+# ── LLMResponse cache fields ────────────────────────────────────────────────
+
+
+class TestLLMResponseCacheFields:
+    def test_defaults_zero(self):
+        r = LLMResponse(
+            text="hi", tool_uses=[], stop_reason="end_turn",
+        )
+        assert r.cache_read_input_tokens == 0
+        assert r.cache_creation_input_tokens == 0
+
+    def test_carry_explicit_values(self):
+        r = LLMResponse(
+            text="hi", tool_uses=[], stop_reason="end_turn",
+            cache_read_input_tokens=5000,
+            cache_creation_input_tokens=100,
+        )
+        assert r.cache_read_input_tokens == 5000
+        assert r.cache_creation_input_tokens == 100
+
+
+# ── status_bar rendering ────────────────────────────────────────────────────
+
+
+class TestStatusBarSegments:
+    """The PR-#229 noise: a mid-f-string conditional ate adjacent literals.
+
+    Both branches must contain ALL of: context %, in/out tokens, elapsed,
+    tool count. The cache segment is the only optional piece.
+    """
+
+    @staticmethod
+    def _render(cache_pct: float = 0.0) -> str:
+        return status_bar(
+            context_fraction=0.5,
+            input_tokens=100,
+            output_tokens=50,
+            elapsed_ms=1234.0,
+            tool_count=2,
+            cache_hit_pct=cache_pct,
+        ).plain
+
+    def test_cache_zero_keeps_all_other_segments(self):
+        s = self._render(cache_pct=0.0)
+        assert "context 50.0%" in s
+        assert "100in / 50out" in s
+        assert "1.2s" in s
+        assert "2 tools" in s
+        # cache segment hidden
+        assert "cache" not in s
+
+    def test_cache_nonzero_keeps_all_segments_and_adds_cache(self):
+        s = self._render(cache_pct=80.0)
+        assert "context 50.0%" in s
+        assert "cache 80%" in s
+        assert "100in / 50out" in s
+        assert "1.2s" in s
+        assert "2 tools" in s
+
+    def test_cache_segment_position_between_context_and_io(self):
+        # Order matters for readability — cache should sit next to context %.
+        s = self._render(cache_pct=42.0)
+        ctx_idx = s.index("context")
+        cache_idx = s.index("cache 42%")
+        io_idx = s.index("100in")
+        assert ctx_idx < cache_idx < io_idx
+
+    def test_singular_tool_label(self):
+        s = status_bar(0.5, 100, 50, 1234.0, 1).plain
+        assert "1 tool" in s and "tools" not in s
+
+    def test_default_cache_pct_is_zero(self):
+        # cache_hit_pct has a default — calls without it must still render
+        # all required segments.
+        s = status_bar(0.5, 100, 50, 1234.0, 2).plain
+        assert "context" in s
+        assert "100in / 50out" in s


### PR DESCRIPTION
## Summary

Implements Prompt Caching for session multi-turn conversations across Anthropic, MiniMax, and DeepSeek, with cache hit % display across CLI and Discord.

### What's Changed

**Core caching (providers.py)**
- LLMResponse gains cache_read_input_tokens / cache_creation_input_tokens (default 0)
- AnthropicProvider._sync_chat() wraps system prompt with explicit cache_control breakpoint
- Uses **explicit breakpoint** — NOT automatic caching (which would place breakpoint on the per-turn user message, causing write-but-never-read)
- Cache metrics extraction compatible with both Anthropic (cache_read_input_tokens) and DeepSeek (prompt_cache_hit_tokens) field names

**Data flow (events.py → session.py)**
- TurnDone event gains cache fields
- Session accumulates cache metrics across tool-call rounds → all 3 TurnDone yields

**Display — CLI (ui.py + main.py)**
- status_bar() shows cache 92% only when cache_read > 0
- First request / non-caching providers stay silent

**Display — Discord (bot.py)**
- Cache hit % appended to both embed footer and compact footer

### Provider Coverage

| Provider | Mechanism | Code Change Needed? | Metrics Field |
|----------|-----------|---------------------|---------------|
| Anthropic | Explicit cache_control (5-min TTL) | Yes — cache_control on system prompt | cache_read_input_tokens |
| MiniMax | Passive caching (auto) + Explicit (Anthropic API) | No — passive works automatically; explicit is bonus | cache_read_input_tokens |
| DeepSeek | Disk-based KV cache (hours-days TTL, default on) | No — enabled by default | prompt_cache_hit_tokens |
| OpenRouter/Ollama/LMStudio | N/A | No — silently returns 0 | — |

### Design Decisions

| Decision | Rationale |
|----------|----------|
| Explicit breakpoint, not automatic | Automatic places breakpoint on user message → never reads |
| Breakpoint on system prompt only | Static within session, survives context compression |
| 5-min TTL (Anthropic, default) | Sufficient for multi-turn; 1h TTL as follow-up |
| Show only when hit > 0 | Avoids noise on first request / non-caching providers |
| Dual field-name extraction | Anthropic + DeepSeek use different usage field names |
| cache_control sent to all Anthropic-compatible endpoints | DeepSeek ignores it; MiniMax recognizes it; no harm |

### Backward Compatibility

All new fields default to 0. Non-Anthropic providers (OpenRouter, Ollama, LMStudio) completely untouched.

Closes #224