### PR TITLE
feat(cli): CLI Refresh PR-E — TaskList floating panel (#236)

### DIFF
--- a/loom/core/tasks/manager.py
+++ b/loom/core/tasks/manager.py
@@ -9,6 +9,8 @@ those concepts went away with ``task_done``.
 
 from __future__ import annotations
 
+from typing import Callable, Optional
+
 from .tasklist import TaskList
 
 
@@ -18,6 +20,12 @@ class TaskListManager:
     def __init__(self, session_id: str) -> None:
         self.session_id = session_id
         self._list: TaskList | None = None
+        # Optional observer fired after every write — UI layers (CLI
+        # floating panel) subscribe so they can re-render. Keep it a
+        # single callback; if more listeners are needed later, swap
+        # for a list. Failures inside the callback are swallowed so a
+        # broken UI never poisons the agent's tool result.
+        self.on_change: Optional[Callable[[dict], None]] = None
 
     @property
     def tasklist(self) -> TaskList | None:
@@ -38,11 +46,18 @@ class TaskListManager:
         """
         if not todos:
             self._list = None
-            return {"total": 0, "by_status": {}, "todos": []}
-        lst = TaskList()
-        lst.replace(todos)
-        self._list = lst
-        return lst.status_summary()
+            summary = {"total": 0, "by_status": {}, "todos": []}
+        else:
+            lst = TaskList()
+            lst.replace(todos)
+            self._list = lst
+            summary = lst.status_summary()
+        if self.on_change is not None:
+            try:
+                self.on_change(summary)
+            except Exception:
+                pass
+        return summary
 
     def status(self) -> dict:
         if self._list is None:

--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -143,6 +143,20 @@ class _PauseState:
     future: asyncio.Future | None = None
 
 
+@dataclass
+class _TaskListState:
+    """Snapshot of the agent's TaskList for the floating panel.
+
+    Replaced wholesale on every ``task_write``. Empty ``todos`` means
+    hide the panel entirely.
+    """
+    todos: list[dict] = field(default_factory=list)
+    # Auto-collapse when every todo is completed — render a single
+    # ``✓ N/N done`` line instead of the full panel. Until expand-toggle
+    # is wired (follow-up), the collapsed view is one-shot
+    collapsed: bool = False
+
+
 # ---------------------------------------------------------------------------
 # Style — extends prompt_toolkit's class-based style with our palette
 # ---------------------------------------------------------------------------
@@ -155,7 +169,7 @@ _APP_STYLE = Style.from_dict(
         # feedback after PR-D1 first run: explicit bg felt obtrusive
         # against varied terminal themes
         "footer":                PARCHMENT_MUTED,
-        "footer.brand":          PARCHMENT_ACCENT,
+        "footer.brand":          f"{PARCHMENT_ACCENT} bold",
         "footer.budget.ok":      PARCHMENT_MUTED,
         "footer.budget.warn":    PARCHMENT_WARNING,
         "footer.budget.high":    PARCHMENT_ERROR,
@@ -166,6 +180,13 @@ _APP_STYLE = Style.from_dict(
         # Thinking indicator above the input separator
         "thinking":              PARCHMENT_MUTED,
         "thinking.dot":          PARCHMENT_ACCENT,
+        # Floating TaskList panel
+        "tasklist.frame":        PARCHMENT_BORDER,
+        "tasklist.title":        f"{PARCHMENT_ACCENT} bold",
+        "tasklist.done":         PARCHMENT_SUCCESS,
+        "tasklist.active":       PARCHMENT_ACCENT,
+        "tasklist.pending":      PARCHMENT_MUTED,
+        "tasklist.collapsed":    PARCHMENT_SUCCESS,
         # Confirm / Pause widget — also no bg, blend with terminal
         "widget.title":          PARCHMENT_TEXT,
         "widget.body":           PARCHMENT_MUTED,
@@ -222,6 +243,7 @@ class LoomApp:
         self._confirm_state: _ConfirmState | None = None
         self._pause_state: _PauseState | None = None
         self._redirect_future: asyncio.Future | None = None
+        self._tasklist_state = _TaskListState()
 
         # Footer state
         self.footer = FooterState()
@@ -318,6 +340,24 @@ class LoomApp:
             self._mode[0] = "input"
             self._app.invalidate()
 
+    def update_tasklist(self, todos: list[dict]) -> None:
+        """Replace the floating task panel snapshot.
+
+        Wired from ``TaskListManager.on_change`` so every ``task_write``
+        propagates here. Empty list hides the panel. When every todo is
+        ``completed`` we auto-collapse to a one-line summary so a finished
+        list doesn't dominate the bottom region.
+        """
+        self._tasklist_state.todos = list(todos or [])
+        if self._tasklist_state.todos and all(
+            (t.get("status") or "").lower() == "completed"
+            for t in self._tasklist_state.todos
+        ):
+            self._tasklist_state.collapsed = True
+        else:
+            self._tasklist_state.collapsed = False
+        self._app.invalidate()
+
     async def request_redirect_text(self) -> str:
         """Switch to redirect mode for free-form text entry (HITL redirect)."""
         future: asyncio.Future = asyncio.get_event_loop().create_future()
@@ -413,6 +453,20 @@ class LoomApp:
             style=f"fg:{PARCHMENT_BORDER}",
         )
 
+        # Floating TaskList panel — sits above the thinking indicator
+        # (highest in the bottom stack) so it's the closest visual
+        # neighbour to scrollback. Hidden entirely when no list is
+        # active. Height is dynamic; ConditionalContainer collapses to
+        # zero when the render emits empty FormattedText
+        tasklist_window = ConditionalContainer(
+            Window(
+                content=FormattedTextControl(self._render_tasklist),
+                height=Dimension(min=1, max=12),
+                wrap_lines=False,
+            ),
+            filter=Condition(lambda: bool(self._tasklist_state.todos)),
+        )
+
         # Thinking indicator — appears as its own line *above* the
         # separator (so visually attached to the input region), only
         # while ``footer.thinking`` is True. Mirrors Claude Code-style
@@ -428,6 +482,7 @@ class LoomApp:
 
         layout = Layout(
             HSplit([
+                tasklist_window,
                 thinking_window,
                 separator_top,
                 input_window,
@@ -456,16 +511,13 @@ class LoomApp:
     def _render_footer(self) -> FormattedText:
         parts: list[tuple[str, str]] = []
 
-        # Far left: Loom ▎ brand mark — anchors the line as Loom's
-        # identity, mirrors the agent guide style.
-        parts.append(("class:footer.brand", " Loom ▎ "))
+        # Far left: bold Loom brand mark — anchors the line as Loom's
+        # identity. Persona is omitted (welcome screen already announces
+        # it; footer real estate goes to live state).
+        parts.append(("class:footer.brand", " Loom "))
 
-        # Then: model · persona (identity context)
-        left = self.footer.model
-        if self.footer.persona:
-            left = f"{self.footer.persona} · {left}"
-        if left:
-            parts.append(("class:footer", f" {left} "))
+        if self.footer.model:
+            parts.append(("class:footer", f"  {self.footer.model} "))
 
         s = self.footer
 
@@ -555,6 +607,58 @@ class LoomApp:
             ("class:thinking.dot", " ● "),
             ("class:thinking", f"Loom is thinking{dots}"),
         ])
+
+    def _render_tasklist(self) -> FormattedText:
+        """Floating TaskList panel — agent's todo board (PR-E, #236).
+
+        Hidden when no list is active. When everything is completed,
+        collapses to a single ``✓ N/N done`` line so the finished list
+        doesn't dominate the bottom region. Otherwise renders a bordered
+        block with one line per todo: ✓ done, ▸ in-progress, ○ pending.
+        """
+        todos = self._tasklist_state.todos
+        if not todos:
+            return FormattedText([])
+
+        total = len(todos)
+        done = sum(
+            1 for t in todos
+            if (t.get("status") or "").lower() == "completed"
+        )
+
+        if self._tasklist_state.collapsed:
+            return FormattedText([
+                ("class:tasklist.collapsed", f" ✓ {done}/{total} done\n"),
+            ])
+
+        parts: list[tuple[str, str]] = []
+        title = f" 📋 task list  {done}/{total} "
+        # Top border with embedded title
+        bar = "─" * max(4, 48 - len(title))
+        parts.append(("class:tasklist.frame", "╭─"))
+        parts.append(("class:tasklist.title", title))
+        parts.append(("class:tasklist.frame", bar + "╮\n"))
+
+        for t in todos:
+            status = (t.get("status") or "pending").lower()
+            content = (t.get("content") or "").strip()
+            # Truncate to fit a reasonable width; full content is in
+            # the agent's own state, the panel is just a glance
+            if len(content) > 56:
+                content = content[:55] + "…"
+            if status == "completed":
+                glyph, cls = "✓", "class:tasklist.done"
+            elif status == "in_progress":
+                glyph, cls = "▸", "class:tasklist.active"
+            else:
+                glyph, cls = "○", "class:tasklist.pending"
+            parts.append(("class:tasklist.frame", "│ "))
+            parts.append((cls, f"{glyph} {content}"))
+            parts.append(("class:tasklist.frame", "\n"))
+
+        parts.append(("class:tasklist.frame",
+                      "╰" + "─" * (len(title) + len(bar) + 2) + "╯\n"))
+        return FormattedText(parts)
 
     def _render_confirm(self) -> FormattedText:
         if self._confirm_state is None:

--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -612,9 +612,16 @@ class LoomApp:
         """Floating TaskList panel — agent's todo board (PR-E, #236).
 
         Hidden when no list is active. When everything is completed,
-        collapses to a single ``✓ N/N done`` line so the finished list
-        doesn't dominate the bottom region. Otherwise renders a bordered
-        block with one line per todo: ✓ done, ▸ in-progress, ○ pending.
+        collapses to a single ``✓ N/N done`` line. Otherwise renders a
+        header line + one row per todo (✓ done, ▸ in-progress, ○ pending).
+
+        Originally drew a closed ╭─╮/╰─╯ box, but it had two problems:
+        (1) emoji width vs ``len()`` mismatch made the right edge jagged,
+        (2) when an active envelope was running, the footer redraw racing
+        with streaming output could displace the top border line. Without
+        a box there is nothing for those races to break — each row is
+        self-contained and the surrounding ``separator_top`` already
+        provides the visual boundary between panel and input.
         """
         todos = self._tasklist_state.todos
         if not todos:
@@ -631,19 +638,12 @@ class LoomApp:
                 ("class:tasklist.collapsed", f" ✓ {done}/{total} done\n"),
             ])
 
-        parts: list[tuple[str, str]] = []
-        title = f" 📋 task list  {done}/{total} "
-        # Top border with embedded title
-        bar = "─" * max(4, 48 - len(title))
-        parts.append(("class:tasklist.frame", "╭─"))
-        parts.append(("class:tasklist.title", title))
-        parts.append(("class:tasklist.frame", bar + "╮\n"))
-
+        parts: list[tuple[str, str]] = [
+            ("class:tasklist.title", f" 📋 task list  {done}/{total}\n"),
+        ]
         for t in todos:
             status = (t.get("status") or "pending").lower()
             content = (t.get("content") or "").strip()
-            # Truncate to fit a reasonable width; full content is in
-            # the agent's own state, the panel is just a glance
             if len(content) > 56:
                 content = content[:55] + "…"
             if status == "completed":
@@ -652,12 +652,7 @@ class LoomApp:
                 glyph, cls = "▸", "class:tasklist.active"
             else:
                 glyph, cls = "○", "class:tasklist.pending"
-            parts.append(("class:tasklist.frame", "│ "))
-            parts.append((cls, f"{glyph} {content}"))
-            parts.append(("class:tasklist.frame", "\n"))
-
-        parts.append(("class:tasklist.frame",
-                      "╰" + "─" * (len(title) + len(bar) + 2) + "╯\n"))
+            parts.append((cls, f"   {glyph} {content}\n"))
         return FormattedText(parts)
 
     def _render_confirm(self) -> FormattedText:

--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -638,7 +638,14 @@ class LoomApp:
                 ("class:tasklist.collapsed", f" ✓ {done}/{total} done\n"),
             ])
 
+        # Leading blank line — separates the panel from whatever
+        # streaming output sits directly above. Without it, when run_bash
+        # or any active envelope is pushing rapid output up into
+        # scrollback, the redraw cycle can visually butt the panel's
+        # first line right against the previous output and look like
+        # the header got displaced
         parts: list[tuple[str, str]] = [
+            ("", "\n"),
             ("class:tasklist.title", f" 📋 task list  {done}/{total}\n"),
         ]
         for t in todos:

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -355,6 +355,15 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
             except asyncio.TimeoutError:
                 continue
 
+            # PR-E follow-up: a fully-completed TaskList (collapsed to
+            # ``✓ N/N done``) is stale the moment the user starts a new
+            # turn. Without this it would linger until the next
+            # task_write call, which feels like a UI leak. Clearing
+            # here ``acknowledges'' the previous list and frees the
+            # bottom region for whatever comes next
+            if app._tasklist_state.collapsed:
+                app.update_tasklist([])
+
             # Slash commands run inline — no streaming turn, no cancel.
             if text.startswith("/"):
                 try:

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -337,6 +337,16 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
     # select_prompt as before.
     session._loom_app = app  # type: ignore[attr-defined]
 
+    # PR-E (#236): mirror task_write into the floating panel. The
+    # manager fires ``on_change`` with the post-write status summary
+    # after every task_write tool call (replace semantics — full list
+    # every time), so the panel just re-renders from that snapshot.
+    tlm = getattr(session, "_tasklist_manager", None)
+    if tlm is not None:
+        def _push_tasklist(summary: dict) -> None:
+            app.update_tasklist(summary.get("todos") or [])
+        tlm.on_change = _push_tasklist
+
     async def turn_loop() -> None:
         nonlocal current_turn_task
         while not shutdown.is_set():
@@ -1327,16 +1337,6 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
     active_tool: str | None = None
     spinner_task: asyncio.Task | None = None
     frame_index = 0
-
-    # ── Loom Agent turn intro ─────────────────────────────────────────────
-    # Loom Agent turn intro — minimal marker, no metadata.
-    # The footer already shows persona · model · context% · stats, so
-    # repeating any of that here just adds visual debt. Keep this to
-    # a single ``Loom ▎`` so the turn boundary is legible without
-    # duplicating footer info.
-    console.print(
-        Text.from_markup("[loom.agent.guide]Loom ▎[/loom.agent.guide]")
-    )
 
     def _cancel_spinner() -> None:
         nonlocal spinner_task


### PR DESCRIPTION
## Summary
- 監聽 `task_write` 事件，把 agent 的 todo list 渲染成 LoomApp 底部浮動面板（在 input 區上方），符合 #236 PR-E 設計。
- 全部完成自動 collapse 成 `✓ N/N done`；空 list 直接隱藏；不會被滾動沖走。
- 兩個小微調：
  - 拔掉聊天窗內的 `Loom ▎` turn intro（user echo prefix 已足夠識別）
  - footer brand `Loom ▎` → 粗體 `Loom`（拿掉 bar 與 personality 顯示）

## 設計重點
- `TaskListManager.on_change` 在每次 `write()` 後觸發，傳入 status summary。UI 純被動訂閱、零 polling。
- `LoomApp.update_tasklist()` replace-style 更新；render 用 `FormattedTextControl` 直接走 prompt_toolkit 樣式，不引入 rich.live（與 LoomApp 持久層一致）。
- Panel 放在 HSplit 最頂端（thinking_window 之上），緊貼 scrollback 邊界。

## Test plan
- [ ] `loom chat` 開啟，agent 呼叫 `task_write` 三筆（pending / in_progress / completed）→ 浮動面板出現
- [ ] 連續寫入更新某 todo 狀態 → 面板原地刷新，scrollback 不留殘影
- [ ] 全部標 completed → collapse 成 `✓ N/N done`
- [ ] 傳 `[]` 清空 → 面板消失
- [ ] 確認 footer 顯示為粗體 `Loom`（無 bar、無 persona）
- [ ] 確認 turn 開頭沒有殘留 `Loom ▎` 行

Closes the last PR of the CLI Refresh milestone (#236).

🤖 Generated with [Claude Code](https://claude.com/claude-code)