### PR TITLE
feat(cli): CLI Refresh PR-A — input layer + abort-on-submit + arrow-key confirm

### DIFF
--- a/doc/49-CLI-Refresh-設計.md
+++ b/doc/49-CLI-Refresh-設計.md
@@ -1,0 +1,268 @@
+# CLI Refresh 設計
+
+本文件記錄 **Loom CLI 介面重構** 的動機、設計哲學、訊息分流策略與 PR 拆分計畫。
+
+替代目標：完成後將取代 `34-TUI-使用指南.md`（屆時 Dashboard 模式淘汰，本文成為 CLI 互動的權威說明）。
+
+關聯：原始討論起點為 issue #160（已關閉，改開新 issue 追蹤本計畫）。
+
+---
+
+## 動機
+
+原 issue #160 起意為「修 TUI 的 markdown 顯示」。深入後重新定義為更根本的問題：
+
+- 現行 `ExecutionDashboard` 全螢幕固定窗格，限制歷史滾動，視覺資訊過載
+- CLI 端與 TUI 端風格分裂，CLI 缺乏羊皮卷美學、缺乏結構化訊息分層
+- prompt_toolkit 級別的現代輸入體驗缺席（無多行擴張、無 slash 補全、無 abort-on-submit）
+- Harness 訊息與絲絲對話視覺混雜，使用者難以分辨「誰在說話」
+
+核心心法：**「底層架構越複雜（Harness, Memory, Jobs），前端介面就要裝得越輕鬆。」**
+
+---
+
+## 設計哲學
+
+### 1. 漸進式揭露 (Progressive Disclosure)
+
+捨棄全螢幕 Dashboard，擁抱 **Linear Stream + 1 行 Live Footer** 的混合形態：
+
+- **歷史軸**：append-only linear stream，自然滾動，留底
+- **當下軸**：底部 1–2 行 `rich.live` footer，只顯示 active envelope / token budget / grant TTL
+- **完成即蒸發**：turn 結束 footer 收回，歷史區留下 solidified envelope panel
+
+### 2. 狀態固化 (Solidification)
+
+執行中的視覺元件是動態的（spinner、閃爍、活躍色）；一旦 `COMMITTED` 或 `ABORTED`，**3 秒後降一階變灰**，自然把視覺重心推給最新內容。
+
+### 3. 並行不展平
+
+Loom 有 Claude Code 沒有的 parallel envelope dispatch（見 `_build_envelope_view()`，#128 之後更明確）。純線性流會逼出兩個壞選擇：強制序列化（騙人）、交錯插入（撕裂）。
+
+正解：**parallel block 用 collapsible group panel 收住**，期間多個 spinner 同時轉，全部 COMMITTED 後 collapse 成 `✓ 3 tools · 4.2s`，可展開。
+
+### 4. 優雅的人類搶佔 (Graceful Interruption)
+
+「打斷」是正常互動，不是錯誤：
+
+- **送出即剎車**：使用者按 Enter 的瞬間，若有 turn 在跑，先 `session.cancel()` 再 queue 新訊息
+- **視覺反饋**：運作中的元件**不直接消失**，轉為 `⏸ ABORTED` 灰色標籤
+- **Context 接力**：下個 turn 開頭注入 system note `[使用者打斷上輪並接續]`，確保絲絲認知連貫
+- 底層已有 `call.abort_signal: asyncio.Event`、`session.cancel()`、`/stop`、Ctrl+C、Escape——只缺「Enter 送出 = 自動剎車」這條邊
+
+---
+
+## Harness 訊息三頻道分流
+
+### 分流判準
+
+```
+                  能做事 ──┐
+                            ▼
+               ┌─ 不知道會出事 ──→ 跳出 (modal)
+時間敏感 ──────┤
+               └─ 知道也沒差 ──→ 底層 (footer)
+                            ▲
+                  能感知 ──┘
+
+非時間敏感 ─────────────→ 流式 (inline，留底)
+```
+
+### 完整訊息來源對照表（13 類）
+
+| # | 來源 | 範例 | 頻道 |
+|---|---|---|---|
+| 1 | EnvelopeStarted/Updated/Completed | tool 執行框 | 流式（panel 主體）+ 底層（執行中摘要） |
+| 2a | `_notify_lifecycle` 綠燈 | `pre-authorized`, `exec_auto`, `scope-allow` | **底層**（閃 0.3s 不留底） |
+| 2b | `_notify_lifecycle` 紅燈 | `user denied`, `circuit breaker tripped` | 流式（forensics 留底） |
+| 3 | Confirm prompt | 工具授權互動 | **跳出**（modal） |
+| 4 | Scope grant 狀態 | TTL 倒數、過期清掃 | 底層（最快過期那個） |
+| 5 | Compaction | `Compacting context (87% used)…` | 底層（執行中）+ 流式（完成摘要） |
+| 6 | History sanitize | orphaned tool_calls 修復 | 流式（**只在真的修了才喊**） |
+| 7 | Session resume / diagnostic | `Resuming session abc123` | 流式 |
+| 8 | Model / Personality 切換 | `Model switched to: ...` | 流式 |
+| 9 | Token budget | input_tokens / context % | 底層（**>60% 才浮出**） |
+| 10 | NotificationRouter | autonomy daemon、external trigger | 流式 |
+| 11 | MemoryGovernor | governed_upsert | 流式（**只顯示 reject，accept 沉默**） |
+| 12 | Reasoning chain | `/reasoning` 回看 | 使用者主動呼叫 |
+| 13 | Error / fatal | API 2013、provider 拒絕 | 流式（一般）/ 跳出（fatal recovery） |
+
+### 三條設計原則
+
+1. **綠燈不出聲，紅燈才講話** — `pre-authorized` / `exec_auto` / `governor accept` 不佔流式空間，降為 footer 閃光
+2. **Sanitize 必須可見** — history 修復是 invariant 級事件；靜默修復會讓使用者懷疑絲絲怪怪的，但只在「真的修了」才喊
+3. **流式訊息一律帶 `⚙ harness ›` 署名** — 與絲絲文本視覺切開；modal 跳出用 `[!]` 框，自然有阻斷感不需署名
+
+---
+
+## 視覺族群（絲絲 vs Harness vs Tool）
+
+| 族群 | 來源 | 視覺 | 範例 |
+|---|---|---|---|
+| **絲絲** | assistant text / think | 無框、奶油 `#e0cfa0`、左緣 `絲 ▎` 絲綢色引線 | 對話、思考、回答 |
+| **Harness** | envelope state、grant、sanitize、token | 暗背景 `#242018` 整段反白、前綴 `⚙ harness ›` 琥珀金 | `⚙ harness › grant L2 expires in 0:43` |
+| **Tool** | ExecutionEnvelope | rounded panel，標題色隨狀態 | 工具執行框 |
+
+**絕不混血**：Harness 不能用奶油色文字假裝是絲絲在說話。
+
+---
+
+## 色彩系統
+
+沿用 TUI 既有羊皮卷 palette（`loom/platform/cli/tui/app.py:7-15`），CLI 端建立 `rich.theme.Theme`：
+
+```python
+LOOM_THEME = Theme({
+    "loom.text":    "#e0cfa0",  # 奶油（主文字）
+    "loom.muted":   "#8a7a5e",  # 米褐（dim）
+    "loom.accent":  "#c8a464",  # 琥珀金（重點）
+    "loom.success": "#7a9e78",  # 鼠尾草（成功）
+    "loom.warning": "#c8924a",  # 赭石（警告）
+    "loom.error":   "#b87060",  # 赤陶（錯誤）
+    "loom.border":  "#4a4038",  # 邊框
+    "loom.harness.bg": "#242018",  # harness 訊息底色
+})
+```
+
+狀態三階淡出：active → committed → frozen（3 秒後降一階）。
+
+---
+
+## 互動：Confirm Prompt
+
+純 y/n/c 過時。既然 PR-A 引入 prompt_toolkit，arrow + enter 是天然來的：
+
+```
+⚠  絲絲想執行 run_bash                      ⚙ L2 · 信任度 GUARDED
+   rm -rf ./build/dist
+
+ ▸ 允許這次
+   允許並記住 5 分鐘 (升 grant)
+   允許並記住到 session 結束
+   拒絕
+   查看完整參數…
+
+   ↑↓ 選擇  ⏎ 確認  esc 取消  · y/n/c 仍可直接按
+```
+
+關鍵：
+
+- **方向鍵預設**，但 `y/n/c` 鍵盤快捷保留（肌肉記憶 + 低頻寬場景）
+- **選項動態生成**：根據當前 trust level 與既有 grant 過濾
+- **「查看完整參數」**：tool args 太長時不直接展開塞 prompt 區
+- **rich.live 暫停**：選擇期間 footer/spinner 凍結，靠 `patch_stdout` 處理重繪
+
+實作層面這是 PR-A 的 sub-mode，不額外開 PR。
+
+---
+
+## prompt_toolkit 輸入層
+
+```
+LoomPrompt (prompt_toolkit Application)
+├─ multiline=True, height=Dynamic(1..10)        # 隨內容擴張，> 10 行才滾動
+├─ patch_stdout()                                # 背景輸出不洗稿
+├─ KeyBindings:
+│   ├─ Enter (no shift)  → submit + 若 turn 在跑：先 cancel 再 queue
+│   ├─ Shift+Enter       → 插入換行
+│   ├─ Esc / Ctrl+C      → 純 cancel，不送
+│   └─ Ctrl+D (空 buffer) → 退出
+├─ Completer：slash 指令 fuzzy auto-complete
+├─ History：~/.loom/cli_history（FileHistory）
+└─ AutoSuggestFromHistory                        # fish-style 灰字補完
+```
+
+多行貼上天然處理；換行不誤觸送出；slash 指令補全沿用現有 dispatch table。
+
+---
+
+## TaskList 可視化
+
+PR #206 收斂為單一 `task_write`，UI 只需監聽一個事件：
+
+```
+╭─ 📋 task list ───────────────────────────────╮
+│ ✓ 看清楚 issue #160                          │
+│ ✓ 評估 rich vs textual                       │
+│ ▸ 設計 prompt_toolkit 輸入層      ← active  │
+│ ○ 實作 abort-on-submit                       │
+│ ○ harness 訊息視覺切分                       │
+╰──────────────────────────────────────────────╯
+```
+
+- `rich.live` 原地重繪，每次 `task_write` 觸發重渲
+- 浮動於 footer 上方，**不是歷史的一部分**（不會被滾動沖走）
+- turn 結束若無變動 → fade 成灰 frozen 樣式
+- 全部完成 → collapse 成一行 `✓ 5/5 done`，可展開
+
+---
+
+## PR 拆分與依賴
+
+```
+PR-A  輸入層改造：prompt_toolkit + multiline + abort-on-submit + arrow-key confirm
+        deps: 無
+        解鎖：所有後續工作的互動基礎
+
+PR-B  Rich Theme + 語義 color token
+        deps: 無（可與 A 並行）
+        純 refactor
+
+PR-C  Harness vs 絲絲 視覺切分（含三頻道分流）
+        deps: B
+        副作用：清理 _notify_lifecycle 綠燈訊息，降為 footer
+
+PR-D  Linear stream + 1 行 live footer + Solidification + 並行 group panel
+        deps: B, C
+        替換現有 ExecutionDashboard 渲染
+
+PR-E  TaskList live 浮動面板
+        deps: D
+        監聽 task_write，rich.live 重繪
+```
+
+順序心法：A 給互動底層，B 給視覺底層，C 釐清訊息族群，D 線性化，E 是 D 上的小工。
+
+建議掛新 milestone「CLI Refresh」，與 Harness Hardening #1 並列。
+
+---
+
+## 已拍板決策
+
+- [x] 採 Linear Stream + 1 行 Live Footer 混合，不沿用 Dashboard
+- [x] 並行 envelope 用 collapsible group panel
+- [x] 沿用 TUI 羊皮卷 palette，CLI 端轉為 `rich.theme.Theme`
+- [x] 絲絲 / Harness / Tool 三族群視覺強切分
+- [x] 綠燈訊息（`pre-authorized` / `exec_auto` / `scope-allow`）降為 footer 閃光，不留底
+- [x] Token budget 採 C 方案：<60% 完全隱藏，>60% 才浮出（呼吸感優先）
+- [x] Confirm prompt 用方向鍵 + enter，y/n/c 快捷保留
+- [x] Scratchpad 概念暫不引入（草稿留給絲絲自己看，需要時直接問）
+- [x] Sanitize 修復必須有可見訊息，但僅在真的修復時觸發
+
+---
+
+## 未決問題
+
+- 「查看完整參數」展開後是 inline 還是另開 pager？需要實作時決定
+- TaskList collapse 的快捷鍵綁定（避免與 vim-style nav 衝突）
+- Discord 端是否同步引入這些族群分類？目前 Discord 已有部分分流（`ThinkCollapsed`、slash command 區隔），需要對齊
+- footer 在窄終端（< 80 col）的退化策略
+
+## 已知 bug（待 PR-D 一併處理）
+
+- **Streaming 行首截斷**（A1 階段確認為老 bug，非 A1 引入）：
+  CLI streaming 輸出長 CJK 段落或多項列表時，個別行的開頭會被吃掉（例如 `3. 數字...` 整段消失、`5. ...` 只剩尾段）。
+  根因推測為 `clear_line()` 用 `\r\033[K` 清行，在 soft-wrap + CJK 字元寬度判定誤差時會清到錯的視覺行，下一個 chunk 從錯位置覆寫前內容。
+  Discord 不受影響（沒有 ANSI raw clear）。TUI 不受影響（用 Textual 自己的渲染）。
+  PR-D 重寫 stream renderer 時一併解決——避免在 A1 scope 修，會讓 PR 失焦。
+
+- **Multiline 輸入暫不啟用**：
+  `multiline=True` 與 Rich 的 `\r\033[K` clear_line 互動會放大上面那個截斷 bug。A1 階段已將 `multiline=False`，Alt+Enter 換行能力延到 PR-D 與 stream renderer 重寫一起做。
+
+---
+
+## 參考
+
+- 原始討論：issue #160（已關）→ 新 issue（CLI Refresh tracking）
+- 既有相關文件：`43-Harness-Execution-可視化規劃.md`、`45-AbortController.md`
+- 將取代：`34-TUI-使用指南.md`（PR-D 完成後廢除）

--- a/doc/49-CLI-Refresh-設計.md
+++ b/doc/49-CLI-Refresh-設計.md
@@ -259,6 +259,30 @@ PR-E  TaskList live 浮動面板
 - **Multiline 輸入暫不啟用**：
   `multiline=True` 與 Rich 的 `\r\033[K` clear_line 互動會放大上面那個截斷 bug。A1 階段已將 `multiline=False`，Alt+Enter 換行能力延到 PR-D 與 stream renderer 重寫一起做。
 
+## PR-D 預計要重寫的東西（讓未來的我們不要驚訝）
+
+PR-A 為了快速上線輸入升級 + abort-on-submit + arrow-key confirm，採用了 **「每輪 `prompt_async` + 短暫 widget Application」** 的模型。PR-D 要切到 **「單一 persistent Application + 固定 bottom Window」** 的 Linear Stream 架構，下面這些東西**幾乎確定要砍掉重寫**，不是 PR-A 的退化、是路線轉換：
+
+- **三事件 stdin 協調協議**（`confirm_active` / `confirm_done` / `input_released`）：
+  目前依賴 `prompt_async` 迴圈模型才需要這套協議——多個 Application 搶 stdin 才有 race。Persistent Application 模型下，confirm widget 變成主 Application 的 sub-mode（layout 切換），沒有 stdin 移交問題，整套協議拿掉。
+
+- **`_run_interactive` 包裝器**：
+  同上，PR-D 之後不再需要「暫停 input loop → 跑 widget → 恢復」的舞蹈。改成主 Application 直接切 mode。
+
+- **`patch_stdout(raw=True)`**：
+  Persistent Application 下不需要 patch_stdout，因為 streaming 輸出本來就走 Application 的 output buffer，不會跟 prompt 區搶。
+
+PR-D 也要在 testing note 裡明確覆蓋：
+
+- **Multi-line input + streaming output 共存**：PR-A deferred multiline，PR-D 既要解 streaming 截斷又要重啟 multiline——兩個改動共用同一條 render path。回歸測試必須驗證**兩者同時打開**沒有交叉 bug，否則無法獨立確認問題出自哪一邊。
+
+## Merge 後追蹤事項（PR-A 留尾）
+
+- 非互動 context（test / script 直接呼叫 `_confirm_tool_cli`）的 widget timeout 行為——目前 `_run_interactive` 缺席時會等到 1s timeout 再啟動，行為正確但缺 smoke test
+- 確認 widget 標題列「Loom」的 L 在某些終端 theme 下顯示為反白（A3 PR review 發現）——色彩微調
+- `_format_scope_panel` 從 `[bold]` 改 `[#c8a464]` 的對比度——透明背景終端下需要驗證閱讀性
+- 多輪連續打斷（連發三條訊息，第二三條的排隊處理）尚未在 test plan 覆蓋
+
 ---
 
 ## 參考

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -280,13 +280,16 @@ class AnthropicProvider(LLMProvider):
         try:
             response = self._client.messages.create(**kwargs)
         except BaseException as _exc:
-            forensics.dump_on_failure(
-                provider="anthropic",
-                model=self.model,
-                canonical_messages=messages,
-                wire_messages=anthropic_msgs,
-                error=_exc,
-            )
+            # User-initiated cancellation is not a failure — don't pollute
+            # the forensics directory with normal abort flow.
+            if not isinstance(_exc, asyncio.CancelledError):
+                forensics.dump_on_failure(
+                    provider="anthropic",
+                    model=self.model,
+                    canonical_messages=messages,
+                    wire_messages=anthropic_msgs,
+                    error=_exc,
+                )
             raise
 
         text: str | None = None
@@ -420,6 +423,10 @@ class AnthropicProvider(LLMProvider):
                     final = None if aborted else await stream.get_final_message()
                 break  # success
             except BaseException as _exc:
+                # User-initiated cancellation: graceful abort path,
+                # don't dump and don't retry. Just propagate.
+                if isinstance(_exc, asyncio.CancelledError):
+                    raise
                 # Dump forensics on the first failure only — retries on the
                 # same payload would just produce identical dumps.
                 if not _forensics_dumped:

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -3073,7 +3073,7 @@ class LoomSession:
                     arg_lines.append(f"  [cyan]{k}[/cyan]: {v!r}")
             args_display = "\n".join(arg_lines) if arg_lines else "  (no args)"
             return (
-                f"[bold]{call.tool_name}[/bold]  {call.trust_level.label}\n"
+                f"[#c8a464]{call.tool_name}[/#c8a464]  {call.trust_level.label}\n"
                 f"{args_display}"
             )
 
@@ -3094,7 +3094,7 @@ class LoomSession:
         )
 
         lines: list[str] = [
-            f"[bold]{call.tool_name}[/bold]  {call.trust_level.label}",
+            f"[#c8a464]{call.tool_name}[/#c8a464]  {call.trust_level.label}",
         ]
 
         # Scope summary: what the tool wants to access
@@ -3123,24 +3123,26 @@ class LoomSession:
 
     async def _confirm_tool_cli(self, call: ToolCall) -> "ConfirmDecision":
         """
-        CLI-specific confirmation prompt (stdin / Rich panel).
+        CLI-specific confirmation prompt — arrow-key inline widget.
 
         Phase C (Issue #45): scope metadata → verdict + diff info.
         Phase B (Issue #88): returns ConfirmDecision (y/s/a/N) instead of bool.
+        PR-A3 (#236): replaces single-key stdin prompt with arrow-key
+        :func:`select_prompt`. Single-letter shortcuts (y/s/a/N) preserved
+        for muscle memory.
 
         Returns
         -------
         ConfirmDecision
-            DENY  — user typed N or Enter (default)
-            ONCE  — user typed y (approve and grant this scope for the session)
-            SCOPE — user typed s (approve with a 30-min lease, auto-expires)
-            AUTO  — user typed a (permanent grant, same scope, no expiry)
+            DENY  — Esc, Ctrl+C, or "N" shortcut
+            ONCE  — "y" shortcut (approve this call only)
+            SCOPE — "s" shortcut (30-min session lease)
+            AUTO  — "a" shortcut (permanent grant for this scope)
         """
         from loom.core.harness.scope import ConfirmDecision, PermissionVerdict
+        from loom.platform.cli.ui import SelectOption, select_prompt
 
-        # Stop any running spinner before printing the confirm panel so the
-        # spinner animation doesn't overwrite the prompt input line.
-        # Write \r\033[K directly to stdout — Rich Console.print strips \r.
+        # Stop any running spinner so it doesn't overwrite the widget area.
         import sys
         if self._cancel_spinner_fn is not None:
             self._cancel_spinner_fn()
@@ -3148,41 +3150,65 @@ class LoomSession:
             sys.stdout.flush()
         console.print()
 
-        # Determine panel styling from verdict
+        # Render the static context panel above the inline widget.
         verdict = call.metadata.get("scope_verdict")
         if verdict == PermissionVerdict.EXPAND_SCOPE:
-            title = "[red]⚠ Scope expansion required[/red]"
-            border_style = "red"
+            title = "[#b87060]⚠ Scope expansion required[/#b87060]"
+            border_style = "#b87060"
         else:
-            title = "[yellow]  Tool requires confirmation[/yellow]"
-            border_style = "yellow"
+            title = "[#c8924a]  Tool requires confirmation[/#c8924a]"
+            border_style = "#c8924a"
 
         console.print(
             Panel(
                 self._format_scope_panel(call),
                 title=title,
-                subtitle="[dim]y=approve  s=lease (30m)  a=permanent  N=deny[/dim]",
                 border_style=border_style,
             )
         )
-        # Use prompt_toolkit so the prompt renders correctly on all terminals.
-        from prompt_toolkit import prompt as pt_prompt
 
-        try:
-            answer = await asyncio.get_event_loop().run_in_executor(
-                None, pt_prompt, "Allow? [y=approve/s=lease/a=permanent/N]: "
+        options = [
+            SelectOption(
+                label="允許這次",
+                value=ConfirmDecision.ONCE,
+                shortcut="y",
+            ),
+            SelectOption(
+                label="允許並記住 30 分鐘 (lease)",
+                value=ConfirmDecision.SCOPE,
+                shortcut="s",
+            ),
+            SelectOption(
+                label="允許並永久授權此 scope",
+                value=ConfirmDecision.AUTO,
+                shortcut="a",
+            ),
+            SelectOption(
+                label="拒絕",
+                value=ConfirmDecision.DENY,
+                shortcut="n",
+            ),
+        ]
+
+        widget_title = (
+            f"Loom 想執行 [{call.tool_name}]  ·  信任度 {call.trust_level.plain}"
+        )
+
+        async def _run():
+            return await select_prompt(
+                title=widget_title,
+                options=options,
+                default_index=3,  # cursor starts on DENY (safer default)
+                cancel_value=ConfirmDecision.DENY,
             )
-        except (EOFError, KeyboardInterrupt):
-            answer = ""
 
-        choice = answer.strip().lower()
-        if choice in {"y", "yes"}:
-            return ConfirmDecision.ONCE
-        if choice in {"s", "scope"}:
-            return ConfirmDecision.SCOPE
-        if choice in {"a", "auto"}:
-            return ConfirmDecision.AUTO
-        return ConfirmDecision.DENY
+        # If running under the CLI chat loop, route through the input-loop
+        # coordinator so we own stdin cleanly. Otherwise (tests, scripts)
+        # run the widget directly.
+        runner = getattr(self, "_run_interactive", None)
+        if runner is not None:
+            return await runner(_run)
+        return await _run()
 
     def _all_authorized(self, tool_uses: list) -> bool:
         """

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -176,11 +176,10 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
 
     try:
         while True:
-            # ── Read user input (prompt_toolkit — history + autocomplete) ──
+            # ── Read user input (prompt_toolkit — multiline + file history + fuzzy slash) ──
             try:
                 user_input: str = await prompt_session.prompt_async(
-                    "\nyou> ",
-                    style=None,
+                    [("class:prompt", "\nyou › ")],
                 )
             except (EOFError, KeyboardInterrupt):
                 break

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -174,31 +174,127 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
 
     prompt_session = make_prompt_session()
 
-    try:
-        while True:
-            # ── Read user input (prompt_toolkit — multiline + file history + fuzzy slash) ──
+    # ── PR-A2: producer/consumer for abort-on-submit ──────────────────────
+    #
+    # Two concurrent tasks share the terminal via prompt_toolkit's
+    # ``patch_stdout`` so the prompt stays anchored at the bottom while
+    # streaming output renders above it:
+    #
+    #   input_loop  — reads user lines, queues them. If a turn is in
+    #                 flight, calls session.cancel() first and prefixes
+    #                 the new message with an interruption marker.
+    #
+    #   turn_loop   — drains the queue: slash commands run inline (no
+    #                 turn cancel), regular text spawns a streaming
+    #                 turn task that input_loop can cancel.
+    #
+    # Race notes:
+    # - current_turn_task is read+cancelled from input_loop and assigned
+    #   from turn_loop. Single-threaded asyncio gives us atomic ref
+    #   reads; cancelling an already-done task is a no-op.
+    # - wait_for(..., timeout=3.0) on cancel ensures we don't block the
+    #   user forever if a turn refuses to unwind.
+    _INTERRUPT_PREFIX = "\x00LOOM_INTERRUPT\x00"
+    input_queue: asyncio.Queue[str] = asyncio.Queue()
+    current_turn_task: asyncio.Task | None = None
+    shutdown = asyncio.Event()
+
+    async def input_loop() -> None:
+        nonlocal current_turn_task
+        while not shutdown.is_set():
             try:
                 user_input: str = await prompt_session.prompt_async(
                     [("class:prompt", "\nyou › ")],
                 )
             except (EOFError, KeyboardInterrupt):
-                break
+                shutdown.set()
+                return
+            except asyncio.CancelledError:
+                return
 
-            if not user_input.strip():
+            text = user_input.strip()
+            if not text:
                 continue
 
-            if user_input.strip().lower() in {"exit", "quit", "q"}:
-                break
+            if text.lower() in {"exit", "quit", "q"}:
+                shutdown.set()
+                return
 
-            # ── Slash commands ────────────────────────────────────────────
-            if user_input.startswith("/"):
-                await _handle_slash(user_input.strip(), session)
+            # If a turn is in flight, abort it and mark the new message
+            # so turn_loop can prepend an interruption note for the LLM.
+            in_flight = current_turn_task is not None and not current_turn_task.done()
+            if in_flight:
+                session.cancel()
+                console.print("[dim #c8924a]⏸  上一輪已中斷，接收新訊息…[/dim #c8924a]")
+                try:
+                    await asyncio.wait_for(current_turn_task, timeout=3.0)
+                except (asyncio.TimeoutError, asyncio.CancelledError):
+                    pass
+                except Exception:
+                    # Turn task may have raised; that's fine — we just
+                    # want it finished before queueing the next message.
+                    pass
+                await input_queue.put(_INTERRUPT_PREFIX + text)
+            else:
+                await input_queue.put(text)
+
+    async def turn_loop() -> None:
+        nonlocal current_turn_task
+        while not shutdown.is_set():
+            try:
+                text = await asyncio.wait_for(input_queue.get(), timeout=0.25)
+            except asyncio.TimeoutError:
                 continue
 
-            # ── Streaming turn with Rich Live display ─────────────────────
+            # Slash commands run inline — no streaming turn, no cancel.
+            if text.startswith("/"):
+                try:
+                    await _handle_slash(text, session)
+                except Exception as exc:
+                    console.print(f"[red]Slash command error: {exc}[/red]")
+                continue
+
+            # Detect interruption marker injected by input_loop.
+            if text.startswith(_INTERRUPT_PREFIX):
+                text = text[len(_INTERRUPT_PREFIX):]
+                # Lightweight cue for the LLM that the prior turn was
+                # cut short by the user — keeps cognition coherent.
+                text = "[使用者打斷上一輪並接續]\n" + text
+
             console.print()
-            await _run_streaming_turn(session, user_input)
+            current_turn_task = asyncio.create_task(
+                _run_streaming_turn(session, text)
+            )
+            try:
+                await current_turn_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:
+                console.print(f"[red]Turn error: {exc}[/red]")
+            finally:
+                current_turn_task = None
 
+    # patch_stdout(raw=True) keeps the prompt anchored while Rich's ANSI
+    # output streams above. raw=True passes escape sequences through so
+    # cursor manipulation (spinner, clear_line) still works.
+    from prompt_toolkit.patch_stdout import patch_stdout
+
+    try:
+        with patch_stdout(raw=True):
+            done, pending = await asyncio.wait(
+                {
+                    asyncio.create_task(input_loop()),
+                    asyncio.create_task(turn_loop()),
+                },
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in pending:
+                task.cancel()
+            for task in pending:
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
     finally:
         await session.stop()
         console.print("\n[dim]Session ended. Goodbye.[/dim]")
@@ -1223,11 +1319,30 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                     )
                 )
 
+    except asyncio.CancelledError:
+        # PR-A2: turn was cancelled by user-initiated abort (Enter on
+        # next message). Render a clean ABORTED marker and re-raise so
+        # the caller's await sees the cancellation.
+        _cancel_spinner()
+        clear_line()
+        console.print()
+        console.print(
+            Rule(
+                "[#c8924a]⏸  ABORTED[/#c8924a]  [dim]turn cut short by user[/dim]",
+                style="#c8924a",
+            )
+        )
+        raise
     except Exception as exc:
         _cancel_spinner()
         clear_line()
         console.print()
         console.print(f"[red]Error: {exc}[/red]")
+    finally:
+        # Defensive: ensure the spinner task never outlives this turn,
+        # even if neither except branch fired (clean exit) or if a path
+        # added later forgets to cancel it.
+        _cancel_spinner()
 
 
 # ---------------------------------------------------------------------------

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -199,18 +199,88 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
     current_turn_task: asyncio.Task | None = None
     shutdown = asyncio.Event()
 
+    # ── PR-A3: confirm-prompt stdin coordination ──────────────────────────
+    #
+    # Interactive widgets (select_prompt in ui.py — used by tool confirm
+    # and HITL pause) need exclusive stdin while running. The challenge:
+    # input_loop's PromptSession runs its own prompt_toolkit Application
+    # that owns stdin's vt100 input handler. If we start a second
+    # Application before the first has fully detached its input, the new
+    # one races with stale key callbacks and crashes ("Application is
+    # not running").
+    #
+    # Coordination protocol:
+    #   - input_released  — set when input_loop is NOT inside prompt_async.
+    #                       Cleared on entry, set on exit (via finally).
+    #   - confirm_active  — set while a widget owns stdin.
+    #   - confirm_done    — set after the widget releases.
+    #
+    # _run_interactive: signals confirm_active, asks the live input
+    # Application to exit, waits for input_loop to actually return from
+    # prompt_async (input_released), then starts the widget. This
+    # guarantees stdin is fully detached before the new Application
+    # tries to attach.
+    confirm_active = asyncio.Event()
+    confirm_done = asyncio.Event()
+    confirm_done.set()
+    input_released = asyncio.Event()
+    input_released.set()  # input_loop hasn't entered prompt_async yet
+
+    async def _run_interactive(coro_factory) -> Any:
+        from prompt_toolkit.application.current import get_app_or_none
+
+        confirm_active.set()
+        confirm_done.clear()
+
+        live_app = get_app_or_none()
+        if live_app is not None and getattr(live_app, "is_running", False):
+            try:
+                live_app.exit(result=None)
+            except Exception:
+                pass
+
+        # Wait for input_loop to fully unwind out of prompt_async — its
+        # finally block sets input_released. Cap the wait at 1s so a
+        # misbehaving prompt_toolkit detach can't deadlock the user.
+        try:
+            await asyncio.wait_for(input_released.wait(), timeout=1.0)
+        except asyncio.TimeoutError:
+            pass
+
+        try:
+            return await coro_factory()
+        finally:
+            confirm_active.clear()
+            confirm_done.set()
+
+    session._run_interactive = _run_interactive  # type: ignore[attr-defined]
+
     async def input_loop() -> None:
         nonlocal current_turn_task
         while not shutdown.is_set():
+            # If a confirm widget owns stdin, sit out until it's done.
+            if confirm_active.is_set():
+                await confirm_done.wait()
+                continue
+
+            input_released.clear()
             try:
-                user_input: str = await prompt_session.prompt_async(
-                    [("class:prompt", "\nyou › ")],
-                )
-            except (EOFError, KeyboardInterrupt):
-                shutdown.set()
-                return
-            except asyncio.CancelledError:
-                return
+                try:
+                    user_input = await prompt_session.prompt_async(
+                        [("class:prompt", "\nyou › ")],
+                    )
+                except (EOFError, KeyboardInterrupt):
+                    shutdown.set()
+                    return
+                except asyncio.CancelledError:
+                    return
+            finally:
+                input_released.set()
+
+            # _run_interactive forces our prompt_async to exit with result=None.
+            # In that case loop back so the confirm_active gate above engages.
+            if user_input is None:
+                continue
 
             text = user_input.strip()
             if not text:
@@ -1268,36 +1338,67 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 console.print()
 
             elif isinstance(event, TurnPaused):
-                # ── HITL pause ────────────────────────────────────────────
+                # ── HITL pause (PR-A3: arrow-key widget) ──────────────────
                 _cancel_spinner()
                 clear_line()
                 if not at_line_start:
                     console.print()
                 console.print(
                     Rule(
-                        f"[yellow]⏸  Paused[/yellow]  [dim]({event.tool_count_so_far} tool(s) so far)[/dim]",
-                        style="yellow",
+                        f"[#c8924a]⏸  Paused[/#c8924a]  "
+                        f"[dim]({event.tool_count_so_far} tool(s) so far)[/dim]",
+                        style="#c8924a",
                     )
                 )
-                console.print(
-                    "[dim]  r[/dim] resume  [dim]·[/dim]  "
-                    "[dim]c[/dim] cancel  [dim]·[/dim]  "
-                    "[dim]<message>[/dim] redirect and resume"
-                )
-                try:
-                    raw = await asyncio.get_event_loop().run_in_executor(
-                        None, lambda: input("pause> ").strip()
-                    )
-                except (EOFError, KeyboardInterrupt):
-                    raw = "c"
 
-                if raw in ("c", "cancel"):
+                from loom.platform.cli.ui import SelectOption, select_prompt
+
+                _PAUSE_RESUME = "resume"
+                _PAUSE_CANCEL = "cancel"
+                _PAUSE_REDIRECT = "redirect"
+
+                async def _pause_pick():
+                    return await select_prompt(
+                        title="絲已暫停，下一步？",
+                        options=[
+                            SelectOption(label="繼續執行剩下的工具",
+                                         value=_PAUSE_RESUME, shortcut="r"),
+                            SelectOption(label="導向新指令並繼續",
+                                         value=_PAUSE_REDIRECT, shortcut="m"),
+                            SelectOption(label="取消這個 turn",
+                                         value=_PAUSE_CANCEL, shortcut="c"),
+                        ],
+                        default_index=0,
+                        cancel_value=_PAUSE_CANCEL,
+                    )
+
+                runner = getattr(session, "_run_interactive", None)
+                choice = await (runner(_pause_pick) if runner else _pause_pick())
+
+                if choice == _PAUSE_CANCEL:
                     session.cancel()
-                elif raw in ("r", "resume", ""):
+                elif choice == _PAUSE_REDIRECT:
+                    # Sub-prompt for the redirect text. Routed through the
+                    # same _run_interactive so input_loop stays paused.
+                    async def _ask_redirect():
+                        from prompt_toolkit import PromptSession as _PS
+                        ps = _PS()
+                        try:
+                            return await ps.prompt_async(
+                                [("class:prompt", "redirect › ")],
+                            )
+                        except (EOFError, KeyboardInterrupt):
+                            return ""
+
+                    raw = await (runner(_ask_redirect) if runner else _ask_redirect())
+                    raw = (raw or "").strip()
+                    if raw:
+                        session.resume_with(raw)
+                        console.print(f"[dim]  Injected: {raw[:80]}[/dim]")
+                    else:
+                        session.resume()
+                else:  # _PAUSE_RESUME
                     session.resume()
-                else:
-                    session.resume_with(raw)
-                    console.print(f"[dim]  Injected: {raw[:80]}[/dim]")
 
             elif isinstance(event, TurnDone):
                 # Cancel any running spinner and clear cursor

--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -19,6 +19,7 @@ Display strategy
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass, field
 from typing import Any
 
 from rich.markdown import Markdown
@@ -28,6 +29,7 @@ from rich.text import Text
 from pathlib import Path
 
 from prompt_toolkit import PromptSession
+from prompt_toolkit.application import Application
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.completion import (
     CompleteEvent,
@@ -37,8 +39,12 @@ from prompt_toolkit.completion import (
 )
 from prompt_toolkit.document import Document
 from prompt_toolkit.filters import has_focus
+from prompt_toolkit.formatted_text import FormattedText
 from prompt_toolkit.history import FileHistory, InMemoryHistory
 from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.layout import HSplit, Layout, Window
+from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.styles import Style
 
 # ---------------------------------------------------------------------------
@@ -233,6 +239,159 @@ def make_prompt_session(
         multiline=False,
         mouse_support=False,
     )
+
+
+# ---------------------------------------------------------------------------
+# select_prompt — arrow-key inline selection (PR-A3)
+# ---------------------------------------------------------------------------
+#
+# Replaces single-key ``input("y/n: ")`` confirms with an inline widget
+# that supports up/down arrow navigation, Enter to confirm, single-key
+# shortcuts (still typeable for muscle memory), and Esc to cancel.
+#
+# The widget runs as a short-lived prompt_toolkit Application which
+# competes for stdin with the main input loop. Callers must ensure the
+# main input loop is paused before invoking — see ``confirm_active``
+# coordination in ``platform/cli/main.py``.
+
+
+@dataclass
+class SelectOption:
+    """One choice in a select_prompt menu."""
+    label: str
+    value: Any
+    shortcut: str | None = None      # single-letter direct selection
+    style: str = ""                   # optional Rich-like style applied to label
+
+
+_SELECT_STYLE = Style.from_dict(
+    {
+        "select.title":    "#e0cfa0",            # parchment cream, no bold/reverse
+        "select.body":     "#8a7a5e",
+        "select.subtle":   "#8a7a5e",
+        "select.option":   "#e0cfa0",
+        "select.option.cursor": "bold #c8a464",  # cursor row: bold amber, no bg flip
+        "select.shortcut": "#8a7a5e",            # shortcut hint: dim, no emphasis
+        "select.footer":   "#8a7a5e italic",
+        "select.deny":     "#b87060",
+        "select.approve":  "#7a9e78",
+    }
+)
+
+
+async def select_prompt(
+    *,
+    title: str,
+    body: str = "",
+    options: list[SelectOption],
+    default_index: int = 0,
+    cancel_value: Any = None,
+    footer_hint: str | None = None,
+) -> Any:
+    """Show an inline arrow-key selection menu and return the chosen value.
+
+    Parameters
+    ----------
+    title : str
+        Single-line header (e.g. tool name + trust level).
+    body : str
+        Optional secondary description (truncated args, justification, …).
+    options : list[SelectOption]
+        Choices in display order. Each option's ``shortcut`` (if set) lets
+        the user pick it directly without arrow nav.
+    default_index : int
+        Cursor starts on this option.
+    cancel_value : Any
+        Returned when the user presses Esc / Ctrl+C.
+    footer_hint : str | None
+        Override the default ``↑↓ select  ⏎ confirm  esc cancel`` hint.
+    """
+    cursor = max(0, min(default_index, len(options) - 1))
+    shortcut_index = {
+        opt.shortcut.lower(): idx
+        for idx, opt in enumerate(options)
+        if opt.shortcut
+    }
+
+    def _render() -> FormattedText:
+        lines: list[tuple[str, str]] = []
+        if title:
+            lines.append(("class:select.title", f"{title}\n"))
+        if body:
+            lines.append(("class:select.body", f"{body}\n"))
+        if title or body:
+            lines.append(("", "\n"))
+
+        for idx, opt in enumerate(options):
+            is_cursor = idx == cursor
+            arrow = " ▸ " if is_cursor else "   "
+            style = "class:select.option.cursor" if is_cursor else "class:select.option"
+            label = opt.label
+            if opt.shortcut and not is_cursor:
+                # Embed shortcut hint as suffix in subtle style
+                lines.append((style, f"{arrow}{label}"))
+                lines.append(("class:select.shortcut", f"  ({opt.shortcut})"))
+                lines.append(("", "\n"))
+            else:
+                lines.append((style, f"{arrow}{label}"))
+                if opt.shortcut and is_cursor:
+                    lines.append(("class:select.option.cursor", f"  ({opt.shortcut})"))
+                lines.append(("", "\n"))
+
+        lines.append(("", "\n"))
+        hint = footer_hint or "↑↓ 選擇  ⏎ 確認  esc 取消"
+        if shortcut_index:
+            shortcuts = "/".join(s for s in shortcut_index)
+            hint += f"  ·  直接按 {shortcuts}"
+        lines.append(("class:select.footer", hint))
+        return FormattedText(lines)
+
+    kb = KeyBindings()
+
+    @kb.add("up")
+    @kb.add("c-p")
+    def _up(event):
+        nonlocal cursor
+        cursor = (cursor - 1) % len(options)
+        event.app.invalidate()
+
+    @kb.add("down")
+    @kb.add("c-n")
+    def _down(event):
+        nonlocal cursor
+        cursor = (cursor + 1) % len(options)
+        event.app.invalidate()
+
+    @kb.add("enter")
+    def _confirm(event):
+        event.app.exit(result=options[cursor].value)
+
+    @kb.add("escape", eager=True)
+    @kb.add("c-c")
+    def _cancel(event):
+        event.app.exit(result=cancel_value)
+
+    # Bind each shortcut key directly
+    for shortcut, idx in shortcut_index.items():
+        @kb.add(shortcut)
+        def _shortcut(event, _idx=idx):  # default-arg captures idx per loop
+            event.app.exit(result=options[_idx].value)
+
+    body_window = Window(
+        content=FormattedTextControl(_render, focusable=True),
+        height=Dimension(min=len(options) + (3 if title or body else 1)),
+        wrap_lines=True,
+    )
+
+    app: Application = Application(
+        layout=Layout(HSplit([body_window])),
+        key_bindings=kb,
+        style=_SELECT_STYLE,
+        full_screen=False,
+        mouse_support=False,
+    )
+
+    return await app.run_async()
 
 
 # ---------------------------------------------------------------------------

--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -25,9 +25,19 @@ from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.text import Text
 
+from pathlib import Path
+
 from prompt_toolkit import PromptSession
-from prompt_toolkit.completion import WordCompleter
-from prompt_toolkit.history import InMemoryHistory
+from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+from prompt_toolkit.completion import (
+    CompleteEvent,
+    Completer,
+    Completion,
+    FuzzyCompleter,
+)
+from prompt_toolkit.document import Document
+from prompt_toolkit.filters import has_focus
+from prompt_toolkit.history import FileHistory, InMemoryHistory
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.styles import Style
 
@@ -50,36 +60,64 @@ from loom.core.events import (  # noqa: E402, F401
 
 
 # ---------------------------------------------------------------------------
-# Slash command autocomplete
+# Slash command catalog — single source of truth for completer + /help
 # ---------------------------------------------------------------------------
+#
+# Each entry: (command, description). Descriptions show as completion meta.
+# Keep alphabetically grouped by command root for predictable nav.
 
-_SLASH_WORDS = [
-    "/personality",
-    "/personality off",
-    "/personality adversarial",
-    "/personality minimalist",
-    "/personality architect",
-    "/personality researcher",
-    "/personality operator",
-    "/think",
-    "/new",
-    "/compact",
-    "/scope",
-    "/scope revoke",
-    "/scope clear",
-    "/pause",
-    "/stop",
-    "/help",
+SLASH_COMMANDS: list[tuple[str, str]] = [
+    ("/auto",                       "toggle run_bash auto-approve (requires strict_sandbox)"),
+    ("/compact",                    "compress older context (smart compaction)"),
+    ("/help",                       "show command reference"),
+    ("/model",                      "show current model + registered providers"),
+    ("/model claude-sonnet-4-6",    "switch to Anthropic Claude Sonnet 4.6"),
+    ("/model claude-opus-4-7",      "switch to Anthropic Claude Opus 4.7"),
+    ("/model MiniMax-M2.7",         "switch to MiniMax-M2.7 (default)"),
+    ("/new",                        "start a fresh session"),
+    ("/pause",                      "toggle HITL pause after each tool batch"),
+    ("/personality",                "show active persona + available list"),
+    ("/personality off",            "clear active persona"),
+    ("/personality adversarial",    "switch persona → adversarial"),
+    ("/personality architect",      "switch persona → architect"),
+    ("/personality minimalist",     "switch persona → minimalist"),
+    ("/personality operator",       "switch persona → operator"),
+    ("/personality researcher",     "switch persona → researcher"),
+    ("/scope",                      "list active scope grants"),
+    ("/scope clear",                "revoke all non-system grants"),
+    ("/scope revoke",               "revoke a specific grant by index"),
+    ("/sessions",                   "browse and switch sessions"),
+    ("/stop",                       "interrupt a running turn (CLI: Ctrl+C)"),
+    ("/think",                      "view last turn's reasoning chain"),
 ]
 
 
-class SlashCompleter(WordCompleter):
-    def __init__(self) -> None:
-        super().__init__(
-            _SLASH_WORDS,
-            match_middle=False,
-            sentence=True,
-        )
+class SlashCompleter(Completer):
+    """Slash-command completer with metadata + prefix matching.
+
+    Wrap with :class:`FuzzyCompleter` for fuzzy match — done in
+    :func:`make_prompt_session`.
+    """
+
+    def __init__(self, commands: list[tuple[str, str]] | None = None) -> None:
+        self._commands = commands if commands is not None else SLASH_COMMANDS
+
+    def get_completions(self, document: Document, _: CompleteEvent):
+        # Only complete on the first line, when text starts with "/".
+        # Avoids triggering completer on subsequent lines of multi-line input.
+        text = document.text_before_cursor
+        if "\n" in text:
+            return
+        if not text.startswith("/"):
+            return
+        for cmd, desc in self._commands:
+            if cmd.startswith(text):
+                yield Completion(
+                    cmd,
+                    start_position=-len(text),
+                    display=cmd,
+                    display_meta=desc,
+                )
 
 
 # ---------------------------------------------------------------------------
@@ -88,35 +126,112 @@ class SlashCompleter(WordCompleter):
 
 _PT_STYLE = Style.from_dict(
     {
-        "prompt": "bold cyan",
+        # Prompt indicator (the "you ›" before input)
+        "prompt": "bold #c8a464",         # amber gold (羊皮卷 accent)
+        # Hint text (continuation prompt on multi-line)
+        "prompt.continuation": "#8a7a5e", # muted parchment
+        # Auto-suggestion ghost text
+        "auto-suggestion": "#4a4038",     # subtle border-grey
+        # Completion menu
+        "completion-menu":         "bg:#242018 #e0cfa0",
+        "completion-menu.completion":         "bg:#242018 #e0cfa0",
+        "completion-menu.completion.current": "bg:#c8a464 #1c1814 bold",
+        "completion-menu.meta.completion":         "bg:#242018 #8a7a5e",
+        "completion-menu.meta.completion.current": "bg:#c8a464 #1c1814",
         "": "",
     }
 )
 
+_HISTORY_PATH = Path.home() / ".loom" / "cli_history"
+
 
 def _build_key_bindings() -> KeyBindings:
-    """Build key bindings for Ctrl+L (clear)."""
+    """Build key bindings.
+
+    Defaults provided by prompt_toolkit (we don't override):
+      - Ctrl+C / Ctrl+D on empty buffer → exit
+      - Up / Down → history navigation (single-line buffer)
+      - Tab → completion
+
+    Custom:
+      - Ctrl+L              → clear screen
+      - Enter               → submit (even in multiline mode)
+      - Alt+Enter / Esc,Enter → insert newline
+      - Esc (alone, double-tap) → clear buffer
+    """
     kb = KeyBindings()
 
     @kb.add("c-l")
-    def clear_screen(_) -> None:
-        """Ctrl+L: clear terminal screen."""
+    def clear_screen(event) -> None:
         from rich.console import Console
-
         _console = Console()
         _console.clear()
+        # Re-render the prompt after clear
+        event.app.renderer.reset()
+        event.app.invalidate()
+
+    @kb.add("enter", filter=has_focus("DEFAULT_BUFFER"))
+    def submit_on_enter(event) -> None:
+        """Plain Enter → submit (overrides multiline default of inserting newline)."""
+        buf = event.current_buffer
+        # Empty buffer → no-op (don't submit empty input)
+        if not buf.text.strip():
+            return
+        buf.validate_and_handle()
+
+    @kb.add("escape", "enter", filter=has_focus("DEFAULT_BUFFER"))
+    def newline_on_alt_enter(event) -> None:
+        """Alt+Enter (sent by terminals as Esc,Enter) → insert newline."""
+        event.current_buffer.insert_text("\n")
 
     return kb
 
 
-def make_prompt_session() -> PromptSession:
-    """Create a PromptSession with input history, slash autocomplete, and key bindings."""
+def make_prompt_session(
+    *,
+    history_path: Path | None = None,
+    slash_commands: list[tuple[str, str]] | None = None,
+) -> PromptSession:
+    """Create a PromptSession with multiline input, file history, and fuzzy slash autocomplete.
+
+    Parameters
+    ----------
+    history_path : Path | None
+        Where to persist input history. Defaults to ``~/.loom/cli_history``.
+        Falls back to in-memory history if the path is not writable.
+    slash_commands : list[(cmd, desc)] | None
+        Override the slash command catalog (e.g., for tests). Defaults to
+        :data:`SLASH_COMMANDS`.
+    """
+    # Resolve history location, with graceful fallback to in-memory.
+    history: FileHistory | InMemoryHistory
+    path = history_path if history_path is not None else _HISTORY_PATH
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        history = FileHistory(str(path))
+    except OSError:
+        history = InMemoryHistory()
+
+    completer = FuzzyCompleter(
+        SlashCompleter(slash_commands),
+        # Empty pattern produces no fuzzy noise; only fuzzy-match real input.
+        enable_fuzzy=True,
+    )
+
     return PromptSession(
-        history=InMemoryHistory(),
-        completer=SlashCompleter(),
+        history=history,
+        completer=completer,
         complete_while_typing=True,
+        auto_suggest=AutoSuggestFromHistory(),
         style=_PT_STYLE,
         key_bindings=_build_key_bindings(),
+        # multiline=True deferred: prompt_toolkit's multi-line cursor
+        # bookkeeping leaves terminal state that interacts badly with
+        # Rich's raw `\r\033[K` clear_line on streaming output (CJK
+        # boundary truncation). Revisit alongside Rich render rewrite
+        # in PR-D.
+        multiline=False,
+        mouse_support=False,
     )
 
 

--- a/tests/test_architecture_guards.py
+++ b/tests/test_architecture_guards.py
@@ -42,6 +42,14 @@ ALLOWED_EXCEPTIONS: list[tuple[str, str]] = [
     # coupling: those tool factories belong in loom.core.tools and will be
     # migrated in a follow-up (issue #69).
     ("loom.core.session", "loom.platform.cli.tools"),
+    # PR-A3 (#236): _confirm_tool_cli renders an arrow-key widget defined
+    # in loom.platform.cli.ui (select_prompt). Same architectural smell as
+    # the cli.tools exception above — interactive UI logic ideally lives
+    # closer to the platform layer, but the confirm path is anchored on
+    # the session because BlastRadiusMiddleware needs a session-scoped
+    # confirm_fn. Will be untangled when CLI-specific session methods
+    # move to a platform adapter.
+    ("loom.core.session", "loom.platform.cli.ui"),
 ]
 
 


### PR DESCRIPTION
First slice of #236 CLI Refresh. Upgrades the CLI's input experience without touching the streaming render path (that's PR-D's job). Three commits, each independently reviewable.

## Design context

`doc/49-CLI-Refresh-設計.md` (added in this PR's first commit) is the authoritative design底稿 for the entire CLI Refresh milestone — read that first if you want the full picture. It defines the three-channel harness message routing (footer / inline / modal), the visual族群 split (Loom Agent / Harness / Tool), the parchment palette, and the PR split A→E.

## What this PR ships

### A1 · Input upgrade (commit 3a9a75f)
- 22-entry slash command catalog (with descriptions for completion meta) replaces the hard-coded 17-word list — `/auto`, `/sessions`, all `/personality` variants now surface in completion
- `FuzzyCompleter` wrapping a custom first-line-only `SlashCompleter` — `/scp` matches `/scope`
- `FileHistory` persists to `~/.loom/cli_history` with graceful fallback to in-memory
- `AutoSuggestFromHistory` adds fish-style ghost text
- Parchment palette applied to prompt + completion menu (matches TUI tone)
- KeyBindings: Enter submits, Ctrl+L clears with re-render, Alt+Enter inserts newline (currently inert under `multiline=False` — see deferred)

### A2 · Abort-on-submit (commit ebbe1d2)
The chat loop becomes producer/consumer under `patch_stdout(raw=True)`:
- `input_loop` reads user lines; if a turn is in flight it calls `session.cancel()`, waits up to 3 s for it to unwind, then queues the new message with an interrupt prefix
- `turn_loop` drains the queue. Slash commands run inline without cancelling the turn; regular text spawns a streaming-turn task that input_loop can cancel
- Messages flagged with the interrupt prefix get prepended with `[使用者打斷上一輪並接續]\n` so the LLM sees the cut-short context and can resume coherently rather than starting cold
- `_run_streaming_turn` gets explicit `CancelledError` handling that prints an `⏸ ABORTED` Rule + a `finally` that prevents spinner-task leaks
- `AnthropicProvider` (sync + streaming paths) skips `dump_on_failure` when the exception is `CancelledError` — user aborts no longer pollute `~/.loom/debug/llm_failure_*.json` or warn-log "LLM request failed"

### A3 · Arrow-key confirm + HITL pause (commit 80af851)
- New `select_prompt()` helper in `ui.py` — short-lived prompt_toolkit Application with arrow nav, Enter confirm, Esc cancel, single-letter shortcuts, parchment styling (no inverse-video rows)
- `_confirm_tool_cli` rewritten to use it: 4 dynamic options (Once / Lease 30 min / Permanent / Deny), default cursor on Deny for safety, `[bold]` styling dropped from `_format_scope_panel` to avoid reverse-video on common terminal themes
- HITL pause uses the same widget for Resume / Redirect / Cancel; choosing Redirect opens a one-shot `PromptSession` for the freeform redirect text
- Three-event stdin coordination protocol (`confirm_active` / `confirm_done` / `input_released`) hands off stdin cleanly between the input loop's persistent PromptSession and the short-lived widget Applications. Without `input_released`, `app.exit()` schedules the exit but stale vt100 input callbacks still fire on the just-exited app, crashing the new widget's first keypress with "Application is not running"
- Adds `loom.core.session` → `loom.platform.cli.ui` to architecture-guard `ALLOWED_EXCEPTIONS`. Same smell as the existing `cli.tools` exception (will untangle in #69 territory)

## Deferred to later PRs

These are listed in `doc/49` "已知 bug" / "未決問題" sections:

- **Multi-line input**: `multiline=True` interacts badly with Rich's `\r\033[K` clear_line during streaming output (CJK soft-wrap truncation). Re-enabled in PR-D alongside the stream renderer rewrite. Alt+Enter binding stays in code, currently inert
- **Streaming line-head truncation**: pre-existing bug in CLI streaming output — long CJK paragraphs / list items lose their first few chars. Confirmed not introduced by this PR (also reproduces on master). PR-D's stream renderer rewrite resolves it
- **Prompt anchored to terminal bottom**: requires a single persistent Application with a fixed bottom Window — that's the entire point of PR-D's "Linear Stream + Live Footer" architecture
- **「查看完整參數」 confirm-prompt expand**: needs ToolCall.args serialisation rework, follow-up

## Test plan

- [ ] `loom chat` starts cleanly, prompt renders with parchment colour
- [ ] Slash completion: `/scp` shows `/scope` variants with descriptions; `/auto` and `/sessions` appear (didn't before)
- [ ] FileHistory: previous session's input is browsable via Up arrow; ghost-suggest shows as灰 text
- [ ] Send a long-running prompt, then send another mid-stream — first turn shows ABORTED rule, no `llm_failure_*.json` is created, second turn's response references the interruption
- [ ] Trigger a GUARDED tool (e.g. `web_search`) — confirm widget shows 4 options with parchment styling, no inverse-video rows; arrow keys + Enter work; `y/s/a/n` shortcuts work; Esc returns DENY
- [ ] `/pause` then trigger tools — HITL pause widget shows 3 options; Redirect opens text prompt
- [ ] No "Application is not running" exceptions during repeated confirm flows
- [ ] Existing test suite (1118 / 1124 passing; 5 failures are pre-existing in `test_cognition.py::TestToAnthropicMessages`, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)