### PR TITLE
fix(telemetry): edge-trigger anomaly alerts (#219)

### DIFF
--- a/loom/core/infra/telemetry.py
+++ b/loom/core/infra/telemetry.py
@@ -575,15 +575,25 @@ class AgentTelemetryTracker:
         blocks = [dim.render_detail() for dim in self._dims.values()]
         return "\n\n".join(blocks)
 
-    def anomaly_report(self) -> str | None:
-        """Compact injectable string when one or more dimensions signal
-        trouble. Returns None when everything is nominal — the turn-boundary
+    def alerting_dimensions(self) -> set[str]:
+        """Names of dimensions currently in an anomalous state."""
+        return {d.name for d in self._dims.values() if d.has_anomaly()}
+
+    def anomaly_report(self, since: set[str] | None = None) -> str | None:
+        """Compact injectable string for dimensions that are currently
+        anomalous. Returns None when nothing fires — the turn-boundary
         injector uses None to stay silent.
+
+        When ``since`` is provided, dimensions already present in that set are
+        treated as "still alerting" and excluded from the report; only rising-
+        edge transitions are surfaced. This is how Issue #219 dedupes the
+        alert — once an anomaly has been announced, it stays quiet until it
+        clears and re-enters the bad state.
         """
         active = [
             (d.name, d.describe_anomaly())
             for d in self._dims.values()
-            if d.has_anomaly()
+            if d.has_anomaly() and (since is None or d.name not in since)
         ]
         if not active:
             return None

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -789,7 +789,12 @@ class LoomSession:
             tuple(_tele_dims) if _tele_dims else DEFAULT_DIMENSIONS
         )
         self._telemetry: "AgentTelemetryTracker | None" = None
-        self._telemetry_alerted_turns: set[int] = set()
+        # Dimensions currently in an alerting state. Edge-triggered: an
+        # anomaly fires once when it rises into this set, then stays quiet
+        # until it recovers (drops out) and crosses the threshold again.
+        # Replaces the old per-turn dedup which still re-fired every turn
+        # while the rolling window stayed bad (#219).
+        self._telemetry_alerting_dims: set[str] = set()
 
     # ------------------------------------------------------------------
     # Personality management
@@ -1776,21 +1781,25 @@ class LoomSession:
                             _jobs_inject_done = True
                             continue
 
-                    # Issue #142: nudge the agent with a self-observability alert
-                    # iff a dimension is outside bounds. Fires at most once per
-                    # turn (tracked via _telemetry_alerted_turns) so repeat
-                    # anomalies don't flood the context.
-                    if (
-                        self._telemetry is not None
-                        and self._turn_index not in self._telemetry_alerted_turns
-                    ):
-                        alert = self._telemetry.anomaly_report()
+                    # Issue #142 / #219: nudge the agent with a self-
+                    # observability alert when a dimension *transitions* into
+                    # an anomalous state. Edge-triggered against
+                    # `_telemetry_alerting_dims` so repeat anomalies don't
+                    # flood the context every turn while the rolling window
+                    # stays bad.
+                    if self._telemetry is not None:
+                        currently = self._telemetry.alerting_dimensions()
+                        alert = self._telemetry.anomaly_report(
+                            since=self._telemetry_alerting_dims
+                        )
+                        # Update tracked set regardless: dimensions that have
+                        # recovered drop out, so they can re-fire on next entry.
+                        self._telemetry_alerting_dims = currently
                         if alert:
                             self.messages.append({
                                 "role": "user",
                                 "content": f"<system-reminder>\n{alert}\n</system-reminder>",
                             })
-                            self._telemetry_alerted_turns.add(self._turn_index)
                             continue
 
                     # Issue #196 Phase 2: turn-boundary judge. Predicate is pure

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -265,6 +265,39 @@ async def test_tracker_anomaly_report_fires(store):
         assert "AGENT TELEMETRY ALERT" in alert
 
 
+async def test_tracker_anomaly_report_edge_triggered(store):
+    """Issue #219: once a dimension has alerted, repeat reports with the
+    same dimension in `since` must stay silent until it recovers and
+    re-enters the bad state."""
+    async with store.connect() as db:
+        tracker = AgentTelemetryTracker(db, "sess-edge")
+        tool_dim = tracker.get("tool_call")
+        tool_dim.record("recall", success=True, duration_ms=1.0)
+        for _ in range(4):
+            tool_dim.record("recall", success=False, duration_ms=1.0, error_msg="oops")
+
+        # Rising edge — first call fires.
+        assert tracker.alerting_dimensions() == {"tool_call"}
+        first = tracker.anomaly_report(since=set())
+        assert first is not None and "tool_call" in first
+
+        # Same condition, but dimension is already known-alerting → silent.
+        assert tracker.anomaly_report(since={"tool_call"}) is None
+
+        # Recover: enough successes push failure rate back below threshold.
+        for _ in range(20):
+            tool_dim.record("recall", success=True, duration_ms=1.0)
+        assert tracker.alerting_dimensions() == set()
+
+        # Re-enter bad state — must fire again on the new rising edge.
+        for _ in range(15):
+            tool_dim.record("recall", success=False, duration_ms=1.0, error_msg="oops again")
+        assert tracker.alerting_dimensions() == {"tool_call"}
+        # Caller's `since` reflects the just-cleared set (empty), so this fires.
+        second = tracker.anomaly_report(since=set())
+        assert second is not None and "tool_call" in second
+
+
 async def test_tracker_reports(store):
     async with store.connect() as db:
         tracker = AgentTelemetryTracker(db, "sess-e")


### PR DESCRIPTION
## Summary
- Closes #219. Telemetry alert (`⚠ AGENT TELEMETRY ALERT …`) used to re-fire on every turn boundary while a dimension's rolling window stayed bad — actionable signal degraded into per-turn noise.
- Fix is approach 3 from the issue (edge trigger): alert fires when a dimension *transitions* into the bad state, stays silent while it remains bad, and re-fires only after recovery + re-entry.

## Changes
- `loom/core/infra/telemetry.py`: add `alerting_dimensions()` and a `since: set[str]` param to `anomaly_report()` so callers can diff turn-over-turn and surface only rising edges.
- `loom/core/session.py`: replace `_telemetry_alerted_turns: set[int]` (per-turn dedup, broken across turns) with `_telemetry_alerting_dims: set[str]`. Recovered dimensions drop out so they can fire again later.
- `tests/test_telemetry.py`: regression test covering rise → silent-while-bad → recover → re-fire.

## Test plan
- [x] `pytest tests/test_telemetry.py` (21 passed)
- [x] `pytest tests/ -k "session or telemetry"` (55 passed)
- [ ] Manual: trigger a `read_file` failure in a session, confirm alert appears once, then stays quiet on subsequent turns until window clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)