### PR TITLE
feat(cli): Markdown reblit at TurnDone (#248)

### DIFF
--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -280,7 +280,8 @@ class LoomApp:
         natural terminal scrollback while the input + footer stay
         anchored at the bottom.
         """
-        await self._app.run_in_terminal(callback)
+        from prompt_toolkit.application import run_in_terminal as _rit
+        await _rit(callback)
 
     async def request_confirm(
         self,

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -1555,7 +1555,9 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                     at_line_start = True
                 active_tool = event.name
                 frame_index = 0
-                console.print(tool_begin_line(event.name, event.args))
+                console.print(
+                    tool_begin_line(event.name, event.args, width=_terminal_width())
+                )
                 # Start spinner animation
                 spinner_task = asyncio.create_task(_spin_loop())
                 # PR-D4: track in footer for live ▸ <tool> · <elapsed>

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -1409,6 +1409,101 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
             _sys.stdout.flush()
             _stream_pending = ""
 
+    # PR-E follow-up #248: markdown reblit at TurnDone.
+    # ``_segment_buffer`` accumulates streamed text since the last
+    # tool row (or turn start). At TurnDone we cursor-up that segment
+    # and re-print it as Rich Markdown so **bold**, headings, code
+    # blocks etc. become formatted instead of raw. Per-segment
+    # tracking — not the whole turn — because tool rows printed
+    # mid-turn are anchored content we cannot rewrite.
+    _segment_buffer = ""
+
+    def _terminal_width() -> int:
+        loom_app = getattr(session, "_loom_app", None)
+        if loom_app is not None:
+            try:
+                return max(20, loom_app.application.output.get_size().columns)
+            except Exception:
+                pass
+        try:
+            import os as _os
+            return max(20, _os.get_terminal_size().columns)
+        except Exception:
+            return 80
+
+    def _segment_visual_rows(text: str, width: int) -> int:
+        """Rows the cursor advanced while writing ``text`` to a
+        terminal of ``width`` cols. Accounts for soft-wrap on long
+        lines and CJK/emoji double-width cells. Used to compute how
+        many lines to cursor-up before re-rendering Markdown."""
+        from wcwidth import wcwidth as _wcw
+        row = 0
+        col = 0
+        for ch in text:
+            if ch == "\n":
+                row += 1
+                col = 0
+                continue
+            w = _wcw(ch)
+            if w < 0:
+                w = 1
+            if col + w > width:
+                row += 1
+                col = w
+            else:
+                col += w
+                if col == width:
+                    row += 1
+                    col = 0
+        return row
+
+    async def _markdown_reblit() -> None:
+        """Replace the last streamed text segment with Rich Markdown.
+
+        Skips plain prose (no markdown markers) — reblitting pure text
+        only causes visual flicker without adding signal. When the
+        segment never produced visible rows (e.g. tool-only turn or
+        ended exactly where it started), there's nothing to overwrite.
+        """
+        text = _segment_buffer
+        if not text or not text.strip():
+            return
+        # Cheap markdown sniff — only reblit when there's something
+        # to gain. Catches bold/italic, headings, code spans, fenced
+        # code, lists, blockquotes, links
+        markers = ("**", "__", "# ", "## ", "### ", "`", "```",
+                   "- ", "* ", "> ", "](", "1. ")
+        if not any(m in text for m in markers):
+            return
+
+        width = _terminal_width()
+        # Cursor at TurnDone always sits at col 0 of the row *below*
+        # the last content row: either the segment's own trailing \n
+        # advanced it there, or the ``if not at_line_start`` branch
+        # in TurnDone printed an extra \n. So:
+        #   ends with \n  → helper already counted the advance
+        #   no trailing \n → helper undercount by 1 (the added \n)
+        rows = _segment_visual_rows(text, width)
+        if not text.endswith("\n"):
+            rows += 1
+
+        from rich.markdown import Markdown as _Markdown
+
+        def _reblit() -> None:
+            import sys as _sys
+            if rows > 0:
+                _sys.stdout.write(f"\r\033[{rows}A\033[J")
+            else:
+                _sys.stdout.write("\r\033[J")
+            _sys.stdout.flush()
+            console.print(_Markdown(text.rstrip()))
+
+        loom_app = getattr(session, "_loom_app", None)
+        if loom_app is not None:
+            await loom_app.print_above(_reblit)
+        else:
+            _reblit()
+
     # PR-D4: clear the "thinking" footer indicator on the first
     # observable event of the turn. After that, the active envelope
     # / streaming output / turn stats take over the footer's middle.
@@ -1430,6 +1525,7 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
             if isinstance(event, TextChunk):
                 _stream_pending += event.text
                 text_buffer += event.text
+                _segment_buffer += event.text
                 _flush_streaming()
                 at_line_start = (not _stream_pending) and event.text.endswith("\n")
 
@@ -1447,6 +1543,10 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
             elif isinstance(event, ToolBegin):
                 # Drain pending streamed text before the tool row
                 _flush_streaming(force=True)
+                # Tool row anchors content we cannot rewrite; close
+                # the current markdown-reblit segment so only post-
+                # tool text gets reblit at TurnDone
+                _segment_buffer = ""
                 # Cancel any running spinner
                 _cancel_spinner()
                 # Ensure tool rows start on a fresh line
@@ -1574,6 +1674,11 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 clear_line()
                 if not at_line_start:
                     console.print()
+                # PR-E follow-up #248: reblit the final text segment
+                # as Rich Markdown. No-op if the turn ended on a tool
+                # row, or if the segment is plain prose with no
+                # markdown markers worth rendering
+                await _markdown_reblit()
                 cache_total = event.cache_read_input_tokens + event.cache_creation_input_tokens + event.input_tokens
                 cache_hit_pct = (event.cache_read_input_tokens / cache_total * 100) if cache_total > 0 else 0.0
                 elapsed = time.monotonic() - t0

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -1469,10 +1469,17 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
         if not text or not text.strip():
             return
         # Cheap markdown sniff — only reblit when there's something
-        # to gain. Catches bold/italic, headings, code spans, fenced
-        # code, lists, blockquotes, links
-        markers = ("**", "__", "# ", "## ", "### ", "`", "```",
-                   "- ", "* ", "> ", "](", "1. ")
+        # to gain. Covers bold/italic/strikethrough, ATX headings,
+        # code spans, fenced code, lists (-/*/+ and 1.), blockquotes
+        # (incl. nested), links, tables. ``***`` (bold-italic) and
+        # ``__`` (alt bold) are subsets of ``**``/``_`` so already
+        # matched by those entries
+        markers = (
+            "**", "__", "_", "~~", "`", "```",
+            "# ", "## ", "### ", "#### ",
+            "- ", "* ", "+ ", "1. ", "2. ",
+            "> ", "](", "| ",
+        )
         if not any(m in text for m in markers):
             return
 
@@ -1489,12 +1496,17 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
 
         from rich.markdown import Markdown as _Markdown
 
+        if rows <= 0:
+            # Cursor is already at the start of where the segment
+            # was; nothing to overwrite. ``text.strip()`` non-empty
+            # combined with rows == 0 only happens for whitespace-
+            # only segments which the early-return covered, so this
+            # is effectively unreachable — guard anyway
+            return
+
         def _reblit() -> None:
             import sys as _sys
-            if rows > 0:
-                _sys.stdout.write(f"\r\033[{rows}A\033[J")
-            else:
-                _sys.stdout.write("\r\033[J")
+            _sys.stdout.write(f"\r\033[{rows}A\033[J")
             _sys.stdout.flush()
             console.print(_Markdown(text.rstrip()))
 

--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -538,23 +538,69 @@ def response_panel(
 # ASCII spinner frames (cp950 safe, Rich-markup safe — no backslash)
 _SPINNER_FRAMES = ["-", "~", "|", "+"]
 
-def tool_spinner_line(name: str, args: dict[str, Any], frame_index: int = 0) -> Text:
+def tool_spinner_line(
+    name: str,
+    args: dict[str, Any],
+    frame_index: int = 0,
+    width: int | None = None,
+) -> Text:
     """
     Rich Text for a tool-call-in-progress line with ASCII spinner.
     Frame index 0 shows [- ], 1 shows [\\ ], etc.
+
+    When ``width`` is given and the rendered line would overflow it,
+    the args body wraps with a hanging indent so continuation lines
+    align under the tool name instead of restarting at column 0.
     """
     spinner = _SPINNER_FRAMES[frame_index % len(_SPINNER_FRAMES)]
     args_preview = _format_args(args)
-    return Text.from_markup(
-        f"  [loom.muted][[/loom.muted][loom.warning]{spinner}[/loom.warning][loom.muted]][/loom.muted] "
-        f"[loom.warning]{name}[/loom.warning]"
-        f"{f'({args_preview})' if args_preview else ''}"
-    )
+    body_plain = f"{name}{f'({args_preview})' if args_preview else ''}"
+    prefix_visual = "  [-] "  # 6 cells; spinner glyph is always 1 wide
+    indent = " " * len(prefix_visual)
+
+    out = Text()
+    out.append("  [", style="loom.muted")
+    out.append(spinner, style="loom.warning")
+    out.append("] ", style="loom.muted")
+
+    if width is None or len(prefix_visual) + len(body_plain) <= width:
+        # Fits on one line — keep the original styled rendering
+        out.append(name, style="loom.warning")
+        if args_preview:
+            out.append(f"({args_preview})")
+        return out
+
+    # Hanging-indent wrap: textwrap on the plain body within the
+    # available width so continuation lines line up under the name
+    import textwrap as _tw
+    body_width = max(20, width - len(prefix_visual))
+    wrapped = _tw.wrap(
+        body_plain,
+        width=body_width,
+        break_long_words=True,
+        break_on_hyphens=False,
+        drop_whitespace=False,
+    ) or [body_plain]
+
+    first = wrapped[0]
+    if first.startswith(name):
+        out.append(name, style="loom.warning")
+        out.append(first[len(name):])
+    else:
+        # Edge case: name itself longer than body_width — fall back
+        # to unstyled split rather than trying to slice a style span
+        out.append(first)
+    for cont in wrapped[1:]:
+        out.append("\n")
+        out.append(indent + cont)
+    return out
 
 
-def tool_begin_line(name: str, args: dict[str, Any]) -> Text:
+def tool_begin_line(
+    name: str, args: dict[str, Any], width: int | None = None
+) -> Text:
     """Rich Text for a tool-call-in-progress line (alias for compatibility)."""
-    return tool_spinner_line(name, args, 0)
+    return tool_spinner_line(name, args, 0, width=width)
 
 
 def tool_running_line(name: str, frame_index: int = 0) -> Text:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "prompt_toolkit>=3.0",
     "textual>=0.60.0",
+    "wcwidth>=0.2.0",
     "httpx>=0.27.0",
     "jsonschema>=4.0.0",
     "pyyaml>=6.0",


### PR DESCRIPTION
## Summary
- TurnDone 後把最後一段 streamed text cursor-up 重塗成 Rich Markdown，**bold** / headings / code blocks / lists 全部變成格式化視覺。
- Per-segment：以 ``ToolBegin`` 為界，只重塗最後一個工具呼叫之後的文字；tool row 之前的內容是錨定的，不會被重寫。
- Markdown sniff：純散文（無 \`**\` / heading / code / bullet 等記號）跳過重塗，避免無意義 flicker。
- Cursor-up 數學考慮 CJK / emoji 雙寬（wcwidth）+ 終端 soft-wrap + TurnDone 補的 \`\\n\`。

## 設計決策
- 走 doc/49-CLI-Refresh-設計.md 的方案 1（cursor-up 重塗），不走方案 2（Panel 並陳）——後者讓使用者讀兩遍同樣內容。
- Reblit 在 ``LoomApp.print_above`` 中執行，prompt_toolkit 的 bottom region 自動 suspend，cursor 操作不會打架到 footer / input。
- 失敗 / 中斷路徑不重塗（保持已串流原貌）。

## Test plan
- [ ] \`loom chat\` → 問一個會吐 markdown 的問題（\"用 markdown 列出三點\"）→ 收尾後看到 bullet 渲染
- [ ] 帶 code fence 的回覆 → 收尾後看到 code block 區塊
- [ ] 純散文回覆 → 不重塗（無 flicker）
- [ ] 帶 tool call 的回覆（先 run_bash 再回答）→ tool 之前的文字保持原樣，tool 之後的最終回答被 reblit
- [ ] CJK 混合 \`**\` 加粗 → cursor up 行數正確（不殘留、不超切）
- [ ] 終端 ≤ 80 col 時的長行 wrap → cursor 計算正確

Closes #248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)