### PR TITLE
fix: scratchpad auto_* refs not retrievable via scratchpad_read (#243)

### DIFF
--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -278,7 +278,7 @@ class JITRetrievalMiddleware(Middleware):
         placeholder = (
             f"[tool output spilled to scratchpad — {size} chars]\n"
             f"  tool: {call.tool_name}\n"
-            f"  ref:  scratchpad:{ref}\n"
+            f"  ref:  scratchpad://{ref}\n"
             f"  size: {size} chars (~{size // 4} tokens)\n"
             f"\n"
             f"  Read with scratchpad_read(ref='{ref}') for cached content,\n"

--- a/loom/core/jobs/scratchpad.py
+++ b/loom/core/jobs/scratchpad.py
@@ -75,7 +75,15 @@ class Scratchpad:
 
     @staticmethod
     def _strip_uri(ref: str) -> str:
-        return ref[len(URI_PREFIX):] if ref.startswith(URI_PREFIX) else ref
+        # Handle both canonical ``scratchpad://ref`` and the single-colon
+        # ``scratchpad:ref`` format that JIT / masking placeholders emit.
+        # Issue #243: agents copy the ref from placeholder text and the
+        # single-colon variant was silently failing lookups.
+        if ref.startswith(URI_PREFIX):
+            return ref[len(URI_PREFIX):]
+        if ref.startswith("scratchpad:"):
+            return ref[len("scratchpad:"):]
+        return ref
 
 
 def _apply_section(text: str, section: str) -> str:

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -2542,7 +2542,7 @@ class LoomSession:
             msg["content"] = (
                 f"[observation folded — {tname or 'tool'} from {age} turns ago, "
                 f"superseded by a more recent call]\n"
-                f"  ref: scratchpad:{ref}\n"
+                f"  ref: scratchpad://{ref}\n"
                 f"  Read with scratchpad_read(ref='{ref}') if you still need "
                 f"the full output."
             )

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -28,6 +28,17 @@ class TestScratchpad:
         pad.write("abc", "data")
         assert pad.read("scratchpad://abc") == "data"
 
+    def test_read_accepts_single_colon_uri(self):
+        """Issue #243: JIT/masking placeholders used ``scratchpad:ref`` (single
+        colon) but ``_strip_uri`` only handled ``scratchpad://``. Agents that
+        copied the ref from placeholder text got KeyError on lookup."""
+        pad = Scratchpad()
+        pad.write("auto_read_file_abcdef", "big content")
+        # Single-colon form — the format JIT placeholders originally emitted
+        assert pad.read("scratchpad:auto_read_file_abcdef") == "big content"
+        assert pad.size("scratchpad:auto_read_file_abcdef") == len(b"big content")
+        assert "scratchpad:auto_read_file_abcdef" in pad
+
     def test_read_bytes_decode(self):
         pad = Scratchpad()
         pad.write("b", b"bytes payload")


### PR DESCRIPTION
## Problem

When `JITRetrievalMiddleware` spills a large tool output, the placeholder tells the agent:
```
ref:  scratchpad:auto_read_file_65d2ae
```

But `Scratchpad._strip_uri()` only strips `scratchpad://` (double-slash). When the agent copies the single-colon format into `scratchpad_read(ref="scratchpad:auto_read_file_65d2ae")`, the prefix is not stripped and the lookup fails with `KeyError`.

## Root Cause

URI format mismatch:
- **JIT placeholder** (middleware.py:281): `scratchpad:{ref}` (single colon)
- **Masking placeholder** (session.py:2545): `scratchpad:{ref}` (single colon)
- **`_strip_uri()`** (scratchpad.py:77): only handles `scratchpad://` (double-slash)

## Fix

1. **`scratchpad.py`**: `_strip_uri` now handles both `scratchpad://` and `scratchpad:` prefixes (lenient, backward compatible)
2. **`middleware.py`**: JIT spill placeholder normalized to `scratchpad://` format
3. **`session.py`**: Observation masking placeholder normalized to `scratchpad://` format

## Testing

All 33 scratchpad-related tests pass:
```
tests/test_jit_retrieval.py       2 passed
tests/test_jobs.py               18 passed
tests/test_jobs_tools.py          8 passed
tests/test_observation_masking.py  1 passed
tests/test_subagent.py            4 passed
```

Closes #243