### PR TITLE
feat(cli): route trajectory-anomaly through harness channel

### DIFF
--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -390,6 +390,15 @@ class LegitimacyGuardMiddleware(Middleware):
         # Tools that have successfully executed once this session; probe
         # requirement is waived for these on subsequent turns (Issue #118).
         self._session_trusted: set[str] = set()
+        # Optional UI callback fired when a trajectory anomaly is flagged.
+        # Wired by the platform layer so the warning can route through
+        # the harness channel (``⚙ harness ›``) instead of the bare
+        # logging path that landed unstyled in scrollback. Signature:
+        # ``(tool_name: str, origin: str) -> None``. Failures inside
+        # the callback are swallowed
+        self._on_trajectory_anomaly: (
+            Callable[[str, str], None] | None
+        ) = None
 
     @staticmethod
     def _is_probe(call: ToolCall) -> bool:
@@ -450,12 +459,27 @@ class LegitimacyGuardMiddleware(Middleware):
                 # readers) can see why an EXEC call lost its exec_auto fast-pass.
                 # Without this, autonomous runs that get blocked by the soft
                 # guard look indistinguishable from a generic permission denial.
-                _log.warning(
-                    "Trajectory anomaly: %s called with EXEC capability before "
-                    "any probe this turn (origin=%s); exec_auto fast-pass will "
-                    "be revoked downstream.",
-                    call.tool_name, call.origin,
-                )
+                # When a UI callback is wired (interactive CLI), demote the
+                # log to DEBUG — the styled harness inline already covers
+                # operator-facing surfacing and the bare log just leaked
+                # unstyled into scrollback. Headless paths (autonomy daemon,
+                # tests) still get the WARNING for forensics
+                if self._on_trajectory_anomaly is not None:
+                    _log.debug(
+                        "Trajectory anomaly: %s (origin=%s); exec_auto revoked.",
+                        call.tool_name, call.origin,
+                    )
+                    try:
+                        self._on_trajectory_anomaly(call.tool_name, call.origin)
+                    except Exception:
+                        pass
+                else:
+                    _log.warning(
+                        "Trajectory anomaly: %s called with EXEC capability before "
+                        "any probe this turn (origin=%s); exec_auto fast-pass will "
+                        "be revoked downstream.",
+                        call.tool_name, call.origin,
+                    )
 
         result = await next(call)
 

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -185,6 +185,24 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
             _mw._on_lifecycle_event = _on_lifecycle
             break
 
+    # Route LegitimacyGuardMiddleware's trajectory-anomaly warning
+    # through the harness channel too. Before this, the message
+    # landed via the stdlib logger and printed unstyled into scrollback,
+    # looking like it belonged to the surrounding tool args (the user
+    # could not tell it was a separate harness signal).
+    def _on_trajectory_anomaly(tool_name: str, origin: str) -> None:
+        harness.inline(
+            f"trajectory anomaly: {tool_name} ran EXEC without a prior "
+            f"probe (origin={origin}); exec_auto fast-pass revoked.",
+            level="warning",
+        )
+
+    from loom.core.harness.middleware import LegitimacyGuardMiddleware
+    for _mw in session._pipeline._middlewares:
+        if isinstance(_mw, LegitimacyGuardMiddleware):
+            _mw._on_trajectory_anomaly = _on_trajectory_anomaly
+            break
+
     # PR-C4: surface history sanitize repairs and governor rejections.
     # Both are silent today; making them visible takes them off the
     # "weird invisible behaviour" list that haunts users of generative

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -1516,6 +1516,62 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
         else:
             _reblit()
 
+    # PR-E follow-up #246: envelope three-stage fade.
+    # After ToolEnd we paint the row in **committed** style (the
+    # default — green/red accent). 3s later, if no other content has
+    # been printed below it, we cursor-up reblit it as **frozen**
+    # (fully muted) so the visual weight sinks. ``_output_seq``
+    # increments on every printable event and the freeze timer
+    # rejects when its captured value no longer matches — that's how
+    # we detect "something else got printed underneath".
+    _output_seq = 0
+    _freeze_task: asyncio.Task | None = None
+
+    def _bump_output_seq() -> None:
+        nonlocal _output_seq
+        _output_seq += 1
+
+    def _cancel_pending_freeze() -> None:
+        nonlocal _freeze_task
+        if _freeze_task and not _freeze_task.done():
+            _freeze_task.cancel()
+        _freeze_task = None
+
+    async def _freeze_envelope(seq_at_schedule: int, name: str, success: bool,
+                                duration_ms: float) -> None:
+        """Sleep, then reblit the most-recent ToolEnd row as frozen.
+
+        Bails if anything else printed in the meantime — only the
+        envelope still anchored at the bottom can have its visual
+        weight reduced via cursor-up.
+        """
+        try:
+            await asyncio.sleep(3.0)
+        except asyncio.CancelledError:
+            return
+        if _output_seq != seq_at_schedule:
+            return
+
+        def _rewrite() -> None:
+            import sys as _sys
+            # Layout above cursor: [tool_end row] [blank row] [cursor]
+            # → up 2, clear forward, reprint frozen + blank
+            _sys.stdout.write("\r\033[2A\033[J")
+            _sys.stdout.flush()
+            console.print(tool_end_line(name, success, duration_ms, frozen=True))
+            console.print()
+
+        loom_app = getattr(session, "_loom_app", None)
+        try:
+            if loom_app is not None:
+                await loom_app.print_above(_rewrite)
+            else:
+                _rewrite()
+        except Exception:
+            # Don't let a cosmetic reblit failure poison the turn —
+            # cursor manipulation can fail under terminal resize, etc.
+            pass
+
     # PR-D4: clear the "thinking" footer indicator on the first
     # observable event of the turn. After that, the active envelope
     # / streaming output / turn stats take over the footer's middle.
@@ -1535,6 +1591,7 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
         async for event in session.stream_turn(user_input):
             _clear_thinking()
             if isinstance(event, TextChunk):
+                _bump_output_seq()
                 _stream_pending += event.text
                 text_buffer += event.text
                 _segment_buffer += event.text
@@ -1553,12 +1610,16 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 pass
 
             elif isinstance(event, ToolBegin):
+                _bump_output_seq()
                 # Drain pending streamed text before the tool row
                 _flush_streaming(force=True)
                 # Tool row anchors content we cannot rewrite; close
                 # the current markdown-reblit segment so only post-
                 # tool text gets reblit at TurnDone
                 _segment_buffer = ""
+                # New tool row prints below the prior committed
+                # envelope — that prior one can no longer freeze
+                _cancel_pending_freeze()
                 # Cancel any running spinner
                 _cancel_spinner()
                 # Ensure tool rows start on a fresh line
@@ -1583,6 +1644,7 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                     loom_app.invalidate()
 
             elif isinstance(event, ToolEnd):
+                _bump_output_seq()
                 # Cancel spinner and clear its line
                 _cancel_spinner()
                 clear_line()
@@ -1592,6 +1654,14 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 at_line_start = True
                 active_tool = None
                 console.print()
+                # Schedule the freeze reblit. Any printable event
+                # before the timer expires bumps _output_seq and
+                # invalidates this scheduled freeze
+                _cancel_pending_freeze()
+                _freeze_task = asyncio.create_task(
+                    _freeze_envelope(_output_seq, event.name,
+                                     event.success, event.duration_ms)
+                )
                 # PR-D4: drop matching envelope from footer
                 loom_app = getattr(session, "_loom_app", None)
                 if loom_app is not None:
@@ -1603,6 +1673,8 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                     loom_app.invalidate()
 
             elif isinstance(event, TurnPaused):
+                _bump_output_seq()
+                _cancel_pending_freeze()
                 # ── HITL pause (PR-A3: arrow-key widget) ──────────────────
                 _cancel_spinner()
                 clear_line()
@@ -1680,6 +1752,11 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                     session.resume()
 
             elif isinstance(event, TurnDone):
+                _bump_output_seq()
+                # Cancel any pending freeze before we touch the
+                # cursor — markdown reblit will move it past the
+                # frozen target row anyway
+                _cancel_pending_freeze()
                 # Drain any unterminated trailing chunk before
                 # printing the post-turn UI
                 _flush_streaming(force=True)
@@ -1744,6 +1821,10 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
         console.print()
         harness.inline(f"turn aborted with error: {exc}", level="error")
     finally:
+        # PR-E follow-up #246: pending freeze must not outlive the turn —
+        # the cursor relationship to the tool_end row breaks once any
+        # post-turn UI prints (status, next prompt, etc.)
+        _cancel_pending_freeze()
         # Defensive: ensure the spinner task never outlives this turn,
         # even if neither except branch fired (clean exit) or if a path
         # added later forgets to cancel it.

--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -615,8 +615,33 @@ def tool_running_line(name: str, frame_index: int = 0) -> Text:
     )
 
 
-def tool_end_line(name: str, success: bool, duration_ms: float) -> Text:
-    """Rich Text for a completed tool-call line."""
+def tool_end_line(
+    name: str, success: bool, duration_ms: float, frozen: bool = False
+) -> Text:
+    """Rich Text for a completed tool-call line.
+
+    Two visual stages share this helper:
+
+    - ``frozen=False`` is the **committed** stage (default): green/red
+      accent on the icon, ms count and status word so the freshly-
+      finished envelope still draws the eye.
+    - ``frozen=True`` is the **frozen** stage: every fragment muted,
+      the row sinks into the visual background. Used by the cursor-up
+      reblit 3s after ToolEnd when no other content has been printed
+      below the row (doc/49 §2 "完成即蒸發").
+    """
+    if frozen:
+        icon_word = "ok" if success else "!!"
+        status_word = "done" if success else "failed"
+        # Build with Text.append rather than from_markup — bare ``[ok]``
+        # in a markup string gets parsed as an (unknown) style tag and
+        # silently swallowed, leaving a blank gap where the icon was
+        out = Text()
+        out.append(
+            f"  [{icon_word}] {name}  {duration_ms:.0f}ms  {status_word}",
+            style="loom.muted",
+        )
+        return out
     icon = "[loom.success]ok[/loom.success]" if success else "[loom.error]!![/loom.error]"
     status = "[loom.success]done[/loom.success]" if success else "[loom.error]failed[/loom.error]"
     return Text.from_markup(


### PR DESCRIPTION
## Summary
\`LegitimacyGuardMiddleware\` 的 trajectory-anomaly 警告原本走 \`_log.warning()\`。\`loom chat\` 沒設 logger handler，這條訊息以裸文字 leak 到 scrollback，夾在 tool_begin / tool_end 之間，看起來像是 tool args 的一部分。

加 \`_on_trajectory_anomaly\` callback，platform 層 wire 進 \`HarnessChannel.inline\` ——和 \`auth denied\` / \`sanitize\` / \`governor blocked\` 同一族群，掛 \`⚙ harness ›\` 簽名 + warning 配色。callback 已 wire 時把 \`_log.warning\` 降 DEBUG 避免雙印；headless 路徑（autonomy daemon、tests）保留 WARNING 便於 forensics。

## Test plan
- [ ] \`loom chat\` 觸發 EXEC 工具且該 turn 內沒先 probe → 看到 \`⚙ harness › trajectory anomaly: …\` 帶 warning 色
- [ ] 同訊息不再以裸文字 leak 到 scrollback
- [ ] autonomy daemon / tests 仍能看到 WARNING-level log

🤖 Generated with [Claude Code](https://claude.com/claude-code)