### PR TITLE
fix(cli): shrink input area after confirm/pause widget closes

### DIFF
--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -314,7 +314,14 @@ class LoomApp:
         finally:
             self._confirm_state = None
             self._mode[0] = "input"
-            self._app.invalidate()
+            # prompt_toolkit's non-fullscreen renderer holds onto the
+            # row count it last drew at — when a tall widget (confirm
+            # with N options) closes, plain ``invalidate()`` redraws
+            # at the new shorter size *but the previously-claimed rows
+            # stay reserved*, leaving the input area visually expanded.
+            # ``renderer.erase()`` clears the rendered region so the
+            # next draw reclaims rows from scratch
+            self._shrink_after_widget_close()
 
     async def request_pause(
         self,
@@ -339,7 +346,7 @@ class LoomApp:
         finally:
             self._pause_state = None
             self._mode[0] = "input"
-            self._app.invalidate()
+            self._shrink_after_widget_close()
 
     def update_tasklist(self, todos: list[dict]) -> None:
         """Replace the floating task panel snapshot.
@@ -371,7 +378,20 @@ class LoomApp:
             self._redirect_future = None
             self._redirect_buffer.text = ""
             self._mode[0] = "input"
-            self._app.invalidate()
+            self._shrink_after_widget_close()
+
+    def _shrink_after_widget_close(self) -> None:
+        """Force the renderer to reclaim rows after a tall mode-widget
+        (confirm / pause / redirect) closes. Without this the input
+        area visually stays at the widget's row count even though the
+        layout has switched back. ``renderer.erase()`` clears the
+        currently-drawn region; ``invalidate()`` schedules a redraw
+        which then claims rows fresh based on the new layout."""
+        try:
+            self._app.renderer.erase(leave_alternate_screen=True)
+        except Exception:
+            pass
+        self._app.invalidate()
 
     # ------------------------------------------------------------------
     # Layout builders


### PR DESCRIPTION
## Summary
auth confirm widget 跑完之後，輸入區的高度不會自己縮回 1 行——這是 prompt_toolkit 在 non-fullscreen 模式下 renderer 的行為：它記住上次畫的最大 row 數，layout 算出新的較小高度時 renderer 不會自己釋放佔用的空間。

修法：confirm / pause / redirect 三條 finally 都改走 \`_shrink_after_widget_close()\`，先 \`renderer.erase(leave_alternate_screen=True)\` 清掉目前畫面，再 \`invalidate()\` 重畫——下一次 render 會從零開始算 row，正確縮到 1。

## Test plan
- [ ] 觸發需要授權的工具 → confirm widget 撐高 → 選擇後輸入區回到 1 行
- [ ] 同樣驗 pause widget（HITL）+ redirect text 輸入路徑
- [ ] 在 confirm widget 中按 Esc 取消 → 一樣縮回
- [ ] 之後正常輸入多行內容 → 仍可隨 buffer 內容自然展開（max=10）

🤖 Generated with [Claude Code](https://claude.com/claude-code)