### PR TITLE
feat(cli): CLI Refresh PR-C — Harness vs Loom Agent message routing

### DIFF
--- a/doc/49a-PR-C-實作草稿.md
+++ b/doc/49a-PR-C-實作草稿.md
@@ -1,0 +1,270 @@
+# PR-C 實作草稿 — Harness vs Loom Agent 視覺切分
+
+本文件是 `doc/49-CLI-Refresh-設計.md` 中 **PR-C** 的詳細實作藍圖。完成後內容會折回 issue #236 PR-C 的 PR body 與相關 follow-up。
+
+---
+
+## 1. 目標回顧
+
+把「Loom Agent 在說話」、「Harness 在報告」、「工具在執行」三類訊息**視覺強切分**，並用三條訊息頻道分流：
+
+- **底層 (footer)**：閃 0.3s 不留底
+- **流式 (inline)**：append-only 留歷史
+- **跳出 (modal)**：阻斷式互動
+
+PR-A/B 已建好基礎（prompt_toolkit producer/consumer + LOOM_THEME），PR-C 把分流邏輯與訊息族群 renderer 補齊。
+
+---
+
+## 2. 13 類訊息來源實際 emission point
+
+從 PR-A 設計階段確認的 13 類，補上具體 file:line。
+
+| # | 類別 | Emission point | 目前頻道 | PR-C 目標頻道 |
+|---|---|---|---|---|
+| 1 | EnvelopeStarted/Updated/Completed | `session.stream_turn()` yields events → `main.py:_run_streaming_turn` | inline (panel) | **inline** + **footer** 摘要 |
+| 2a | Auth 綠燈（`pre-authorized` / `exec_auto` / `scope-allow`） | `middleware.py:573 _notify_lifecycle` 配合 `permissions.py:label/plain` 進 trace；目前**不直接 print**，只寫進 lifecycle ctx + middleware_trace | 流式（透過 trace）| **footer 閃 0.3s 不留底** |
+| 2b | Auth 紅燈（`user denied` / `circuit-breaker tripped` / `scope-deny` / `unattended-deny`） | 同上但 `result=False` | 流式 | **流式留底**（forensics） |
+| 3 | Confirm prompt | `session.py:_confirm_tool_cli` → `select_prompt` widget | modal | **modal**（已是） |
+| 4 | Scope grant 狀態（active grants、TTL、過期清掃） | `main.py:/scope` slash command 列表；過期清掃在 `permissions.py` 內部，目前無顯示 | 流式（手動查）/ 沉默（清掃）| 底層（最快過期那個 TTL）+ 流式（手動查） |
+| 5 | Compaction | `main.py:394 /compact` 手動觸發；`session.py:_smart_compact` 自動觸發；目前 `console.print("[dim]Compacting context (X% used)…[/dim]")` | 流式 | 底層（執行中 spinner）+ 流式（完成摘要） |
+| 6 | History sanitize | `session.py:2539 _sanitize_history` — **完全沉默**，無 log 無 print | 沉默 | **流式 1 行**（但只在真的有修才喊） |
+| 7 | Session resume / diagnostic | `main.py:124 console.print("[dim]Resuming session ...")`；`main.py:143 _cli_diagnostic` callback | 流式 | 流式（保留現狀）|
+| 8 | Model / Personality 切換 | `main.py:_handle_slash` 各 `console.print` | 流式 | 流式（保留現狀）|
+| 9 | Token budget | `main.py:status_bar()` 在 turn 結束印一次 | inline (turn 結束)| **底層常駐（>60% 才浮出）** |
+| 10 | NotificationRouter | `notify/router.py` fan-out → `cli.py CLINotifier.send` 印 Panel | 流式（Panel）| 流式（族群明確化：autonomy / external trigger 視覺區分）|
+| 11 | MemoryGovernor | `governance.py:139 governed_upsert` 回傳 `GovernedWriteResult`；**目前不打印**，只回傳結果給 caller | 沉默 | **流式（reject only，accept 沉默）** |
+| 12 | Reasoning chain | `main.py:387 /think` 手動查 | 使用者主動 | 不變 |
+| 13 | Error / fatal | `main.py:1322 except CancelledError`、`except Exception` 在 `_run_streaming_turn`；provider 錯誤從 cognition 層拋上來 | 流式 / modal（fatal recovery）| 流式（一般）/ modal（fatal） |
+
+---
+
+## 3. 新抽象：`HarnessChannel`
+
+把分流邏輯集中在一個薄抽象，避免散落 `console.print` 的 ad-hoc 處理。
+
+```python
+# loom/platform/cli/harness_channel.py（新檔）
+
+class HarnessChannel:
+    """Harness 訊息分流器：footer / inline / modal 三條路。"""
+
+    def __init__(self, console: Console, footer: "FooterController"):
+        self._console = console
+        self._footer = footer
+
+    # 流式（留底）
+    def inline(self, message: str, *, level: str = "info") -> None:
+        """印一條帶 ⚙ harness › 署名的 inline 訊息。
+        level: 'info' | 'success' | 'warning' | 'error'
+        """
+        ...
+
+    # 底層（閃光，不留底）
+    def flash(self, message: str, duration: float = 0.3) -> None:
+        """在 footer 區閃一次，duration 後消失。"""
+        self._footer.flash(message, duration)
+
+    # 底層（持續顯示）
+    def status(self, key: str, value: str | None) -> None:
+        """設定/清除 footer 上的某個 status field。
+        value=None 清除該 field。
+        """
+        self._footer.set_status(key, value)
+```
+
+**為什麼是 HarnessChannel 不是 LoomAgentChannel**：
+Loom Agent 的訊息走 `_run_streaming_turn` 既有路徑（TextChunk / Markdown），不需要新抽象。Harness 訊息才有「該不該留底」的決策歧義，需要明確 API。
+
+---
+
+## 4. 新抽象：`FooterController`（PR-D 完整版的前哨）
+
+PR-D 才會做完整的 1 行 live footer。但 PR-C 的「綠燈閃光」、「token budget 浮出」、「grant TTL 倒數」需要一個最小可用的 footer，才能把分流落地。
+
+```python
+# loom/platform/cli/footer.py（新檔）
+
+class FooterController:
+    """1 行 status footer 的最小實作。
+
+    PR-C 階段：用 Rich Live 在 main_loop 底層維護一行可變狀態。
+    PR-D 階段：合併進 persistent Application 的固定 bottom Window。
+    """
+
+    def __init__(self, console: Console):
+        self._console = console
+        self._status: dict[str, str] = {}
+        self._flash_message: str | None = None
+        self._live: Live | None = None
+
+    async def start(self) -> None: ...
+    async def stop(self) -> None: ...
+    def set_status(self, key: str, value: str | None) -> None: ...
+    def flash(self, msg: str, duration: float) -> None: ...
+    def _render(self) -> Text: ...
+```
+
+**status 欄位順序**（從左到右）：
+
+```
+🔑 L2·0:43   ⚡ tok 67%   ▸ run_bash·1.2s
+^ grant       ^ budget     ^ active envelope
+```
+
+**flash 顯示策略**：覆蓋整行，到期後恢復原 status。flash 不堆疊，新 flash 取代舊 flash。
+
+---
+
+## 5. 視覺族群 renderer
+
+### 5.1 Loom Agent 文本
+
+走既有 `_run_streaming_turn` 的 `TextChunk` 路徑，**不改架構**，只調 visual：
+
+- 每個 turn 開頭：印 `Loom ▎` 引線（絲綢色 = `loom.accent`）+ Rule 但 Rule 樣式弱化
+- streaming 過程：`[loom.text]` 奶油色
+- think summary：`[loom.muted]💭 ...[/loom.muted]`（已是）
+
+### 5.2 Harness renderer
+
+寫一個 helper 把 `⚙ harness › <message>` 包成統一格式：
+
+```python
+def render_harness_inline(message: str, level: str = "info") -> Text:
+    """Render harness inline message: ⚙ harness › <msg>
+
+    Level mapping:
+      info     → loom.muted   (sanitize, compaction 完成)
+      success  → loom.success (auth 綠燈紅燈不會走 inline，但保留)
+      warning  → loom.warning (deny, governor reject)
+      error    → loom.error   (forensics, fatal)
+    """
+    return Text.from_markup(
+        f"[loom.accent]⚙ harness ›[/loom.accent] [loom.{level_to_token(level)}]{message}[/loom.{level_to_token(level)}]"
+    )
+```
+
+**對齊 doc/49 設計原則**：harness 訊息一律帶署名，跟 Loom Agent 文本視覺切開。
+
+---
+
+## 6. 攔截點與改動清單
+
+按照 file:line 列出需要動的點：
+
+### `loom/core/harness/middleware.py`
+
+- **L573 `_notify_lifecycle`**：判斷 `reason` 屬於綠燈還是紅燈
+  - 綠燈集合：`{"pre-authorized", "exec_auto", "scope-confirm-legacy-authorized"}` 與 `reason.startswith("scope-allow:")`
+  - 紅燈：其餘 `result=False` 或 `reason.startswith("user denied")` / `circuit breaker` / `scope-deny`
+- 增加可選 callback hook：`self._on_lifecycle_event` 由 platform 注入
+  - 綠燈 → `harness_channel.flash(...)` 0.3s
+  - 紅燈 → `harness_channel.inline(..., level='warning')`
+- **不能** 在 middleware 內直接呼叫 channel（會逆向 import），用 callback 注入
+
+### `loom/core/session.py`
+
+- **L2539 `_sanitize_history`**：在 Pass 1/2 真的修了東西時設定 `self._last_sanitize_repaired: tuple[int, int]`，由 platform 層讀取後印 inline
+- **L203 `governed_upsert`**：caller 那邊判斷 `result.written == False` 就 emit harness inline
+
+### `loom/platform/cli/main.py`
+
+- **L79 `console = Console(...)`**：新增 `harness_channel` instance + `footer` instance
+- **L1244-1249 Opening Rule (`bold green loom`)**：改成 `Loom ▎` 引線風格（visual）
+- **L1322-1323 EnvelopeStart/End rendering**：保留 inline panel，但同時 `footer.set_status('active_envelope', ...)`；envelope 完成後 `set_status('active_envelope', None)`
+- **L1381-1404 status_bar**：拆解，token budget 進 footer（>60% 才顯示），其他資訊保留 inline
+- **L584-588 `_handle_slash` 中 /compact / /scope** 等命令：訊息走 `harness_channel.inline`
+- **L1322-1326 `except` 路徑**：error inline 加上 `⚙ harness ›` 署名（fatal 走 modal）
+
+### `loom/notify/adapters/cli.py`
+
+- 把 `CLINotifier.send` 印的 Panel 加上族群署名（`[autonomy]` / `[external]`）
+
+### `loom/core/memory/__init__` 或 caller
+
+- 確認 `governed_upsert` 的 caller（`session.py:203`）會把 reject 結果通報出去
+
+---
+
+## 7. 三頻道實作順序（commit 拆分）
+
+PR-C 收斂為 C1-C4。C5 移到 PR-D。
+
+| Commit | 主題 | 依賴 |
+|---|---|---|
+| **C1** | `theme.py` 補 `loom.harness.bg` token；新增 `harness_channel.py`（inline / flash 兩個方法，flash 在 PR-C 是 no-op） | 無 |
+| **C2** | Loom Agent 引線重畫；Harness inline renderer（`⚙ harness ›` 署名）覆蓋現有 `console.print`；明確分清 Loom Agent 文本 vs Harness 訊息 | C1 |
+| **C3** | `_notify_lifecycle` 綠燈/紅燈分類；綠燈 flash (no-op) 不印，紅燈走 inline；middleware 注入 callback hook | C1 |
+| **C4** | sanitize 修復可見化（inline once-per-turn）；governor reject 可見化（accept 沉默） | C1 |
+
+---
+
+## 8. 風險與對策
+
+### 風險 1 — Footer Live 跟 patch_stdout 互動
+
+`prompt_toolkit.patch_stdout` 已經吃掉 stdout，再疊一層 Rich Live 可能打架。**對策**：先用最 simple 的 footer 方案（每次 status 變化重印一行 + ANSI cursor up），不上 `Live`。完整 Live footer 留到 PR-D。
+
+### 風險 2 — middleware → platform callback 注入打破 layering
+
+對策：callback 是 `Optional[Callable]`，預設 None（無動作）；platform 層在 `LoomSession.start()` 後注入。沿用 `session._cancel_spinner_fn` 的模式。
+
+### 風險 3 — `_sanitize_history` 修復頻率高 → 流式被洗版
+
+對策：每個 turn 最多印一次（dedup by turn_index）。狀態存 `session._last_sanitize_repaired_turn`，下一個 turn 才能再印。
+
+### 風險 4 — Harness 訊息族群分類偏差
+
+對策：先做 C2/C3/C4 只關注「該分到哪個族群」，視覺細節（icon、空白、emoji）C5 之前都先用最簡格式，等實際看效果再調。
+
+---
+
+## 9. 已拍板（doc/49 → 此 PR）
+
+- [x] 綠燈不出聲（footer flash），紅燈才講話（inline）
+- [x] sanitize 必須可見（但只在真的修了才喊）
+- [x] 流式訊息一律帶 `⚙ harness ›` 署名
+- [x] MemoryGovernor 只顯示 reject，accept 沉默
+- [x] Token budget 採 C 方案（<60% 隱藏，>60% 浮出）
+- [x] Loom Agent / Harness / Tool 三族群視覺強切分
+
+---
+
+## 10. 已拍板的細節決議（2026-04-29）
+
+1. **Footer 實作策略**：簡單 ANSI cursor 移動 → 完整 Live 留到 PR-D
+2. **多 envelope 並行 footer 顯示**：要把數量寫出來，例如 `2× ▸ run_bash · 1.2s`，不只顯示最新
+3. **Grant TTL 倒數頻率**：turn 邊界刷新（不每秒 redraw）
+4. **Compaction spinner**：要，壓縮中 footer 顯示 `⚡ 壓縮中…`，完成後 inline 摘要——避免使用者看到停頓困惑
+
+## 11. PR-C scope 收斂：C1-C4，C5 移到 PR-D
+
+確認 C5 (footer 整合 token budget / active envelope / grant TTL / compaction spinner) 全部移到 PR-D 跟 Linear Stream 一氣呵成做。**PR-C 不引入 footer**，只做訊息族群切分 + 三頻道分流的 inline / modal 部分。
+
+這意味著：
+- `harness_channel.flash()` 在 PR-C 階段降級為「印一行 dim 訊息然後立即下一行」的 best-effort 實作（沒有真的「閃 0.3s 消失」），完整版等 PR-D footer
+- 綠燈訊息在 PR-C 階段選擇：(a) 完全不印 (b) 印一行很 dim 的訊息。**選 (a)**——綠燈不出聲，flash 當作 no-op；PR-D 上 footer 後再加閃光
+- 這個收斂讓 PR-C 純粹處理「訊息族群、署名、留底決策」，PR-D 處理「視覺常駐、footer 邏輯」
+
+---
+
+## 11. 出關後 Test plan 草稿
+
+- [ ] Confirm widget 觸發時，Loom Agent 文本與 Harness 訊息視覺差異明顯
+- [ ] `pre-authorized` / `exec_auto` 不再印進歷史（grep `~/.loom/debug` log 不再出現）
+- [ ] `user denied` / `circuit breaker` 留底 inline 可見
+- [ ] sanitize 修復發生時 inline 出現一次（用人為構造 orphan tool_call 觸發）
+- [ ] `governed_upsert` reject 訊息 inline 可見；accept 沉默
+- [ ] Token budget 在 <60% 時 footer 看不到；65%、85%、95% 顏色階梯正確
+- [ ] 多輪連續 abort 時 footer 不殘留 spinner
+
+---
+
+## 12. 出處與相依
+
+- 設計母文件：`doc/49-CLI-Refresh-設計.md`
+- Tracking issue：#236
+- 已 merge：PR-A (#237) PR-B (#242)
+- 後續：PR-D (Linear stream + Live Footer)、PR-E (TaskList)
+

--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -500,6 +500,14 @@ class BlastRadiusMiddleware(Middleware):
         self._confirm = confirm_fn
         self._exec_escape_fn = exec_escape_fn
         self._registry = registry
+        # PR-C: optional platform-side hook fired on every authorisation
+        # decision. Lets the CLI route green-light events to the footer
+        # (no留底) and red-light events to the inline harness stream.
+        # Signature: (call, result, reason) -> None. Kept Optional so the
+        # core stays platform-agnostic — main.py wires it in _chat().
+        self._on_lifecycle_event: (
+            "Callable[[ToolCall, bool, str], None] | None"
+        ) = None
 
     def _exec_auto_approved(self, call: ToolCall) -> bool:
         """
@@ -595,6 +603,15 @@ class BlastRadiusMiddleware(Middleware):
             "authorize" if result else "deny",
             reason=reason,
         )
+
+        # PR-C: optional platform hook for surfacing the decision in the
+        # CLI/Discord stream. Wrapped in a broad except so a buggy
+        # listener can never abort the harness pipeline.
+        if self._on_lifecycle_event is not None:
+            try:
+                self._on_lifecycle_event(call, result, reason)
+            except Exception:
+                pass
 
     async def _enter_awaiting_confirm(self, call: ToolCall) -> None:
         """Transition ActionRecord to AWAITING_CONFIRM before prompting user (#109)."""

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -951,7 +951,19 @@ class LoomSession:
         # ``self._memory`` was built up-front (right after governor init).
         # See "Issue #147 Phase C: build the facade up-front" above.
         self.registry.register(make_recall_tool(self._memory))
-        self.registry.register(make_memorize_tool(self._memory))
+        # PR-C4: when the governor blocks a write, fire the session-level
+        # hook so the platform layer can surface a "governor rejected"
+        # harness inline. Accept stays silent.
+        def _governor_reject_hook(key: str, tier: str, contradictions: int) -> None:
+            cb = getattr(self, "_on_governor_reject", None)
+            if cb is not None:
+                try:
+                    cb(key, tier, contradictions)
+                except Exception:
+                    pass
+        self.registry.register(
+            make_memorize_tool(self._memory, on_reject=_governor_reject_hook)
+        )
         self.registry.register(make_relate_tool(self._memory))
         self.registry.register(make_query_relations_tool(self._memory))
         self.registry.register(make_memory_health_tool(self._governor))
@@ -2545,8 +2557,15 @@ class LoomSession:
            Re-serialize from an empty dict so the API accepts the message.
         2. Trim any assistant message whose tool_calls are not all followed by
            matching tool result messages (orphaned tool_calls → 2013 error).
+
+        PR-C4: when a repair actually happens, populate
+        ``self._last_sanitize_repaired`` so the platform layer can surface
+        a one-line "⚙ harness › sanitize: …" message. ``None`` means
+        "ran but found nothing to fix" — silent.
         """
         msgs = self.messages
+        _args_fixed = 0
+        _msgs_before = len(msgs)
 
         # Pass 1: repair invalid arguments JSON in-place
         for msg in msgs:
@@ -2557,11 +2576,13 @@ class LoomSession:
                 raw_args = fn.get("arguments", "{}")
                 if not isinstance(raw_args, str):
                     fn["arguments"] = json.dumps(raw_args, ensure_ascii=False)
+                    _args_fixed += 1
                     continue
                 try:
                     json.loads(raw_args)
                 except (json.JSONDecodeError, ValueError):
                     fn["arguments"] = "{}"
+                    _args_fixed += 1
 
         # Pass 2: remove assistant messages with orphaned tool_calls
         # Build set of all tool result ids present in the history.
@@ -2694,6 +2715,26 @@ class LoomSession:
                 continue
             keep3.append(msg)
         self.messages = keep3
+
+        # PR-C4: surface a one-line harness note when sanitize actually
+        # repaired anything. Three signals:
+        #   _args_fixed  — Pass 1 truncated/non-string arg blobs rebuilt
+        #   _msgs_dropped — Pass 2/3/4 dropped orphaned tool_use or
+        #                   tool_result messages
+        # Stored on the session so the platform layer can pick it up at
+        # the start of the next turn (once-per-turn dedup is the caller's
+        # job — see _sanitize_callback wiring in main.py).
+        _msgs_dropped = max(0, _msgs_before - len(self.messages))
+        if _args_fixed or _msgs_dropped:
+            self._last_sanitize_repaired = (_args_fixed, _msgs_dropped)
+            cb = getattr(self, "_on_sanitize_repaired", None)
+            if cb is not None:
+                try:
+                    cb(_args_fixed, _msgs_dropped)
+                except Exception:
+                    pass
+        else:
+            self._last_sanitize_repaired = None
 
     def _telemetry_record_tool(
         self,

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -2717,24 +2717,20 @@ class LoomSession:
         self.messages = keep3
 
         # PR-C4: surface a one-line harness note when sanitize actually
-        # repaired anything. Three signals:
+        # repaired anything. Two signals:
         #   _args_fixed  — Pass 1 truncated/non-string arg blobs rebuilt
         #   _msgs_dropped — Pass 2/3/4 dropped orphaned tool_use or
         #                   tool_result messages
-        # Stored on the session so the platform layer can pick it up at
-        # the start of the next turn (once-per-turn dedup is the caller's
-        # job — see _sanitize_callback wiring in main.py).
+        # When nothing changed, stays silent (the design point: only
+        # speak when something actually moved).
         _msgs_dropped = max(0, _msgs_before - len(self.messages))
         if _args_fixed or _msgs_dropped:
-            self._last_sanitize_repaired = (_args_fixed, _msgs_dropped)
             cb = getattr(self, "_on_sanitize_repaired", None)
             if cb is not None:
                 try:
                     cb(_args_fixed, _msgs_dropped)
                 except Exception:
                     pass
-        else:
-            self._last_sanitize_repaired = None
 
     def _telemetry_record_tool(
         self,

--- a/loom/platform/cli/harness_channel.py
+++ b/loom/platform/cli/harness_channel.py
@@ -1,0 +1,103 @@
+"""
+HarnessChannel — three-channel routing for harness-emitted messages.
+
+Issue #236 PR-C. Centralises the decision *which channel* a harness
+message belongs to:
+
+- ``inline(message, level)``  →  flow stream, append-only, signed
+                                  with ``⚙ harness ›`` prefix
+- ``flash(message)``          →  footer ephemeral (PR-D); no-op in
+                                  PR-C — green-light auth events
+                                  simply don't print
+- ``modal``                   →  intentionally not exposed here.
+                                  Modal prompts (confirm / fatal
+                                  recovery) live in
+                                  ``loom.platform.cli.ui.select_prompt``
+
+Why this abstraction
+--------------------
+Before PR-C the call sites scattered ``console.print(...)`` with
+ad-hoc styling, and the routing decision (留底 vs 不留底) lived inside
+human heads. This module makes the choice explicit at the call site,
+lets us audit channel consistency by grepping ``harness_channel.``,
+and gives PR-D a single seam to swap the no-op ``flash`` for a real
+footer.
+
+Levels
+------
+``info``     — neutral state change (sanitize, compaction summary)
+``success``  — positive outcome (rare on inline; usually quiet)
+``warning``  — denial / governor reject / non-fatal anomaly
+``error``    — fatal / forensics-worthy
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from rich.console import Console
+from rich.text import Text
+
+
+Level = Literal["info", "success", "warning", "error"]
+
+_LEVEL_TO_TOKEN: dict[Level, str] = {
+    "info":    "loom.muted",
+    "success": "loom.success",
+    "warning": "loom.warning",
+    "error":   "loom.error",
+}
+
+
+def render_harness_inline(message: str, level: Level = "info") -> Text:
+    """Build the formatted Text for a single inline harness message.
+
+    Public so callers that want to embed the formatted line into a
+    larger Rich renderable (Panel, Table) can share the same look.
+    """
+    body_token = _LEVEL_TO_TOKEN[level]
+    return Text.from_markup(
+        f"[loom.harness.signature]⚙ harness ›[/loom.harness.signature] "
+        f"[{body_token}]{message}[/{body_token}]"
+    )
+
+
+class HarnessChannel:
+    """Routing front-end for harness-emitted messages.
+
+    A single instance lives on the platform-cli surface (created in
+    :func:`loom.platform.cli.main._chat`). Core / cognition layers do
+    NOT import this directly — they emit via callbacks that the
+    platform layer wires. Keeps the architecture-guard one-way rule
+    intact.
+    """
+
+    def __init__(self, console: Console) -> None:
+        self._console = console
+
+    # ------------------------------------------------------------------
+    # Inline — append-only,留底
+    # ------------------------------------------------------------------
+
+    def inline(self, message: str, *, level: Level = "info") -> None:
+        """Print ``⚙ harness › <message>`` to the stream and leave it there."""
+        self._console.print(render_harness_inline(message, level))
+
+    # ------------------------------------------------------------------
+    # Flash — ephemeral, deferred to PR-D
+    # ------------------------------------------------------------------
+
+    def flash(self, message: str) -> None:  # noqa: ARG002 — accept for API stability
+        """Footer flash for green-light events.
+
+        PR-C: **no-op**. Green-light auth (``pre-authorized`` /
+        ``exec_auto`` / ``scope-allow``) intentionally produces no
+        output during this PR. The footer arrives in PR-D and the
+        flash will manifest there.
+
+        Kept as a method (not omitted) so call sites can express
+        intent — "this would flash if we had a footer" — and PR-D's
+        wire-up is a one-method change here, not a hunt across the
+        codebase.
+        """
+        return None

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -186,6 +186,31 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
             _mw._on_lifecycle_event = _on_lifecycle
             break
 
+    # PR-C4: surface history sanitize repairs and governor rejections.
+    # Both are silent today; making them visible takes them off the
+    # "weird invisible behaviour" list that haunts users of generative
+    # systems.
+    def _on_sanitize(args_fixed: int, msgs_dropped: int) -> None:
+        parts: list[str] = []
+        if args_fixed:
+            parts.append(f"{args_fixed} arg(s) repaired")
+        if msgs_dropped:
+            parts.append(f"{msgs_dropped} orphan message(s) dropped")
+        if parts:
+            harness.inline(f"sanitize: {', '.join(parts)}", level="info")
+
+    def _on_governor_reject(key: str, tier: str, contradictions: int) -> None:
+        detail = f"tier={tier}"
+        if contradictions:
+            detail += f", {contradictions} contradiction(s)"
+        harness.inline(
+            f"governor blocked memorize {key!r} ({detail})",
+            level="warning",
+        )
+
+    session._on_sanitize_repaired = _on_sanitize       # type: ignore[attr-defined]
+    session._on_governor_reject = _on_governor_reject  # type: ignore[attr-defined]
+
     console.print(render_header(model, db))
 
     if not session._memory_index.is_empty:

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -1315,14 +1315,15 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
         if session.current_personality
         else ""
     )
+    # Plain Text instead of Rule — Rule always extends a horizontal line
+    # after the title, which crowds the marker. The Loom Agent intro is
+    # meant to read as a quiet signature, not a banner.
     console.print(
-        Rule(
+        Text.from_markup(
             f"[loom.agent.guide]Loom ▎[/loom.agent.guide]"
             f"[loom.muted]  context [/loom.muted]"
             f"[{ctx_token}]{pct:.1f}%[/{ctx_token}]"
-            f"{persona_tag}",
-            style="loom.border",
-            align="left",
+            f"{persona_tag}"
         )
     )
 

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -55,6 +55,7 @@ from loom.core.memory.relational import RelationalMemory
 from loom.core.memory.semantic import SemanticMemory
 from loom.core.memory.store import SQLiteStore
 from loom.core.memory.session_log import SessionLog
+from loom.platform.cli.harness_channel import HarnessChannel
 from loom.platform.cli.theme import LOOM_THEME
 from loom.platform.cli.ui import (
     ActionRolledBack,
@@ -78,6 +79,11 @@ from loom.platform.cli.ui import (
 )
 
 console = Console(highlight=False, theme=LOOM_THEME)
+
+# Harness messages route through this channel — see harness_channel.py.
+# Module-level instance so non-_chat code paths (slash commands, error
+# handlers) can emit without threading a parameter through every call.
+harness = HarnessChannel(console)
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -296,7 +302,7 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
             in_flight = current_turn_task is not None and not current_turn_task.done()
             if in_flight:
                 session.cancel()
-                console.print("[loom.muted]⏸  上一輪已中斷，接收新訊息…[/loom.muted]")
+                harness.inline("⏸ 上一輪已中斷，接收新訊息…", level="info")
                 try:
                     await asyncio.wait_for(current_turn_task, timeout=3.0)
                 except (asyncio.TimeoutError, asyncio.CancelledError):
@@ -322,7 +328,7 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
                 try:
                     await _handle_slash(text, session)
                 except Exception as exc:
-                    console.print(f"[loom.error]Slash command error: {exc}[/loom.error]")
+                    harness.inline(f"slash command error: {exc}", level="error")
                 continue
 
             # Detect interruption marker injected by input_loop.
@@ -341,7 +347,7 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
             except asyncio.CancelledError:
                 pass
             except Exception as exc:
-                console.print(f"[loom.error]Turn error: {exc}[/loom.error]")
+                harness.inline(f"turn error: {exc}", level="error")
             finally:
                 current_turn_task = None
 
@@ -559,7 +565,7 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
 
     elif command == "/compact":
         pct = session.budget.usage_fraction * 100
-        console.print(f"[loom.muted]  Compacting context ({pct:.1f}% used)…[/loom.muted]")
+        harness.inline(f"compacting context ({pct:.1f}% used)…", level="info")
         await session._smart_compact()
 
     elif command == "/stop":
@@ -1250,20 +1256,30 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
     spinner_task: asyncio.Task | None = None
     frame_index = 0
 
-    # ── Opening rule ──────────────────────────────────────────────────────────
+    # ── Loom Agent turn intro ─────────────────────────────────────────────
+    # PR-C: replace the bold-green "loom" Rule with a Loom Agent-themed
+    # marker. Per-line "Loom ▎" left-edge guide on streaming text is
+    # deferred to PR-D's renderer rewrite — would need newline-detection
+    # in the streaming loop, which is the same path PR-D rebuilds anyway.
     pct = session.budget.usage_fraction * 100
-    ctx_color = "green" if pct < 60 else "yellow" if pct < 85 else "red"
+    ctx_token = (
+        "loom.success" if pct < 60
+        else "loom.warning" if pct < 85
+        else "loom.error"
+    )
     persona_tag = (
-        f"  [loom.muted]|  persona: {session.current_personality}[/loom.muted]"
+        f"  [loom.muted]·  persona: {session.current_personality}[/loom.muted]"
         if session.current_personality
         else ""
     )
     console.print(
         Rule(
-            f"[bold loom.success]loom[/bold loom.success]"
-            f"[loom.muted]  |  [{ctx_color}]context {pct:.1f}%[/{ctx_color}][/loom.muted]"
+            f"[loom.agent.guide]Loom ▎[/loom.agent.guide]"
+            f"[loom.muted]  context [/loom.muted]"
+            f"[{ctx_token}]{pct:.1f}%[/{ctx_token}]"
             f"{persona_tag}",
-            style="green",
+            style="loom.border",
+            align="left",
         )
     )
 
@@ -1439,7 +1455,7 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
         _cancel_spinner()
         clear_line()
         console.print()
-        console.print(f"[loom.error]Error: {exc}[/loom.error]")
+        harness.inline(f"turn aborted with error: {exc}", level="error")
     finally:
         # Defensive: ensure the spinner task never outlives this turn,
         # even if neither except branch fired (clean exit) or if a path

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -169,13 +169,15 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
     session.subscribe_promotion(_cli_promotion)
 
     # PR-C3: route BlastRadiusMiddleware authorisation decisions through
-    # the harness channel. Green-light events go to flash() (no-op in
-    # PR-C, footer in PR-D); red-light events留底 inline so the user can
-    # forensically trace why a tool was blocked.
+    # the harness channel. Red-light events留底 inline so the user can
+    # forensically trace why a tool was blocked. Green-light events stay
+    # silent — pre-authorized / exec_auto / scope-allow are routine
+    # successes, not events worth announcing. PR-D will reassess whether
+    # any *specific* green-light kind (e.g. "new scope grant just issued")
+    # deserves a footer flash, but blanket flashing every approval would
+    # spam the surface and contradict doc/49's "綠燈不出聲" principle.
     def _on_lifecycle(call: "ToolCall", result: bool, reason: str) -> None:
-        if result:
-            harness.flash(f"auth: {call.tool_name} ok ({reason})")
-        else:
+        if not result:
             harness.inline(
                 f"auth denied: {call.tool_name} — {reason}",
                 level="warning",

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -168,6 +168,24 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
 
     session.subscribe_promotion(_cli_promotion)
 
+    # PR-C3: route BlastRadiusMiddleware authorisation decisions through
+    # the harness channel. Green-light events go to flash() (no-op in
+    # PR-C, footer in PR-D); red-light events留底 inline so the user can
+    # forensically trace why a tool was blocked.
+    def _on_lifecycle(call: "ToolCall", result: bool, reason: str) -> None:
+        if result:
+            harness.flash(f"auth: {call.tool_name} ok ({reason})")
+        else:
+            harness.inline(
+                f"auth denied: {call.tool_name} — {reason}",
+                level="warning",
+            )
+
+    for _mw in session._pipeline._middlewares:
+        if isinstance(_mw, BlastRadiusMiddleware):
+            _mw._on_lifecycle_event = _on_lifecycle
+            break
+
     console.print(render_header(model, db))
 
     if not session._memory_index.is_empty:

--- a/loom/platform/cli/theme.py
+++ b/loom/platform/cli/theme.py
@@ -58,6 +58,14 @@ LOOM_THEME = Theme(
         "loom.border":      PARCHMENT_BORDER,
         # Surfaces
         "loom.harness.bg":  f"on {PARCHMENT_SURFACE}",
+        # Harness signature — the "⚙ harness ›" prefix on inline harness
+        # messages. Distinct token so PR-D can tweak it without rippling
+        # to every call site.
+        "loom.harness.signature": PARCHMENT_ACCENT,
+        # Loom Agent intro guide — the "Loom ▎" left-edge silk-coloured
+        # marker that opens each turn. Kept distinct from accent in case
+        # we want a different shade later (e.g. silk-pink for personality).
+        "loom.agent.guide":  PARCHMENT_ACCENT,
         # Convenience composites — emphasis variants used at multiple call
         # sites. Add sparingly; prefer composing tokens at the call site.
         "loom.accent.bold": f"bold {PARCHMENT_ACCENT}",

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -872,7 +872,11 @@ def make_recall_tool(memory: "MemoryFacade") -> ToolDefinition:
     )
 
 
-def make_memorize_tool(memory: "MemoryFacade") -> ToolDefinition:
+def make_memorize_tool(
+    memory: "MemoryFacade",
+    *,
+    on_reject: "Callable[[str, str, int], None] | None" = None,
+) -> ToolDefinition:
     """
     Create a GUARDED ``memorize`` tool bound to the given MemoryFacade.
 
@@ -882,6 +886,15 @@ def make_memorize_tool(memory: "MemoryFacade") -> ToolDefinition:
     falls back to a direct semantic upsert.  Either way the result shape
     (``GovernedWriteResult``) is uniform, and embedding-write failures
     are surfaced through a structured WARN log inside the facade.
+
+    Parameters
+    ----------
+    on_reject : callable, optional
+        Fired when the governor blocks a write. Signature:
+        ``(key, trust_tier, contradictions_found) -> None``. Used by the
+        platform layer to surface a harness inline message — accept events
+        stay silent (PR-C4 design: governor only speaks when it stops
+        something).
     """
     from loom.core.memory.semantic import SemanticEntry
 
@@ -903,6 +916,11 @@ def make_memorize_tool(memory: "MemoryFacade") -> ToolDefinition:
                 f"Memorize skipped for {key!r}: existing entry has higher trust "
                 f"(tier={gov_result.trust_tier}, contradictions={gov_result.contradictions_found})"
             )
+            if on_reject is not None:
+                try:
+                    on_reject(key, gov_result.trust_tier, gov_result.contradictions_found)
+                except Exception:
+                    pass
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
                               success=True, output=msg)
 


### PR DESCRIPTION
Third slice of #236 CLI Refresh. Splits "Loom Agent talking" from "Harness reporting" visually, and routes auth / sanitize / governor events through three distinct channels (footer / inline / modal) with explicit semantics. Footer integration (token budget, active envelope summary, grant TTL, compaction spinner) is **deferred to PR-D** along with the Linear Stream rewrite — see `doc/49a-PR-C-實作草稿.md` § 11.

## Design context

`doc/49a-PR-C-實作草稿.md` (added in this PR) is the implementation draft used to plan the C1→C4 split, including the four UX decisions you ratified (simple ANSI footer, multi-envelope count display, grant TTL refresh on turn boundary, compaction spinner). Read it alongside the parent `doc/49`.

## What this PR ships

### C1 · HarnessChannel + theme tokens (commit 26cc709)

- New `loom/platform/cli/harness_channel.py` with `HarnessChannel.inline(level)` (留底, signed) and `HarnessChannel.flash()` (no-op in PR-C, footer in PR-D)
- New theme tokens `loom.harness.signature` and `loom.agent.guide` — distinct (same hex today) so PR-D can re-tone the two layers independently
- `render_harness_inline()` exposed publicly so future callers can embed the formatted line into Panels / Tables with the same look
- Pure addition, zero existing code touched

### C2 · Visual族群 split (commit f0b3877 + fix 8a712a0)

- Opening Rule (was `bold green loom`) replaced with `Loom ▎  context X%  ·  persona: Y`. Plain `Text.from_markup` not `Rule` — Rule's trailing horizontal line crowded the marker and made it read as a banner instead of a quiet turn signature
- Per-line `Loom ▎` left-edge guide on streaming body text **deferred to PR-D's renderer rewrite**, which already touches that path
- `ctx_color` migrated from raw `"green"`/`"yellow"`/`"red"` to semantic tokens
- Module-level `harness = HarnessChannel(console)` so non-`_chat` paths emit without threading a parameter
- Migrated to `harness.inline`: slash command error, turn loop error, `_run_streaming_turn` aborted-with-error, `/compact` start, "上一輪已中斷，接收新訊息…"

### C3 · Auth lifecycle routing (commit 675db03)

- `BlastRadiusMiddleware._on_lifecycle_event: Optional[Callable[[ToolCall, bool, str], None]]` — fires on every `_notify_lifecycle`, defaults None so core stays platform-agnostic
- Wrapped in `except Exception: pass` so a buggy listener can't abort the harness pipeline
- `main.py._chat()` wires the hook: `result=True` → `harness.flash()` (no-op now, footer flash in PR-D); `result=False` → `harness.inline(level=warning)`
- Effect: `pre-authorized` / `exec_auto` / `scope-allow` events stop polluting the inline stream. `user denied` / `circuit-breaker tripped` / `scope-deny` / `unattended-deny` print as `⚙ harness › auth denied: <tool> — <reason>`

### C4 · Sanitize + governor visibility (commit c47d5ba)

- `_sanitize_history` counts repaired arg blobs and net-dropped messages. When non-zero, sets `self._last_sanitize_repaired` and fires `self._on_sanitize_repaired`. Silent when nothing changed (the design point: only speak when something actually changed)
- `make_memorize_tool` accepts `on_reject: (key, tier, contradictions) → None`, fired only on `gov_result.written = False`. Accept events stay silent (governor speaks when it stops something, not when it cooperates)
- `main.py` wires both hooks. Output formats:
  - `⚙ harness › sanitize: 2 arg(s) repaired, 1 orphan message(s) dropped` (info)
  - `⚙ harness › governor blocked memorize 'foo' (tier=external, 1 contradiction(s))` (warning)

## Live test results (testing under previous "Loom 想執行" commit)

- ✅ Loom Agent turn intro reads as quiet signature (rule fix)
- ✅ `/compact` triggers `⚙ harness › compacting context (X%)…`
- ✅ Tool deny → `⚙ harness › auth denied: write_file — user denied (confirm)`
- ✅ Tool approve → no green-light noise
- ✅ Tool then immediately allowed within scope → silent (correct, was previously dim "scope-allow:..." spam)
- ✅ `/foo` unknown command → still uses existing "Unknown command" path. Intentional: that's a help nudge to the user, not a harness state report

## Architecture compliance

- Core layers (`loom.core.*`) do NOT import `harness_channel`. The pattern is: core exposes optional callbacks, platform wires them in `_chat()`. No new architecture-guard exceptions needed beyond what PR-A already added

## Deferred to PR-D

Tracked in `doc/49a` § 7 + § 11:

- C5 footer integration: token budget浮出 (>60%), active envelope multi-count `2× ▸ run_bash`, grant TTL on turn boundary, `⚡ 壓縮中…` spinner during compaction
- Per-line `Loom ▎` left-edge guide on Loom Agent body text
- Real flash for green-light auth events (PR-C: `flash()` is a no-op kept around so call sites express intent and PR-D's wire-up is one method, not a hunt)

## Test plan

- [ ] `loom chat` boots, opening line shows as `Loom ▎  context 0.0%  ·  persona: ...` with no trailing rule line
- [ ] Trigger a GUARDED tool, deny → see `⚙ harness › auth denied: ...` in warning ochre with accent-gold prefix
- [ ] Trigger same tool, approve → no inline noise (green-light is silent in PR-C)
- [ ] `/compact` triggers `⚙ harness › compacting context (...)…`
- [ ] Memorize a value where the governor would reject (existing higher-trust entry) → see `⚙ harness › governor blocked memorize ...`
- [ ] Force a sanitize event (mid-stream cancel + new message) → see `⚙ harness › sanitize: ...` if any repair happened
- [ ] `/foo` unknown command → still says "Unknown command '/foo'" (intentional; not migrated)
- [ ] All 1119 non-discord tests pass; 5 pre-existing test_cognition failures unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)