### PR TITLE
revert: parallel envelope group panel (#247 / #261)

### DIFF
--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -61,9 +61,6 @@ from loom.platform.cli.ui import (
     ActionRolledBack,
     ActionStateChange,
     CompressDone,
-    EnvelopeCompleted,
-    EnvelopeStarted,
-    EnvelopeUpdated,
     TextChunk,
     ThinkCollapsed,
     ToolBegin,
@@ -72,9 +69,6 @@ from loom.platform.cli.ui import (
     TurnDropped,
     TurnPaused,
     clear_line,
-    parallel_group_footer,
-    parallel_group_header,
-    parallel_group_row,
     status_bar,
     tool_begin_line,
     tool_end_line,
@@ -1596,18 +1590,6 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
             # cursor manipulation can fail under terminal resize, etc.
             pass
 
-    # PR-E follow-up #247: parallel envelope group panel.
-    # When the agent dispatches >1 tools in a single envelope, we
-    # suppress the per-tool ``[-] tool(...)`` rows + spinner (the
-    # footer ``Nx ▸ tool · elapsed`` already covers live state) and
-    # frame the completed rows under a thin rule. Single-tool batches
-    # behave exactly as before.
-    _parallel_mode = False
-    _parallel_total = 0
-    _parallel_done_ok = 0
-    _parallel_done_total = 0
-    _parallel_started_at: float = 0.0
-
     # PR-D4: clear the "thinking" footer indicator on the first
     # observable event of the turn. After that, the active envelope
     # / streaming output / turn stats take over the footer's middle.
@@ -1645,45 +1627,6 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 # ThinkCollapsed in their own way and aren't affected
                 pass
 
-            elif isinstance(event, EnvelopeStarted):
-                # #247: enter parallel mode only when the batch holds
-                # multiple tools. Single-tool envelopes fall through to
-                # ToolBegin's existing inline rendering
-                if event.envelope.node_count > 1:
-                    _bump_output_seq()
-                    _flush_streaming(force=True)
-                    _segment_buffer = ""
-                    _cancel_pending_freeze()
-                    if not at_line_start:
-                        console.print()
-                        at_line_start = True
-                    _parallel_mode = True
-                    _parallel_total = event.envelope.node_count
-                    _parallel_done_ok = 0
-                    _parallel_done_total = 0
-                    _parallel_started_at = time.monotonic()
-                    console.print(parallel_group_header(_parallel_total))
-
-            elif isinstance(event, EnvelopeUpdated):
-                # No-op for the CLI — per-tool ToolEnd already drives
-                # the row-by-row redraw inside the group
-                pass
-
-            elif isinstance(event, EnvelopeCompleted):
-                if _parallel_mode:
-                    elapsed_ms = (time.monotonic() - _parallel_started_at) * 1000
-                    console.print(
-                        parallel_group_footer(
-                            _parallel_done_ok, _parallel_total, elapsed_ms
-                        )
-                    )
-                    console.print()
-                    at_line_start = True
-                    _parallel_mode = False
-                    _parallel_total = 0
-                    _parallel_done_ok = 0
-                    _parallel_done_total = 0
-
             elif isinstance(event, ToolBegin):
                 _bump_output_seq()
                 # Drain pending streamed text before the tool row
@@ -1692,24 +1635,6 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 # the current markdown-reblit segment so only post-
                 # tool text gets reblit at TurnDone
                 _segment_buffer = ""
-                # In parallel mode the per-tool row is suppressed —
-                # footer ``Nx ▸ tool · elapsed`` covers live state and
-                # individual ToolEnd rows print under the group header
-                # as they complete. Still update footer envelope list
-                active_tool = event.name
-                if _parallel_mode:
-                    loom_app = getattr(session, "_loom_app", None)
-                    if loom_app is not None:
-                        from loom.platform.cli.app import _ActiveEnvelope
-                        import time as _t
-                        loom_app.footer.active_envelopes.append(
-                            _ActiveEnvelope(
-                                name=event.name,
-                                started_monotonic=_t.monotonic(),
-                            )
-                        )
-                        loom_app.invalidate()
-                    continue
                 # New tool row prints below the prior committed
                 # envelope — that prior one can no longer freeze
                 _cancel_pending_freeze()
@@ -1719,6 +1644,7 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 if not at_line_start:
                     console.print()
                     at_line_start = True
+                active_tool = event.name
                 frame_index = 0
                 console.print(
                     tool_begin_line(event.name, event.args, width=_terminal_width())
@@ -1740,30 +1666,6 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 # Cancel spinner and clear its line
                 _cancel_spinner()
                 clear_line()
-                if _parallel_mode:
-                    # Group-panel row, no per-tool freeze (cursor-up
-                    # math doesn't compose with sibling rows). Still
-                    # drop the matching footer envelope so the live
-                    # ``Nx ▸ tool · elapsed`` decrements correctly
-                    console.print(
-                        parallel_group_row(
-                            event.name, event.success, event.duration_ms
-                        )
-                    )
-                    at_line_start = True
-                    active_tool = None
-                    _parallel_done_total += 1
-                    if event.success:
-                        _parallel_done_ok += 1
-                    loom_app = getattr(session, "_loom_app", None)
-                    if loom_app is not None:
-                        envs = loom_app.footer.active_envelopes
-                        for i in range(len(envs) - 1, -1, -1):
-                            if envs[i].name == event.name:
-                                envs.pop(i)
-                                break
-                        loom_app.invalidate()
-                    continue
                 console.print(
                     tool_end_line(event.name, event.success, event.duration_ms)
                 )

--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -55,9 +55,6 @@ from loom.core.events import (  # noqa: E402, F401
     ActionRolledBack,
     ActionStateChange,
     CompressDone,
-    EnvelopeCompleted,
-    EnvelopeStarted,
-    EnvelopeUpdated,
     TextChunk,
     ThinkCollapsed,
     ToolBegin,
@@ -660,70 +657,6 @@ def tool_end_line(
         f"  [loom.muted][[/loom.muted]{icon}[loom.muted]][/loom.muted] "
         f"[loom.muted]{name}[/loom.muted]  "
         f"[{('green' if success else 'red')}]{duration_ms:.0f}ms[/{('green' if success else 'red')}]  "
-        f"[loom.muted]{status}[/loom.muted]"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Parallel envelope group panel (#247)
-# ---------------------------------------------------------------------------
-#
-# When the agent dispatches >1 tools in a single envelope, the CLI groups
-# their rows under a thin rule header instead of letting them line up flat
-# alongside serial calls. No box (lessons from TaskList #236) — just a
-# dashed rule + label, indented child rows, dashed close.
-#
-#     ── parallel · 3 tools ─────────────
-#        [ok] read_file       12ms  done
-#        [ok] list_dir         3ms  done
-#        [ok] web_search    1230ms  done
-#     ── ✓ 3/3 tools · 1.3s ─────────────
-#
-# The header / footer rules emit at PARCHMENT_BORDER muted weight so the
-# group reads as scaffolding, not content.
-
-_PARALLEL_RULE_TOTAL = 36  # visual length cap for the dashed rule
-
-
-def parallel_group_header(node_count: int) -> Text:
-    label = f" parallel · {node_count} tools "
-    pad = max(4, _PARALLEL_RULE_TOTAL - len(label) - 2)
-    return Text.from_markup(
-        f"  [loom.muted]──[/loom.muted]"
-        f"[loom.accent]{label}[/loom.accent]"
-        f"[loom.muted]{'─' * pad}[/loom.muted]"
-    )
-
-
-def parallel_group_footer(done: int, total: int, elapsed_ms: float) -> Text:
-    """Closing rule for the group. ``done`` is success count; failures
-    flip the icon to warning so the user sees something dropped."""
-    all_ok = done == total
-    icon = "✓" if all_ok else "⚠"
-    icon_style = "loom.success" if all_ok else "loom.warning"
-    secs = elapsed_ms / 1000.0
-    label = f" {icon} {done}/{total} tools · {secs:.1f}s "
-    pad = max(4, _PARALLEL_RULE_TOTAL - len(label) - 2)
-    return Text.from_markup(
-        f"  [loom.muted]──[/loom.muted]"
-        f"[{icon_style}]{label}[/{icon_style}]"
-        f"[loom.muted]{'─' * pad}[/loom.muted]"
-    )
-
-
-def parallel_group_row(name: str, success: bool, duration_ms: float) -> Text:
-    """One tool's completed row inside the group panel. Reuses the same
-    icon/colour vocabulary as ``tool_end_line`` so a serial vs grouped
-    completion of the same tool reads identically — just with a deeper
-    indent to signal containment."""
-    icon = "[loom.success]ok[/loom.success]" if success else "[loom.error]!![/loom.error]"
-    status = "[loom.success]done[/loom.success]" if success else "[loom.error]failed[/loom.error]"
-    name_style = "loom.muted" if success else "loom.error"
-    ms_color = "green" if success else "red"
-    return Text.from_markup(
-        f"     [loom.muted][[/loom.muted]{icon}[loom.muted]][/loom.muted] "
-        f"[{name_style}]{name}[/{name_style}]  "
-        f"[{ms_color}]{duration_ms:.0f}ms[/{ms_color}]  "
         f"[loom.muted]{status}[/loom.muted]"
     )
 


### PR DESCRIPTION
## Why
PR #261 加的 parallel envelope group panel 經實測判定為過度工程：

1. **實際從沒觸發過 bug** — \`EnvelopeStarted\` 在 session.py:1895 yield 時，envelope 剛建立還沒加任何 record，\`_build_envelope_view\` 回傳 \`node_count=0\`。CLI 端 \`if event.envelope.node_count > 1\` 永遠 False。要修需要動 events.py payload 與三個 consumer (CLI / TUI / Discord)
2. **既有信號已足夠** — parallel dispatch 時 session.py:1899-1900 一口氣 yield 所有 \`ToolBegin\` 才開始 gather，CLI 上看到的就是「3 個 \`[-]\` 連發 → 3 個 \`[ok]\` 連發」，跟序列模式視覺差異夠大
3. **Footer 已 cover live state** — \`Nx ▸ tool · elapsed\` 即時顯示並行工具數
4. **真實命中率低** — 大多 fan-out 走 \`async_mode=True\` 背景 job 子系統，根本不經過 \`_dispatch_parallel\`

修 bug + 維護成本（abort 中段、harness inline 夾在中間、edge cases）對換到的視覺價值不成比例。

## What stays
- ✅ \`tests/test_parallel_dispatch.py\` — 並行 infrastructure 仍由 #263 的測試守護
- ✅ \`Agent.md.example\` 「同回合並行工具呼叫」章節 — agent 指引仍然有獨立價值
- ✅ \`_dispatch_parallel\` / \`_all_authorized\` 等 harness 機制完全不動

## Test plan
- [x] \`pytest tests/test_parallel_dispatch.py tests/test_legitimacy.py\` → 20 passed
- [x] \`py_compile main.py ui.py\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)