### PR TITLE
feat(discord): send_discord_select tool for bounded-choice prompts (#190)

### DIFF
--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -78,7 +78,11 @@ from loom.platform.cli.ui import (
     CompressDone, TextChunk, ThinkCollapsed, ToolBegin, ToolEnd,
     TurnDone, TurnDropped, TurnPaused,
 )
-from loom.platform.discord.tools import make_send_discord_file_tool, make_send_discord_embed_tool
+from loom.platform.discord.tools import (
+    make_send_discord_embed_tool,
+    make_send_discord_file_tool,
+    make_send_discord_select_tool,
+)
 
 if TYPE_CHECKING:
     from loom.core.session import LoomSession
@@ -226,6 +230,10 @@ class LoomDiscordBot:
         self._running_turns: dict[int, asyncio.Task] = {}
         # thread_id → currently active confirmation message (Allow/Deny prompt)
         self._active_confirmations: dict[int, discord.Message] = {}
+        # thread_id → currently active SelectMenu message (#190). Same role
+        # as _active_confirmations: cancelled-turn cleanup disables the view
+        # so the user isn't left staring at a stale dropdown.
+        self._active_selects: dict[int, discord.Message] = {}
         # Turn summary display mode: "off" | "on" | "detail"
         self._summary_mode: str = "on"
 
@@ -426,8 +434,17 @@ class LoomDiscordBot:
         # Inject Discord tools
         session.registry.register(make_send_discord_file_tool(self._client, thread_id, session.workspace))
         session.registry.register(make_send_discord_embed_tool(self._client, thread_id))
+        session.registry.register(
+            make_send_discord_select_tool(
+                self._client,
+                thread_id,
+                register_active=lambda tid, msg: self._active_selects.__setitem__(tid, msg),
+                unregister_active=lambda tid: self._active_selects.pop(tid, None),
+            )
+        )
         session.perm.authorize("send_discord_file")
         session.perm.authorize("send_discord_embed")
+        session.perm.authorize("send_discord_select")
 
         confirm_fn = self._make_confirm_fn(thread_id)
         for mw in session._pipeline._middlewares:
@@ -1010,6 +1027,15 @@ class LoomDiscordBot:
                 if conf_msg:
                     try:
                         await _safe_edit(conf_msg, "🛑 **Turn Cancelled** — authorization revoked.", view=None)
+                    except Exception:
+                        pass
+
+                # Same for any in-flight SelectMenu (#190): disable so the user
+                # isn't left with a clickable menu pointing at an aborted turn.
+                sel_msg = self._active_selects.pop(message.channel.id, None)
+                if sel_msg:
+                    try:
+                        await _safe_edit(sel_msg, "🛑 **Turn Cancelled** — selection discarded.", view=None)
                     except Exception:
                         pass
 

--- a/loom/platform/discord/tools.py
+++ b/loom/platform/discord/tools.py
@@ -5,8 +5,9 @@ Provides capabilities to send files and rich embeds directly to the Discord thre
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     import discord
@@ -14,6 +15,15 @@ if TYPE_CHECKING:
 from loom.core.harness.registry import ToolDefinition
 from loom.core.harness.permissions import TrustLevel
 from loom.core.harness.middleware import ToolCall, ToolResult
+
+
+# Discord SelectMenu hard limits — surface as constants so callers and tests
+# can reference them without re-deriving from the API docs.
+_SELECT_MAX_OPTIONS = 25
+_SELECT_LABEL_MAX = 100
+_SELECT_DESCRIPTION_MAX = 100
+_SELECT_TIMEOUT_DEFAULT = 60
+_SELECT_TIMEOUT_MAX = 600  # 10 min — anything longer is almost certainly a bug
 
 def make_send_discord_file_tool(client: discord.Client, thread_id: int, workspace: Path) -> ToolDefinition:
     async def executor(call: ToolCall) -> ToolResult:
@@ -113,4 +123,233 @@ def make_send_discord_embed_tool(client: discord.Client, thread_id: int) -> Tool
             "required": ["title", "description"]
         },
         executor=executor
+    )
+
+
+def _validate_select_args(args: dict[str, Any]) -> str | None:
+    """Return an error string if args are unusable, else None.
+
+    Validation runs before we touch Discord so the agent gets a clean tool
+    error instead of a 50035 from the API. Discord's hard caps (25 options,
+    100-char label/description) are non-negotiable — exceeding them silently
+    truncates or 400s; we'd rather reject and let the agent retry.
+    """
+    title = args.get("title")
+    if not isinstance(title, str) or not title.strip():
+        return "Missing or empty 'title'."
+
+    options = args.get("options")
+    if not isinstance(options, list) or not options:
+        return "'options' must be a non-empty list."
+    if len(options) > _SELECT_MAX_OPTIONS:
+        return f"Discord allows at most {_SELECT_MAX_OPTIONS} options per select menu (got {len(options)})."
+
+    seen_values: set[str] = set()
+    for i, opt in enumerate(options):
+        if not isinstance(opt, dict):
+            return f"options[{i}] must be an object."
+        label = opt.get("label")
+        value = opt.get("value")
+        if not isinstance(label, str) or not label:
+            return f"options[{i}].label is required."
+        if not isinstance(value, str) or not value:
+            return f"options[{i}].value is required."
+        if len(label) > _SELECT_LABEL_MAX:
+            return f"options[{i}].label exceeds {_SELECT_LABEL_MAX} chars."
+        desc = opt.get("description")
+        if desc is not None:
+            if not isinstance(desc, str):
+                return f"options[{i}].description must be a string."
+            if len(desc) > _SELECT_DESCRIPTION_MAX:
+                return f"options[{i}].description exceeds {_SELECT_DESCRIPTION_MAX} chars."
+        if value in seen_values:
+            return f"Duplicate option value: {value!r}."
+        seen_values.add(value)
+
+    max_values = args.get("max_values", 1)
+    if not isinstance(max_values, int) or max_values < 1:
+        return "'max_values' must be a positive integer."
+    if max_values > len(options):
+        return f"'max_values' ({max_values}) cannot exceed option count ({len(options)})."
+
+    timeout = args.get("timeout_seconds", _SELECT_TIMEOUT_DEFAULT)
+    if not isinstance(timeout, (int, float)) or timeout <= 0:
+        return "'timeout_seconds' must be a positive number."
+    if timeout > _SELECT_TIMEOUT_MAX:
+        return f"'timeout_seconds' must be ≤ {_SELECT_TIMEOUT_MAX}."
+
+    return None
+
+
+def make_send_discord_select_tool(
+    client: discord.Client,
+    thread_id: int,
+    *,
+    register_active: Callable[[int, Any], None] | None = None,
+    unregister_active: Callable[[int], None] | None = None,
+) -> ToolDefinition:
+    """Tool factory for ``send_discord_select`` (#190).
+
+    Renders a Discord SelectMenu in the bound thread and **blocks** the tool
+    call until the user picks an option or the timeout expires. This is the
+    same pattern as ``_ConfirmView`` — choosing is just a different verb than
+    confirming, but the lifecycle (render → wait → disable) is identical.
+
+    The optional ``register_active`` / ``unregister_active`` hooks let the bot
+    track in-flight select menus per thread so a cancelled turn can disable
+    them mid-flight (matches ``_active_confirmations`` behaviour). They are
+    optional so the factory stays unit-testable without a live bot.
+    """
+    async def executor(call: ToolCall) -> ToolResult:
+        import discord as _discord
+
+        err = _validate_select_args(call.args)
+        if err:
+            return ToolResult(call.id, call.tool_name, False, error=err)
+
+        channel = client.get_channel(thread_id)
+        if channel is None:
+            return ToolResult(
+                call.id, call.tool_name, False,
+                error="Discord channel/thread not found or accessible.",
+            )
+
+        title: str = call.args["title"]
+        placeholder: str = call.args.get("placeholder") or "Choose an option"
+        options: list[dict[str, Any]] = call.args["options"]
+        max_values: int = int(call.args.get("max_values", 1))
+        timeout: float = float(call.args.get("timeout_seconds", _SELECT_TIMEOUT_DEFAULT))
+
+        # Build the options + view.
+        select_options = [
+            _discord.SelectOption(
+                label=o["label"],
+                value=o["value"],
+                description=o.get("description"),
+            )
+            for o in options
+        ]
+
+        done: asyncio.Event = asyncio.Event()
+        result_state: dict[str, Any] = {"selected": None, "cancelled": False}
+
+        select = _discord.ui.Select(
+            placeholder=placeholder[:_SELECT_LABEL_MAX],
+            min_values=1,
+            max_values=max_values,
+            options=select_options,
+        )
+
+        async def _on_select(interaction: _discord.Interaction) -> None:
+            picks = list(select.values)
+            label_for = {o["value"]: o["label"] for o in options}
+            result_state["selected"] = picks
+            result_state["labels"] = [label_for.get(v, v) for v in picks]
+            done.set()
+            # Edit the message to disable further interaction. Echo the choice
+            # so the thread reads as a coherent dialogue instead of leaving a
+            # frozen menu behind.
+            picked_str = ", ".join(label_for.get(v, v) for v in picks)
+            try:
+                await interaction.response.edit_message(
+                    content=f"✅ **{title}** → {picked_str}", view=None,
+                )
+            except _discord.HTTPException:
+                pass
+
+        select.callback = _on_select
+        view = _discord.ui.View(timeout=timeout)
+        view.add_item(select)
+
+        msg = None
+        try:
+            msg = await channel.send(content=f"**{title}**", view=view)
+        except _discord.HTTPException as e:
+            return ToolResult(
+                call.id, call.tool_name, False,
+                error=f"Failed to send select menu: {e}",
+            )
+
+        if register_active is not None:
+            register_active(thread_id, msg)
+
+        try:
+            # asyncio.wait_for drives the timeout authoritatively. The View's
+            # own timer is parallel but only governs Discord's UI-side
+            # disable; this loop owns the agent's wait.
+            await asyncio.wait_for(done.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            # View timeout already fired; tidy the message so the menu doesn't
+            # linger as a clickable trap.
+            result_state["cancelled"] = True
+            try:
+                await msg.edit(content=f"⌛ **{title}** — no response (timed out).", view=None)
+            except _discord.HTTPException:
+                pass
+        finally:
+            if unregister_active is not None:
+                unregister_active(thread_id)
+
+        if result_state["cancelled"] or result_state["selected"] is None:
+            return ToolResult(
+                call.id, call.tool_name, True,
+                output={"cancelled": True},
+            )
+
+        picks = result_state["selected"]
+        labels = result_state["labels"]
+        if max_values == 1:
+            output = {"selected": picks[0], "label": labels[0]}
+        else:
+            output = {"selected": picks, "labels": labels}
+        return ToolResult(call.id, call.tool_name, True, output=output)
+
+    return ToolDefinition(
+        name="send_discord_select",
+        description=(
+            "Present the user with a bounded set of choices via a Discord "
+            "SelectMenu (dropdown) and **block** until they pick one. Use "
+            "*sparingly* — only when the choice set is inherently bounded "
+            "(≤25), typing the answer would be high-friction, and a free-text "
+            "reply would be ambiguous. For open-ended questions, just ask in "
+            "natural language. Returns either {selected, label[s]} on a pick "
+            "or {cancelled: true} on timeout."
+        ),
+        trust_level=TrustLevel.SAFE,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "Prompt shown above the menu.",
+                },
+                "placeholder": {
+                    "type": "string",
+                    "description": "Greyed-out hint inside the dropdown before a choice is made.",
+                },
+                "options": {
+                    "type": "array",
+                    "description": f"Choices (max {_SELECT_MAX_OPTIONS}). Values must be unique.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "label": {"type": "string", "description": f"Visible text (max {_SELECT_LABEL_MAX} chars)."},
+                            "value": {"type": "string", "description": "Stable identifier returned to the agent."},
+                            "description": {"type": "string", "description": f"Optional sub-text (max {_SELECT_DESCRIPTION_MAX} chars)."},
+                        },
+                        "required": ["label", "value"],
+                    },
+                },
+                "max_values": {
+                    "type": "integer",
+                    "description": "How many options the user may pick. Default 1.",
+                },
+                "timeout_seconds": {
+                    "type": "number",
+                    "description": f"Seconds before auto-cancel. Default {_SELECT_TIMEOUT_DEFAULT}, max {_SELECT_TIMEOUT_MAX}.",
+                },
+            },
+            "required": ["title", "options"],
+        },
+        executor=executor,
     )

--- a/tests/test_discord_select_tool.py
+++ b/tests/test_discord_select_tool.py
@@ -1,0 +1,317 @@
+"""Issue #190 — `send_discord_select` tool: validation + lifecycle tests.
+
+Live Discord interaction (rendering the SelectMenu, real button clicks) is
+exercised via mocks here; manual verification still required for the visual
+side. These tests pin the contract that the **agent** sees: a clean tool
+result on every code path, no exceptions leaking out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import discord
+
+from loom.core.harness.middleware import ToolCall
+from loom.core.harness.permissions import TrustLevel
+from loom.platform.discord.tools import (
+    _SELECT_MAX_OPTIONS,
+    _SELECT_TIMEOUT_MAX,
+    _validate_select_args,
+    make_send_discord_select_tool,
+)
+
+
+def _call(args: dict) -> ToolCall:
+    return ToolCall(
+        tool_name="send_discord_select",
+        args=args,
+        trust_level=TrustLevel.SAFE,
+        session_id="test-session",
+    )
+
+
+# ── Validation ───────────────────────────────────────────────────────────
+
+
+def test_validate_rejects_missing_title():
+    err = _validate_select_args({"options": [{"label": "L", "value": "v"}]})
+    assert err and "title" in err.lower()
+
+
+def test_validate_rejects_empty_options():
+    err = _validate_select_args({"title": "t", "options": []})
+    assert err and "non-empty" in err
+
+
+def test_validate_rejects_too_many_options():
+    opts = [{"label": f"L{i}", "value": f"v{i}"} for i in range(_SELECT_MAX_OPTIONS + 1)]
+    err = _validate_select_args({"title": "t", "options": opts})
+    assert err and str(_SELECT_MAX_OPTIONS) in err
+
+
+def test_validate_rejects_duplicate_values():
+    err = _validate_select_args({
+        "title": "t",
+        "options": [
+            {"label": "A", "value": "x"},
+            {"label": "B", "value": "x"},
+        ],
+    })
+    assert err and "duplicate" in err.lower()
+
+
+def test_validate_rejects_oversize_label():
+    err = _validate_select_args({
+        "title": "t",
+        "options": [{"label": "x" * 101, "value": "v"}],
+    })
+    assert err and "label" in err.lower()
+
+
+def test_validate_rejects_max_values_above_options():
+    err = _validate_select_args({
+        "title": "t",
+        "options": [{"label": "A", "value": "a"}],
+        "max_values": 2,
+    })
+    assert err and "max_values" in err
+
+
+def test_validate_rejects_oversize_timeout():
+    err = _validate_select_args({
+        "title": "t",
+        "options": [{"label": "A", "value": "a"}],
+        "timeout_seconds": _SELECT_TIMEOUT_MAX + 1,
+    })
+    assert err and "timeout" in err
+
+
+def test_validate_accepts_minimal_valid_args():
+    err = _validate_select_args({
+        "title": "t",
+        "options": [{"label": "A", "value": "a"}],
+    })
+    assert err is None
+
+
+# ── Tool definition shape ────────────────────────────────────────────────
+
+
+def test_tool_definition_metadata():
+    tool = make_send_discord_select_tool(MagicMock(), 123)
+    assert tool.name == "send_discord_select"
+    assert tool.trust_level == TrustLevel.SAFE
+    assert "title" in tool.input_schema["required"]
+    assert "options" in tool.input_schema["required"]
+
+
+# ── Executor: error paths short-circuit before touching Discord ──────────
+
+
+@pytest.mark.asyncio
+async def test_executor_returns_validation_error_without_calling_discord():
+    client = MagicMock()
+    client.get_channel = MagicMock()
+    tool = make_send_discord_select_tool(client, 123)
+
+    result = await tool.executor(_call({"title": "t", "options": []}))
+    assert not result.success
+    assert "non-empty" in result.error
+    client.get_channel.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_executor_returns_error_when_channel_missing():
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=None)
+    tool = make_send_discord_select_tool(client, 999)
+
+    result = await tool.executor(_call({
+        "title": "t",
+        "options": [{"label": "A", "value": "a"}],
+    }))
+    assert not result.success
+    assert "channel" in result.error.lower()
+
+
+# ── Executor: happy path + cancellation via timeout ──────────────────────
+
+
+def _patch_select_view(monkeypatch):
+    """Replace `discord.ui.Select` and `discord.ui.View` with stand-ins that
+    don't try to talk to a real Discord gateway. We capture the callback so
+    the test can fire a synthetic interaction."""
+    captured: dict = {}
+
+    class _FakeSelect:
+        def __init__(self, *, placeholder, min_values, max_values, options):
+            self.values: list[str] = []
+            self.callback = None
+            captured["select"] = self
+            captured["max_values"] = max_values
+
+    class _FakeView:
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+            self.items = []
+
+        def add_item(self, item):
+            self.items.append(item)
+
+    monkeypatch.setattr(discord.ui, "Select", _FakeSelect)
+    monkeypatch.setattr(discord.ui, "View", _FakeView)
+
+    class _FakeOption:
+        def __init__(self, *, label, value, description=None):
+            self.label = label
+            self.value = value
+            self.description = description
+
+    monkeypatch.setattr(discord, "SelectOption", _FakeOption)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_executor_returns_selection_after_user_picks(monkeypatch):
+    captured = _patch_select_view(monkeypatch)
+
+    sent_msg = MagicMock()
+    sent_msg.edit = AsyncMock()
+
+    channel = MagicMock()
+    channel.send = AsyncMock(return_value=sent_msg)
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=channel)
+
+    tool = make_send_discord_select_tool(client, 123)
+
+    async def _drive_selection():
+        # Wait until the executor wires the callback, then simulate a click.
+        for _ in range(50):
+            if "select" in captured and captured["select"].callback is not None:
+                break
+            await asyncio.sleep(0.01)
+        select = captured["select"]
+        select.values = ["b"]
+        interaction = MagicMock()
+        interaction.response = MagicMock()
+        interaction.response.edit_message = AsyncMock()
+        await select.callback(interaction)
+
+    driver = asyncio.create_task(_drive_selection())
+    result = await tool.executor(_call({
+        "title": "Pick one",
+        "options": [
+            {"label": "Apple", "value": "a"},
+            {"label": "Banana", "value": "b"},
+        ],
+        "timeout_seconds": 2,
+    }))
+    await driver
+
+    assert result.success is True
+    assert result.output == {"selected": "b", "label": "Banana"}
+
+
+@pytest.mark.asyncio
+async def test_executor_returns_cancelled_on_timeout(monkeypatch):
+    _patch_select_view(monkeypatch)
+
+    sent_msg = MagicMock()
+    sent_msg.edit = AsyncMock()
+
+    channel = MagicMock()
+    channel.send = AsyncMock(return_value=sent_msg)
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=channel)
+
+    tool = make_send_discord_select_tool(client, 123)
+
+    result = await tool.executor(_call({
+        "title": "Pick one",
+        "options": [{"label": "A", "value": "a"}],
+        "timeout_seconds": 0.05,
+    }))
+
+    assert result.success is True
+    assert result.output == {"cancelled": True}
+
+
+@pytest.mark.asyncio
+async def test_executor_multi_select_returns_list(monkeypatch):
+    captured = _patch_select_view(monkeypatch)
+
+    sent_msg = MagicMock()
+    sent_msg.edit = AsyncMock()
+
+    channel = MagicMock()
+    channel.send = AsyncMock(return_value=sent_msg)
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=channel)
+
+    tool = make_send_discord_select_tool(client, 123)
+
+    async def _drive_selection():
+        for _ in range(50):
+            if "select" in captured and captured["select"].callback is not None:
+                break
+            await asyncio.sleep(0.01)
+        select = captured["select"]
+        select.values = ["a", "c"]
+        interaction = MagicMock()
+        interaction.response = MagicMock()
+        interaction.response.edit_message = AsyncMock()
+        await select.callback(interaction)
+
+    driver = asyncio.create_task(_drive_selection())
+    result = await tool.executor(_call({
+        "title": "Pick many",
+        "options": [
+            {"label": "A", "value": "a"},
+            {"label": "B", "value": "b"},
+            {"label": "C", "value": "c"},
+        ],
+        "max_values": 2,
+        "timeout_seconds": 2,
+    }))
+    await driver
+
+    assert result.success is True
+    assert result.output == {"selected": ["a", "c"], "labels": ["A", "C"]}
+
+
+# ── Active-tracking hook is exercised on success and timeout ─────────────
+
+
+@pytest.mark.asyncio
+async def test_register_unregister_called_on_timeout(monkeypatch):
+    _patch_select_view(monkeypatch)
+
+    channel = MagicMock()
+    channel.send = AsyncMock(return_value=MagicMock(edit=AsyncMock()))
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=channel)
+
+    registered: list[tuple[int, object]] = []
+    unregistered: list[int] = []
+
+    tool = make_send_discord_select_tool(
+        client, 42,
+        register_active=lambda tid, msg: registered.append((tid, msg)),
+        unregister_active=lambda tid: unregistered.append(tid),
+    )
+
+    await tool.executor(_call({
+        "title": "t",
+        "options": [{"label": "A", "value": "a"}],
+        "timeout_seconds": 0.05,
+    }))
+
+    assert len(registered) == 1 and registered[0][0] == 42
+    assert unregistered == [42]


### PR DESCRIPTION
## Summary
Closes #190. Adds `send_discord_select` — a tool that renders a Discord SelectMenu (dropdown) and **blocks** the agent's tool call until the user picks an option (or the timeout expires). Capability enabler for the cases the issue calls out (mood tarot, briefing track selection); not a mandate. Open-ended questions should still be plain natural-language prompts.

## Behaviour
| Path | Tool result |
|---|---|
| User picks (single) | `success=True`, `output={"selected": value, "label": label}` |
| User picks (multi, `max_values>1`) | `success=True`, `output={"selected": [v1,v2], "labels": [L1,L2]}` |
| Timeout / view dismissed | `success=True`, `output={"cancelled": true}` — *not* a failure |
| Validation rejects args | `success=False` with reason (caught **before** Discord call) |
| Channel missing / send fails | `success=False` with reason |

## Design choices (called out for review)
1. **Blocking model** — same as `_ConfirmView`. `asyncio.Event` + `asyncio.wait_for(timeout)`.
2. **Trust level: SAFE** — pure UI presentation, no state mutation.
3. **Validation up front** — Discord's hard caps (≤25 options, ≤100-char labels, unique values) checked before the API call so the agent gets a clean tool error instead of a 50035 surprise (related to #231).
4. **Cancellation cleanup** — bot tracks active selects in `_active_selects` and disables the view when the turn is cancelled, mirroring the `_active_confirmations` flow.
5. **Cancelled = success=True** — \"user declined\" isn't a tool failure; it's a control-flow signal the agent should branch on.
6. **No `BlockingView` abstraction yet** — only two concrete blocking views exist (`_ConfirmView`, this). YAGNI; revisit if a third lands.
7. **No per-user scoping** — matches existing `_ConfirmView` (thread members can interact). Acceptable since threads are effectively 1-on-1.
8. **Naming** — `send_discord_select` per issue, despite the verb implying fire-and-forget. Tool description explicitly states it blocks. Keeps the `send_discord_*` family consistent.

## Test plan
- [x] `pytest tests/test_discord_select_tool.py` (15 passed) — validation cases, error short-circuits, single-pick happy path, multi-pick happy path, timeout returns cancelled, register/unregister hook invocation.
- [ ] Manual: trigger an agent flow that calls `send_discord_select` in a real thread; confirm dropdown renders, picking returns to the agent, timeout works, `/stop` cleans up the view.

## Out of scope
- Abstracting a `BlockingView` base class (premature with N=2)
- Embed-field length limits (#231 follow-up)
- Per-user click scoping inside multi-member threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)