### PR TITLE
Fix: whitelist expected non-zero exits in run_bash

### DIFF
--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -727,6 +727,31 @@ def make_run_bash_tool(
 
             output = stdout.decode("utf-8", errors="replace")
             success = proc.returncode == 0
+
+            # Issue #254: Whitelist legitimate non-zero shell exits so they
+            # aren't flagged as tool failures (polluting telemetry) and
+            # don't trigger is_error=True in the LLM.
+            if not success:
+                cmd_stripped = command.strip()
+                # Use split to check the last command in a pipeline, or just look for the tool name
+                # in the command string if it's simple enough.
+                is_grep = "grep " in cmd_stripped or "egrep " in cmd_stripped or "fgrep " in cmd_stripped
+                is_test = "test " in cmd_stripped or "[ " in cmd_stripped
+                is_git_diff = "git diff" in cmd_stripped
+                is_gh_jq = "gh api" in cmd_stripped and "--jq" in cmd_stripped
+
+                if proc.returncode == 1 and (is_grep or is_test or is_git_diff):
+                    success = True
+                elif proc.returncode == 5 and is_gh_jq:
+                    success = True
+
+            if success and proc.returncode != 0:
+                # We converted a non-zero exit to a success. Inject the exit
+                # code into the output so the agent still receives the boolean
+                # signal (e.g., test -f returning false).
+                marker = f"[Command exited with {proc.returncode}]"
+                output = f"{output}\n{marker}" if output else marker
+
             return ToolResult(
                 call_id=call.id, tool_name=call.tool_name,
                 success=success, output=output,

--- a/tests/test_jobs_tools.py
+++ b/tests/test_jobs_tools.py
@@ -86,6 +86,54 @@ class TestRunBashAsyncMode:
         assert result.success
         assert "fallback" in result.output
 
+# --- async_mode on run_bash -----------------------------------------
+
+
+class TestRunBashExpectedNonZero:
+    async def test_grep_no_match_is_success(self, tmp_path: Path):
+        tool = make_run_bash_tool(tmp_path)
+        # grep -q exits 1 when no lines are matched. Should be success=True.
+        result = await tool.executor(_call("run_bash", {
+            "command": "echo 'foo' | grep -q 'bar'",
+            "justification": "test",
+        }))
+        assert result.success is True
+        assert result.metadata["exit_code"] == 1
+        assert "[Command exited with 1]" in result.output
+
+    async def test_test_f_false_is_success(self, tmp_path: Path):
+        tool = make_run_bash_tool(tmp_path)
+        # test -f exits 1 when file doesn't exist. Should be success=True.
+        result = await tool.executor(_call("run_bash", {
+            "command": "test -f /tmp/definitely_not_a_real_file_123",
+            "justification": "test",
+        }))
+        assert result.success is True
+        assert result.metadata["exit_code"] == 1
+        assert "[Command exited with 1]" in result.output
+
+    async def test_gh_api_jq_empty_is_success(self, tmp_path: Path):
+        tool = make_run_bash_tool(tmp_path)
+        # Mocking gh api --jq since gh might not be installed or authenticated.
+        # We just need bash to return 5 and the command to start with gh api.
+        result = await tool.executor(_call("run_bash", {
+            "command": "gh api --jq '.items' || exit 5",
+            "justification": "test",
+        }))
+        assert result.success is True
+        assert result.metadata["exit_code"] == 5
+        assert "[Command exited with 5]" in result.output
+
+    async def test_grep_syntax_error_is_failure(self, tmp_path: Path):
+        tool = make_run_bash_tool(tmp_path)
+        # grep without pattern exits 2. Should be success=False.
+        result = await tool.executor(_call("run_bash", {
+            "command": "grep",
+            "justification": "test",
+        }))
+        assert result.success is False
+        assert result.metadata["exit_code"] == 2
+        assert "Exit code 2" in result.error
 
 # --- jobs_* tools ----------------------------------------------------
 


### PR DESCRIPTION
Resolves #254.

- Added whitelist in `run_bash` for common expected non-zero exits (`grep`, `test`, `gh api --jq`, `git diff`).
- Converts these to `success=True` to prevent polluting telemetry failure rates.
- Injects the non-zero exit code into the output so the LLM retains the boolean signal without triggering `is_error=True`.
- Added unit tests.