### PR TITLE
feat(cli): CLI Refresh PR-D — persistent Application + Linear Stream + Footer

### DIFF
--- a/doc/49b-PR-D-實作草稿.md
+++ b/doc/49b-PR-D-實作草稿.md
@@ -724,7 +724,36 @@ $ loom chat
 
 ---
 
-## 19. 出處與相依
+## 19. PR-D 完成度（2026-04-29）
+
+實作落地後檢核：
+
+### ✅ 已完成
+- Persistent prompt_toolkit Application（取代 prompt_async 迴圈 + 三事件協議）
+- Multiline 輸入重啟（Alt+Enter / Ctrl+J 換行）
+- Footer：model · persona · context% · 🔑 grants · ▸ active envelope · last-turn stats · ▎ Loom brand
+- Footer 中段 compaction spinner 模式（壓縮中時其他資訊靜音）
+- Confirm / HITL pause / Redirect 用 mode-flag widget（用過即焚，零 scrollback 殘留）
+- Streaming line-buffer fix（CJK 截斷 bug 解決）
+- Welcome ceremony：`console.clear()` + 5 行 ASCII signature（取代雙 Panel）
+- Thinking indicator：input 上方 `● Loom is thinking···`，2Hz 動畫，第一個 stream event 自動消失
+- Input 區頂端視覺分隔線（`───`）
+- Bottom anchor：app 啟動時 cursor padding 推到終端底部
+- 整段刪除 PR-A 的支點 code（`_run_interactive`、三事件 events、`_INTERRUPT_PREFIX`、render_cursor、streaming cursor + clear_line）
+
+### 🟡 延到 PR-D merge 後 follow-up
+這幾件涉及 scrollback cursor 操作，風險較大、可獨立追蹤：
+- **三階淡出**（active → committed → frozen）— 需要 cursor up 重塗已輸出 envelope，跟 patch_stdout 互動敏感
+- **並行 envelope group panel** — 多 spinner 同時轉 + 全 COMMITTED 後 collapse；buffer envelope events 邏輯重，影響面廣
+- **Markdown 渲染** — streaming 中無法乾淨 render（chunk 可能切在 `**hel` 中段）；turn 結束後 cursor 回去重塗已 stream 過的 markdown 也是 scrollback 修改
+- **Loom Agent per-line guide** — 移除後實測下不需要
+
+### 🚫 取消
+- 「取代 doc/34-TUI-使用指南.md」— 原案以為 PR-D 會取代 TUI 模式，實際上 TUI（`loom chat --tui`）跟 plain CLI 是兩個並存模式，PR-D 只動 plain CLI
+
+---
+
+## 20. 出處與相依
 
 - 設計母文件：`doc/49-CLI-Refresh-設計.md`
 - 已合併：PR-A (#237) PR-B (#242) PR-C (#244)

--- a/doc/49b-PR-D-實作草稿.md
+++ b/doc/49b-PR-D-實作草稿.md
@@ -1,0 +1,726 @@
+# PR-D 實作草稿 — Linear Stream + Live Footer + Solidification
+
+本文件是 `doc/49-CLI-Refresh-設計.md` PR-D 的詳細實作藍圖。是 **整個 CLI Refresh milestone 工作量最大的一刀**——核心是把 PR-A 的「每輪 `prompt_async` + 短暫 widget Application」模型砍掉，換成「單一 persistent Application + 固定 bottom 區（input + footer）」。前 PR 為了快速落地引入的支點全部要拆。
+
+---
+
+## 1. 目標回顧
+
+把 CLI 從「文字列印 + 偶爾彈出 widget」變成「**底部恆定區（input + footer）+ 上方自然 scrollback**」的混合形態。具體想要的觀感：
+
+- 輸入區永遠黏在底部，多行輸入自然展開（重啟 multiline）
+- 底部 1 行 footer 顯示當下狀態（token budget / active envelope / grant TTL / compaction spinner）
+- Streaming 輸出在 input 區之上自然滾動，不被洗稿
+- Confirm / HITL 廣告**就地展開取代 input 區**，決策後立即收回——不留 scrollback
+- Loom Agent 文本左緣帶 `Loom ▎` 引線，跨行延續
+- envelope 完成後三階淡出（active 黃 → committed 綠 → frozen 灰）
+- 並行 envelope 群組化呈現（`2× ▸ run_bash`）
+
+---
+
+## 2. 架構轉換：per-iteration → persistent
+
+### 現況（PR-A 引入的支點）
+
+```python
+# main.py _chat()
+with patch_stdout(raw=True):
+    while True:
+        text = await prompt_session.prompt_async(...)  # 每輪新 Application
+        # ...
+        # confirm 時：_run_interactive(coro) 暫停 input_loop，啟動新 widget Application
+
+# 維護 3 個 events 協調 stdin
+confirm_active = asyncio.Event()
+confirm_done = asyncio.Event()
+input_released = asyncio.Event()
+```
+
+問題：
+- 每次 `prompt_async` 起新 Application，confirm widget 也起新 Application，兩者搶 stdin → 需要 3-event 協議
+- `patch_stdout` 把 stdout 改線，對 Rich `\r\033[K` 等 ANSI 互動微妙
+- 沒有「常駐底部區」概念，footer 無處掛
+
+### 目標（PR-D 的單一 Application 模型）
+
+```python
+# main.py _chat()
+app = build_loom_application(session, ...)
+await app.run_async()
+```
+
+整個 chat 期間**只有一個 Application**。Layout 大致：
+
+```
+┌──────────────────────────────────────────────┐
+│                                              │
+│  (terminal scrollback — output flows here)   │  ← 真實終端 scrollback
+│  Loom ▎ context 0.3% · persona: ...          │     output 用 app.print_text()
+│  Loom ▎ 你好我是 Loom，今天想做什麼？        │     往這裡寫，自然滾動
+│  ⚙ harness › auth denied: ...                │
+│  ▸ run_bash · 1.2s ✓                         │
+│                                              │
+├──────────────────────────────────────────────┤  ← Application 底部區開始
+│ you › 寫個小說                              │  ← input area (multiline)
+│      .........                               │     或 confirm/HITL 區
+├──────────────────────────────────────────────┤
+│ 🔑 L2·0:43  ⚡ tok 67%  ▸ run_bash · 1.2s   │  ← footer (height=1)
+└──────────────────────────────────────────────┘
+```
+
+input area 跟 footer 是 Application 的 layout（恆定，prompt_toolkit 渲染在終端底部）。上方輸出走 scrollback——終端處理捲動。
+
+`patch_stdout` 不再需要，因為 Application 只負責底部區，上方 scrollback 是普通 terminal output。
+
+3-event 協議全部刪除——只有一個 Application，不存在 stdin 搶奪。
+
+---
+
+## 3. Layout 結構
+
+```python
+from prompt_toolkit.application import Application
+from prompt_toolkit.layout import Layout, HSplit, Window
+from prompt_toolkit.layout.containers import ConditionalContainer
+from prompt_toolkit.layout.controls import BufferControl, FormattedTextControl
+from prompt_toolkit.layout.dimension import Dimension
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.filters import Condition
+
+# 1. Mode flag — controls which "bottom area" widget shows
+class CLIMode:
+    INPUT = "input"          # 一般狀態：使用者輸入
+    CONFIRM = "confirm"      # 工具確認 widget
+    PAUSE = "pause"          # HITL pause widget
+    PAUSE_REDIRECT = "redirect"  # HITL redirect text input
+
+current_mode = ["input"]  # mutable so closures see updates
+
+# 2. Buffers / state
+input_buffer = Buffer(multiline=True, ...)
+redirect_buffer = Buffer(multiline=False, ...)
+
+# 3. Bottom-area conditional containers
+def is_mode(m: str):
+    return Condition(lambda: current_mode[0] == m)
+
+input_window = ConditionalContainer(
+    Window(content=BufferControl(buffer=input_buffer),
+           height=Dimension(min=1, max=10),
+           wrap_lines=True),
+    filter=is_mode(CLIMode.INPUT),
+)
+
+confirm_window = ConditionalContainer(
+    Window(content=FormattedTextControl(render_confirm),
+           height=Dimension(min=1, max=12)),
+    filter=is_mode(CLIMode.CONFIRM),
+)
+
+pause_window = ConditionalContainer(
+    Window(content=FormattedTextControl(render_pause),
+           height=Dimension(min=1, max=8)),
+    filter=is_mode(CLIMode.PAUSE),
+)
+
+redirect_window = ConditionalContainer(
+    Window(content=BufferControl(buffer=redirect_buffer), height=1),
+    filter=is_mode(CLIMode.PAUSE_REDIRECT),
+)
+
+# 4. Footer — always visible, height=1
+footer_window = Window(
+    height=1,
+    content=FormattedTextControl(render_footer),
+    style="class:footer",
+)
+
+# 5. Layout assembled
+layout = Layout(HSplit([
+    input_window,
+    confirm_window,
+    pause_window,
+    redirect_window,
+    footer_window,
+]))
+
+app = Application(
+    layout=layout,
+    key_bindings=key_bindings,  # mode-aware bindings
+    style=LOOM_STYLE,
+    full_screen=False,           # ← key: render only bottom, scrollback above
+    mouse_support=False,
+)
+```
+
+### Mode 切換語意
+
+mode 是個簡單字串旗標（包在 list 裡讓 closures 看見變更）。切換時：
+
+```python
+def enter_confirm_mode(scope_info, options):
+    confirm_state.scope = scope_info
+    confirm_state.options = options
+    current_mode[0] = CLIMode.CONFIRM
+    app.invalidate()  # trigger redraw
+    # await confirm_decision_future
+    # ...
+    current_mode[0] = CLIMode.INPUT
+    app.invalidate()
+```
+
+`ConditionalContainer.filter` 收到變更後自動只 render 對應 window。**Confirm 結束時其畫面區域被 input_window 取代——zero scrollback 殘留**。這就是「用過即焚」的天然實現。
+
+---
+
+## 4. 輸出走向：`console.print` → `app.print_text`
+
+prompt_toolkit `Application` 有個關鍵 API：
+
+```python
+from prompt_toolkit.application import in_terminal
+
+async def print_above(formatted):
+    async with in_terminal():
+        # 暫時釋放底部區的繪製，把 formatted 印到 scrollback
+        sys.stdout.write(formatted)
+```
+
+或用同步版本：
+
+```python
+app.print_text(formatted_text)  # 自動 above-the-bottom-area
+```
+
+Streaming output 這樣寫：
+
+```python
+async for event in session.stream_turn(text):
+    if isinstance(event, TextChunk):
+        # 不再用 console.print(end='')
+        rendered = render_loom_agent_chunk(event.text)
+        app.print_text(rendered)
+    elif isinstance(event, ToolBegin):
+        app.print_text(render_tool_begin(event))
+        footer_state.active_envelopes.append(...)
+        app.invalidate()
+    # ...
+```
+
+對 Rich 物件（Panel, Text）：用 `Console.capture()` 把 Rich 渲染成 ANSI 字串再丟進 `app.print_text`：
+
+```python
+from rich.console import Console
+_render_console = Console(theme=LOOM_THEME, force_terminal=True)
+
+def rich_to_ansi(renderable) -> str:
+    with _render_console.capture() as cap:
+        _render_console.print(renderable)
+    return cap.get()
+
+app.print_text(rich_to_ansi(panel))
+```
+
+這樣 Rich 的所有 markup / Panel / Rule 都能繼續用，只是渲染輸出走 prompt_toolkit 的 above-area。
+
+---
+
+## 5. 修 streaming 行首截斷老 bug
+
+PR-A 階段確認的 bug：CJK soft-wrap 時 `clear_line()` 用 `\r\033[K` 清錯視覺行，下個 chunk 從錯位置覆寫。
+
+PR-D 改寫 streaming 後**這個 bug 自然消失**，因為：
+- 不再用 `\r\033[K` 清行（沒有 spinner cursor 要清——spinner 改進 footer）
+- TextChunk 直接 `app.print_text` 累積，prompt_toolkit 自己處理斷行
+- Streaming cursor 也由 footer 區內的小指示器處理（不再印在 inline）
+
+---
+
+## 6. Footer 渲染（簡單 ANSI 實作）
+
+`render_footer` 是個 callable，每次 `app.invalidate()` 重新算：
+
+```python
+def render_footer() -> FormattedText:
+    parts: list[tuple[str, str]] = []
+
+    # Grant TTL — 最快過期那個
+    grant = footer_state.next_grant_expiry
+    if grant:
+        parts.append(("class:footer.grant", f"🔑 {grant.label}·{format_ttl(grant)}"))
+        parts.append(("", "  "))
+
+    # Token budget — >60% 才浮出
+    pct = footer_state.token_pct
+    if pct > 60:
+        token = "footer.budget.warn" if pct > 80 else "footer.budget.high"
+        parts.append((f"class:{token}", f"⚡ tok {pct:.0f}%"))
+        parts.append(("", "  "))
+
+    # Active envelope — 多並行寫數量
+    envs = footer_state.active_envelopes
+    if envs:
+        if len(envs) == 1:
+            parts.append(("class:footer.envelope", f"▸ {envs[0].name} · {envs[0].elapsed:.1f}s"))
+        else:
+            latest = envs[-1]
+            parts.append(("class:footer.envelope",
+                         f"{len(envs)}× ▸ {latest.name} · {latest.elapsed:.1f}s"))
+
+    # Compaction spinner
+    if footer_state.compacting:
+        parts.append(("class:footer.compaction", f"⚡ 壓縮中… {footer_state.compaction_pct:.0f}%"))
+
+    return FormattedText(parts)
+```
+
+footer state 是個簡單 dataclass，session/event handler 修改後呼叫 `app.invalidate()`。**沒用 `Live`**——用 prompt_toolkit 自己的 invalidate 機制就夠。
+
+Grant TTL 倒數**只在 turn 邊界刷新**（決議 #3）：每個 turn 開始時 `app.invalidate()` 一次重算，而不是每秒 redraw。
+
+Compaction spinner 在 `_smart_compact` 開頭 set `footer_state.compacting = True`，`app.invalidate()`；完成後 clear + invalidate + inline 印摘要。
+
+---
+
+## 7. 並行 envelope group panel + 三階淡出
+
+EnvelopeStarted/Updated/Completed 事件同上 `app.print_text`，但兩個新增行為：
+
+### 三階淡出
+
+每個 envelope panel 列印時帶 `created_at`。一個背景 task 每 1s 檢查：completed >3s 的 envelope 「重印一次」用 frozen 樣式覆蓋舊位置——但 scrollback 改寫困難（已經滾過的內容回不去）。
+
+**現實妥協**：只有「**最後一個還在底部可見的 envelope**」才有三階淡出（用 `app.print_text` 重印 + cursor 上移）。已捲過的歷史就讓它保留 committed 樣式。這比 PR-D 設計的「全歷史 frozen」務實——對使用者實際感知差異不大。
+
+### 並行 group panel
+
+並行 envelope 在 `_build_envelope_view()` 已經有 levels >0 概念。當 view.levels > 1 時，把 envelopes 收進一個 group panel 渲染：
+
+```
+╭─ parallel · 3 tools ──────────────────╮
+│ ▸ run_bash · 0.5s                     │
+│ ▸ web_search · 1.2s                   │
+│ ▸ minimax:text_to_image · 2.1s        │
+╰────────────────────────────────────────╯
+```
+
+全部 COMMITTED 後 collapse 成一行：
+
+```
+✓ 3 tools · 4.2s   [parallel]
+```
+
+實作：監聽 `EnvelopeStarted` 事件，若 view 顯示 multi-level 就先 buffer 起 envelope events，等所有 sibling completed 後再一次印一個 group panel。
+
+---
+
+## 8. Confirm widget 用過即焚
+
+新需求（user 今天加的）：`Tool requires confirmation` 整塊（含 scope panel + 選項 widget）在 user 確認/拒絕後從 scrollback 消失。
+
+PR-D 的 layout 模型**天然滿足這需求**：
+
+```python
+async def _confirm_tool(call) -> ConfirmDecision:
+    confirm_state.call = call
+    confirm_state.scope = format_scope_panel(call)
+    confirm_state.options = build_confirm_options(call)
+    confirm_state.future = asyncio.Future()
+    
+    current_mode[0] = CLIMode.CONFIRM
+    app.invalidate()
+    
+    try:
+        return await confirm_state.future
+    finally:
+        confirm_state.call = None
+        current_mode[0] = CLIMode.INPUT
+        app.invalidate()
+```
+
+`render_confirm` 的輸出寫在 `confirm_window` 裡（layout 的一部分，**不是** scrollback）。當 mode 切回 INPUT，`confirm_window` 變不可見，input_window 接管那塊區域——**confirm 從未進過 scrollback，直接消失**。
+
+scope panel 也包進 `render_confirm` 的 FormattedText 裡，**不再單獨 console.print**。這是 PR-C 的 `console.print(Panel(...))` 改點：scope panel 的存在本來就只在「決策中」，沒理由佔 scrollback。
+
+ToolBegin / ToolEnd 自然會記下「這個 tool 跑了/被拒絕了」，所以決策結果**不會被遺失**——只是中間的 UI 過渡不留底。
+
+---
+
+## 9. HITL Pause 同此原理
+
+HITL pause 也是 mode 切換：`CLIMode.PAUSE` 顯示 3 選項；選 redirect 後切到 `CLIMode.PAUSE_REDIRECT` 用 redirect_buffer 收文字；都決策完切回 INPUT。整個過程不留 scrollback。
+
+---
+
+## 10. Per-line `Loom ▎` 左邊引線
+
+streaming text 跨行時要每行帶 guide。在 `render_loom_agent_chunk` 處理：
+
+```python
+def render_loom_agent_chunk(text: str) -> str:
+    # split on newlines, prefix each non-first line with guide
+    lines = text.split("\n")
+    if len(lines) == 1:
+        return text  # no newlines, no per-line guide needed for this chunk
+    guide = "[loom.agent.guide]Loom ▎[/loom.agent.guide]  "
+    return "\n".join(
+        line if i == 0 else f"{guide}{line}"
+        for i, line in enumerate(lines)
+    )
+```
+
+注意：streaming 是 chunk-by-chunk 的，連續 chunk 可能斷在行中。需要在 render 層維護「上一個 chunk 是否以 newline 結尾」狀態，決定本 chunk 第一行要不要加 guide。
+
+---
+
+## 11. 要刪的舊 code
+
+PR-D 刪除：
+
+| 檔案 | 行數 | 內容 |
+|---|---|---|
+| `loom/platform/cli/main.py` | ~80 行 | `_INTERRUPT_PREFIX`、`confirm_active`/`confirm_done`/`input_released` events、`_run_interactive`、`patch_stdout(raw=True)` 整段 wrapper |
+| `loom/platform/cli/main.py` | ~30 行 | `_run_streaming_turn` 的 spinner_task / `_print_spinner` / `_spin_loop`（spinner 改進 footer） |
+| `loom/platform/cli/main.py` | ~10 行 | `clear_line()` 呼叫（不再需要） |
+| `loom/platform/cli/ui.py` | `clear_line()`, `set_show_cursor`, `streaming_cursor`, `clear_line_escape` 整組 helper | 不再需要 |
+| `loom/core/session.py` | `_confirm_tool_cli` 內 `console.print(Panel(...))` + `_run_interactive` routing | 改成 future-based mode 切換 |
+
+新增：
+
+| 檔案 | 內容 |
+|---|---|
+| `loom/platform/cli/app.py` | 新檔——`build_loom_application()` factory、CLIMode、FooterState、各 render_* 函式 |
+| 改寫 `_chat` | 變成「build app + run_async」薄包裝 |
+
+---
+
+## 12. Commit 拆分
+
+PR-D 是大刀，建議拆 4 個 commit：
+
+| Commit | 主題 | 風險 | 依賴 |
+|---|---|---|---|
+| **D1** | Application skeleton：persistent app + input/footer layout，實作最簡 footer（只顯示 token budget），刪 patch_stdout / 三事件 | **高** | 無 |
+| **D2** | Streaming output 改走 `app.print_text`；rich_to_ansi helper；修 CJK 截斷 bug 自然消失 | 中 | D1 |
+| **D3** | Confirm + HITL mode 切換（用過即焚）；scope panel 收進 confirm_window | 中 | D1, D2 |
+| **D4** | Per-line `Loom ▎` 引線；多行 input 重啟；Footer 補完（envelope summary、grant TTL、compaction spinner、三階淡出、parallel group panel） | 中 | D1, D2, D3 |
+
+D1 是最高風險——架構翻新，要小心測 abort-on-submit、slash commands、長 streaming、多輪正常運作。
+
+---
+
+## 13. 風險與對策
+
+### 風險 1 — `Application.run_async` 跟 streaming 互動
+
+streaming turn 跑的時候 Application 是 running 狀態，`app.print_text` 應該能用。但如果 streaming 異常退出，要確保 app 還活著。
+
+**對策**：streaming task 包在 `try / except`，異常時 `harness.inline(error)` + 不退出 app。
+
+### 風險 2 — `console.capture()` 跟 force_terminal
+
+Rich 的 force_terminal=True 模式渲染 ANSI 顏色字串。但 Application 的 colour mode 可能跟 Rich 預期不同——比如 truecolor vs 256-color。
+
+**對策**：實測，必要時把 `_render_console` 設成跟 Application 同 colour mode（透過 `color_system="truecolor"` 等明確指定）。
+
+### 風險 3 — Mode 切換時的 race
+
+streaming turn 中突然 confirm 觸發，layout 切到 confirm，input_buffer 內容怎麼辦？
+
+**對策**：input_buffer 是純 buffer，mode 切走時不會丟內容，切回來內容還在。確認測試覆蓋。
+
+### 風險 4 — Confirm 期間 streaming 還在跑（被切到背景）
+
+streaming turn 會印中間結果到 scrollback。confirm widget 在底部 layout。兩者互不干擾 — `app.print_text` 自動 above-bottom-area。
+
+**對策**：理論上 ok，但要實測。如果視覺上不舒服（streaming 還在輸出時下面卡個 confirm widget），可以考慮 streaming 暫停直到 confirm 結束。
+
+### 風險 5 — 三階淡出沒法 retroactively 改 scrollback
+
+scrollback 已經滾過去的 envelope panel 沒法重塗。
+
+**對策（已收進 §7）**：只對「最後 N 個還在底部可見」的 envelope 做淡出。用 cursor up 重印實作。歷史就讓它停在 committed 樣式。
+
+### 風險 6 — Discord / TUI 端不受影響
+
+PR-D 只動 CLI 端（`loom/platform/cli/`）。Discord 端有自己的 renderer（不受影響）；TUI 端走 Textual（更不受影響）。要確認沒有跨模組 import 遺漏。
+
+**對策**：grep 確認 PR-D 動的檔案沒被 Discord/TUI 引用。
+
+---
+
+## 14. 已知 bug 一併解掉
+
+PR-A 留底（doc/49 已知 bug 段）：
+
+- ✅ Streaming 行首截斷（CJK soft-wrap）→ 改寫 streaming 自然消失
+- ✅ Multiline input 暫不啟用 → multiline=True 重啟
+- ✅ 三事件 stdin coordination 拿掉
+- ✅ `_run_interactive` wrapper 拿掉
+- ✅ `patch_stdout(raw=True)` 不再需要
+
+---
+
+## 15. 已決議
+
+從 doc/49 + #236 + 本 PR 設計過程累積：
+
+- [x] Footer 簡單 ANSI（不上 Live）
+- [x] 多並行 envelope footer 顯示數量 `2× ▸ run_bash`
+- [x] Grant TTL turn 邊界刷新（不每秒 redraw）
+- [x] Compaction spinner 必要
+- [x] Confirm widget 用過即焚（含 scope panel）
+- [x] 綠燈訊息維持沉默；不 blanket flash
+- [x] **三階淡出**只對最新 1 個底部可見的 envelope，更早的就讓它停在 committed 樣式（2026-04-29）
+- [x] **Streaming 中觸發 confirm 預設暫停 streaming**，實測若視覺上沒問題再放寬（2026-04-29）
+- [x] **Mode 切換動畫硬切，不 fade**（2026-04-29）。對齊主流終端 CLI（Claude Code / Codex / Gemini / charm 系列），premium 感由排版/節奏/色彩處理而非動畫
+- [x] **Loom 視覺識別差異化**（2026-04-29）：靠羊皮卷 palette + `Loom ▎` + `⚙ harness ›` + `you ›` 琥珀 prompt 為主軸；D4 再加 footer 永久 `▎ Loom` 角標、首次啟動迷你 ASCII signature、footer 左下 model + persona
+- [x] **啟動瞬間整合**（2026-04-29）：捨棄現有的 `render_header` + `MemoryIndex.render()` 雙 Panel，改成 3 行迷你 signature 帶數字（skills / facts / mcp / episodes 一行帶過）。MemoryIndex 完整資料繼續餵 LLM system prompt 不變
+
+- ✅ **三階淡出對 scrollback 範圍**：只對最新 1 個還在底部可見的 envelope，更早的就讓它停在 committed 樣式
+- ✅ **Streaming 中觸發 confirm**：預設**暫停 streaming**，實測若視覺上沒問題再放寬
+- ✅ **Mode 切換動畫**：硬切（無動畫）。對齊主流終端 CLI（Claude Code / Codex / Gemini / charm 系列）的選擇，premium 感由排版/節奏/色彩處理，不是動畫
+- ✅ **Loom 視覺識別差異化**：靠羊皮卷 palette + `Loom ▎` + `⚙ harness ›` + `you ›` 琥珀 prompt 為主軸；D4 再加 footer 永久 `▎ Loom` 角標、首次啟動迷你 ASCII signature、footer 左下 model + persona
+
+## 16. 未決問題
+
+- **`force_terminal` colour mode**：實測時遇到 colour 不對再決定（PR-D2）
+- **動畫補丁的觸發條件**：D4 完成後若實測視覺太突兀，加 50ms dim 過渡幀（follow-up）
+
+---
+
+## 17. Test plan 草稿
+
+- [ ] 啟動 `loom chat`，input 區黏底，footer 出現
+- [ ] 簡單對話：輸入 → 送出 → streaming 從上方出現 → 結束後 footer 收回 spinner
+- [ ] Multiline 輸入：Alt+Enter 換行，Enter 送出
+- [ ] 觸發 GUARDED 工具 → confirm widget 出現在底部 input 區位置 → 選擇後消失，scrollback 不留 panel
+- [ ] HITL pause → 3 選項出現 → 選 redirect → 文字輸入 → 全部消失
+- [ ] 長 CJK 段落 streaming：行首不再被截斷
+- [ ] 並行工具：footer 顯示 `3× ▸ ...`，全完成後 group panel collapse 為單行
+- [ ] `/compact` 觸發：footer 出現 `⚡ 壓縮中…`，完成後 inline 摘要
+- [ ] Token budget 從 0 累積到 65%，footer 出現 `⚡ tok 65%`
+- [ ] Grant 5min 後過期，下個 turn 開始時 footer TTL 數字正確
+- [ ] Abort：streaming 中送新訊息 → 上一輪截斷標記 → 新訊息接續
+- [ ] 多輪連續 abort 不卡死
+- [ ] Discord / TUI 端不受影響（smoke test）
+
+---
+
+## 18. D4 視覺對齊草圖（mockups）
+
+D4 是視覺打磨的最後一刀。下面是預期的各狀態 ASCII 草圖，作為 user 與實作對齊的參照。**真實渲染會帶羊皮卷色（奶油/琥珀/赭石），這裡為純文字示意**。
+
+### 18.1 Idle（剛進 chat 或 turn 結束）
+
+```
+─────────────────── above is terminal scrollback ──────────────────
+
+    Loom ▎ context 0.0% · persona: tarot
+    Loom ▎ 你好，今天想做什麼？
+
+    ╭───────────────────────────────────────────────────────────╮
+    │ you › ▏                                                    │  ← input area
+    ╰───────────────────────────────────────────────────────────╯
+     tarot · MiniMax-M2.7                                ▎ Loom    ← footer
+```
+
+footer 兩端對稱：左下 `model · persona`（dim），右下 `▎ Loom` brand marker（dim 琥珀）。中間 idle 時留白。
+
+### 18.2 Streaming 中（單一工具進行）
+
+```
+─────────────────── scrollback flows here ──────────────────
+
+    Loom ▎ context 0.3% · persona: tarot
+    Loom ▎ 我來幫你查一下最新動態，等等。
+
+    ▸ web_search · running
+
+    ╭───────────────────────────────────────────────────────────╮
+    │ you › 你也可以打字構思下一個訊息 ▏                         │  ← 可同時打字
+    ╰───────────────────────────────────────────────────────────╯
+     tarot · MiniMax-M2.7   ▸ web_search · 1.2s          ▎ Loom    ← footer
+```
+
+footer 中間多了 `▸ web_search · 1.2s` 即時顯示 active envelope。
+
+### 18.3 多工並行
+
+```
+    Loom ▎ context 1.2%
+    Loom ▎ 我同時跑幾個查詢，方便比對。
+
+    ╭─ parallel · 3 tools ────────────────────────────────────╮
+    │ ▸ web_search · 0.5s         (running)                   │
+    │ ▸ minimax:text_to_image · 1.2s   (running)              │
+    │ ▸ run_bash · 2.1s            (running)                  │
+    ╰──────────────────────────────────────────────────────────╯
+
+    ╭───────────────────────────────────────────────────────────╮
+    │ you › ▏                                                    │
+    ╰───────────────────────────────────────────────────────────╯
+     tarot · MiniMax-M2.7   3× ▸ web_search · 0.5s       ▎ Loom    ← 數量寫出
+```
+
+完成後 group panel collapse 為一行：
+
+```
+    ✓ 3 tools · 4.2s   [parallel]
+```
+
+### 18.4 三階淡出（最新 1 個）
+
+剛完成 envelope 樣式：
+
+```
+    ▸ write_file · 1.2s ✓        ← committed (鼠尾草綠)
+```
+
+3 秒後同一行就地重塗：
+
+```
+    ▸ write_file · 1.2s ✓        ← frozen (米褐 dim)
+```
+
+實作：保留 cursor 位置，cursor up + 重印同一行。只對「**最新一個還在底部可見**」的 envelope 生效。早於它的歷史就讓它定格在 committed 樣式（cursor 回不去）。
+
+### 18.5 Confirm mode（用過即焚）
+
+```
+─────────────────── scrollback flows here ──────────────────
+
+    Loom ▎ context 1.2%
+    Loom ▎ 我來幫你寫一份檔案。
+
+    ▸ write_file (awaiting confirmation)
+
+    ╭─ ⚠ Loom 想執行 [write_file] · GUARDED ─────────────────╮
+    │   path:write → tmp                                       │
+    │   New resource type not previously authorized            │
+    │                                                          │
+    │  ▸ 允許這次  (y)                                         │
+    │    允許並記住 30 分鐘 (lease)  (s)                       │
+    │    允許並永久授權此 scope  (a)                           │
+    │    拒絕  (n)                                             │
+    │                                                          │
+    │  ↑↓ 選擇  ⏎ 確認  esc 取消                               │
+    ╰──────────────────────────────────────────────────────────╯
+     tarot · MiniMax-M2.7   ▸ write_file (awaiting)      ▎ Loom    ← footer
+```
+
+選擇後，**整個 confirm 區塊原地消失**，input area 回來——scrollback 不留 panel。決策結果由後續的 ToolBegin/ToolEnd（或 ABORTED rule）負責記。
+
+### 18.6 HITL Pause mode
+
+```
+    Loom ▎ context 2.3%
+    Loom ▎ 已經跑完查資料的部分。
+
+    ▸ web_search · 1.2s ✓
+    ▸ minimax:text_to_image · 8.4s ✓
+
+    ╭─ ⏸ Loom 已暫停，下一步？ ─────────────────────────────╮
+    │  ▸ 繼續執行剩下的工具  (r)                             │
+    │    導向新指令並繼續  (m)                               │
+    │    取消這個 turn  (c)                                  │
+    │                                                        │
+    │  ↑↓ 選擇  ⏎ 確認  esc 取消                             │
+    ╰────────────────────────────────────────────────────────╯
+     tarot · MiniMax-M2.7   ⏸ HITL paused                ▎ Loom
+```
+
+選 `m` 後切到 redirect 模式：
+
+```
+    ╭───────────────────────────────────────────────────────────╮
+    │ redirect › 跳過圖片，只給文字摘要 ▏                        │
+    ╰───────────────────────────────────────────────────────────╯
+```
+
+文字輸入結束後一樣**整塊消失**，恢復 input mode。
+
+### 18.7 Compaction in progress
+
+`/compact` 觸發或自動觸發時：
+
+```
+    Loom ▎ context 87.3%
+    Loom ▎ 等等，先讓我整理一下記憶，避免後面對話跑掉軌道。
+
+    ⚙ harness › compacting context (87.3% used)…
+
+    ╭───────────────────────────────────────────────────────────╮
+    │ you › ▏                                                    │
+    ╰───────────────────────────────────────────────────────────╯
+     tarot · MiniMax-M2.7   ⚡ 壓縮中… 23%                ▎ Loom    ← footer 表示忙
+```
+
+完成後：
+
+```
+    ⚙ harness › 已壓縮 47 → 12 turns（保留 user 5 / system 3 · -4.8k tokens）
+    Loom ▎ 好，可以接著聊。剛剛你問的是…
+     tarot · MiniMax-M2.7                                ▎ Loom    ← spinner 退場
+```
+
+### 18.8 Token budget 浮出（>60%）
+
+footer 中間自動出現琥珀色 `⚡ tok 67%`，破 80% 變赭石、破 95% 變赤陶：
+
+```
+     tarot · MiniMax-M2.7   ⚡ tok 67%   ▸ run_bash · 0.3s   ▎ Loom
+     tarot · MiniMax-M2.7   ⚡ tok 84%   ▸ run_bash · 0.3s   ▎ Loom    ← 警告色
+     tarot · MiniMax-M2.7   ⚡ tok 96%                       ▎ Loom    ← 危險色
+```
+
+### 18.9 Grant TTL（最快過期那個）
+
+`/scope` 有 active grants 時，footer 左半段加上：
+
+```
+     tarot · MiniMax-M2.7   🔑 L2·0:43   ⚡ tok 67%         ▎ Loom
+```
+
+倒數只在 turn 邊界刷新（不每秒 redraw）。
+
+### 18.10 啟動瞬間（迷你 signature + 整合資訊）
+
+**現況（要改）**：`render_header(model, db)` 印一個 Panel，緊接著 `_memory_index.render()` 又印一個多行 Memory Index Panel（skills 數、semantic facts、relations、anti-patterns…）。一次啟動連印 2 個 Panel + 多行清單，視覺壅塞。
+
+**PR-D 整合方向**：把 header + memory index counts 收成一個 3 行迷你 signature。MemoryIndex 完整資料**繼續餵 LLM 的 system prompt**（沒改），只是不再給使用者看完整清單——使用者要查時 `/memory list`、`/skills` 等命令還在。
+
+```
+$ loom chat
+
+         ╱ Loom v0.3.4 · 'parchment'
+    ───── 12 skills · 14k facts · 3 mcp · 47 episodes
+         ╲ MiniMax-M2.7 · persona: tarot
+
+    ╭───────────────────────────────────────────────────────────╮
+    │ you › ▏                                                    │
+    ╰───────────────────────────────────────────────────────────╯
+     tarot · MiniMax-M2.7                                ▎ Loom
+```
+
+中間那行「stats line」根據 `MemoryIndex` 取數：
+- `12 skills` — `index.skill_count`
+- `14k facts` — `index.semantic_count`（人類友善縮寫，>1k 用 k，>1m 用 M）
+- `3 mcp` — 從 `session._mcp_servers` 拿（待 D4 實作時 wire）
+- `47 episodes` — `index.episode_sessions`
+
+額外 fields 視情況選顯：`relational_count > 0` 時顯示 `· N relations`；`anti_pattern_count > 0` 時加 `· N anti-patterns`。沒有的 field 不佔位。
+
+第一次 streaming 開始後 signature 自然被推上 scrollback，永遠不再出現——是「會話開始」的記號，不是常駐 chrome。
+
+---
+
+## 19. 出處與相依
+
+- 設計母文件：`doc/49-CLI-Refresh-設計.md`
+- 已合併：PR-A (#237) PR-B (#242) PR-C (#244)
+- Tracking issue：#236
+- 後續：PR-E (TaskList 浮動面板)
+- 取代目標：`doc/34-TUI-使用指南.md`（PR-D 完成後廢除）
+- 相關 follow-up issues：#238 #239 #240 #241
+

--- a/doc/49b-PR-D-實作草稿.md
+++ b/doc/49b-PR-D-實作草稿.md
@@ -489,6 +489,15 @@ PR-A 留底（doc/49 已知 bug 段）：
 
 ---
 
+## D1 live-test 後新增的 D2 任務
+
+從第一次 `loom chat` 實測累積：
+
+- **Footer logo 方向**：✅ 已改為 `Loom ▎`（與 agent guide 同向），不再是 `▎ Loom` 中斷風
+- **💭 think 顯示時序錯位**（待 D2 處理）：Anthropic native thinking blocks 必須在 `stream.text_stream` 完成後才能讀到（在 `response.raw_message["_thinking_blocks"]`），所以目前 ThinkCollapsed 是在 response text 全部 stream 完之後才 yield 的。但語意順序是「先想後答」——使用者期待 💭 在回應**之前**而不是之後。D2 streaming renderer 改寫時要解決：候選方案 (a) turn 開頭印 `💭 thinking…` 占位，讀到內容後 cursor up 重塗 (b) 改用 stream events 級 API 提早抓 thinking (c) buffer response text、ThinkCollapsed 後再印（破 streaming）。傾向 (a)
+- **Loom Agent per-line 引線**（已在 D2 計畫內）：streaming text 跨行時每行帶 `Loom ▎` guide
+- **CJK 截斷 bug**（已在 D2 計畫內）：streaming 行首被吃，老 bug
+
 ## 17. Test plan 草稿
 
 - [ ] 啟動 `loom chat`，input 區黏底，footer 出現

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -3204,44 +3204,46 @@ class LoomSession:
             )
         )
 
-        options = [
-            SelectOption(
-                label="允許這次",
-                value=ConfirmDecision.ONCE,
-                shortcut="y",
-            ),
-            SelectOption(
-                label="允許並記住 30 分鐘 (lease)",
-                value=ConfirmDecision.SCOPE,
-                shortcut="s",
-            ),
-            SelectOption(
-                label="允許並永久授權此 scope",
-                value=ConfirmDecision.AUTO,
-                shortcut="a",
-            ),
-            SelectOption(
-                label="拒絕",
-                value=ConfirmDecision.DENY,
-                shortcut="n",
-            ),
-        ]
-
         widget_title = (
             f"Loom 想執行 [{call.tool_name}]  ·  信任度 {call.trust_level.plain}"
         )
+
+        # PR-D1: when running under the persistent LoomApp, route through
+        # its mode-flag widget so confirm renders inside the layout (not
+        # in scrollback) and disappears completely after decision —
+        # satisfies the "用過即焚" requirement #236 added.
+        loom_app = getattr(self, "_loom_app", None)
+        if loom_app is not None:
+            return await loom_app.request_confirm(
+                title=widget_title,
+                body=self._format_scope_panel(call),
+                options=[
+                    ("允許這次",                        ConfirmDecision.ONCE,   "y"),
+                    ("允許並記住 30 分鐘 (lease)",      ConfirmDecision.SCOPE,  "s"),
+                    ("允許並永久授權此 scope",          ConfirmDecision.AUTO,   "a"),
+                    ("拒絕",                            ConfirmDecision.DENY,   "n"),
+                ],
+                default_index=3,  # cursor on DENY for safety
+                cancel_value=ConfirmDecision.DENY,
+            )
+
+        # Fallback for tests / scripts without a running LoomApp:
+        # use the standalone select_prompt (PR-A3 widget).
+        options = [
+            SelectOption(label="允許這次",                   value=ConfirmDecision.ONCE,  shortcut="y"),
+            SelectOption(label="允許並記住 30 分鐘 (lease)", value=ConfirmDecision.SCOPE, shortcut="s"),
+            SelectOption(label="允許並永久授權此 scope",     value=ConfirmDecision.AUTO,  shortcut="a"),
+            SelectOption(label="拒絕",                       value=ConfirmDecision.DENY,  shortcut="n"),
+        ]
 
         async def _run():
             return await select_prompt(
                 title=widget_title,
                 options=options,
-                default_index=3,  # cursor starts on DENY (safer default)
+                default_index=3,
                 cancel_value=ConfirmDecision.DENY,
             )
 
-        # If running under the CLI chat loop, route through the input-loop
-        # coordinator so we own stdin cleanly. Otherwise (tests, scripts)
-        # run the widget directly.
         runner = getattr(self, "_run_interactive", None)
         if runner is not None:
             return await runner(_run)

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -3158,6 +3158,57 @@ class LoomSession:
 
         return "\n".join(lines)
 
+    @staticmethod
+    def _format_scope_summary_plain(call: ToolCall) -> str:
+        """Plain-text scope summary for the LoomApp confirm widget.
+
+        Mirrors :meth:`_format_scope_panel` but strips Rich markup so it
+        renders cleanly inside a prompt_toolkit FormattedTextControl,
+        which doesn't speak Rich's ``[bold]`` syntax.
+        """
+        from loom.core.harness.scope import (
+            DiffReason, ScopeDiff, ScopeRequest,
+        )
+
+        scope_req: ScopeRequest | None = call.metadata.get("scope_request")
+        diff: ScopeDiff | None = call.metadata.get("scope_diff")
+
+        if scope_req is None:
+            arg_lines: list[str] = []
+            for k, v in call.args.items():
+                if isinstance(v, str):
+                    display = v if len(v) <= 120 else v[:40] + "…" + v[-40:]
+                    arg_lines.append(f"  {k}: {display}")
+                else:
+                    arg_lines.append(f"  {k}: {v!r}")
+            return "\n".join(arg_lines) if arg_lines else "(no args)"
+
+        _REASON_LABELS: dict[DiffReason, str] = {
+            DiffReason.FIRST_TIME: "First time accessing this resource",
+            DiffReason.SELECTOR_EXPANSION: "Expanding beyond previously approved scope",
+            DiffReason.CONSTRAINT_EXPANSION: "Exceeding previously approved limits",
+            DiffReason.RESOURCE_TYPE_NEW: "New resource type not previously authorized",
+        }
+
+        lines: list[str] = []
+        for req in scope_req.requirements:
+            line = f"  {req.resource}:{req.action} → {req.selector}"
+            if req.constraints.get("scope_unknown"):
+                line += "  ⚠ scope could not be fully resolved"
+            lines.append(line)
+        if diff is not None and not diff.is_fully_covered:
+            reason_label = _REASON_LABELS.get(diff.reason, str(diff.reason.value))
+            lines.append(reason_label)
+            if diff.covered:
+                lines.append(
+                    "  ✓ covered: " + ", ".join(r.selector for r in diff.covered)
+                )
+            if diff.missing:
+                lines.append(
+                    "  ● new: " + ", ".join(r.selector for r in diff.missing)
+                )
+        return "\n".join(lines)
+
     async def _confirm_tool_cli(self, call: ToolCall) -> "ConfirmDecision":
         """
         CLI-specific confirmation prompt — arrow-key inline widget.
@@ -3185,38 +3236,26 @@ class LoomSession:
             self._cancel_spinner_fn()
             sys.stdout.write("\r\033[K")
             sys.stdout.flush()
-        console.print()
 
-        # Render the static context panel above the inline widget.
         verdict = call.metadata.get("scope_verdict")
-        if verdict == PermissionVerdict.EXPAND_SCOPE:
-            title = "[#b87060]⚠ Scope expansion required[/#b87060]"
-            border_style = "#b87060"
-        else:
-            title = "[#c8924a]  Tool requires confirmation[/#c8924a]"
-            border_style = "#c8924a"
-
-        console.print(
-            Panel(
-                self._format_scope_panel(call),
-                title=title,
-                border_style=border_style,
-            )
-        )
 
         widget_title = (
             f"Loom 想執行 [{call.tool_name}]  ·  信任度 {call.trust_level.plain}"
         )
+        if verdict == PermissionVerdict.EXPAND_SCOPE:
+            widget_title = "⚠ " + widget_title
 
         # PR-D1: when running under the persistent LoomApp, route through
         # its mode-flag widget so confirm renders inside the layout (not
         # in scrollback) and disappears completely after decision —
-        # satisfies the "用過即焚" requirement #236 added.
+        # satisfies the "用過即焚" requirement #236 added. Scope summary
+        # is folded into the widget body so we don't print a separate
+        # Rich Panel that would leak into scrollback.
         loom_app = getattr(self, "_loom_app", None)
         if loom_app is not None:
             return await loom_app.request_confirm(
                 title=widget_title,
-                body=self._format_scope_panel(call),
+                body=self._format_scope_summary_plain(call),
                 options=[
                     ("允許這次",                        ConfirmDecision.ONCE,   "y"),
                     ("允許並記住 30 分鐘 (lease)",      ConfirmDecision.SCOPE,  "s"),
@@ -3228,7 +3267,23 @@ class LoomSession:
             )
 
         # Fallback for tests / scripts without a running LoomApp:
-        # use the standalone select_prompt (PR-A3 widget).
+        # render the legacy Rich Panel (which leaves scrollback residue,
+        # acceptable in non-interactive contexts) and use the standalone
+        # select_prompt widget.
+        console.print()
+        if verdict == PermissionVerdict.EXPAND_SCOPE:
+            title = "[loom.error]⚠ Scope expansion required[/loom.error]"
+            border_style = "loom.error"
+        else:
+            title = "[loom.warning]  Tool requires confirmation[/loom.warning]"
+            border_style = "loom.warning"
+        console.print(
+            Panel(
+                self._format_scope_panel(call),
+                title=title,
+                border_style=border_style,
+            )
+        )
         options = [
             SelectOption(label="允許這次",                   value=ConfirmDecision.ONCE,  shortcut="y"),
             SelectOption(label="允許並記住 30 分鐘 (lease)", value=ConfirmDecision.SCOPE, shortcut="s"),

--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -395,19 +395,19 @@ class LoomApp:
     def _render_footer(self) -> FormattedText:
         parts: list[tuple[str, str]] = []
 
-        # Left: model · persona (identity reminder)
+        # Far left: Loom ▎ brand mark — anchors the line as Loom's
+        # identity, mirrors the agent guide style.
+        parts.append(("class:footer.brand", " Loom ▎ "))
+
+        # Then: model · persona (identity context)
         left = self.footer.model
         if self.footer.persona:
             left = f"{self.footer.persona} · {left}"
         if left:
             parts.append(("class:footer", f" {left} "))
 
-        # Middle: turn stats (context %, cache %, in/out, elapsed,
-        # tool count). Folded in from PR-A's inline status_bar so the
-        # post-turn metrics live in one place instead of scrolling
-        # away. Hidden until at least one turn has completed
+        # Token budget when >60%
         s = self.footer
-        stats: list[str] = []
         if s.token_pct > 60:
             token = (
                 "footer.budget.high" if s.token_pct > 95
@@ -416,6 +416,11 @@ class LoomApp:
             )
             parts.append(("class:footer", "  "))
             parts.append((f"class:{token}", f"⚡ tok {s.token_pct:.0f}%"))
+
+        # Last-turn stats — folded in from the old inline status_bar
+        # so the post-turn metrics live in one place instead of
+        # scrolling away. Hidden until at least one turn has completed
+        stats: list[str] = []
         if s.last_turn_cache_hit is not None:
             stats.append(f"cache {s.last_turn_cache_hit:.0f}%")
         if (s.last_turn_input_tokens is not None
@@ -431,12 +436,6 @@ class LoomApp:
         if stats:
             parts.append(("class:footer", "  "))
             parts.append(("class:footer.stats", " · ".join(stats)))
-
-        # Right: Loom ▎ brand mark — bar to the right of "Loom" so the
-        # marker mirrors the agent guide style ("Loom ▎ ...") rather
-        # than reading as "interrupted by a vertical line".
-        parts.append(("class:footer", "  "))
-        parts.append(("class:footer.brand", " Loom ▎ "))
 
         return FormattedText(parts)
 

--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -102,9 +102,14 @@ class FooterState:
     # like a hang
     compacting: bool = False
     # Loom is thinking (LLM call dispatched, no stream output yet).
-    # Surfaces as a soft animated indicator in the footer so the user
-    # knows their input is being chewed on
+    # Surfaces as a soft animated indicator above the input separator
+    # so the user knows their input is being chewed on
     thinking: bool = False
+    # Number of active scope grants and seconds until the nearest one
+    # expires. Refreshed at turn boundaries (per doc/49 decision —
+    # don't tick every second). 0 grants → both fields 0
+    grants_active: int = 0
+    grants_next_expiry_secs: float = 0.0
     # Last-turn stats. Kept out of scrollback (PR-A printed these
     # inline as the "context X% | cache Y% | A in / B out | Cs | N
     # tools" status_bar; that's noise the user doesn't need to keep
@@ -157,6 +162,7 @@ _APP_STYLE = Style.from_dict(
         "footer.stats":          PARCHMENT_MUTED,
         "footer.envelope":       PARCHMENT_ACCENT,
         "footer.compaction":     PARCHMENT_WARNING,
+        "footer.grant":          PARCHMENT_MUTED,
         # Thinking indicator above the input separator
         "thinking":              PARCHMENT_MUTED,
         "thinking.dot":          PARCHMENT_ACCENT,
@@ -472,6 +478,22 @@ class LoomApp:
         )
         parts.append(("class:footer", "  "))
         parts.append((f"class:{token}", f"context {s.token_pct:.1f}%"))
+
+        # Active scope grants — show 🔑 N · M:SS for the nearest
+        # expiring lease. Refreshed at turn boundaries (no per-second
+        # ticking; doc/49 decision)
+        if s.grants_active > 0:
+            ttl = s.grants_next_expiry_secs
+            if ttl > 0:
+                m, sec = divmod(int(ttl), 60)
+                ttl_label = f"{m}:{sec:02d}" if m < 60 else f"{m // 60}h{m % 60}m"
+            else:
+                ttl_label = "∞"  # session-scoped grant, no expiry
+            parts.append(("class:footer", "  "))
+            parts.append(
+                ("class:footer.grant",
+                 f"🔑 {s.grants_active}·{ttl_label}")
+            )
 
         # Active envelopes — show the most recent one with elapsed
         # time. When >1 in flight, prefix with count: ``3× ▸ ...``.

--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -157,6 +157,9 @@ _APP_STYLE = Style.from_dict(
         "footer.stats":          PARCHMENT_MUTED,
         "footer.envelope":       PARCHMENT_ACCENT,
         "footer.compaction":     PARCHMENT_WARNING,
+        # Thinking indicator above the input separator
+        "thinking":              PARCHMENT_MUTED,
+        "thinking.dot":          PARCHMENT_ACCENT,
         # Confirm / Pause widget — also no bg, blend with terminal
         "widget.title":          PARCHMENT_TEXT,
         "widget.body":           PARCHMENT_MUTED,
@@ -398,8 +401,22 @@ class LoomApp:
             style=f"fg:{PARCHMENT_BORDER}",
         )
 
+        # Thinking indicator — appears as its own line *above* the
+        # separator (so visually attached to the input region), only
+        # while ``footer.thinking`` is True. Mirrors Claude Code-style
+        # "● thinking…" status above the prompt rather than tucking
+        # it into the footer
+        thinking_window = ConditionalContainer(
+            Window(
+                content=FormattedTextControl(self._render_thinking),
+                height=1,
+            ),
+            filter=Condition(lambda: self.footer.thinking),
+        )
+
         layout = Layout(
             HSplit([
+                thinking_window,
                 separator_window,
                 input_window,
                 confirm_window,
@@ -468,15 +485,8 @@ class LoomApp:
             label += f"▸ {latest.name} · {elapsed:.1f}s"
             parts.append(("class:footer", "  "))
             parts.append(("class:footer.envelope", label))
-        elif s.thinking:
-            # Thinking indicator — animated dots driven by ticker
-            # invalidate. ``import time`` here so we can use
-            # monotonic() as the animation phase
-            import time as _t
-            phase = int(_t.monotonic() * 2) % 4
-            dots = "·" * phase + " " * (3 - phase)
-            parts.append(("class:footer", "  "))
-            parts.append(("class:footer.envelope", f"▸ Loom thinking{dots}"))
+        # Thinking indicator no longer rendered here — moved to its
+        # own window above the input separator (see _render_thinking)
 
         # Last-turn stats — only show when no tool is currently in
         # flight (otherwise the active envelope already tells the
@@ -500,6 +510,22 @@ class LoomApp:
                 parts.append(("class:footer.stats", " · ".join(stats)))
 
         return FormattedText(parts)
+
+    def _render_thinking(self) -> FormattedText:
+        """Animated thinking indicator above the input separator.
+
+        Style: ``● Loom is thinking···`` with the dots cycling on the
+        ticker invalidate. Bullet glyph in accent gold so it reads as
+        a status pip; the rest in muted parchment so the line stays
+        quiet relative to streaming output.
+        """
+        import time as _t
+        phase = int(_t.monotonic() * 2) % 4
+        dots = "·" * phase + " " * (3 - phase)
+        return FormattedText([
+            ("class:thinking.dot", " ● "),
+            ("class:thinking", f"Loom is thinking{dots}"),
+        ])
 
     def _render_confirm(self) -> FormattedText:
         if self._confirm_state is None:

--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -75,6 +75,13 @@ Mode = Literal["input", "confirm", "pause", "redirect"]
 
 
 @dataclass
+class _ActiveEnvelope:
+    """A tool envelope currently in flight — for footer summary."""
+    name: str
+    started_monotonic: float
+
+
+@dataclass
 class FooterState:
     """Mutable state read by ``render_footer`` on every redraw.
 
@@ -87,6 +94,13 @@ class FooterState:
     persona: str | None = None
     # Context window utilisation — surfaces in footer when >60%
     token_pct: float = 0.0
+    # Tools currently running. footer shows the most recent one's
+    # name + elapsed; if multiple, prefix with ``Nx`` count
+    active_envelopes: list[_ActiveEnvelope] = field(default_factory=list)
+    # Compaction in progress — when True, footer hides everything
+    # else and shows ``⚡ 壓縮中…`` so the long pause doesn't look
+    # like a hang
+    compacting: bool = False
     # Last-turn stats. Kept out of scrollback (PR-A printed these
     # inline as the "context X% | cache Y% | A in / B out | Cs | N
     # tools" status_bar; that's noise the user doesn't need to keep
@@ -137,6 +151,8 @@ _APP_STYLE = Style.from_dict(
         "footer.budget.warn":    PARCHMENT_WARNING,
         "footer.budget.high":    PARCHMENT_ERROR,
         "footer.stats":          PARCHMENT_MUTED,
+        "footer.envelope":       PARCHMENT_ACCENT,
+        "footer.compaction":     PARCHMENT_WARNING,
         # Confirm / Pause widget — also no bg, blend with terminal
         "widget.title":          PARCHMENT_TEXT,
         "widget.body":           PARCHMENT_MUTED,
@@ -406,13 +422,17 @@ class LoomApp:
         if left:
             parts.append(("class:footer", f" {left} "))
 
-        # Context % — always visible. Originally hidden under 60% per
-        # doc/49 § C-plan, but the once-per-turn intro that used to
-        # carry it has been pared back to just ``Loom ▎``, so keeping
-        # context% visible in footer is the only place it lives now.
-        # Colour ladder unchanged: muted under 60%, ochre 60-80%,
-        # warning 80-95%, error >95%
         s = self.footer
+
+        # If compacting: replace the middle area with the spinner
+        # message so the user doesn't think the agent has hung
+        if s.compacting:
+            parts.append(("class:footer", "  "))
+            parts.append(("class:footer.compaction", "⚡ 壓縮中…"))
+            return FormattedText(parts)
+
+        # Context % — always visible. Colour ladder: muted under 60%,
+        # ochre 60-80%, warning 80-95%, error >95%
         token = (
             "footer.budget.high" if s.token_pct > 95
             else "footer.budget.warn" if s.token_pct > 80
@@ -421,25 +441,39 @@ class LoomApp:
         parts.append(("class:footer", "  "))
         parts.append((f"class:{token}", f"context {s.token_pct:.1f}%"))
 
-        # Last-turn stats — folded in from the old inline status_bar
-        # so the post-turn metrics live in one place instead of
-        # scrolling away. Hidden until at least one turn has completed
-        stats: list[str] = []
-        if s.last_turn_cache_hit is not None:
-            stats.append(f"cache {s.last_turn_cache_hit:.0f}%")
-        if (s.last_turn_input_tokens is not None
-                and s.last_turn_output_tokens is not None):
-            stats.append(
-                f"{s.last_turn_input_tokens}in / {s.last_turn_output_tokens}out"
-            )
-        if s.last_turn_elapsed_s is not None:
-            stats.append(f"{s.last_turn_elapsed_s:.1f}s")
-        if s.last_turn_tool_count is not None:
-            n = s.last_turn_tool_count
-            stats.append(f"{n} tool{'s' if n != 1 else ''}")
-        if stats:
+        # Active envelopes — show the most recent one with elapsed
+        # time. When >1 in flight, prefix with count: ``3× ▸ ...``.
+        # Updates as ToolBegin / ToolEnd fire (see main.py wiring)
+        envs = s.active_envelopes
+        if envs:
+            import time as _t
+            latest = envs[-1]
+            elapsed = max(0.0, _t.monotonic() - latest.started_monotonic)
+            label = f"{len(envs)}× " if len(envs) > 1 else ""
+            label += f"▸ {latest.name} · {elapsed:.1f}s"
             parts.append(("class:footer", "  "))
-            parts.append(("class:footer.stats", " · ".join(stats)))
+            parts.append(("class:footer.envelope", label))
+
+        # Last-turn stats — only show when no tool is currently in
+        # flight (otherwise the active envelope already tells the
+        # user "we're busy")
+        if not envs:
+            stats: list[str] = []
+            if s.last_turn_cache_hit is not None:
+                stats.append(f"cache {s.last_turn_cache_hit:.0f}%")
+            if (s.last_turn_input_tokens is not None
+                    and s.last_turn_output_tokens is not None):
+                stats.append(
+                    f"{s.last_turn_input_tokens}in / {s.last_turn_output_tokens}out"
+                )
+            if s.last_turn_elapsed_s is not None:
+                stats.append(f"{s.last_turn_elapsed_s:.1f}s")
+            if s.last_turn_tool_count is not None:
+                n = s.last_turn_tool_count
+                stats.append(f"{n} tool{'s' if n != 1 else ''}")
+            if stats:
+                parts.append(("class:footer", "  "))
+                parts.append(("class:footer.stats", " · ".join(stats)))
 
         return FormattedText(parts)
 

--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -432,9 +432,11 @@ class LoomApp:
             parts.append(("class:footer", "  "))
             parts.append(("class:footer.stats", " · ".join(stats)))
 
-        # Right: ▎ Loom brand mark
+        # Right: Loom ▎ brand mark — bar to the right of "Loom" so the
+        # marker mirrors the agent guide style ("Loom ▎ ...") rather
+        # than reading as "interrupted by a vertical line".
         parts.append(("class:footer", "  "))
-        parts.append(("class:footer.brand", "▎ Loom "))
+        parts.append(("class:footer.brand", " Loom ▎ "))
 
         return FormattedText(parts)
 

--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -1,0 +1,670 @@
+"""
+LoomApp — persistent prompt_toolkit Application for the CLI chat surface.
+
+PR-D1 (#236). Replaces the per-iteration ``PromptSession.prompt_async``
++ ``patch_stdout`` + three-event stdin coordinator architecture with a
+single long-running Application that owns the bottom region of the
+terminal (input area + footer + transient confirm/pause overlays).
+
+Design
+------
+- The Application's layout is ``HSplit([mode_container, footer])``
+  where ``mode_container`` is a ``ConditionalContainer`` switch over a
+  ``mode`` flag — INPUT / CONFIRM / PAUSE / REDIRECT
+- ``mode`` is a simple string held in a single-element list so closures
+  see updates. Switching modes calls ``app.invalidate()`` to redraw
+- ``request_confirm`` / ``request_pause`` / ``request_redirect_text``
+  flip the mode, await a Future, and restore mode in a ``finally``.
+  The transient widget rendering happens entirely inside the layout —
+  it never reaches the terminal scrollback (the "用過即焚" property
+  required by #236)
+- Streaming output goes through ``app.run_in_terminal`` so it lands in
+  the natural scrollback above the persistent bottom area; no
+  ``patch_stdout`` plumbing required
+
+Constraints honoured
+--------------------
+- Input area is multiline-capable (Alt+Enter newline, Enter submit) —
+  this finally re-enables the multi-line input that PR-A had to disable
+- Slash commands and abort-on-submit semantics from PR-A preserved
+- Confirm widget renders within the layout, not via a nested
+  Application — so the "Application is not running" race that PR-A
+  worked around with three-event coordination simply cannot occur
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, Callable, Awaitable, Literal
+
+from prompt_toolkit.application import Application
+from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.completion import FuzzyCompleter
+from prompt_toolkit.filters import Condition, has_focus
+from prompt_toolkit.formatted_text import FormattedText
+from prompt_toolkit.history import FileHistory, History, InMemoryHistory
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.layout import HSplit, Layout, Window
+from prompt_toolkit.layout.containers import ConditionalContainer
+from prompt_toolkit.layout.controls import BufferControl, FormattedTextControl
+from prompt_toolkit.layout.dimension import Dimension
+from prompt_toolkit.styles import Style
+
+from loom.platform.cli.theme import (
+    PARCHMENT_ACCENT,
+    PARCHMENT_BG,
+    PARCHMENT_BORDER,
+    PARCHMENT_ERROR,
+    PARCHMENT_MUTED,
+    PARCHMENT_SUCCESS,
+    PARCHMENT_SURFACE,
+    PARCHMENT_TEXT,
+    PARCHMENT_WARNING,
+)
+from loom.platform.cli.ui import SLASH_COMMANDS, SlashCompleter
+
+
+Mode = Literal["input", "confirm", "pause", "redirect"]
+
+
+# ---------------------------------------------------------------------------
+# Footer state
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FooterState:
+    """Mutable state read by ``render_footer`` on every redraw.
+
+    Fields are written from event handlers (e.g. envelope start/end,
+    turn complete updates token_pct) and read inside the render
+    callback. ``app.invalidate()`` after writes triggers redraw.
+    """
+
+    model: str = ""
+    persona: str | None = None
+    token_pct: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Confirm / Pause widget state
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ConfirmState:
+    title: str
+    body: str
+    options: list[tuple[str, Any, str | None]]  # (label, value, shortcut)
+    cursor: int = 0
+    future: asyncio.Future | None = None
+
+
+@dataclass
+class _PauseState:
+    title: str
+    options: list[tuple[str, Any, str | None]]
+    cursor: int = 0
+    future: asyncio.Future | None = None
+
+
+# ---------------------------------------------------------------------------
+# Style — extends prompt_toolkit's class-based style with our palette
+# ---------------------------------------------------------------------------
+
+_APP_STYLE = Style.from_dict(
+    {
+        # Input area
+        "input.prompt":          f"bold {PARCHMENT_ACCENT}",
+        "input.text":            PARCHMENT_TEXT,
+        # Footer — minimal in D1; D4 expands
+        "footer":                f"bg:{PARCHMENT_SURFACE} {PARCHMENT_MUTED}",
+        "footer.brand":          f"bg:{PARCHMENT_SURFACE} {PARCHMENT_ACCENT}",
+        "footer.budget.ok":      f"bg:{PARCHMENT_SURFACE} {PARCHMENT_MUTED}",
+        "footer.budget.warn":    f"bg:{PARCHMENT_SURFACE} {PARCHMENT_WARNING}",
+        "footer.budget.high":    f"bg:{PARCHMENT_SURFACE} {PARCHMENT_ERROR}",
+        # Confirm / Pause widget
+        "widget.title":          PARCHMENT_TEXT,
+        "widget.body":           PARCHMENT_MUTED,
+        "widget.option":         PARCHMENT_TEXT,
+        "widget.option.cursor":  f"bold {PARCHMENT_ACCENT}",
+        "widget.shortcut":       PARCHMENT_MUTED,
+        "widget.footer":         f"italic {PARCHMENT_MUTED}",
+        # Auto-suggestion ghost text
+        "auto-suggestion":       PARCHMENT_BORDER,
+        # Completion menu
+        "completion-menu":                         f"bg:{PARCHMENT_SURFACE} {PARCHMENT_TEXT}",
+        "completion-menu.completion":              f"bg:{PARCHMENT_SURFACE} {PARCHMENT_TEXT}",
+        "completion-menu.completion.current":      f"bg:{PARCHMENT_ACCENT} {PARCHMENT_BG} bold",
+        "completion-menu.meta.completion":         f"bg:{PARCHMENT_SURFACE} {PARCHMENT_MUTED}",
+        "completion-menu.meta.completion.current": f"bg:{PARCHMENT_ACCENT} {PARCHMENT_BG}",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# LoomApp
+# ---------------------------------------------------------------------------
+
+
+class LoomApp:
+    """Owns the persistent prompt_toolkit Application backing ``loom chat``.
+
+    Construct with :meth:`build`, then call :meth:`run` to start the
+    main loop. The caller (``_chat`` in main.py) registers callbacks
+    for input submission and runs the streaming-turn loop concurrently.
+    """
+
+    def __init__(
+        self,
+        *,
+        history: History,
+        on_submit: Callable[[str], Awaitable[None]] | None = None,
+    ) -> None:
+        self._mode: list[Mode] = ["input"]
+        self._on_submit = on_submit
+
+        # Buffers
+        self._input_buffer = Buffer(
+            multiline=True,
+            history=history,
+            auto_suggest=AutoSuggestFromHistory(),
+            completer=FuzzyCompleter(SlashCompleter(), enable_fuzzy=True),
+            complete_while_typing=True,
+        )
+        self._redirect_buffer = Buffer(multiline=False)
+
+        # Widget state
+        self._confirm_state: _ConfirmState | None = None
+        self._pause_state: _PauseState | None = None
+        self._redirect_future: asyncio.Future | None = None
+
+        # Footer state
+        self.footer = FooterState()
+
+        # Build layout + key bindings + Application
+        self._app = self._build_application()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def application(self) -> Application:
+        return self._app
+
+    @property
+    def mode(self) -> Mode:
+        return self._mode[0]
+
+    async def run(self) -> None:
+        """Run the application until the user quits."""
+        await self._app.run_async()
+
+    def invalidate(self) -> None:
+        self._app.invalidate()
+
+    async def print_above(self, callback: Callable[[], None]) -> None:
+        """Run ``callback`` above the application's bottom region.
+
+        Use this for streaming output from a turn — Rich console.print,
+        Panel rendering, etc. The callback runs synchronously while the
+        Application's bottom area is briefly suspended, then redrawn
+        below the new output. Result: streaming text flows into the
+        natural terminal scrollback while the input + footer stay
+        anchored at the bottom.
+        """
+        await self._app.run_in_terminal(callback)
+
+    async def request_confirm(
+        self,
+        *,
+        title: str,
+        body: str,
+        options: list[tuple[str, Any, str | None]],
+        default_index: int = 0,
+        cancel_value: Any = None,
+    ) -> Any:
+        """Switch to confirm mode and await the user's selection.
+
+        Returns whatever ``options[i][1]`` is for the chosen index, or
+        ``cancel_value`` if Esc/Ctrl+C is pressed.
+        """
+        future: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._confirm_state = _ConfirmState(
+            title=title,
+            body=body,
+            options=options,
+            cursor=max(0, min(default_index, len(options) - 1)),
+            future=future,
+        )
+        # Stash cancel_value on the future so the Esc handler can use it
+        future._loom_cancel_value = cancel_value  # type: ignore[attr-defined]
+        self._mode[0] = "confirm"
+        self._app.invalidate()
+        try:
+            return await future
+        finally:
+            self._confirm_state = None
+            self._mode[0] = "input"
+            self._app.invalidate()
+
+    async def request_pause(
+        self,
+        *,
+        title: str,
+        options: list[tuple[str, Any, str | None]],
+        default_index: int = 0,
+        cancel_value: Any = None,
+    ) -> Any:
+        future: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._pause_state = _PauseState(
+            title=title,
+            options=options,
+            cursor=max(0, min(default_index, len(options) - 1)),
+            future=future,
+        )
+        future._loom_cancel_value = cancel_value  # type: ignore[attr-defined]
+        self._mode[0] = "pause"
+        self._app.invalidate()
+        try:
+            return await future
+        finally:
+            self._pause_state = None
+            self._mode[0] = "input"
+            self._app.invalidate()
+
+    async def request_redirect_text(self) -> str:
+        """Switch to redirect mode for free-form text entry (HITL redirect)."""
+        future: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._redirect_future = future
+        self._mode[0] = "redirect"
+        self._app.invalidate()
+        try:
+            return await future
+        finally:
+            self._redirect_future = None
+            self._redirect_buffer.text = ""
+            self._mode[0] = "input"
+            self._app.invalidate()
+
+    # ------------------------------------------------------------------
+    # Layout builders
+    # ------------------------------------------------------------------
+
+    def _build_application(self) -> Application:
+        # Mode-aware filters
+        is_input = Condition(lambda: self._mode[0] == "input")
+        is_confirm = Condition(lambda: self._mode[0] == "confirm")
+        is_pause = Condition(lambda: self._mode[0] == "pause")
+        is_redirect = Condition(lambda: self._mode[0] == "redirect")
+
+        # Input area — always height ≥ 1, expands as user types up to ~10
+        input_window = ConditionalContainer(
+            HSplit([
+                Window(
+                    content=FormattedTextControl(
+                        lambda: FormattedText([("class:input.prompt", "you › ")]),
+                        focusable=False,
+                    ),
+                    height=1,
+                    dont_extend_height=True,
+                ),
+                Window(
+                    content=BufferControl(buffer=self._input_buffer),
+                    wrap_lines=True,
+                    height=Dimension(min=1, max=10),
+                    style="class:input.text",
+                ),
+            ]),
+            filter=is_input,
+        )
+
+        # Confirm widget
+        confirm_window = ConditionalContainer(
+            Window(
+                content=FormattedTextControl(self._render_confirm, focusable=True),
+                height=Dimension(min=4, max=15),
+                wrap_lines=True,
+            ),
+            filter=is_confirm,
+        )
+
+        # Pause widget
+        pause_window = ConditionalContainer(
+            Window(
+                content=FormattedTextControl(self._render_pause, focusable=True),
+                height=Dimension(min=4, max=10),
+                wrap_lines=True,
+            ),
+            filter=is_pause,
+        )
+
+        # Redirect text input
+        redirect_window = ConditionalContainer(
+            HSplit([
+                Window(
+                    content=FormattedTextControl(
+                        lambda: FormattedText([("class:input.prompt", "redirect › ")]),
+                        focusable=False,
+                    ),
+                    height=1,
+                    dont_extend_height=True,
+                ),
+                Window(
+                    content=BufferControl(buffer=self._redirect_buffer),
+                    height=1,
+                    style="class:input.text",
+                ),
+            ]),
+            filter=is_redirect,
+        )
+
+        # Footer — always visible
+        footer_window = Window(
+            content=FormattedTextControl(self._render_footer),
+            height=1,
+            style="class:footer",
+        )
+
+        layout = Layout(
+            HSplit([
+                input_window,
+                confirm_window,
+                pause_window,
+                redirect_window,
+                footer_window,
+            ]),
+            focused_element=self._input_buffer,
+        )
+
+        return Application(
+            layout=layout,
+            key_bindings=self._build_key_bindings(),
+            style=_APP_STYLE,
+            full_screen=False,
+            mouse_support=False,
+            erase_when_done=False,
+        )
+
+    # ------------------------------------------------------------------
+    # Render callbacks
+    # ------------------------------------------------------------------
+
+    def _render_footer(self) -> FormattedText:
+        parts: list[tuple[str, str]] = []
+
+        # Left edge: model · persona
+        left = self.footer.model
+        if self.footer.persona:
+            left = f"{self.footer.persona} · {left}"
+        if left:
+            parts.append(("class:footer", f" {left} "))
+
+        # Centre: token budget when >60%
+        pct = self.footer.token_pct
+        if pct > 60:
+            token = (
+                "footer.budget.high" if pct > 95
+                else "footer.budget.warn" if pct > 80
+                else "footer.budget.ok"
+            )
+            parts.append(("class:footer", "  "))
+            parts.append((f"class:{token}", f"⚡ tok {pct:.0f}%"))
+
+        # Right edge: ▎ Loom brand mark — pad with spaces to push it
+        # right. We don't know terminal width here so rely on
+        # FormattedTextControl's natural alignment.
+        # (D4 will refine layout; D1 keeps it simple)
+        parts.append(("class:footer", "  "))
+        parts.append(("class:footer.brand", "▎ Loom "))
+
+        return FormattedText(parts)
+
+    def _render_confirm(self) -> FormattedText:
+        if self._confirm_state is None:
+            return FormattedText([])
+        state = self._confirm_state
+        parts: list[tuple[str, str]] = []
+        parts.append(("class:widget.title", f"{state.title}\n"))
+        if state.body:
+            parts.append(("class:widget.body", f"{state.body}\n"))
+        parts.append(("", "\n"))
+        for idx, (label, _value, shortcut) in enumerate(state.options):
+            arrow = " ▸ " if idx == state.cursor else "   "
+            style = (
+                "class:widget.option.cursor" if idx == state.cursor
+                else "class:widget.option"
+            )
+            parts.append((style, f"{arrow}{label}"))
+            if shortcut:
+                parts.append(("class:widget.shortcut", f"  ({shortcut})"))
+            parts.append(("", "\n"))
+        parts.append(("", "\n"))
+        parts.append(
+            (
+                "class:widget.footer",
+                "↑↓ 選擇  ⏎ 確認  esc 取消",
+            )
+        )
+        return FormattedText(parts)
+
+    def _render_pause(self) -> FormattedText:
+        if self._pause_state is None:
+            return FormattedText([])
+        state = self._pause_state
+        parts: list[tuple[str, str]] = []
+        parts.append(("class:widget.title", f"{state.title}\n"))
+        parts.append(("", "\n"))
+        for idx, (label, _value, shortcut) in enumerate(state.options):
+            arrow = " ▸ " if idx == state.cursor else "   "
+            style = (
+                "class:widget.option.cursor" if idx == state.cursor
+                else "class:widget.option"
+            )
+            parts.append((style, f"{arrow}{label}"))
+            if shortcut:
+                parts.append(("class:widget.shortcut", f"  ({shortcut})"))
+            parts.append(("", "\n"))
+        parts.append(("", "\n"))
+        parts.append(
+            ("class:widget.footer", "↑↓ 選擇  ⏎ 確認  esc 取消")
+        )
+        return FormattedText(parts)
+
+    # ------------------------------------------------------------------
+    # Key bindings
+    # ------------------------------------------------------------------
+
+    def _build_key_bindings(self) -> KeyBindings:
+        kb = KeyBindings()
+
+        # ── Input mode ────────────────────────────────────────────────
+        @kb.add("enter", filter=Condition(lambda: self._mode[0] == "input"))
+        def _input_submit(event):
+            text = self._input_buffer.text
+            if not text.strip():
+                return
+            # Reset buffer immediately so the user sees their input cleared
+            self._input_buffer.reset()
+            # Schedule the submission callback
+            if self._on_submit is not None:
+                asyncio.create_task(self._on_submit(text))
+
+        @kb.add("escape", "enter",
+                filter=Condition(lambda: self._mode[0] == "input"))
+        def _input_newline(event):
+            """Alt+Enter (Esc,Enter on most terminals) → insert newline."""
+            self._input_buffer.insert_text("\n")
+
+        @kb.add("c-d",
+                filter=Condition(lambda: self._mode[0] == "input"))
+        def _input_eof(event):
+            if not self._input_buffer.text:
+                event.app.exit()
+
+        @kb.add("c-c",
+                filter=Condition(lambda: self._mode[0] == "input"))
+        def _input_interrupt(event):
+            if self._input_buffer.text:
+                self._input_buffer.reset()
+            else:
+                event.app.exit()
+
+        @kb.add("c-l")
+        def _clear_screen(event):
+            event.app.renderer.clear()
+
+        # ── Confirm mode ──────────────────────────────────────────────
+        is_confirm = Condition(lambda: self._mode[0] == "confirm")
+
+        @kb.add("up", filter=is_confirm)
+        @kb.add("c-p", filter=is_confirm)
+        def _confirm_up(event):
+            if self._confirm_state:
+                n = len(self._confirm_state.options)
+                self._confirm_state.cursor = (self._confirm_state.cursor - 1) % n
+                event.app.invalidate()
+
+        @kb.add("down", filter=is_confirm)
+        @kb.add("c-n", filter=is_confirm)
+        def _confirm_down(event):
+            if self._confirm_state:
+                n = len(self._confirm_state.options)
+                self._confirm_state.cursor = (self._confirm_state.cursor + 1) % n
+                event.app.invalidate()
+
+        @kb.add("enter", filter=is_confirm)
+        def _confirm_pick(event):
+            state = self._confirm_state
+            if state and state.future and not state.future.done():
+                _label, value, _shortcut = state.options[state.cursor]
+                state.future.set_result(value)
+
+        @kb.add("escape", eager=True, filter=is_confirm)
+        @kb.add("c-c", filter=is_confirm)
+        def _confirm_cancel(event):
+            state = self._confirm_state
+            if state and state.future and not state.future.done():
+                cancel_value = getattr(state.future, "_loom_cancel_value", None)
+                state.future.set_result(cancel_value)
+
+        # Confirm-mode shortcuts: any single letter matches an option whose
+        # shortcut == that letter. We bind a generic letter handler that
+        # reads ``event.data`` (the typed character) and matches against
+        # the dynamic options list.
+        @kb.add("<any>", filter=is_confirm)
+        def _confirm_shortcut(event):
+            state = self._confirm_state
+            if not state or not state.future or state.future.done():
+                return
+            pressed = (event.data or "").lower()
+            if not pressed or len(pressed) != 1:
+                return
+            for _label, value, sc in state.options:
+                if sc and sc.lower() == pressed:
+                    state.future.set_result(value)
+                    return
+
+        # ── Pause mode (HITL) ─────────────────────────────────────────
+        is_pause = Condition(lambda: self._mode[0] == "pause")
+
+        @kb.add("up", filter=is_pause)
+        @kb.add("c-p", filter=is_pause)
+        def _pause_up(event):
+            if self._pause_state:
+                n = len(self._pause_state.options)
+                self._pause_state.cursor = (self._pause_state.cursor - 1) % n
+                event.app.invalidate()
+
+        @kb.add("down", filter=is_pause)
+        @kb.add("c-n", filter=is_pause)
+        def _pause_down(event):
+            if self._pause_state:
+                n = len(self._pause_state.options)
+                self._pause_state.cursor = (self._pause_state.cursor + 1) % n
+                event.app.invalidate()
+
+        @kb.add("enter", filter=is_pause)
+        def _pause_pick(event):
+            state = self._pause_state
+            if state and state.future and not state.future.done():
+                _label, value, _shortcut = state.options[state.cursor]
+                state.future.set_result(value)
+
+        @kb.add("escape", eager=True, filter=is_pause)
+        @kb.add("c-c", filter=is_pause)
+        def _pause_cancel(event):
+            state = self._pause_state
+            if state and state.future and not state.future.done():
+                cancel_value = getattr(state.future, "_loom_cancel_value", None)
+                state.future.set_result(cancel_value)
+
+        @kb.add("<any>", filter=is_pause)
+        def _pause_shortcut(event):
+            state = self._pause_state
+            if not state or not state.future or state.future.done():
+                return
+            pressed = (event.data or "").lower()
+            if not pressed or len(pressed) != 1:
+                return
+            for _label, value, sc in state.options:
+                if sc and sc.lower() == pressed:
+                    state.future.set_result(value)
+                    return
+
+        # ── Redirect mode (HITL text input) ───────────────────────────
+        is_redirect = Condition(lambda: self._mode[0] == "redirect")
+
+        @kb.add("enter", filter=is_redirect)
+        def _redirect_submit(event):
+            future = self._redirect_future
+            if future and not future.done():
+                future.set_result(self._redirect_buffer.text)
+
+        @kb.add("escape", eager=True, filter=is_redirect)
+        @kb.add("c-c", filter=is_redirect)
+        def _redirect_cancel(event):
+            future = self._redirect_future
+            if future and not future.done():
+                future.set_result("")
+
+        return kb
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def build_loom_app(
+    *,
+    history_path: "Path | None" = None,
+    on_submit: Callable[[str], Awaitable[None]] | None = None,
+) -> LoomApp:
+    """Construct a :class:`LoomApp` with sensible defaults.
+
+    Parameters
+    ----------
+    history_path : Path | None
+        Where to persist input history. Defaults to ``~/.loom/cli_history``.
+    on_submit : async callable, optional
+        Called when the user submits text (presses Enter in INPUT mode).
+        The string passed has not been stripped — handler decides.
+    """
+    from pathlib import Path
+
+    history: History
+    path = history_path or Path.home() / ".loom" / "cli_history"
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        history = FileHistory(str(path))
+    except OSError:
+        history = InMemoryHistory()
+
+    return LoomApp(history=history, on_submit=on_submit)
+
+
+__all__ = ["LoomApp", "build_loom_app", "FooterState", "Mode"]

--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -406,16 +406,20 @@ class LoomApp:
         if left:
             parts.append(("class:footer", f" {left} "))
 
-        # Token budget when >60%
+        # Context % — always visible. Originally hidden under 60% per
+        # doc/49 § C-plan, but the once-per-turn intro that used to
+        # carry it has been pared back to just ``Loom ▎``, so keeping
+        # context% visible in footer is the only place it lives now.
+        # Colour ladder unchanged: muted under 60%, ochre 60-80%,
+        # warning 80-95%, error >95%
         s = self.footer
-        if s.token_pct > 60:
-            token = (
-                "footer.budget.high" if s.token_pct > 95
-                else "footer.budget.warn" if s.token_pct > 80
-                else "footer.budget.ok"
-            )
-            parts.append(("class:footer", "  "))
-            parts.append((f"class:{token}", f"⚡ tok {s.token_pct:.0f}%"))
+        token = (
+            "footer.budget.high" if s.token_pct > 95
+            else "footer.budget.warn" if s.token_pct > 80
+            else "footer.budget.ok"
+        )
+        parts.append(("class:footer", "  "))
+        parts.append((f"class:{token}", f"context {s.token_pct:.1f}%"))
 
         # Last-turn stats — folded in from the old inline status_bar
         # so the post-turn metrics live in one place instead of

--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -397,11 +397,17 @@ class LoomApp:
             style="class:footer",
         )
 
-        # Separator above the bottom region — makes the visual
-        # boundary between scrollback and the persistent input/footer
-        # explicit. Filled with a horizontal rule character; styled
-        # in the muted-border palette
-        separator_window = Window(
+        # Separators above + below the input region — make the visual
+        # boundary between scrollback / input / footer explicit. Filled
+        # with a horizontal rule character; styled in the muted-border
+        # palette. Two separate Window instances so each can sit at its
+        # correct position in the HSplit
+        separator_top = Window(
+            char="─",
+            height=1,
+            style=f"fg:{PARCHMENT_BORDER}",
+        )
+        separator_bottom = Window(
             char="─",
             height=1,
             style=f"fg:{PARCHMENT_BORDER}",
@@ -423,11 +429,12 @@ class LoomApp:
         layout = Layout(
             HSplit([
                 thinking_window,
-                separator_window,
+                separator_top,
                 input_window,
                 confirm_window,
                 pause_window,
                 redirect_window,
+                separator_bottom,
                 footer_window,
             ]),
             focused_element=self._input_buffer,

--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -85,7 +85,17 @@ class FooterState:
 
     model: str = ""
     persona: str | None = None
+    # Context window utilisation — surfaces in footer when >60%
     token_pct: float = 0.0
+    # Last-turn stats. Kept out of scrollback (PR-A printed these
+    # inline as the "context X% | cache Y% | A in / B out | Cs | N
+    # tools" status_bar; that's noise the user doesn't need to keep
+    # scrolling past). All four cleared between turns
+    last_turn_cache_hit: float | None = None
+    last_turn_input_tokens: int | None = None
+    last_turn_output_tokens: int | None = None
+    last_turn_elapsed_s: float | None = None
+    last_turn_tool_count: int | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -116,16 +126,18 @@ class _PauseState:
 
 _APP_STYLE = Style.from_dict(
     {
-        # Input area
-        "input.prompt":          f"bold {PARCHMENT_ACCENT}",
+        # Input area — no prompt label; the buffer text is the input
         "input.text":            PARCHMENT_TEXT,
-        # Footer — minimal in D1; D4 expands
-        "footer":                f"bg:{PARCHMENT_SURFACE} {PARCHMENT_MUTED}",
-        "footer.brand":          f"bg:{PARCHMENT_SURFACE} {PARCHMENT_ACCENT}",
-        "footer.budget.ok":      f"bg:{PARCHMENT_SURFACE} {PARCHMENT_MUTED}",
-        "footer.budget.warn":    f"bg:{PARCHMENT_SURFACE} {PARCHMENT_WARNING}",
-        "footer.budget.high":    f"bg:{PARCHMENT_SURFACE} {PARCHMENT_ERROR}",
-        # Confirm / Pause widget
+        # Footer — transparent background (follows terminal). User
+        # feedback after PR-D1 first run: explicit bg felt obtrusive
+        # against varied terminal themes
+        "footer":                PARCHMENT_MUTED,
+        "footer.brand":          PARCHMENT_ACCENT,
+        "footer.budget.ok":      PARCHMENT_MUTED,
+        "footer.budget.warn":    PARCHMENT_WARNING,
+        "footer.budget.high":    PARCHMENT_ERROR,
+        "footer.stats":          PARCHMENT_MUTED,
+        # Confirm / Pause widget — also no bg, blend with terminal
         "widget.title":          PARCHMENT_TEXT,
         "widget.body":           PARCHMENT_MUTED,
         "widget.option":         PARCHMENT_TEXT,
@@ -134,7 +146,8 @@ _APP_STYLE = Style.from_dict(
         "widget.footer":         f"italic {PARCHMENT_MUTED}",
         # Auto-suggestion ghost text
         "auto-suggestion":       PARCHMENT_BORDER,
-        # Completion menu
+        # Completion menu — keep subtle bg; this is dropdown UI not
+        # ambient surface. Dropdowns benefit from contrast
         "completion-menu":                         f"bg:{PARCHMENT_SURFACE} {PARCHMENT_TEXT}",
         "completion-menu.completion":              f"bg:{PARCHMENT_SURFACE} {PARCHMENT_TEXT}",
         "completion-menu.completion.current":      f"bg:{PARCHMENT_ACCENT} {PARCHMENT_BG} bold",
@@ -301,24 +314,20 @@ class LoomApp:
         is_pause = Condition(lambda: self._mode[0] == "pause")
         is_redirect = Condition(lambda: self._mode[0] == "redirect")
 
-        # Input area — always height ≥ 1, expands as user types up to ~10
+        # Input area — single Window, no separate prompt label.
+        # Feedback after PR-D1 first run: the "you ›" label was visually
+        # noisy and a separate Window for it caused the bottom area to
+        # re-flow during streaming, sometimes attaching the label to
+        # the end of the agent's last sentence. Submitted text echoes
+        # to scrollback (see _on_submit in main.py) so the input area
+        # doesn't need its own label
         input_window = ConditionalContainer(
-            HSplit([
-                Window(
-                    content=FormattedTextControl(
-                        lambda: FormattedText([("class:input.prompt", "you › ")]),
-                        focusable=False,
-                    ),
-                    height=1,
-                    dont_extend_height=True,
-                ),
-                Window(
-                    content=BufferControl(buffer=self._input_buffer),
-                    wrap_lines=True,
-                    height=Dimension(min=1, max=10),
-                    style="class:input.text",
-                ),
-            ]),
+            Window(
+                content=BufferControl(buffer=self._input_buffer),
+                wrap_lines=True,
+                height=Dimension(min=1, max=10),
+                style="class:input.text",
+            ),
             filter=is_input,
         )
 
@@ -342,23 +351,13 @@ class LoomApp:
             filter=is_pause,
         )
 
-        # Redirect text input
+        # Redirect text input — same simplification: single Window
         redirect_window = ConditionalContainer(
-            HSplit([
-                Window(
-                    content=FormattedTextControl(
-                        lambda: FormattedText([("class:input.prompt", "redirect › ")]),
-                        focusable=False,
-                    ),
-                    height=1,
-                    dont_extend_height=True,
-                ),
-                Window(
-                    content=BufferControl(buffer=self._redirect_buffer),
-                    height=1,
-                    style="class:input.text",
-                ),
-            ]),
+            Window(
+                content=BufferControl(buffer=self._redirect_buffer),
+                height=1,
+                style="class:input.text",
+            ),
             filter=is_redirect,
         )
 
@@ -396,28 +395,44 @@ class LoomApp:
     def _render_footer(self) -> FormattedText:
         parts: list[tuple[str, str]] = []
 
-        # Left edge: model · persona
+        # Left: model · persona (identity reminder)
         left = self.footer.model
         if self.footer.persona:
             left = f"{self.footer.persona} · {left}"
         if left:
             parts.append(("class:footer", f" {left} "))
 
-        # Centre: token budget when >60%
-        pct = self.footer.token_pct
-        if pct > 60:
+        # Middle: turn stats (context %, cache %, in/out, elapsed,
+        # tool count). Folded in from PR-A's inline status_bar so the
+        # post-turn metrics live in one place instead of scrolling
+        # away. Hidden until at least one turn has completed
+        s = self.footer
+        stats: list[str] = []
+        if s.token_pct > 60:
             token = (
-                "footer.budget.high" if pct > 95
-                else "footer.budget.warn" if pct > 80
+                "footer.budget.high" if s.token_pct > 95
+                else "footer.budget.warn" if s.token_pct > 80
                 else "footer.budget.ok"
             )
             parts.append(("class:footer", "  "))
-            parts.append((f"class:{token}", f"⚡ tok {pct:.0f}%"))
+            parts.append((f"class:{token}", f"⚡ tok {s.token_pct:.0f}%"))
+        if s.last_turn_cache_hit is not None:
+            stats.append(f"cache {s.last_turn_cache_hit:.0f}%")
+        if (s.last_turn_input_tokens is not None
+                and s.last_turn_output_tokens is not None):
+            stats.append(
+                f"{s.last_turn_input_tokens}in / {s.last_turn_output_tokens}out"
+            )
+        if s.last_turn_elapsed_s is not None:
+            stats.append(f"{s.last_turn_elapsed_s:.1f}s")
+        if s.last_turn_tool_count is not None:
+            n = s.last_turn_tool_count
+            stats.append(f"{n} tool{'s' if n != 1 else ''}")
+        if stats:
+            parts.append(("class:footer", "  "))
+            parts.append(("class:footer.stats", " · ".join(stats)))
 
-        # Right edge: ▎ Loom brand mark — pad with spaces to push it
-        # right. We don't know terminal width here so rely on
-        # FormattedTextControl's natural alignment.
-        # (D4 will refine layout; D1 keeps it simple)
+        # Right: ▎ Loom brand mark
         parts.append(("class:footer", "  "))
         parts.append(("class:footer.brand", "▎ Loom "))
 
@@ -495,8 +510,19 @@ class LoomApp:
 
         @kb.add("escape", "enter",
                 filter=Condition(lambda: self._mode[0] == "input"))
+        @kb.add("c-j",
+                filter=Condition(lambda: self._mode[0] == "input"))
         def _input_newline(event):
-            """Alt+Enter (Esc,Enter on most terminals) → insert newline."""
+            """Insert newline.
+
+            Two bindings because terminals are inconsistent:
+              - ``Esc, Enter`` is the canonical prompt_toolkit form for
+                Alt+Enter, requires "Use Option as Meta" enabled in
+                Terminal.app / iTerm2 (off by default on macOS — the
+                first PR-D1 test caught this)
+              - ``Ctrl+J`` sends a literal newline byte across all
+                terminals, no profile setting required
+            """
             self._input_buffer.insert_text("\n")
 
         @kb.add("c-d",

--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -101,6 +101,10 @@ class FooterState:
     # else and shows ``⚡ 壓縮中…`` so the long pause doesn't look
     # like a hang
     compacting: bool = False
+    # Loom is thinking (LLM call dispatched, no stream output yet).
+    # Surfaces as a soft animated indicator in the footer so the user
+    # knows their input is being chewed on
+    thinking: bool = False
     # Last-turn stats. Kept out of scrollback (PR-A printed these
     # inline as the "context X% | cache Y% | A in / B out | Cs | N
     # tools" status_bar; that's noise the user doesn't need to keep
@@ -384,8 +388,19 @@ class LoomApp:
             style="class:footer",
         )
 
+        # Separator above the bottom region — makes the visual
+        # boundary between scrollback and the persistent input/footer
+        # explicit. Filled with a horizontal rule character; styled
+        # in the muted-border palette
+        separator_window = Window(
+            char="─",
+            height=1,
+            style=f"fg:{PARCHMENT_BORDER}",
+        )
+
         layout = Layout(
             HSplit([
+                separator_window,
                 input_window,
                 confirm_window,
                 pause_window,
@@ -453,6 +468,15 @@ class LoomApp:
             label += f"▸ {latest.name} · {elapsed:.1f}s"
             parts.append(("class:footer", "  "))
             parts.append(("class:footer.envelope", label))
+        elif s.thinking:
+            # Thinking indicator — animated dots driven by ticker
+            # invalidate. ``import time`` here so we can use
+            # monotonic() as the animation phase
+            import time as _t
+            phase = int(_t.monotonic() * 2) % 4
+            dots = "·" * phase + " " * (3 - phase)
+            parts.append(("class:footer", "  "))
+            parts.append(("class:footer.envelope", f"▸ Loom thinking{dots}"))
 
         # Last-turn stats — only show when no tool is currently in
         # flight (otherwise the active envelope already tells the

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -1286,27 +1286,50 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
     # Give the session a handle to cancel the spinner before confirm prompts.
     session._cancel_spinner_fn = _cancel_spinner
 
+    # PR-D2 attempt 3 at the CJK truncation bug. Hypothesis: chunks
+    # arriving from the LLM are split at arbitrary byte offsets — a
+    # Chinese line of 7 wide chars is roughly 14 cells / 21 bytes,
+    # arriving as 2-3 separate chunks. patch_stdout's StdoutProxy
+    # buffers + flushes asynchronously via run_in_terminal; if the
+    # bottom-area redraw fires *between* two chunks of the same line,
+    # the redraw repositions cursor to col 0 of the line, and the
+    # next chunk overwrites whatever was already there — eating the
+    # opening characters of that line.
+    #
+    # Fix: buffer streaming chunks line-by-line, flush on newline. A
+    # full line is written atomically, so the bottom-area redraw
+    # cycle can't interleave inside it
+    _stream_pending = ""
+
+    def _flush_streaming(force: bool = False) -> None:
+        """Drain the line buffer.
+
+        Lines (text up to and including a ``\n``) are written
+        atomically. With ``force=True`` (called at TurnDone) any
+        partial trailing text is also flushed.
+        """
+        nonlocal _stream_pending
+        import sys as _sys
+        if not _stream_pending:
+            return
+        if "\n" in _stream_pending:
+            idx = _stream_pending.rfind("\n")
+            done = _stream_pending[: idx + 1]
+            _stream_pending = _stream_pending[idx + 1:]
+            _sys.stdout.write(done)
+            _sys.stdout.flush()
+        if force and _stream_pending:
+            _sys.stdout.write(_stream_pending)
+            _sys.stdout.flush()
+            _stream_pending = ""
+
     try:
         async for event in session.stream_turn(user_input):
             if isinstance(event, TextChunk):
-                # PR-D2 attempt 2 at the CJK truncation bug. The
-                # earlier "drop the streaming cursor" attempt didn't
-                # fix it, so the root cause isn't the ``\r\033[K`` —
-                # it's most likely Rich's own wrap calculation on
-                # wide-char (CJK) content racing the persistent app's
-                # bottom-area redraw via patch_stdout.
-                #
-                # Bypass Rich for streaming text entirely: write the
-                # raw chunk to stdout. ``patch_stdout`` (active in
-                # ``_chat``) still intercepts and routes through
-                # ``run_in_terminal``, so the output lands cleanly
-                # above the bottom region — but without Rich's wrap /
-                # ANSI processing that was producing the truncation
-                import sys as _sys
-                _sys.stdout.write(event.text)
-                _sys.stdout.flush()
+                _stream_pending += event.text
                 text_buffer += event.text
-                at_line_start = event.text.endswith("\n")
+                _flush_streaming()
+                at_line_start = (not _stream_pending) and event.text.endswith("\n")
 
             elif isinstance(event, ThinkCollapsed):
                 # PR-D2: silent in CLI. Anthropic native thinking blocks
@@ -1320,6 +1343,8 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 pass
 
             elif isinstance(event, ToolBegin):
+                # Drain pending streamed text before the tool row
+                _flush_streaming(force=True)
                 # Cancel any running spinner
                 _cancel_spinner()
                 # Ensure tool rows start on a fresh line
@@ -1421,6 +1446,9 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                     session.resume()
 
             elif isinstance(event, TurnDone):
+                # Drain any unterminated trailing chunk before
+                # printing the post-turn UI
+                _flush_streaming(force=True)
                 # Cancel any running spinner and clear cursor
                 _cancel_spinner()
                 clear_line()
@@ -1459,6 +1487,7 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
         # PR-A2: turn was cancelled by user-initiated abort (Enter on
         # next message). Render a clean ABORTED marker and re-raise so
         # the caller's await sees the cancellation.
+        _flush_streaming(force=True)
         _cancel_spinner()
         clear_line()
         console.print()
@@ -1470,6 +1499,7 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
         )
         raise
     except Exception as exc:
+        _flush_streaming(force=True)
         _cancel_spinner()
         clear_line()
         console.print()
@@ -1478,6 +1508,7 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
         # Defensive: ensure the spinner task never outlives this turn,
         # even if neither except branch fired (clean exit) or if a path
         # added later forgets to cancel it.
+        _flush_streaming(force=True)
         _cancel_spinner()
 
 

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -268,6 +268,19 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
             app.application.exit()
             return
 
+        # Echo the submitted text to scrollback so the user can see
+        # what they sent. The persistent app's input buffer clears on
+        # submit (so the bottom area becomes ready for the next
+        # message), and without an explicit echo there'd be no record
+        # of what was typed.
+        echo_lines = stripped.splitlines() or [stripped]
+        first, *rest = echo_lines
+        console.print(
+            f"[loom.muted]you ›[/loom.muted] [loom.text]{first}[/loom.text]"
+        )
+        for line in rest:
+            console.print(f"[loom.muted]      [/loom.muted][loom.text]{line}[/loom.text]")
+
         # Abort-on-submit: if a turn is in flight, cancel and queue
         # the new message with the interrupt prefix.
         in_flight = current_turn_task is not None and not current_turn_task.done()
@@ -1424,16 +1437,31 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 cache_total = event.cache_read_input_tokens + event.cache_creation_input_tokens + event.input_tokens
                 cache_hit_pct = (event.cache_read_input_tokens / cache_total * 100) if cache_total > 0 else 0.0
                 elapsed = time.monotonic() - t0
-                console.print(
-                    status_bar(
-                        context_fraction=session.budget.usage_fraction,
-                        input_tokens=event.input_tokens,
-                        output_tokens=event.output_tokens,
-                        elapsed_ms=elapsed * 1000,
-                        tool_count=event.tool_count,
-                        cache_hit_pct=cache_hit_pct,
+                # PR-D1: route turn stats into the persistent footer
+                # instead of printing an inline status_bar that scrolls
+                # away after the next turn. When no LoomApp is wired
+                # (tests / scripts) fall back to the inline print so
+                # CLI ergonomics outside `loom chat` don't regress
+                loom_app = getattr(session, "_loom_app", None)
+                if loom_app is not None:
+                    s = loom_app.footer
+                    s.last_turn_cache_hit = cache_hit_pct
+                    s.last_turn_input_tokens = event.input_tokens
+                    s.last_turn_output_tokens = event.output_tokens
+                    s.last_turn_elapsed_s = elapsed
+                    s.last_turn_tool_count = event.tool_count
+                    loom_app.invalidate()
+                else:
+                    console.print(
+                        status_bar(
+                            context_fraction=session.budget.usage_fraction,
+                            input_tokens=event.input_tokens,
+                            output_tokens=event.output_tokens,
+                            elapsed_ms=elapsed * 1000,
+                            tool_count=event.tool_count,
+                            cache_hit_pct=cache_hit_pct,
+                        )
                     )
-                )
 
     except asyncio.CancelledError:
         # PR-A2: turn was cancelled by user-initiated abort (Enter on

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -69,7 +69,6 @@ from loom.platform.cli.ui import (
     TurnDropped,
     TurnPaused,
     clear_line,
-    render_cursor,
     render_header,
     status_bar,
     tool_begin_line,
@@ -1305,21 +1304,63 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
     # Give the session a handle to cancel the spinner before confirm prompts.
     session._cancel_spinner_fn = _cancel_spinner
 
+    # PR-D2: per-line agent guide.
+    # Each line of streaming agent text begins with "Loom ▎  " in muted
+    # parchment colour. Streaming chunks arrive in arbitrary
+    # boundaries, so we maintain ``at_line_start`` across calls and
+    # split chunks on ``\n`` to prefix each new line.
+    _AGENT_GUIDE = "[loom.muted]Loom ▎[/loom.muted]  "
+
+    def _print_agent_chunk(chunk: str, at_start: bool) -> bool:
+        """Print a streaming text chunk with per-line agent guide.
+
+        Returns the new ``at_line_start`` state — True iff the chunk
+        ended with a newline (next chunk should begin with a guide).
+        """
+        if not chunk:
+            return at_start
+
+        parts = chunk.split("\n")
+        # parts[0] continues the current line. If we're at line start
+        # and the part has content, prepend a guide.
+        if at_start and parts[0]:
+            console.print(Text.from_markup(_AGENT_GUIDE), end="", markup=True)
+            at_start = False
+        if parts[0]:
+            console.print(parts[0], end="", markup=False, highlight=False)
+
+        # Each subsequent part is preceded by a newline + a fresh guide
+        # (skip guide if the part is empty — rare, doubled newlines).
+        for part in parts[1:]:
+            console.print()  # newline
+            at_start = True
+            if part:
+                console.print(Text.from_markup(_AGENT_GUIDE), end="", markup=True)
+                at_start = False
+                console.print(part, end="", markup=False, highlight=False)
+
+        return at_start
+
     try:
         async for event in session.stream_turn(user_input):
             if isinstance(event, TextChunk):
-                # Clear cursor from previous position
-                clear_line()
-                # Print text chunk
-                console.print(event.text, end="", markup=False, highlight=False)
+                # PR-D2: drop the streaming cursor + clear_line. The
+                # persistent app's footer signals "active" via active-
+                # envelope tracking; the per-chunk ">" cursor was only
+                # useful as a visual liveness hint and its companion
+                # ``\r\033[K`` clear was the root cause of the CJK
+                # soft-wrap truncation old bug
+                at_line_start = _print_agent_chunk(event.text, at_line_start)
                 text_buffer += event.text
-                at_line_start = event.text.endswith("\n")
-                # Print streaming cursor at end
-                console.print(render_cursor(), end="")
 
             elif isinstance(event, ThinkCollapsed):
-                # Show condensed reasoning summary inline; use /think for full content.
-                clear_line()
+                # Show condensed reasoning summary inline; /think for
+                # full content. Note: for Anthropic native thinking
+                # blocks this fires *after* response text streamed (see
+                # session.py:1707), so the summary appears below the
+                # response. Reordering would require Anthropic stream-
+                # event-level integration — out of D2 scope, tracked
+                # in doc/49b
                 if not at_line_start:
                     console.print()
                 console.print(

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -353,6 +353,14 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
             app.footer.persona = session.current_personality
             app.invalidate()
 
+    async def footer_ticker() -> None:
+        """Tick the footer at 2 Hz so live fields (active envelope
+        elapsed, compaction spinner) progress visibly."""
+        while not shutdown.is_set():
+            if app.footer.active_envelopes or app.footer.compacting:
+                app.invalidate()
+            await asyncio.sleep(0.5)
+
     # patch_stdout makes console.print flow above the app's persistent
     # bottom region. raw=True passes escape sequences through so the
     # existing Rich rendering (panels, spinners) keeps working.
@@ -362,8 +370,9 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
         with patch_stdout(raw=True):
             app_task = asyncio.create_task(app.run())
             turn_task = asyncio.create_task(turn_loop())
+            ticker_task = asyncio.create_task(footer_ticker())
             done, pending = await asyncio.wait(
-                {app_task, turn_task},
+                {app_task, turn_task, ticker_task},
                 return_when=asyncio.FIRST_COMPLETED,
             )
             shutdown.set()
@@ -568,7 +577,18 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
     elif command == "/compact":
         pct = session.budget.usage_fraction * 100
         harness.inline(f"compacting context ({pct:.1f}% used)…", level="info")
-        await session._smart_compact()
+        # PR-D4: surface compaction in footer so the multi-second pause
+        # doesn't read as a hang
+        loom_app = getattr(session, "_loom_app", None)
+        if loom_app is not None:
+            loom_app.footer.compacting = True
+            loom_app.invalidate()
+        try:
+            await session._smart_compact()
+        finally:
+            if loom_app is not None:
+                loom_app.footer.compacting = False
+                loom_app.invalidate()
 
     elif command == "/stop":
         # In CLI the turn is a blocking await — the user can't type while it runs.
@@ -1363,6 +1383,15 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 console.print(tool_begin_line(event.name, event.args))
                 # Start spinner animation
                 spinner_task = asyncio.create_task(_spin_loop())
+                # PR-D4: track in footer for live ▸ <tool> · <elapsed>
+                loom_app = getattr(session, "_loom_app", None)
+                if loom_app is not None:
+                    from loom.platform.cli.app import _ActiveEnvelope
+                    import time as _t
+                    loom_app.footer.active_envelopes.append(
+                        _ActiveEnvelope(name=event.name, started_monotonic=_t.monotonic())
+                    )
+                    loom_app.invalidate()
 
             elif isinstance(event, ToolEnd):
                 # Cancel spinner and clear its line
@@ -1374,6 +1403,15 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 at_line_start = True
                 active_tool = None
                 console.print()
+                # PR-D4: drop matching envelope from footer
+                loom_app = getattr(session, "_loom_app", None)
+                if loom_app is not None:
+                    envs = loom_app.footer.active_envelopes
+                    for i in range(len(envs) - 1, -1, -1):
+                        if envs[i].name == event.name:
+                            envs.pop(i)
+                            break
+                    loom_app.invalidate()
 
             elif isinstance(event, TurnPaused):
                 # ── HITL pause (PR-A3: arrow-key widget) ──────────────────

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -210,11 +210,20 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
     session._on_sanitize_repaired = _on_sanitize       # type: ignore[attr-defined]
     session._on_governor_reject = _on_governor_reject  # type: ignore[attr-defined]
 
-    # PR-D4: 3-line mini signature replaces the old render_header Panel
-    # + MemoryIndex Panel splatter. The full MemoryIndex still feeds
-    # the LLM's system prompt unchanged — only the user-facing greeting
-    # is consolidated. Counts pulled from the index so the user gets a
-    # sense of session weight without paging through skill catalogs.
+    # PR-D4: clear the noisy startup output (resume log, MCP load,
+    # diagnostic block, …) before drawing the welcome signature so
+    # the user sees a clean ceremony instead of scrollback debris.
+    # The original log lines are still there before the clear and
+    # technically scrollable up if anyone really wants them; in
+    # practice the signature anchors the session start.
+    console.clear()
+
+    # 5-line ASCII signature replaces the old render_header Panel +
+    # MemoryIndex Panel splatter. The full MemoryIndex still feeds
+    # the LLM's system prompt unchanged — only the user-facing
+    # greeting is consolidated. Counts pulled from the index so the
+    # user gets a sense of session weight without paging through
+    # skill catalogs.
     from loom.platform.cli.ui import render_welcome_signature
     _idx = session._memory_index
     console.print(
@@ -336,6 +345,14 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
                 text = "[使用者打斷上一輪並接續]\n" + text
 
             console.print()
+            # PR-D4: thinking indicator. Set True the moment we
+            # dispatch the streaming turn; cleared inside
+            # _run_streaming_turn the first time anything visible
+            # happens (TextChunk / ToolBegin / TurnDone). If turn
+            # crashes / aborts before that, the finally below still
+            # clears it
+            app.footer.thinking = True
+            app.invalidate()
             current_turn_task = asyncio.create_task(
                 _run_streaming_turn(session, text)
             )
@@ -347,6 +364,7 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
                 harness.inline(f"turn error: {exc}", level="error")
             finally:
                 current_turn_task = None
+                app.footer.thinking = False
 
             # Update footer token budget after each turn boundary.
             app.footer.token_pct = session.budget.usage_fraction * 100
@@ -355,9 +373,12 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
 
     async def footer_ticker() -> None:
         """Tick the footer at 2 Hz so live fields (active envelope
-        elapsed, compaction spinner) progress visibly."""
+        elapsed, compaction spinner, thinking dots) progress
+        visibly."""
         while not shutdown.is_set():
-            if app.footer.active_envelopes or app.footer.compacting:
+            if (app.footer.active_envelopes
+                    or app.footer.compacting
+                    or app.footer.thinking):
                 app.invalidate()
             await asyncio.sleep(0.5)
 
@@ -576,18 +597,24 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
 
     elif command == "/compact":
         pct = session.budget.usage_fraction * 100
-        harness.inline(f"compacting context ({pct:.1f}% used)…", level="info")
-        # PR-D4: surface compaction in footer so the multi-second pause
-        # doesn't read as a hang
+        # PR-D4: surface compaction in footer BEFORE the inline message
+        # so the spinner is visible from the very first frame; clear
+        # immediately after _smart_compact returns so the footer
+        # snaps back to normal without waiting for the next ticker
         loom_app = getattr(session, "_loom_app", None)
         if loom_app is not None:
             loom_app.footer.compacting = True
             loom_app.invalidate()
+        harness.inline(f"compacting context ({pct:.1f}% used)…", level="info")
         try:
             await session._smart_compact()
         finally:
             if loom_app is not None:
                 loom_app.footer.compacting = False
+                loom_app.invalidate()
+                # Update token% from the just-finished compaction so
+                # the user sees the new context% immediately
+                loom_app.footer.token_pct = session.budget.usage_fraction * 100
                 loom_app.invalidate()
 
     elif command == "/stop":
@@ -1350,8 +1377,24 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
             _sys.stdout.flush()
             _stream_pending = ""
 
+    # PR-D4: clear the "thinking" footer indicator on the first
+    # observable event of the turn. After that, the active envelope
+    # / streaming output / turn stats take over the footer's middle.
+    _thinking_cleared = False
+
+    def _clear_thinking() -> None:
+        nonlocal _thinking_cleared
+        if _thinking_cleared:
+            return
+        _thinking_cleared = True
+        loom_app = getattr(session, "_loom_app", None)
+        if loom_app is not None:
+            loom_app.footer.thinking = False
+            loom_app.invalidate()
+
     try:
         async for event in session.stream_turn(user_input):
+            _clear_thinking()
             if isinstance(event, TextChunk):
                 _stream_pending += event.text
                 text_buffer += event.text

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -1289,14 +1289,22 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
     try:
         async for event in session.stream_turn(user_input):
             if isinstance(event, TextChunk):
-                # PR-D2: plain stream into scrollback — no per-chunk
-                # cursor (was the source of the CJK soft-wrap clear
-                # bug, dropped earlier in D2) and no per-line agent
-                # guide (the once-per-turn ``Loom ▎  context X%``
-                # header is enough identity; per-line markers read as
-                # quote-block clutter, especially across paragraph
-                # breaks)
-                console.print(event.text, end="", markup=False, highlight=False)
+                # PR-D2 attempt 2 at the CJK truncation bug. The
+                # earlier "drop the streaming cursor" attempt didn't
+                # fix it, so the root cause isn't the ``\r\033[K`` —
+                # it's most likely Rich's own wrap calculation on
+                # wide-char (CJK) content racing the persistent app's
+                # bottom-area redraw via patch_stdout.
+                #
+                # Bypass Rich for streaming text entirely: write the
+                # raw chunk to stdout. ``patch_stdout`` (active in
+                # ``_chat``) still intercepts and routes through
+                # ``run_in_terminal``, so the output lands cleanly
+                # above the bottom region — but without Rich's wrap /
+                # ANSI processing that was producing the truncation
+                import sys as _sys
+                _sys.stdout.write(event.text)
+                _sys.stdout.flush()
                 text_buffer += event.text
                 at_line_start = event.text.endswith("\n")
 

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -1304,69 +1304,30 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
     # Give the session a handle to cancel the spinner before confirm prompts.
     session._cancel_spinner_fn = _cancel_spinner
 
-    # PR-D2: per-line agent guide.
-    # Each line of streaming agent text begins with "Loom ▎  " in muted
-    # parchment colour. Streaming chunks arrive in arbitrary
-    # boundaries, so we maintain ``at_line_start`` across calls and
-    # split chunks on ``\n`` to prefix each new line.
-    _AGENT_GUIDE = "[loom.muted]Loom ▎[/loom.muted]  "
-
-    def _print_agent_chunk(chunk: str, at_start: bool) -> bool:
-        """Print a streaming text chunk with per-line agent guide.
-
-        Returns the new ``at_line_start`` state — True iff the chunk
-        ended with a newline (next chunk should begin with a guide).
-        """
-        if not chunk:
-            return at_start
-
-        parts = chunk.split("\n")
-        # parts[0] continues the current line. If we're at line start
-        # and the part has content, prepend a guide.
-        if at_start and parts[0]:
-            console.print(Text.from_markup(_AGENT_GUIDE), end="", markup=True)
-            at_start = False
-        if parts[0]:
-            console.print(parts[0], end="", markup=False, highlight=False)
-
-        # Each subsequent part is preceded by a newline + a fresh guide
-        # (skip guide if the part is empty — rare, doubled newlines).
-        for part in parts[1:]:
-            console.print()  # newline
-            at_start = True
-            if part:
-                console.print(Text.from_markup(_AGENT_GUIDE), end="", markup=True)
-                at_start = False
-                console.print(part, end="", markup=False, highlight=False)
-
-        return at_start
-
     try:
         async for event in session.stream_turn(user_input):
             if isinstance(event, TextChunk):
-                # PR-D2: drop the streaming cursor + clear_line. The
-                # persistent app's footer signals "active" via active-
-                # envelope tracking; the per-chunk ">" cursor was only
-                # useful as a visual liveness hint and its companion
-                # ``\r\033[K`` clear was the root cause of the CJK
-                # soft-wrap truncation old bug
-                at_line_start = _print_agent_chunk(event.text, at_line_start)
+                # PR-D2: plain stream into scrollback — no per-chunk
+                # cursor (was the source of the CJK soft-wrap clear
+                # bug, dropped earlier in D2) and no per-line agent
+                # guide (the once-per-turn ``Loom ▎  context X%``
+                # header is enough identity; per-line markers read as
+                # quote-block clutter, especially across paragraph
+                # breaks)
+                console.print(event.text, end="", markup=False, highlight=False)
                 text_buffer += event.text
+                at_line_start = event.text.endswith("\n")
 
             elif isinstance(event, ThinkCollapsed):
-                # Show condensed reasoning summary inline; /think for
-                # full content. Note: for Anthropic native thinking
-                # blocks this fires *after* response text streamed (see
-                # session.py:1707), so the summary appears below the
-                # response. Reordering would require Anthropic stream-
-                # event-level integration — out of D2 scope, tracked
-                # in doc/49b
-                if not at_line_start:
-                    console.print()
-                console.print(
-                    Text.from_markup(f"[loom.muted]💭 {event.summary}[/loom.muted]")
-                )
-                at_line_start = True
+                # PR-D2: silent in CLI. Anthropic native thinking blocks
+                # only become readable after ``stream.text_stream``
+                # completes (session.py:1707), so the inline summary
+                # always landed *below* the response — visually out of
+                # order and crowding the input area. The full chain is
+                # still stored on ``session._last_think`` and accessible
+                # via ``/think``. Other platforms (Discord, TUI) render
+                # ThinkCollapsed in their own way and aren't affected
+                pass
 
             elif isinstance(event, ToolBegin):
                 # Cancel any running spinner

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -378,9 +378,18 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
                 current_turn_task = None
                 app.footer.thinking = False
 
-            # Update footer token budget after each turn boundary.
+            # Update footer token budget + grants at each turn boundary
+            # (per doc/49 decision: TTL refresh on turn edge, not per-
+            # second tick — keeps the footer visually stable while the
+            # user is reading).
             app.footer.token_pct = session.budget.usage_fraction * 100
             app.footer.persona = session.current_personality
+            try:
+                snapshot = session._build_grants_snapshot()
+                app.footer.grants_active = snapshot.active_count
+                app.footer.grants_next_expiry_secs = snapshot.next_expiry_secs
+            except Exception:
+                pass
             app.invalidate()
 
     async def footer_ticker() -> None:

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -1252,31 +1252,13 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
     frame_index = 0
 
     # ── Loom Agent turn intro ─────────────────────────────────────────────
-    # PR-C: replace the bold-green "loom" Rule with a Loom Agent-themed
-    # marker. Per-line "Loom ▎" left-edge guide on streaming text is
-    # deferred to PR-D's renderer rewrite — would need newline-detection
-    # in the streaming loop, which is the same path PR-D rebuilds anyway.
-    pct = session.budget.usage_fraction * 100
-    ctx_token = (
-        "loom.success" if pct < 60
-        else "loom.warning" if pct < 85
-        else "loom.error"
-    )
-    persona_tag = (
-        f"  [loom.muted]·  persona: {session.current_personality}[/loom.muted]"
-        if session.current_personality
-        else ""
-    )
-    # Plain Text instead of Rule — Rule always extends a horizontal line
-    # after the title, which crowds the marker. The Loom Agent intro is
-    # meant to read as a quiet signature, not a banner.
+    # Loom Agent turn intro — minimal marker, no metadata.
+    # The footer already shows persona · model · context% · stats, so
+    # repeating any of that here just adds visual debt. Keep this to
+    # a single ``Loom ▎`` so the turn boundary is legible without
+    # duplicating footer info.
     console.print(
-        Text.from_markup(
-            f"[loom.agent.guide]Loom ▎[/loom.agent.guide]"
-            f"[loom.muted]  context [/loom.muted]"
-            f"[{ctx_token}]{pct:.1f}%[/{ctx_token}]"
-            f"{persona_tag}"
-        )
+        Text.from_markup("[loom.agent.guide]Loom ▎[/loom.agent.guide]")
     )
 
     def _cancel_spinner() -> None:

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -245,8 +245,10 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
     import sys as _sys
     _term_h = _shutil.get_terminal_size(fallback=(80, 24)).lines
     # Welcome sig footprint ~ 6 lines (5 visible + leading newline);
-    # bottom area ~ 4 lines (thinking + separator + input + footer)
-    _pad = max(0, _term_h - 6 - 4)
+    # bottom area ~ 5 lines (thinking + sep_top + input + sep_bottom +
+    # footer). Conditional/thinking only shows during agent calls so a
+    # frame more is fine.
+    _pad = max(0, _term_h - 6 - 5)
     _sys.stdout.write("\n" * _pad)
     _sys.stdout.flush()
 

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -213,17 +213,11 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
     # PR-D4: clear the noisy startup output (resume log, MCP load,
     # diagnostic block, …) before drawing the welcome signature so
     # the user sees a clean ceremony instead of scrollback debris.
-    # The original log lines are still there before the clear and
-    # technically scrollable up if anyone really wants them; in
-    # practice the signature anchors the session start.
     console.clear()
 
     # 5-line ASCII signature replaces the old render_header Panel +
     # MemoryIndex Panel splatter. The full MemoryIndex still feeds
-    # the LLM's system prompt unchanged — only the user-facing
-    # greeting is consolidated. Counts pulled from the index so the
-    # user gets a sense of session weight without paging through
-    # skill catalogs.
+    # the LLM's system prompt unchanged.
     from loom.platform.cli.ui import render_welcome_signature
     _idx = session._memory_index
     console.print(
@@ -237,6 +231,24 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
             relation_count=getattr(_idx, "relational_count", 0),
         )
     )
+
+    # PR-D4: anchor the persistent app's bottom region to the actual
+    # bottom of the terminal. ``full_screen=False`` mode draws the
+    # bottom area at whatever row the cursor was on when run() was
+    # called — without padding, that's just below the welcome sig
+    # near the top of the terminal, leaving a sea of empty rows
+    # underneath. Pad with blank lines so the cursor sits near the
+    # terminal's last row before the app starts. As streaming output
+    # arrives via patch_stdout, those padding rows scroll up and out
+    # naturally
+    import shutil as _shutil
+    import sys as _sys
+    _term_h = _shutil.get_terminal_size(fallback=(80, 24)).lines
+    # Welcome sig footprint ~ 6 lines (5 visible + leading newline);
+    # bottom area ~ 4 lines (thinking + separator + input + footer)
+    _pad = max(0, _term_h - 6 - 4)
+    _sys.stdout.write("\n" * _pad)
+    _sys.stdout.flush()
 
     # ── PR-D1: persistent prompt_toolkit Application ──────────────────────
     #

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -69,7 +69,6 @@ from loom.platform.cli.ui import (
     TurnDropped,
     TurnPaused,
     clear_line,
-    make_prompt_session,
     render_cursor,
     render_header,
     status_bar,
@@ -224,141 +223,77 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
             )
         )
 
-    prompt_session = make_prompt_session()
-
-    # ── PR-A2: producer/consumer for abort-on-submit ──────────────────────
+    # ── PR-D1: persistent prompt_toolkit Application ──────────────────────
     #
-    # Two concurrent tasks share the terminal via prompt_toolkit's
-    # ``patch_stdout`` so the prompt stays anchored at the bottom while
-    # streaming output renders above it:
+    # Replaces PR-A's per-iteration ``prompt_async`` + three-event stdin
+    # coordinator. The LoomApp owns the bottom region of the terminal
+    # (input area + footer + transient confirm/pause overlays) for the
+    # entire chat session. Streaming output flows into the natural
+    # scrollback above it via ``patch_stdout``, which is still needed
+    # to keep ``console.print`` calls cooperating with the persistent
+    # bottom rendering.
     #
-    #   input_loop  — reads user lines, queues them. If a turn is in
-    #                 flight, calls session.cancel() first and prefixes
-    #                 the new message with an interruption marker.
+    # Producer/consumer architecture:
+    #   - LoomApp.on_submit  — fires when user presses Enter in INPUT
+    #                          mode; pushes the text into input_queue.
+    #                          If a turn is in flight, cancel + queue
+    #                          with an interrupt prefix.
+    #   - turn_loop          — drains the queue and runs streaming
+    #                          turns via _run_streaming_turn.
     #
-    #   turn_loop   — drains the queue: slash commands run inline (no
-    #                 turn cancel), regular text spawns a streaming
-    #                 turn task that input_loop can cancel.
-    #
-    # Race notes:
-    # - current_turn_task is read+cancelled from input_loop and assigned
-    #   from turn_loop. Single-threaded asyncio gives us atomic ref
-    #   reads; cancelling an already-done task is a no-op.
-    # - wait_for(..., timeout=3.0) on cancel ensures we don't block the
-    #   user forever if a turn refuses to unwind.
+    # Confirm / HITL pause / HITL redirect — all routed through the
+    # app's mode-flag mechanism (LoomApp.request_confirm / request_pause
+    # / request_redirect_text). No nested Applications; the widgets
+    # render inside the same app's layout, so the "Application is not
+    # running" race that PR-A worked around with three-event coordination
+    # simply cannot occur.
     _INTERRUPT_PREFIX = "\x00LOOM_INTERRUPT\x00"
     input_queue: asyncio.Queue[str] = asyncio.Queue()
     current_turn_task: asyncio.Task | None = None
     shutdown = asyncio.Event()
 
-    # ── PR-A3: confirm-prompt stdin coordination ──────────────────────────
-    #
-    # Interactive widgets (select_prompt in ui.py — used by tool confirm
-    # and HITL pause) need exclusive stdin while running. The challenge:
-    # input_loop's PromptSession runs its own prompt_toolkit Application
-    # that owns stdin's vt100 input handler. If we start a second
-    # Application before the first has fully detached its input, the new
-    # one races with stale key callbacks and crashes ("Application is
-    # not running").
-    #
-    # Coordination protocol:
-    #   - input_released  — set when input_loop is NOT inside prompt_async.
-    #                       Cleared on entry, set on exit (via finally).
-    #   - confirm_active  — set while a widget owns stdin.
-    #   - confirm_done    — set after the widget releases.
-    #
-    # _run_interactive: signals confirm_active, asks the live input
-    # Application to exit, waits for input_loop to actually return from
-    # prompt_async (input_released), then starts the widget. This
-    # guarantees stdin is fully detached before the new Application
-    # tries to attach.
-    confirm_active = asyncio.Event()
-    confirm_done = asyncio.Event()
-    confirm_done.set()
-    input_released = asyncio.Event()
-    input_released.set()  # input_loop hasn't entered prompt_async yet
+    # Build the persistent app first so we can register its callbacks
+    # before kicking off the run loop. ``app`` is captured by the
+    # on_submit closure below.
+    from loom.platform.cli.app import build_loom_app
 
-    async def _run_interactive(coro_factory) -> Any:
-        from prompt_toolkit.application.current import get_app_or_none
+    async def _on_submit(text: str) -> None:
+        nonlocal current_turn_task
+        stripped = text.strip()
+        if not stripped:
+            return
 
-        confirm_active.set()
-        confirm_done.clear()
+        if stripped.lower() in {"exit", "quit", "q"}:
+            shutdown.set()
+            app.application.exit()
+            return
 
-        live_app = get_app_or_none()
-        if live_app is not None and getattr(live_app, "is_running", False):
+        # Abort-on-submit: if a turn is in flight, cancel and queue
+        # the new message with the interrupt prefix.
+        in_flight = current_turn_task is not None and not current_turn_task.done()
+        if in_flight:
+            session.cancel()
+            harness.inline("⏸ 上一輪已中斷，接收新訊息…", level="info")
             try:
-                live_app.exit(result=None)
+                await asyncio.wait_for(current_turn_task, timeout=3.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                pass
             except Exception:
                 pass
+            await input_queue.put(_INTERRUPT_PREFIX + stripped)
+        else:
+            await input_queue.put(stripped)
 
-        # Wait for input_loop to fully unwind out of prompt_async — its
-        # finally block sets input_released. Cap the wait at 1s so a
-        # misbehaving prompt_toolkit detach can't deadlock the user.
-        try:
-            await asyncio.wait_for(input_released.wait(), timeout=1.0)
-        except asyncio.TimeoutError:
-            pass
+    app = build_loom_app(on_submit=_on_submit)
+    app.footer.model = model
+    app.footer.persona = session.current_personality
 
-        try:
-            return await coro_factory()
-        finally:
-            confirm_active.clear()
-            confirm_done.set()
-
-    session._run_interactive = _run_interactive  # type: ignore[attr-defined]
-
-    async def input_loop() -> None:
-        nonlocal current_turn_task
-        while not shutdown.is_set():
-            # If a confirm widget owns stdin, sit out until it's done.
-            if confirm_active.is_set():
-                await confirm_done.wait()
-                continue
-
-            input_released.clear()
-            try:
-                try:
-                    user_input = await prompt_session.prompt_async(
-                        [("class:prompt", "\nyou › ")],
-                    )
-                except (EOFError, KeyboardInterrupt):
-                    shutdown.set()
-                    return
-                except asyncio.CancelledError:
-                    return
-            finally:
-                input_released.set()
-
-            # _run_interactive forces our prompt_async to exit with result=None.
-            # In that case loop back so the confirm_active gate above engages.
-            if user_input is None:
-                continue
-
-            text = user_input.strip()
-            if not text:
-                continue
-
-            if text.lower() in {"exit", "quit", "q"}:
-                shutdown.set()
-                return
-
-            # If a turn is in flight, abort it and mark the new message
-            # so turn_loop can prepend an interruption note for the LLM.
-            in_flight = current_turn_task is not None and not current_turn_task.done()
-            if in_flight:
-                session.cancel()
-                harness.inline("⏸ 上一輪已中斷，接收新訊息…", level="info")
-                try:
-                    await asyncio.wait_for(current_turn_task, timeout=3.0)
-                except (asyncio.TimeoutError, asyncio.CancelledError):
-                    pass
-                except Exception:
-                    # Turn task may have raised; that's fine — we just
-                    # want it finished before queueing the next message.
-                    pass
-                await input_queue.put(_INTERRUPT_PREFIX + text)
-            else:
-                await input_queue.put(text)
+    # Wire confirm + pause routing into the session so _confirm_tool_cli
+    # and the HITL pause path can render through the app's mode flag
+    # instead of spinning their own short-lived Applications. Sessions
+    # used outside `loom chat` (tests, scripts) still fall back to
+    # select_prompt as before.
+    session._loom_app = app  # type: ignore[attr-defined]
 
     async def turn_loop() -> None:
         nonlocal current_turn_task
@@ -376,11 +311,9 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
                     harness.inline(f"slash command error: {exc}", level="error")
                 continue
 
-            # Detect interruption marker injected by input_loop.
+            # Detect interruption marker injected by _on_submit.
             if text.startswith(_INTERRUPT_PREFIX):
                 text = text[len(_INTERRUPT_PREFIX):]
-                # Lightweight cue for the LLM that the prior turn was
-                # cut short by the user — keeps cognition coherent.
                 text = "[使用者打斷上一輪並接續]\n" + text
 
             console.print()
@@ -396,20 +329,25 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
             finally:
                 current_turn_task = None
 
-    # patch_stdout(raw=True) keeps the prompt anchored while Rich's ANSI
-    # output streams above. raw=True passes escape sequences through so
-    # cursor manipulation (spinner, clear_line) still works.
+            # Update footer token budget after each turn boundary.
+            app.footer.token_pct = session.budget.usage_fraction * 100
+            app.footer.persona = session.current_personality
+            app.invalidate()
+
+    # patch_stdout makes console.print flow above the app's persistent
+    # bottom region. raw=True passes escape sequences through so the
+    # existing Rich rendering (panels, spinners) keeps working.
     from prompt_toolkit.patch_stdout import patch_stdout
 
     try:
         with patch_stdout(raw=True):
+            app_task = asyncio.create_task(app.run())
+            turn_task = asyncio.create_task(turn_loop())
             done, pending = await asyncio.wait(
-                {
-                    asyncio.create_task(input_loop()),
-                    asyncio.create_task(turn_loop()),
-                },
+                {app_task, turn_task},
                 return_when=asyncio.FIRST_COMPLETED,
             )
+            shutdown.set()
             for task in pending:
                 task.cancel()
             for task in pending:
@@ -1414,46 +1352,60 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                     )
                 )
 
-                from loom.platform.cli.ui import SelectOption, select_prompt
-
                 _PAUSE_RESUME = "resume"
                 _PAUSE_CANCEL = "cancel"
                 _PAUSE_REDIRECT = "redirect"
 
-                async def _pause_pick():
-                    return await select_prompt(
-                        title="絲已暫停，下一步？",
+                # PR-D1: route through LoomApp's mode-flag widgets so the
+                # pause + redirect overlays render inside the layout
+                # (用過即焚, no scrollback residue) rather than spinning
+                # nested Applications.
+                loom_app = getattr(session, "_loom_app", None)
+                if loom_app is not None:
+                    choice = await loom_app.request_pause(
+                        title="Loom 已暫停，下一步？",
                         options=[
-                            SelectOption(label="繼續執行剩下的工具",
-                                         value=_PAUSE_RESUME, shortcut="r"),
-                            SelectOption(label="導向新指令並繼續",
-                                         value=_PAUSE_REDIRECT, shortcut="m"),
-                            SelectOption(label="取消這個 turn",
-                                         value=_PAUSE_CANCEL, shortcut="c"),
+                            ("繼續執行剩下的工具", _PAUSE_RESUME,   "r"),
+                            ("導向新指令並繼續",   _PAUSE_REDIRECT, "m"),
+                            ("取消這個 turn",     _PAUSE_CANCEL,   "c"),
                         ],
                         default_index=0,
                         cancel_value=_PAUSE_CANCEL,
                     )
-
-                runner = getattr(session, "_run_interactive", None)
-                choice = await (runner(_pause_pick) if runner else _pause_pick())
+                else:
+                    # Fallback for tests / scripts without a running app.
+                    from loom.platform.cli.ui import SelectOption, select_prompt
+                    async def _pause_pick():
+                        return await select_prompt(
+                            title="Loom 已暫停，下一步？",
+                            options=[
+                                SelectOption(label="繼續執行剩下的工具", value=_PAUSE_RESUME,   shortcut="r"),
+                                SelectOption(label="導向新指令並繼續",   value=_PAUSE_REDIRECT, shortcut="m"),
+                                SelectOption(label="取消這個 turn",     value=_PAUSE_CANCEL,   shortcut="c"),
+                            ],
+                            default_index=0,
+                            cancel_value=_PAUSE_CANCEL,
+                        )
+                    runner = getattr(session, "_run_interactive", None)
+                    choice = await (runner(_pause_pick) if runner else _pause_pick())
 
                 if choice == _PAUSE_CANCEL:
                     session.cancel()
                 elif choice == _PAUSE_REDIRECT:
-                    # Sub-prompt for the redirect text. Routed through the
-                    # same _run_interactive so input_loop stays paused.
-                    async def _ask_redirect():
+                    if loom_app is not None:
+                        raw = await loom_app.request_redirect_text()
+                    else:
                         from prompt_toolkit import PromptSession as _PS
-                        ps = _PS()
-                        try:
-                            return await ps.prompt_async(
-                                [("class:prompt", "redirect › ")],
-                            )
-                        except (EOFError, KeyboardInterrupt):
-                            return ""
-
-                    raw = await (runner(_ask_redirect) if runner else _ask_redirect())
+                        async def _ask_redirect():
+                            ps = _PS()
+                            try:
+                                return await ps.prompt_async(
+                                    [("class:prompt", "redirect › ")],
+                                )
+                            except (EOFError, KeyboardInterrupt):
+                                return ""
+                        runner = getattr(session, "_run_interactive", None)
+                        raw = await (runner(_ask_redirect) if runner else _ask_redirect())
                     raw = (raw or "").strip()
                     if raw:
                         session.resume_with(raw)

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -69,7 +69,6 @@ from loom.platform.cli.ui import (
     TurnDropped,
     TurnPaused,
     clear_line,
-    render_header,
     status_bar,
     tool_begin_line,
     tool_end_line,
@@ -211,16 +210,24 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
     session._on_sanitize_repaired = _on_sanitize       # type: ignore[attr-defined]
     session._on_governor_reject = _on_governor_reject  # type: ignore[attr-defined]
 
-    console.print(render_header(model, db))
-
-    if not session._memory_index.is_empty:
-        console.print(
-            Panel(
-                session._memory_index.render(),
-                title="[loom.accent]Memory[/loom.accent]",
-                border_style="dim",
-            )
+    # PR-D4: 3-line mini signature replaces the old render_header Panel
+    # + MemoryIndex Panel splatter. The full MemoryIndex still feeds
+    # the LLM's system prompt unchanged — only the user-facing greeting
+    # is consolidated. Counts pulled from the index so the user gets a
+    # sense of session weight without paging through skill catalogs.
+    from loom.platform.cli.ui import render_welcome_signature
+    _idx = session._memory_index
+    console.print(
+        render_welcome_signature(
+            model=model,
+            persona=session.current_personality,
+            skill_count=getattr(_idx, "skill_count", 0),
+            fact_count=getattr(_idx, "semantic_count", 0),
+            mcp_count=len(session._mcp_clients),
+            episode_count=getattr(_idx, "episode_sessions", 0),
+            relation_count=getattr(_idx, "relational_count", 0),
         )
+    )
 
     # ── PR-D1: persistent prompt_toolkit Application ──────────────────────
     #

--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -410,7 +410,12 @@ async def select_prompt(
 
 
 def render_header(model: str, db: str) -> Panel:
-    """Top-of-session banner."""
+    """Top-of-session banner — legacy 2-line greeting.
+
+    PR-D4 introduced :func:`render_welcome_signature` which consolidates
+    this header + the MemoryIndex Panel into a 3-line mini signature.
+    Kept for tests / non-CLI callers that still construct it.
+    """
     return Panel(
         Text.from_markup(
             f"[bold loom.accent]Loom[/bold loom.accent]  [loom.muted]v0.3.0[/loom.muted]\n"
@@ -419,6 +424,67 @@ def render_header(model: str, db: str) -> Panel:
             f"/personality <name>  |  /compact  |  /help[/loom.muted]"
         ),
         border_style="cyan",
+    )
+
+
+def render_welcome_signature(
+    *,
+    model: str,
+    persona: str | None,
+    skill_count: int = 0,
+    fact_count: int = 0,
+    mcp_count: int = 0,
+    episode_count: int = 0,
+    relation_count: int = 0,
+) -> Text:
+    """3-line mini signature for ``loom chat`` startup.
+
+    Replaces the previous render_header Panel + MemoryIndex Panel
+    splatter with a single compact identity marker. The full
+    MemoryIndex still feeds the LLM's system prompt — this only
+    changes what the user sees on startup.
+
+    Format::
+
+             ╱ Loom v0.3.x
+        ───── 12 skills · 14k facts · 3 mcp · 47 episodes
+             ╲ minimax-m2.7 · persona: tarot
+
+    Stats fields with zero counts are silently skipped — short
+    sessions don't carry ``· 0 episodes`` clutter.
+    """
+    from loom import __version__
+
+    def _abbrev(n: int) -> str:
+        # Strip trailing zero before suffix: 14000 → "14k" not "14.0k"
+        if n >= 1_000_000:
+            return f"{n / 1_000_000:.1f}".rstrip("0").rstrip(".") + "m"
+        if n >= 1_000:
+            return f"{n / 1_000:.1f}".rstrip("0").rstrip(".") + "k"
+        return str(n)
+
+    stats: list[str] = []
+    if skill_count:
+        stats.append(f"{_abbrev(skill_count)} skills")
+    if fact_count:
+        stats.append(f"{_abbrev(fact_count)} facts")
+    if mcp_count:
+        stats.append(f"{mcp_count} mcp")
+    if episode_count:
+        stats.append(f"{_abbrev(episode_count)} episodes")
+    if relation_count:
+        stats.append(f"{_abbrev(relation_count)} relations")
+    stats_line = " · ".join(stats) if stats else "fresh session"
+
+    persona_tag = f"  ·  persona: {persona}" if persona else ""
+
+    return Text.from_markup(
+        f"\n"
+        f"[loom.muted]      ╱[/loom.muted]  [loom.accent]Loom[/loom.accent] "
+        f"[loom.muted]v{__version__}[/loom.muted]\n"
+        f"[loom.muted] ─────  {stats_line}[/loom.muted]\n"
+        f"[loom.muted]      ╲[/loom.muted]  [loom.text]{model}[/loom.text]"
+        f"[loom.muted]{persona_tag}[/loom.muted]\n"
     )
 
 

--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -437,21 +437,25 @@ def render_welcome_signature(
     episode_count: int = 0,
     relation_count: int = 0,
 ) -> Text:
-    """3-line mini signature for ``loom chat`` startup.
+    """ASCII signature + stats block for ``loom chat`` startup.
 
     Replaces the previous render_header Panel + MemoryIndex Panel
-    splatter with a single compact identity marker. The full
-    MemoryIndex still feeds the LLM's system prompt — this only
-    changes what the user sees on startup.
+    splatter with a compact branded greeting. The full MemoryIndex
+    still feeds the LLM's system prompt — this only changes what
+    the user sees on startup.
 
     Format::
 
-             ╱ Loom v0.3.x
-        ───── 12 skills · 14k facts · 3 mcp · 47 episodes
-             ╲ minimax-m2.7 · persona: tarot
+           ╱╲╱╲╱╲╱╲╱
+          ╱  Loom  ╲       v0.3.x
+           ╲╱╲╱╲╱╲╱
+        ─────  12 skills · 14k facts · 3 mcp · 47 episodes
+              ╲    minimax-m2.7  ·  persona: tarot
 
-    Stats fields with zero counts are silently skipped — short
-    sessions don't carry ``· 0 episodes`` clutter.
+    The triple top row is a loose nod to the warp/weft weave that
+    gives the project its name; deliberately understated so it
+    doesn't dominate the terminal. Stats fields with zero counts
+    are silently skipped.
     """
     from loom import __version__
 
@@ -478,12 +482,15 @@ def render_welcome_signature(
 
     persona_tag = f"  ·  persona: {persona}" if persona else ""
 
+    # Five-line signature: woven mark on top, stats + identity below
     return Text.from_markup(
-        f"\n"
-        f"[loom.muted]      ╱[/loom.muted]  [loom.accent]Loom[/loom.accent] "
-        f"[loom.muted]v{__version__}[/loom.muted]\n"
+        "\n"
+        "[loom.muted]    ╱╲╱╲╱╲╱╲╱[/loom.muted]\n"
+        "[loom.muted]   ╱  [/loom.muted][loom.accent]Loom[/loom.accent]"
+        f"[loom.muted]  ╲     v{__version__}[/loom.muted]\n"
+        "[loom.muted]    ╲╱╲╱╲╱╲╱[/loom.muted]\n"
         f"[loom.muted] ─────  {stats_line}[/loom.muted]\n"
-        f"[loom.muted]      ╲[/loom.muted]  [loom.text]{model}[/loom.text]"
+        f"[loom.muted]      ╲   [/loom.muted][loom.text]{model}[/loom.text]"
         f"[loom.muted]{persona_tag}[/loom.muted]\n"
     )
 


### PR DESCRIPTION
Fourth slice of #236 CLI Refresh — the architectural pivot from per-iteration ``prompt_async`` + three-event stdin coordinator to a single long-running prompt_toolkit Application that owns the bottom region of the terminal. 15 commits across 4 logical phases (D1 → D4) plus iterative live-test polish.

## Design context

`doc/49b-PR-D-實作草稿.md` is the implementation draft (added in this PR's first commit). §18 has the visual mockups the user signed off on; §19 maps the original scope against what landed, what's deferred to follow-up, and what's dropped.

## What this PR ships

### D1 · Persistent Application (commit a260cd6 + polish 6d3b6a1, c8fbde8)

- New `loom/platform/cli/app.py` — `LoomApp` class with one persistent `Application(full_screen=False)` that hosts an input area, a 1-line footer, and `ConditionalContainer` overlays for INPUT / CONFIRM / PAUSE / REDIRECT modes
- Mode-flag widgets: `request_confirm`, `request_pause`, `request_redirect_text` toggle the mode, await a Future, restore on finally. Confirm and HITL pause render **inside the layout, not in scrollback** — satisfies the "用過即焚" requirement
- Multi-line input is back. Enter submits; Alt+Enter (Esc,Enter) inserts newline; Ctrl+J fallback for Mac (where Option-Meta is off by default in Terminal.app)
- Footer (D1 minimal): model · persona · token% · turn stats · ▎ Loom brand
- Submitted text echoes to scrollback as `you › <text>` so the user has a record of what they sent

**Deleted**: `_INTERRUPT_PREFIX`-keyed three-event protocol (`confirm_active` / `confirm_done` / `input_released`), `_run_interactive` wrapper, the per-iteration `prompt_async` flow, the streaming cursor + `clear_line` mechanism that was the suspected cause of CJK truncation.

### D2 · Streaming output rewrite (commits 8b03730 → ef41942)

The CJK truncation bug had to be hunted across **three** attempts:

- **Attempt 1**: drop streaming cursor + `\r\033[K`. Didn't fix it
- **Attempt 2**: bypass Rich Console, use raw `sys.stdout.write` for streaming text. Didn't fix it either
- **Attempt 3** (the fix): line-buffer streaming output. Chunks accumulate in `_stream_pending`; flush on newline or at turn-boundary force-flush. A whole line is written atomically so patch_stdout's bottom-area redraw cycle can't interleave inside it

Also dropped: per-line `Loom ▎` guide (live test → "笨"), inline 💭 ThinkCollapsed print (only readable post-hoc for Anthropic, always landed below response — full chain still in `/think`), the inline turn status_bar (folded into footer state).

Turn intro pared to bare `Loom ▎` marker — context% and persona already live in footer.

### D4 · Polish (commits f2b0d1c, 59563be, f1ac8c5, b1e4cc5, c76acee)

- **Welcome signature**: `console.clear()` then a 5-line ASCII signature with woven warp/weft mark replaces the old render_header Panel + MemoryIndex Panel splatter. Counts (skills · facts · mcp · episodes · relations) folded into one row; zero counts skipped silently
- **Live footer envelope tracking**: `▸ <tool> · <elapsed>s` pulls from `ToolBegin`/`ToolEnd` events, `Nx` count when multiple are in flight. Updated by a 2 Hz background ticker that idles when nothing is running
- **Compaction spinner**: `⚡ 壓縮中…` takes over the footer middle while `_smart_compact` runs; everything else suppressed so the multi-second pause doesn't read as a hang
- **Thinking indicator**: `● Loom is thinking···` line above the input separator (not in footer — moved per live-test feedback). Animated dots driven by the same ticker
- **Input separator**: 1-row `───` rule above the bottom region, marks the visual boundary between scrollback and persistent UI
- **Bottom anchor**: pad with blank lines on startup so the cursor sits near the terminal's last row when the app starts. Persistent area renders at the bottom from frame one
- **Grant TTL**: `🔑 N·M:SS` in footer when grants exist; refreshed at turn-boundary per doc/49 decision (no per-second tick)

## Footer at a glance (post-D4)

```
─────────────────────────────────────────────────────
[input area]
─────────────────────────────────────────────────────
 Loom ▎  tarot · minimax-m2.7   context 1.2%   🔑 1·4:43   ▸ run_bash · 2.1s
```

When thinking, replace the line above the separator:

```
 ● Loom is thinking···
─────────────────────────────────────────────────────
```

When confirming:

```
─────────────────────────────────────────────────────
[confirm widget body — scope summary + 4 options]
─────────────────────────────────────────────────────
 Loom ▎  ...
```

## Caveats

- **Not in this PR** (deferred to follow-up): three-stage envelope fade (active → committed → frozen), parallel envelope group panel + collapse, Markdown rendering at TurnDone. All three involve scrollback cursor manipulation that interacts subtly with patch_stdout — better as isolated PRs
- **doc/34-TUI-使用指南.md preserved** — original plan said deprecate, but the Textual TUI (`loom chat --tui`) remains a separate mode that some users prefer over the streaming CLI. PR-D only touches plain CLI
- patch_stdout(raw=True) **kept** — necessary for `console.print` to flow above the persistent bottom area. Earlier I'd thought it was a source of bugs; it isn't, the issues were the per-iteration app architecture which this PR removes

## Test plan

- [ ] `loom chat` boots, welcome signature displays clean (no diagnostic noise visible), input area sits at terminal bottom from frame one
- [ ] Typing message + Enter: text echoes to scrollback as `you › <text>`, input clears
- [ ] Submit while a previous turn is still streaming: previous aborts cleanly with ⏸ ABORTED rule, new message is queued and shows interrupt context to the LLM
- [ ] Long CJK paragraphs (e.g. ask for a 七言律詩): no first-character truncation on lines
- [ ] Multi-line input: Alt+Enter or Ctrl+J inserts newline; Enter submits
- [ ] Trigger a GUARDED tool: confirm widget appears in bottom region, options visible, arrow keys work, decision causes widget to vanish without leaving any trace in scrollback
- [ ] `/pause` then trigger tools: pause widget shows 3 options, redirect option opens text input, both vanish on completion
- [ ] `/compact`: footer middle becomes `⚡ 壓縮中…` until completion, then snaps back to normal
- [ ] Footer thinking indicator (`● Loom is thinking···`) appears above input separator while waiting for first stream chunk; disappears on first event
- [ ] Footer envelope (`▸ run_bash · 1.2s`) ticks live while a tool runs
- [ ] Grant TTL (`🔑 1·4:43`) shows after granting a 30-min lease
- [ ] All 1119 non-discord tests pass; 5 pre-existing test_cognition failures unchanged

## Three follow-up issues opened

- [ ] Three-stage envelope fade
- [ ] Parallel envelope group panel
- [ ] Markdown rendering at TurnDone

🤖 Generated with [Claude Code](https://claude.com/claude-code)