### PR TITLE
feat(cli): parallel envelope group panel (#247)

### DIFF
--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -61,6 +61,9 @@ from loom.platform.cli.ui import (
     ActionRolledBack,
     ActionStateChange,
     CompressDone,
+    EnvelopeCompleted,
+    EnvelopeStarted,
+    EnvelopeUpdated,
     TextChunk,
     ThinkCollapsed,
     ToolBegin,
@@ -69,6 +72,9 @@ from loom.platform.cli.ui import (
     TurnDropped,
     TurnPaused,
     clear_line,
+    parallel_group_footer,
+    parallel_group_header,
+    parallel_group_row,
     status_bar,
     tool_begin_line,
     tool_end_line,
@@ -1590,6 +1596,18 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
             # cursor manipulation can fail under terminal resize, etc.
             pass
 
+    # PR-E follow-up #247: parallel envelope group panel.
+    # When the agent dispatches >1 tools in a single envelope, we
+    # suppress the per-tool ``[-] tool(...)`` rows + spinner (the
+    # footer ``Nx ▸ tool · elapsed`` already covers live state) and
+    # frame the completed rows under a thin rule. Single-tool batches
+    # behave exactly as before.
+    _parallel_mode = False
+    _parallel_total = 0
+    _parallel_done_ok = 0
+    _parallel_done_total = 0
+    _parallel_started_at: float = 0.0
+
     # PR-D4: clear the "thinking" footer indicator on the first
     # observable event of the turn. After that, the active envelope
     # / streaming output / turn stats take over the footer's middle.
@@ -1627,6 +1645,45 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 # ThinkCollapsed in their own way and aren't affected
                 pass
 
+            elif isinstance(event, EnvelopeStarted):
+                # #247: enter parallel mode only when the batch holds
+                # multiple tools. Single-tool envelopes fall through to
+                # ToolBegin's existing inline rendering
+                if event.envelope.node_count > 1:
+                    _bump_output_seq()
+                    _flush_streaming(force=True)
+                    _segment_buffer = ""
+                    _cancel_pending_freeze()
+                    if not at_line_start:
+                        console.print()
+                        at_line_start = True
+                    _parallel_mode = True
+                    _parallel_total = event.envelope.node_count
+                    _parallel_done_ok = 0
+                    _parallel_done_total = 0
+                    _parallel_started_at = time.monotonic()
+                    console.print(parallel_group_header(_parallel_total))
+
+            elif isinstance(event, EnvelopeUpdated):
+                # No-op for the CLI — per-tool ToolEnd already drives
+                # the row-by-row redraw inside the group
+                pass
+
+            elif isinstance(event, EnvelopeCompleted):
+                if _parallel_mode:
+                    elapsed_ms = (time.monotonic() - _parallel_started_at) * 1000
+                    console.print(
+                        parallel_group_footer(
+                            _parallel_done_ok, _parallel_total, elapsed_ms
+                        )
+                    )
+                    console.print()
+                    at_line_start = True
+                    _parallel_mode = False
+                    _parallel_total = 0
+                    _parallel_done_ok = 0
+                    _parallel_done_total = 0
+
             elif isinstance(event, ToolBegin):
                 _bump_output_seq()
                 # Drain pending streamed text before the tool row
@@ -1635,6 +1692,24 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 # the current markdown-reblit segment so only post-
                 # tool text gets reblit at TurnDone
                 _segment_buffer = ""
+                # In parallel mode the per-tool row is suppressed —
+                # footer ``Nx ▸ tool · elapsed`` covers live state and
+                # individual ToolEnd rows print under the group header
+                # as they complete. Still update footer envelope list
+                active_tool = event.name
+                if _parallel_mode:
+                    loom_app = getattr(session, "_loom_app", None)
+                    if loom_app is not None:
+                        from loom.platform.cli.app import _ActiveEnvelope
+                        import time as _t
+                        loom_app.footer.active_envelopes.append(
+                            _ActiveEnvelope(
+                                name=event.name,
+                                started_monotonic=_t.monotonic(),
+                            )
+                        )
+                        loom_app.invalidate()
+                    continue
                 # New tool row prints below the prior committed
                 # envelope — that prior one can no longer freeze
                 _cancel_pending_freeze()
@@ -1644,7 +1719,6 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 if not at_line_start:
                     console.print()
                     at_line_start = True
-                active_tool = event.name
                 frame_index = 0
                 console.print(
                     tool_begin_line(event.name, event.args, width=_terminal_width())
@@ -1666,6 +1740,30 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 # Cancel spinner and clear its line
                 _cancel_spinner()
                 clear_line()
+                if _parallel_mode:
+                    # Group-panel row, no per-tool freeze (cursor-up
+                    # math doesn't compose with sibling rows). Still
+                    # drop the matching footer envelope so the live
+                    # ``Nx ▸ tool · elapsed`` decrements correctly
+                    console.print(
+                        parallel_group_row(
+                            event.name, event.success, event.duration_ms
+                        )
+                    )
+                    at_line_start = True
+                    active_tool = None
+                    _parallel_done_total += 1
+                    if event.success:
+                        _parallel_done_ok += 1
+                    loom_app = getattr(session, "_loom_app", None)
+                    if loom_app is not None:
+                        envs = loom_app.footer.active_envelopes
+                        for i in range(len(envs) - 1, -1, -1):
+                            if envs[i].name == event.name:
+                                envs.pop(i)
+                                break
+                        loom_app.invalidate()
+                    continue
                 console.print(
                     tool_end_line(event.name, event.success, event.duration_ms)
                 )

--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -55,6 +55,9 @@ from loom.core.events import (  # noqa: E402, F401
     ActionRolledBack,
     ActionStateChange,
     CompressDone,
+    EnvelopeCompleted,
+    EnvelopeStarted,
+    EnvelopeUpdated,
     TextChunk,
     ThinkCollapsed,
     ToolBegin,
@@ -657,6 +660,70 @@ def tool_end_line(
         f"  [loom.muted][[/loom.muted]{icon}[loom.muted]][/loom.muted] "
         f"[loom.muted]{name}[/loom.muted]  "
         f"[{('green' if success else 'red')}]{duration_ms:.0f}ms[/{('green' if success else 'red')}]  "
+        f"[loom.muted]{status}[/loom.muted]"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parallel envelope group panel (#247)
+# ---------------------------------------------------------------------------
+#
+# When the agent dispatches >1 tools in a single envelope, the CLI groups
+# their rows under a thin rule header instead of letting them line up flat
+# alongside serial calls. No box (lessons from TaskList #236) — just a
+# dashed rule + label, indented child rows, dashed close.
+#
+#     ── parallel · 3 tools ─────────────
+#        [ok] read_file       12ms  done
+#        [ok] list_dir         3ms  done
+#        [ok] web_search    1230ms  done
+#     ── ✓ 3/3 tools · 1.3s ─────────────
+#
+# The header / footer rules emit at PARCHMENT_BORDER muted weight so the
+# group reads as scaffolding, not content.
+
+_PARALLEL_RULE_TOTAL = 36  # visual length cap for the dashed rule
+
+
+def parallel_group_header(node_count: int) -> Text:
+    label = f" parallel · {node_count} tools "
+    pad = max(4, _PARALLEL_RULE_TOTAL - len(label) - 2)
+    return Text.from_markup(
+        f"  [loom.muted]──[/loom.muted]"
+        f"[loom.accent]{label}[/loom.accent]"
+        f"[loom.muted]{'─' * pad}[/loom.muted]"
+    )
+
+
+def parallel_group_footer(done: int, total: int, elapsed_ms: float) -> Text:
+    """Closing rule for the group. ``done`` is success count; failures
+    flip the icon to warning so the user sees something dropped."""
+    all_ok = done == total
+    icon = "✓" if all_ok else "⚠"
+    icon_style = "loom.success" if all_ok else "loom.warning"
+    secs = elapsed_ms / 1000.0
+    label = f" {icon} {done}/{total} tools · {secs:.1f}s "
+    pad = max(4, _PARALLEL_RULE_TOTAL - len(label) - 2)
+    return Text.from_markup(
+        f"  [loom.muted]──[/loom.muted]"
+        f"[{icon_style}]{label}[/{icon_style}]"
+        f"[loom.muted]{'─' * pad}[/loom.muted]"
+    )
+
+
+def parallel_group_row(name: str, success: bool, duration_ms: float) -> Text:
+    """One tool's completed row inside the group panel. Reuses the same
+    icon/colour vocabulary as ``tool_end_line`` so a serial vs grouped
+    completion of the same tool reads identically — just with a deeper
+    indent to signal containment."""
+    icon = "[loom.success]ok[/loom.success]" if success else "[loom.error]!![/loom.error]"
+    status = "[loom.success]done[/loom.success]" if success else "[loom.error]failed[/loom.error]"
+    name_style = "loom.muted" if success else "loom.error"
+    ms_color = "green" if success else "red"
+    return Text.from_markup(
+        f"     [loom.muted][[/loom.muted]{icon}[loom.muted]][/loom.muted] "
+        f"[{name_style}]{name}[/{name_style}]  "
+        f"[{ms_color}]{duration_ms:.0f}ms[/{ms_color}]  "
         f"[loom.muted]{status}[/loom.muted]"
     )
 


### PR DESCRIPTION
## Summary
監聽 \`EnvelopeStarted\`，\`node_count > 1\` 時進入 parallel 模式：

- 印一條 \`── parallel · N tools ──────\` header rule
- 抑制 per-tool \`[-] tool(...)\` row + spinner（footer 的 \`Nx ▸ tool · elapsed\` 已 cover live state）
- 每個 \`ToolEnd\` 印一行縮排的完成 row
- \`EnvelopeCompleted\` 印 closing rule 含 \`✓ N/N tools · X.Xs\`（有失敗就 \`⚠ ok/total\`）

單 tool envelope（\`node_count == 1\`）行為完全不變。

## 設計取捨
- **無框**：照 TaskList 的教訓，dashed rule 取代 \`╭─╮/╰─╯\` box，避開 emoji/CJK width 跟終端 soft-wrap 的舊雷
- **Skip envelope freeze (#246) 在 parallel 內**：cursor-up 2 行的算式不接受多 sibling rows
- **Footer 不變**：\`Nx ▸ tool · elapsed\` 仍然 ticking
- **TaskList panel 不影響**：浮動於 bottom region，跟 scrollback 互不干擾

## Test plan
- [ ] 同一 turn 觸發 ≥2 tools（讓 LLM 並行 dispatch）→ 看到 group 完整收納
- [ ] 單 tool 行為不變
- [ ] 並行中其中 1 個失敗 → closing 顯示 \`⚠\` + 不完整 ok 數
- [ ] 並行 + harness inline 訊息（trajectory anomaly 等）→ 訊息夾在中間但 \`⚙ harness ›\` 簽名仍可識別
- [ ] turn abort 在 parallel 中段 → ABORTED rule 正常印出，無殘留

Closes #247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)