### PR TITLE
feat(cli): /sessions picker + /name + --name flag (#260)

### DIFF
--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -367,10 +367,24 @@ class LoomApp:
         self._app.invalidate()
 
     async def request_redirect_text(self) -> str:
-        """Switch to redirect mode for free-form text entry (HITL redirect)."""
+        """Switch to redirect mode for free-form text entry (HITL redirect).
+
+        Focus is explicitly transferred to ``_redirect_buffer`` and back.
+        Without this, the still-focused (but hidden) ``_input_buffer``
+        receives keystrokes — digits/letters land in the wrong buffer
+        and Enter both submits that hidden text as a fresh turn and
+        resolves the redirect future with an empty string. Confirm
+        widgets don't hit this because they use FormattedTextControl
+        with their own ``<any>`` keybindings, but BufferControl needs
+        focus to receive characters.
+        """
         future: asyncio.Future = asyncio.get_event_loop().create_future()
         self._redirect_future = future
         self._mode[0] = "redirect"
+        try:
+            self._app.layout.focus(self._redirect_buffer)
+        except Exception:
+            pass
         self._app.invalidate()
         try:
             return await future
@@ -378,6 +392,10 @@ class LoomApp:
             self._redirect_future = None
             self._redirect_buffer.text = ""
             self._mode[0] = "input"
+            try:
+                self._app.layout.focus(self._input_buffer)
+            except Exception:
+                pass
             self._shrink_after_widget_close()
 
     def _shrink_after_widget_close(self) -> None:

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -99,9 +99,12 @@ def cli() -> None:
 @click.option("--tui", is_flag=True, default=False, help="Use Textual TUI interface.")
 @click.option("--resume", is_flag=True, default=False, help="Resume the most recent session.")
 @click.option("--session", "resume_id", default=None, metavar="ID", help="Resume a specific session by ID.")
-def chat(model: str, db: str, tui: bool, resume: bool, resume_id: str | None) -> None:
+@click.option("--name", "name", default=None, metavar="TITLE",
+              help="Set a title on the new (or resumed) session for easier identification.")
+def chat(model: str, db: str, tui: bool, resume: bool, resume_id: str | None,
+         name: str | None) -> None:
     """Start an interactive agent session."""
-    asyncio.run(_resolve_and_chat(model, db, tui, resume, resume_id))
+    asyncio.run(_resolve_and_chat(model, db, tui, resume, resume_id, name))
 
 
 async def _resolve_and_chat(
@@ -110,6 +113,7 @@ async def _resolve_and_chat(
     tui: bool,
     resume: bool,
     resume_id: str | None,
+    name: str | None = None,
 ) -> None:
     """Resolve --resume / --session flags, then launch the appropriate interface."""
     if model is None:
@@ -132,12 +136,58 @@ async def _resolve_and_chat(
     if tui:
         await _chat_tui(model, db, resume_session_id=resolved_id)
     else:
-        await _chat(model, db, resume_session_id=resolved_id)
+        # Issue #260: CLI session switch loop — ``/sessions`` and
+        # ``/new`` set ``session._cli_next_target`` and then exit the
+        # LoomApp. ``_chat`` returns that target string; we restart with
+        # the requested session. ``--name`` is applied only on first
+        # iteration (subsequent switches inherit whatever title is in DB)
+        next_target: str | None = resolved_id
+        init_title: str | None = name
+        while True:
+            switch_to = await _chat(
+                model, db,
+                resume_session_id=next_target,
+                init_title=init_title,
+            )
+            init_title = None
+            if switch_to is None:
+                return
+            if switch_to == "__new__":
+                next_target = None
+            else:
+                next_target = switch_to
 
 
-async def _chat(model: str, db: str, resume_session_id: str | None = None) -> None:
+async def _chat(
+    model: str,
+    db: str,
+    resume_session_id: str | None = None,
+    init_title: str | None = None,
+) -> str | None:
+    """Run one chat session. Returns:
+
+    - ``None`` on normal exit (user closed the app)
+    - a ``session_id`` string when ``/sessions`` picked a different session
+    - ``"__new__"`` when ``/new`` requested a fresh session
+    """
     session = LoomSession(model=model, db_path=db, resume_session_id=resume_session_id)
     await session.start()
+
+    # Issue #260: apply ``--name`` (or the title set by ``/name``) so the
+    # session shows up in the picker / ``loom sessions list`` with the
+    # operator-friendly label rather than just its UUID
+    if init_title:
+        try:
+            async with session._store.connect() as conn:
+                await SessionLog(conn).update_title(session.session_id, init_title)
+        except Exception:
+            pass
+
+    # Issue #260: signal channel for ``/sessions`` and ``/new`` to
+    # request a session restart. Slash handler sets it; ``turn_loop``
+    # observes it and exits the LoomApp; this function reads + returns
+    # it so the outer loop in ``_resolve_and_chat`` can act
+    session._cli_next_target = None  # type: ignore[attr-defined]
 
     # Issue #120 PR1: show diagnostic summaries inline in the CLI.
     async def _cli_diagnostic(diagnostic):
@@ -388,6 +438,16 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
                     await _handle_slash(text, session)
                 except Exception as exc:
                     harness.inline(f"slash command error: {exc}", level="error")
+                # Issue #260: ``/sessions`` / ``/new`` set a switch
+                # target on the session. Exit the LoomApp so the outer
+                # loop in ``_resolve_and_chat`` can restart with the
+                # requested session
+                if getattr(session, "_cli_next_target", None) is not None:
+                    shutdown.set()
+                    try:
+                        app.application.exit()
+                    except Exception:
+                        pass
                 continue
 
             # Detect interruption marker injected by _on_submit.
@@ -465,8 +525,11 @@ async def _chat(model: str, db: str, resume_session_id: str | None = None) -> No
                 except (asyncio.CancelledError, Exception):
                     pass
     finally:
+        switch_to = getattr(session, "_cli_next_target", None)
         await session.stop()
-        console.print("\n[loom.muted]Session ended. Goodbye.[/loom.muted]")
+        if switch_to is None:
+            console.print("\n[loom.muted]Session ended. Goodbye.[/loom.muted]")
+    return switch_to
 
 
 def _format_ttl(g: Any) -> str:
@@ -677,6 +740,96 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
                 loom_app.footer.token_pct = session.budget.usage_fraction * 100
                 loom_app.invalidate()
 
+    elif command == "/sessions":
+        # Issue #260: list recent sessions, let the user pick one by
+        # number. Submitting an empty line is a no-op (stay in current
+        # session). The actual switch is performed by the outer loop in
+        # ``_resolve_and_chat`` after we set ``_cli_next_target`` and
+        # exit the LoomApp; here we only persist the intent
+        from loom.core.memory.session_log import SessionLog as _SL
+
+        async with session._store.connect() as conn:
+            rows = await _SL(conn).list_sessions(limit=20)
+
+        if not rows:
+            console.print("[loom.muted]No sessions found.[/loom.muted]")
+            return
+
+        console.print("[bold]Sessions[/bold]")
+        for i, r in enumerate(rows, 1):
+            sid = r.get("session_id", "")
+            sid_short = sid[:8]
+            title = r.get("title") or "(untitled)"
+            last = (r.get("last_active") or "")[:16].replace("T", " ")
+            turns = r.get("turn_count", 0)
+            mark = (
+                "[loom.accent]●[/loom.accent]"
+                if sid == session.session_id
+                else " "
+            )
+            console.print(
+                f"  {mark} [loom.warning]{i:>2}[/loom.warning] "
+                f"[loom.text]{title[:40]:<40}[/loom.text] "
+                f"[loom.muted]{sid_short}  {last}  {turns}t[/loom.muted]"
+            )
+        console.print(
+            "[loom.muted]  Enter a number to switch, "
+            "[loom.warning]n[/loom.warning] for new session, or just press Enter to stay.[/loom.muted]"
+        )
+
+        loom_app = getattr(session, "_loom_app", None)
+        if loom_app is None:
+            console.print(
+                "[loom.muted]  (no LoomApp wired — interactive picker unavailable)[/loom.muted]"
+            )
+            return
+
+        try:
+            choice = (await loom_app.request_redirect_text()).strip().lower()
+        except Exception:
+            choice = ""
+
+        if not choice:
+            return
+        if choice in ("n", "new"):
+            session._cli_next_target = "__new__"  # type: ignore[attr-defined]
+            return
+        if choice.isdigit():
+            idx = int(choice) - 1
+            if 0 <= idx < len(rows):
+                target = rows[idx].get("session_id", "")
+                if target and target != session.session_id:
+                    session._cli_next_target = target  # type: ignore[attr-defined]
+                else:
+                    console.print("[loom.muted]  Already in this session.[/loom.muted]")
+                return
+        console.print(f"[loom.warning]  Invalid choice: {choice!r}[/loom.warning]")
+
+    elif command == "/new":
+        # Mirrors TUI's behaviour — start a fresh session. Outer loop
+        # picks up the marker and restarts with no resume_session_id
+        session._cli_next_target = "__new__"  # type: ignore[attr-defined]
+
+    elif command == "/name":
+        # Issue #260: rename the current session in place. Title shows
+        # up immediately in ``loom sessions list`` and on the next
+        # ``/sessions`` picker open
+        if not arg:
+            console.print(
+                "[loom.muted]Usage: [loom.warning]/name <title>[/loom.warning][/loom.muted]"
+            )
+        else:
+            try:
+                from loom.core.memory.session_log import SessionLog as _SL
+                async with session._store.connect() as conn:
+                    await _SL(conn).update_title(session.session_id, arg)
+                console.print(
+                    f"[loom.muted]  ✓ Session renamed → "
+                    f"[loom.accent]{arg}[/loom.accent][/loom.muted]"
+                )
+            except Exception as exc:
+                console.print(f"[loom.error]  Rename failed: {exc}[/loom.error]")
+
     elif command == "/stop":
         # In CLI the turn is a blocking await — the user can't type while it runs.
         # /stop typed before a turn starts is a no-op; the real interrupt is Ctrl+C.
@@ -732,7 +885,8 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
                 "  List sessions:          [loom.warning]loom sessions list[/loom.warning]\n\n"
                 "[bold]Slash commands[/bold]\n\n"
                 "  [loom.warning]/new[/loom.warning]                       Start a fresh session\n"
-                "  [loom.warning]/sessions[/loom.warning]                  Browse and switch sessions\n"
+                "  [loom.warning]/sessions[/loom.warning]                  List + switch sessions (numbered picker)\n"
+                "  [loom.warning]/name[/loom.warning] [loom.muted]<title>[/loom.muted]             Rename the current session\n"
                 "  [loom.warning]/model[/loom.warning]                     Show current model + registered providers\n"
                 "  [loom.warning]/model[/loom.warning] [loom.muted]<name>[/loom.muted]              Switch model at runtime\n"
                 "    [loom.muted]MiniMax-M2.7            → MiniMax via Anthropic SDK (MINIMAX_API_KEY)[/loom.muted]\n"

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -149,6 +149,10 @@ async def _resolve_and_chat(
                 resume_session_id=next_target,
                 init_title=init_title,
             )
+            # ``--name`` is intentionally a one-shot: it labels the
+            # session the user just opened, not every session they
+            # might subsequently switch to via ``/sessions``. Each
+            # post-switch session keeps whatever title is in the DB
             init_title = None
             if switch_to is None:
                 return
@@ -180,8 +184,11 @@ async def _chat(
         try:
             async with session._store.connect() as conn:
                 await SessionLog(conn).update_title(session.session_id, init_title)
-        except Exception:
-            pass
+        except Exception as exc:
+            harness.inline(
+                f"could not apply --name {init_title!r}: {exc}",
+                level="error",
+            )
 
     # Issue #260: signal channel for ``/sessions`` and ``/new`` to
     # request a session restart. Slash handler sets it; ``turn_loop``
@@ -298,8 +305,10 @@ async def _chat(
             _meta = await SessionLog(conn).get_session(session.session_id)
         if _meta:
             _session_title = _meta.get("title")
-    except Exception:
-        pass
+    except Exception as exc:
+        # Cosmetic: title is a presentation field. Fail open with a
+        # debug-level note so prod issues are still traceable
+        logger.debug("session title lookup failed: %s", exc)
 
     console.print(
         render_welcome_signature(
@@ -324,7 +333,8 @@ async def _chat(
         try:
             async with session._store.connect() as conn:
                 _msgs = await SessionLog(conn).load_messages(session.session_id)
-        except Exception:
+        except Exception as exc:
+            logger.debug("resume preview load_messages failed: %s", exc)
             _msgs = []
         # Keep only user/assistant text turns; drop tool messages and
         # blank assistant entries (those usually mean a tool-only turn)
@@ -491,16 +501,26 @@ async def _chat(
                     await _handle_slash(text, session)
                 except Exception as exc:
                     harness.inline(f"slash command error: {exc}", level="error")
-                # Issue #260: ``/sessions`` / ``/new`` set a switch
-                # target on the session. Exit the LoomApp so the outer
-                # loop in ``_resolve_and_chat`` can restart with the
-                # requested session
+                # Issue #260: ``/sessions`` / ``/new`` request a session
+                # restart by setting ``session._cli_next_target``. The
+                # full restart path is intentionally indirect:
+                #   slash handler sets _cli_next_target
+                #   → here: shutdown.set() + app.application.exit()
+                #   → ``app.run()`` task completes → asyncio.wait wakes
+                #   → ``_chat`` finally reads _cli_next_target and returns it
+                #   → outer loop in ``_resolve_and_chat`` restarts with the
+                #     new session_id
+                # Don't shortcut this by returning directly — patch_stdout
+                # cleanup + session.stop() must run via the existing path
                 if getattr(session, "_cli_next_target", None) is not None:
                     shutdown.set()
                     try:
                         app.application.exit()
-                    except Exception:
-                        pass
+                    except Exception as _exc:
+                        harness.inline(
+                            f"app exit signalling failed: {_exc}",
+                            level="error",
+                        )
                 continue
 
             # Detect interruption marker injected by _on_submit.
@@ -832,8 +852,15 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
 
         loom_app = getattr(session, "_loom_app", None)
         if loom_app is None:
+            # Non-interactive context (tests / scripts) — picker can't
+            # take input. Tell the user where to look instead so they
+            # don't just see the list and wonder what to do
             console.print(
-                "[loom.muted]  (no LoomApp wired — interactive picker unavailable)[/loom.muted]"
+                "[loom.warning]  Interactive picker unavailable in this "
+                "context.[/loom.warning] [loom.muted]Use [/loom.muted]"
+                "[loom.warning]loom sessions list[/loom.warning][loom.muted] / "
+                "[/loom.muted][loom.warning]loom chat --session <id>[/loom.warning] "
+                "[loom.muted]from the shell instead.[/loom.muted]"
             )
             return
 

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -288,6 +288,19 @@ async def _chat(
     # the LLM's system prompt unchanged.
     from loom.platform.cli.ui import render_welcome_signature
     _idx = session._memory_index
+
+    # Issue #260: surface session title + short id in the signature so
+    # the user always knows which thread they're sitting in (after
+    # ``/sessions`` switch, or after ``--resume``)
+    _session_title: str | None = None
+    try:
+        async with session._store.connect() as conn:
+            _meta = await SessionLog(conn).get_session(session.session_id)
+        if _meta:
+            _session_title = _meta.get("title")
+    except Exception:
+        pass
+
     console.print(
         render_welcome_signature(
             model=model,
@@ -297,8 +310,48 @@ async def _chat(
             mcp_count=len(session._mcp_clients),
             episode_count=getattr(_idx, "episode_sessions", 0),
             relation_count=getattr(_idx, "relational_count", 0),
+            session_title=_session_title,
+            session_id_short=session.session_id[:8],
         )
     )
+
+    # Issue #260: when resuming a session that has prior content, echo
+    # the last few user / assistant turns into scrollback so the user
+    # has visual context for what was discussed before. Limited to last
+    # 4 messages and 240 chars each — full history is in the DB and
+    # still in the LLM's context, this is just a visual aid
+    if resume_session_id and session.session_id == resume_session_id:
+        try:
+            async with session._store.connect() as conn:
+                _msgs = await SessionLog(conn).load_messages(session.session_id)
+        except Exception:
+            _msgs = []
+        # Keep only user/assistant text turns; drop tool messages and
+        # blank assistant entries (those usually mean a tool-only turn)
+        _preview = [
+            m for m in _msgs
+            if m.get("role") in ("user", "assistant")
+            and isinstance(m.get("content"), str)
+            and m.get("content", "").strip()
+        ][-4:]
+        if _preview:
+            console.print()
+            console.print(
+                "[loom.muted]  ↳ previous turns "
+                f"({len(_msgs)} messages total)[/loom.muted]"
+            )
+            for m in _preview:
+                role = m.get("role", "")
+                content = m.get("content", "").strip().replace("\n", " ")
+                if len(content) > 240:
+                    content = content[:237] + "…"
+                tag = (
+                    "[loom.accent]you ›[/loom.accent]"
+                    if role == "user"
+                    else "[loom.muted]Loom ▎[/loom.muted]"
+                )
+                console.print(f"  {tag} [loom.muted]{content}[/loom.muted]")
+            console.print()
 
     # PR-D4: anchor the persistent app's bottom region to the actual
     # bottom of the terminal. ``full_screen=False`` mode draws the

--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -80,6 +80,7 @@ SLASH_COMMANDS: list[tuple[str, str]] = [
     ("/model claude-sonnet-4-6",    "switch to Anthropic Claude Sonnet 4.6"),
     ("/model claude-opus-4-7",      "switch to Anthropic Claude Opus 4.7"),
     ("/model MiniMax-M2.7",         "switch to MiniMax-M2.7 (default)"),
+    ("/name",                       "rename the current session"),
     ("/new",                        "start a fresh session"),
     ("/pause",                      "toggle HITL pause after each tool batch"),
     ("/personality",                "show active persona + available list"),

--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -437,6 +437,8 @@ def render_welcome_signature(
     mcp_count: int = 0,
     episode_count: int = 0,
     relation_count: int = 0,
+    session_title: str | None = None,
+    session_id_short: str | None = None,
 ) -> Text:
     """ASCII signature + stats block for ``loom chat`` startup.
 
@@ -483,6 +485,20 @@ def render_welcome_signature(
 
     persona_tag = f"  ·  persona: {persona}" if persona else ""
 
+    # Session identity line — title (when set) + short id, so the user
+    # always knows which thread they're in. Hidden entirely when both
+    # are absent (e.g. very first chat before any session exists)
+    session_line = ""
+    if session_title or session_id_short:
+        bits: list[str] = []
+        if session_title:
+            bits.append(f"[loom.accent]{session_title}[/loom.accent]")
+        if session_id_short:
+            bits.append(f"[loom.muted]({session_id_short})[/loom.muted]")
+        session_line = (
+            f"[loom.muted]      ╲   [/loom.muted]" + "  ".join(bits) + "\n"
+        )
+
     # Five-line signature: woven mark on top, stats + identity below
     return Text.from_markup(
         "\n"
@@ -493,6 +509,7 @@ def render_welcome_signature(
         f"[loom.muted] ─────  {stats_line}[/loom.muted]\n"
         f"[loom.muted]      ╲   [/loom.muted][loom.text]{model}[/loom.text]"
         f"[loom.muted]{persona_tag}[/loom.muted]\n"
+        + session_line
     )
 
 


### PR DESCRIPTION
## Summary
TUI 模式有完整的 session 切換 + 命名功能，CLI 模式以前沒有——\`/sessions\` 列在 /help 卻未實作，session 也只能靠 UUID 識別。

PR 加三個入口，各自最小可用：

**\`/sessions\`** — 印 20 筆最近 session 的編號清單（title · session_id 前綴 · last_active · turn_count，當前 session 標 ●），透過 LoomApp 既有的 redirect mode 接一行輸入：
- 數字 → 切換到該 session
- \`n\` / \`new\` → 開新 session
- 空 / Enter → 留在當前 session

實際切換由 \`_resolve_and_chat\` 的外層 restart loop 完成；slash handler 只設 \`session._cli_next_target\` 後 exit LoomApp。

**\`/name <title>\`** — 即時改名當前 session，\`loom sessions list\` 立刻看到。

**\`--name <title>\`** — 啟動時直接帶 title。

## Test plan
- [x] \`pytest test_session.py test_legitimacy.py test_parallel_dispatch.py\` → 51 passed
- [ ] \`loom chat --name "Test Session"\` → \`loom sessions list\` 看到該 title
- [ ] chat 中輸入 \`/name 新名字\` → 即時生效
- [ ] chat 中輸入 \`/sessions\` → 看到清單，輸入數字 → 切換成功
- [ ] \`/sessions\` 後輸入 \`n\` → 開新 session
- [ ] \`/sessions\` 後直接 Enter → 留在當前 session
- [ ] \`/new\` → 開新 session（路徑與 \`/sessions\` 後 \`n\` 一致）

Closes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)