### PR TITLE
feat(cognition): provider native_max_tokens + fix /model dispatcher (#272)

### DIFF
--- a/loom.toml.example
+++ b/loom.toml.example
@@ -41,18 +41,26 @@ personality = ""
 default_model = "claude-sonnet-4-6"
 max_tokens    = 8096
 
-# Output-token cap for the main stream_turn() LLM call. Different providers
-# have wildly different ceilings — MiniMax-M2.7 supports ~64K, Claude Sonnet
-# 4.6 supports ~64K, small local models often 4-8K. Set a conservative
-# session-wide default and override per-model below.
-output_max_tokens = 32768
-
-# Per-model overrides (table key = exact model name). Entries here win over
-# the default above. Unknown models fall through to output_max_tokens.
-[cognition.output_max_tokens_overrides]
-"MiniMax-M2.7"       = 65536
-"claude-sonnet-4-6"  = 65536
-"claude-opus-4-7"    = 32768
+# Output-token cap for the main stream_turn() LLM call.
+#
+# Issue #272: providers now declare native limits in their
+# NATIVE_OUTPUT_LIMITS table (loom/core/cognition/providers.py), so the
+# values below are no longer required for supported models. Set them
+# only when you genuinely want a *shorter* response than the model can
+# produce — e.g. for cost control on free tiers, or to force concise
+# answers in a specific deployment.
+#
+# Resolution order:
+#   1. [cognition.output_max_tokens_overrides][<model>]  ← user override
+#   2. [cognition].output_max_tokens                      ← global user-set
+#   3. provider's NATIVE_OUTPUT_LIMITS[<model>]           ← provider truth
+#   4. _DEFAULT_OUTPUT_MAX_TOKENS = 8192                  ← last-resort
+#
+# output_max_tokens = 8192
+#
+# [cognition.output_max_tokens_overrides]
+# "MiniMax-M2.7"       = 32768   # cap a chatty model
+# "claude-opus-4-7"    = 16384
 
 # ─────────────────────────────────────────────
 # Local providers

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -120,6 +120,25 @@ class LLMProvider(ABC):
     """Abstract base for all LLM providers."""
     name: str
 
+    # Issue #272: each provider declares its own model→native max output
+    # tokens table here. ``native_max_tokens`` consults the table; the
+    # session-level resolver uses this as a fallback when loom.toml
+    # doesn't override. Subclasses populate; default is empty.
+    NATIVE_OUTPUT_LIMITS: dict[str, int] = {}
+
+    def native_max_tokens(self, model: str) -> int | None:
+        """Return the provider's declared native output cap for *model*.
+
+        Returns ``None`` when the model is unknown to this provider — the
+        session resolver should then fall back to its conservative default.
+        Lookup is case-insensitive so loom.toml entries like
+        ``"MiniMax-M2.7"`` and ``"minimax-m2.7"`` both resolve correctly
+        against the canonical lower-cased table.
+        """
+        if not model:
+            return None
+        return self.NATIVE_OUTPUT_LIMITS.get(model.lower())
+
     @abstractmethod
     async def chat(
         self,
@@ -203,6 +222,33 @@ class AnthropicProvider(LLMProvider):
     """
 
     name = "anthropic"
+
+    # Issue #272: model→native output cap. Keys are lower-cased for
+    # case-insensitive lookup. Includes MiniMax + DeepSeek because both
+    # ride the Anthropic-compatible endpoint via this same class.
+    #
+    # Sources:
+    #   - Anthropic: https://docs.anthropic.com/en/docs/about-claude/models
+    #     Sonnet 4.6 needs the ``output-128k-2025-02-19`` beta header to
+    #     reach 64K; without it the cap is 8K. We assume the harness's
+    #     anthropic SDK opt-in is active (it is, per providers.py:228).
+    #   - MiniMax: 64K matches the user-validated value previously sitting
+    #     in loom.toml ``output_max_tokens_overrides``.
+    #   - DeepSeek: 8K is the documented standard cap for deepseek-chat
+    #     and deepseek-coder; deepseek-reasoner is the same.
+    NATIVE_OUTPUT_LIMITS: dict[str, int] = {
+        # Anthropic Claude family
+        "claude-opus-4-7": 32768,
+        "claude-sonnet-4-6": 65536,
+        "claude-haiku-4-5": 8192,
+        "claude-haiku-4-5-20251001": 8192,
+        # MiniMax via Anthropic-compat endpoint
+        "minimax-m2.7": 65536,
+        # DeepSeek via Anthropic-compat endpoint
+        "deepseek-v3": 8192,
+        "deepseek-chat": 8192,
+        "deepseek-reasoner": 8192,
+    }
 
     def __init__(
         self,

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -282,11 +282,23 @@ _DEFAULT_OUTPUT_MAX_TOKENS = 8192
 _MAX_REASONING_CONTINUATIONS = 2
 
 
-def _resolve_output_max_tokens(cfg: dict, model: str) -> int:
-    """Return the output-token cap for *model* from ``[cognition]``.
+def _resolve_output_max_tokens(
+    cfg: dict, model: str, router: "LLMRouter | None" = None,
+) -> int:
+    """Return the output-token cap for *model*.
 
-    Precedence: ``[cognition.output_max_tokens_overrides][<model>]`` →
-    ``[cognition].output_max_tokens`` → ``_DEFAULT_OUTPUT_MAX_TOKENS``.
+    Precedence (Issue #272):
+      1. ``[cognition.output_max_tokens_overrides][<model>]`` — explicit
+         user override, case-sensitive (intentional: user typed it).
+      2. ``[cognition].output_max_tokens`` — global user-set cap.
+      3. **Provider-declared native limit** — provider class knows what its
+         own models support. Lookup is case-insensitive. New models become
+         available without loom.toml edits.
+      4. ``_DEFAULT_OUTPUT_MAX_TOKENS`` — last-resort fallback.
+
+    The provider-native step (3) is the one that lets users drop the
+    overrides table entirely once their models are in the provider's
+    ``NATIVE_OUTPUT_LIMITS``.
     """
     cog = cfg.get("cognition", {}) or {}
     overrides = cog.get("output_max_tokens_overrides", {}) or {}
@@ -300,6 +312,17 @@ def _resolve_output_max_tokens(cfg: dict, model: str) -> int:
         try:
             return int(default)
         except (TypeError, ValueError):
+            pass
+    # Step 3 — ask the provider what its native ceiling is for this model.
+    if router is not None:
+        try:
+            provider = router.get_provider(model)
+            native = provider.native_max_tokens(model)
+            if native is not None and native > 0:
+                return int(native)
+        except Exception:
+            # Routing failures or missing provider shouldn't break the call;
+            # fall through to the constant default.
             pass
     return _DEFAULT_OUTPUT_MAX_TOKENS
 
@@ -1627,7 +1650,7 @@ class LoomSession:
                     messages=self.messages,
                     tools=tools,
                     max_tokens=_resolve_output_max_tokens(
-                        self._loom_config, self.model,
+                        self._loom_config, self.model, router=self.router,
                     ),
                     abort_signal=abort_signal,
                 ):

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -763,7 +763,7 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
                     "(check API key in .env or enable in loom.toml).[/loom.muted]"
                 )
 
-    if command == "/personality":
+    elif command == "/personality":
         if not arg:
             p = session.current_personality
             avail = session._stack.available_personalities()

--- a/tests/test_output_max_tokens_resolver.py
+++ b/tests/test_output_max_tokens_resolver.py
@@ -1,0 +1,175 @@
+"""
+Tests for ``_resolve_output_max_tokens`` provider-aware resolution (Issue #272).
+
+Resolution order:
+  1. ``[cognition.output_max_tokens_overrides][<model>]`` — user explicit
+  2. ``[cognition].output_max_tokens`` — global user-set
+  3. Provider's ``native_max_tokens(model)`` — provider-declared truth
+  4. ``_DEFAULT_OUTPUT_MAX_TOKENS`` — last-resort constant
+
+Step 3 is the new layer that lets users drop the overrides table.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from loom.core.cognition.providers import AnthropicProvider, LLMProvider
+from loom.core.session import (
+    _DEFAULT_OUTPUT_MAX_TOKENS,
+    _resolve_output_max_tokens,
+)
+
+
+class _StubProvider(LLMProvider):
+    """Minimal provider double for resolver tests — does nothing real."""
+
+    name = "stub"
+    NATIVE_OUTPUT_LIMITS = {"stub-large": 100000, "stub-small": 4096}
+
+    async def chat(self, *args, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+    def format_tool_result(self, *args, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+
+class _Router:
+    """Just enough surface for ``_resolve_output_max_tokens``."""
+
+    def __init__(self, provider: LLMProvider) -> None:
+        self._provider = provider
+
+    def get_provider(self, model: str) -> LLMProvider:
+        return self._provider
+
+
+class TestPrecedenceOrder:
+    """The four-step ladder must be honoured top-to-bottom."""
+
+    def test_explicit_override_wins(self) -> None:
+        cfg = {
+            "cognition": {
+                "output_max_tokens": 8192,
+                "output_max_tokens_overrides": {"stub-large": 1024},
+            }
+        }
+        router = _Router(_StubProvider())
+        # Override (1024) beats global (8192), provider (100000), and default
+        assert _resolve_output_max_tokens(cfg, "stub-large", router) == 1024
+
+    def test_global_default_used_when_no_override(self) -> None:
+        cfg = {"cognition": {"output_max_tokens": 16384}}
+        router = _Router(_StubProvider())
+        # Global (16384) beats provider native (100000) and constant default
+        assert _resolve_output_max_tokens(cfg, "stub-large", router) == 16384
+
+    def test_provider_native_used_when_config_silent(self) -> None:
+        cfg: dict = {}
+        router = _Router(_StubProvider())
+        # No user config → provider's table wins for known models
+        assert _resolve_output_max_tokens(cfg, "stub-large", router) == 100000
+        assert _resolve_output_max_tokens(cfg, "stub-small", router) == 4096
+
+    def test_constant_fallback_when_provider_unknown(self) -> None:
+        cfg: dict = {}
+        router = _Router(_StubProvider())
+        # Model not in provider's table → fall through to constant
+        assert (
+            _resolve_output_max_tokens(cfg, "stub-mystery", router)
+            == _DEFAULT_OUTPUT_MAX_TOKENS
+        )
+
+
+class TestRouterOptional:
+    """The router parameter is optional for backward compat."""
+
+    def test_no_router_skips_provider_layer(self) -> None:
+        cfg: dict = {}
+        # Without router, step 3 is skipped → constant default
+        assert (
+            _resolve_output_max_tokens(cfg, "stub-large")
+            == _DEFAULT_OUTPUT_MAX_TOKENS
+        )
+
+    def test_no_router_with_global_default(self) -> None:
+        cfg = {"cognition": {"output_max_tokens": 12345}}
+        assert _resolve_output_max_tokens(cfg, "anything") == 12345
+
+
+class TestRouterFailureSafe:
+    """Routing exceptions must not break the resolver — fall through silently."""
+
+    def test_router_raising_falls_through_to_default(self) -> None:
+        class _BrokenRouter:
+            def get_provider(self, model):
+                raise RuntimeError("provider not registered")
+
+        cfg: dict = {}
+        # No exception leaks; we get the constant default
+        assert (
+            _resolve_output_max_tokens(cfg, "anything", _BrokenRouter())
+            == _DEFAULT_OUTPUT_MAX_TOKENS
+        )
+
+    def test_provider_returning_none_falls_through(self) -> None:
+        class _NullProvider(LLMProvider):
+            name = "null"
+
+            async def chat(self, *a, **k):  # pragma: no cover
+                raise NotImplementedError
+
+            def format_tool_result(self, *a, **k):  # pragma: no cover
+                raise NotImplementedError
+
+        cfg: dict = {}
+        assert (
+            _resolve_output_max_tokens(cfg, "anything", _Router(_NullProvider()))
+            == _DEFAULT_OUTPUT_MAX_TOKENS
+        )
+
+
+class TestAnthropicProviderTable:
+    """The shipped table for Claude / MiniMax / DeepSeek must cover the
+    models the project actually uses (regression guard against accidental
+    deletions / typos in NATIVE_OUTPUT_LIMITS)."""
+
+    def test_known_anthropic_models_have_entries(self) -> None:
+        p = object.__new__(AnthropicProvider)  # bypass __init__ (needs API key)
+        for model, expected in [
+            ("claude-opus-4-7", 32768),
+            ("claude-sonnet-4-6", 65536),
+            ("claude-haiku-4-5", 8192),
+        ]:
+            assert p.native_max_tokens(model) == expected, model
+
+    def test_minimax_lookup_is_case_insensitive(self) -> None:
+        """The user's loom.toml had both ``"minimax-M2.7"`` and
+        ``"MiniMax-M2.7"`` because case mismatches were silently failing.
+        Provider lookup must canonicalize."""
+        p = object.__new__(AnthropicProvider)
+        for variant in ("minimax-m2.7", "MiniMax-M2.7", "MINIMAX-M2.7"):
+            assert p.native_max_tokens(variant) == 65536, variant
+
+    def test_deepseek_models_have_entries(self) -> None:
+        p = object.__new__(AnthropicProvider)
+        assert p.native_max_tokens("deepseek-chat") == 8192
+        assert p.native_max_tokens("deepseek-reasoner") == 8192
+
+    def test_unknown_model_returns_none(self) -> None:
+        p = object.__new__(AnthropicProvider)
+        assert p.native_max_tokens("claude-gibberish-99") is None
+        assert p.native_max_tokens("") is None
+
+
+class TestEmptyModelHandling:
+    """Edge cases on the model parameter."""
+
+    def test_empty_model_string(self) -> None:
+        cfg: dict = {}
+        router = _Router(_StubProvider())
+        # Empty model should not crash; provider returns None → constant
+        assert (
+            _resolve_output_max_tokens(cfg, "", router)
+            == _DEFAULT_OUTPUT_MAX_TOKENS
+        )

--- a/tests/test_slash_model.py
+++ b/tests/test_slash_model.py
@@ -1,0 +1,105 @@
+"""
+Regression test for the ``/model`` slash command (#272 follow-up).
+
+Bug: ``main._handle_slash`` had two independent ``if command == ...``
+chains; ``/model`` matched the first chain at L742 but execution then
+continued into the second chain (which started with another bare ``if``
+at L766), and the trailing ``else`` at L1000 fired with
+``Unknown command '/model'``.
+
+Symptom the user observed::
+
+    you › /model deepseek-v4-pro
+    Model switched to: deepseek-v4-pro
+    Unknown command '/model'. Type /help for help.
+
+Fix: change the second chain's leading ``if`` to ``elif`` so the dispatcher
+becomes a single chain whose ``else`` only fires when no command matches.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from loom.platform.cli import main as cli_main
+
+
+@pytest.fixture
+def capture_console(monkeypatch):
+    """Capture all console.print payloads as plain strings."""
+    captured: list[str] = []
+
+    def _print(*args, **kwargs) -> None:
+        captured.append(" ".join(str(a) for a in args))
+
+    monkeypatch.setattr(cli_main.console, "print", _print)
+    return captured
+
+
+def _stub_session(switch_ok: bool = True) -> SimpleNamespace:
+    """Minimal session with the surface ``/model`` reads."""
+    return SimpleNamespace(
+        model="minimax-m2.7",
+        router=SimpleNamespace(providers=["anthropic", "deepseek"]),
+        set_model=lambda model: switch_ok,
+        # Other slash branches reach for these — provide no-op stubs so the
+        # full dispatcher walk doesn't AttributeError on unrelated paths.
+        current_personality=None,
+        _stack=MagicMock(),
+        _last_think="",
+    )
+
+
+class TestSlashModel:
+    async def test_model_switch_does_not_print_unknown_command(
+        self, capture_console
+    ) -> None:
+        """The bug: dispatcher fell through to the else branch after a
+        successful /model command. Output must NOT contain 'Unknown command'."""
+        session = _stub_session()
+        await cli_main._handle_slash("/model deepseek-v4-pro", session)
+
+        joined = "\n".join(capture_console)
+        assert "Model switched to" in joined
+        assert "Unknown command" not in joined, (
+            "Dispatcher fell through to the else branch — /model bug regressed.\n"
+            f"Captured output:\n{joined}"
+        )
+
+    async def test_model_query_without_arg_does_not_print_unknown(
+        self, capture_console
+    ) -> None:
+        """Bare ``/model`` (no arg) shows the providers list and must
+        likewise not trigger the 'Unknown command' fallthrough."""
+        session = _stub_session()
+        await cli_main._handle_slash("/model", session)
+
+        joined = "\n".join(capture_console)
+        assert "Current model" in joined
+        assert "Unknown command" not in joined
+
+    async def test_model_switch_failure_shows_error_not_unknown(
+        self, capture_console
+    ) -> None:
+        """When set_model returns False, the user sees the targeted
+        'Could not switch' message — never the generic 'Unknown command'."""
+        session = _stub_session(switch_ok=False)
+        await cli_main._handle_slash("/model nonexistent-model", session)
+
+        joined = "\n".join(capture_console)
+        assert "Could not switch" in joined
+        assert "Unknown command" not in joined
+
+    async def test_actually_unknown_command_still_caught(
+        self, capture_console
+    ) -> None:
+        """The else branch must still fire for genuinely unknown commands —
+        we fixed the over-firing, not removed it."""
+        session = _stub_session()
+        await cli_main._handle_slash("/zzz-not-a-real-command", session)
+
+        joined = "\n".join(capture_console)
+        assert "Unknown command" in joined


### PR DESCRIPTION
Closes #272.

## TL;DR

Move "what's this model's max output?" knowledge out of user-edited
loom.toml and into provider classes. New models become available
without users editing config. Drive-by: fix the ``/model`` slash
command's "Unknown command" false-positive.

## The architectural change

Adds ``LLMProvider.native_max_tokens(model)`` and a class-level
``NATIVE_OUTPUT_LIMITS`` dict on each provider. The session-level
``_resolve_output_max_tokens`` now consults the provider as a layer
between user config and the constant default.

**Before:** user loom.toml had to enumerate every model with a number,
and case mismatches (``"minimax-M2.7"`` vs ``"MiniMax-M2.7"``) silently
fell through.

**After:** user only writes overrides when they want *shorter* than the
model's native cap (cost control / forced concision). Provider classes
ship the table.

```
Resolution order:
  1. [cognition.output_max_tokens_overrides][<model>]   ← user explicit
  2. [cognition].output_max_tokens                       ← global user-set
  3. provider.native_max_tokens(model)                   ← NEW
  4. _DEFAULT_OUTPUT_MAX_TOKENS = 8192                   ← last-resort
```

## What's in the AnthropicProvider table

(Single class serves Anthropic + MiniMax + DeepSeek via the
Anthropic-compatible endpoint, so one combined table covers all three.)

| Model                    | Native cap |
|--------------------------|-----------:|
| claude-opus-4-7          |     32 768 |
| claude-sonnet-4-6        |     65 536 |
| claude-haiku-4-5(-…)     |      8 192 |
| minimax-m2.7             |     65 536 |
| deepseek-{chat,reasoner,v3} |   8 192 |

Lookup is case-insensitive (one of the bugs we found in the existing
config — both ``minimax-M2.7`` and ``MiniMax-M2.7`` were duplicated to
work around case mismatches).

OpenRouter / Ollama / LMStudio inherit the empty default — they get
``None`` from ``native_max_tokens`` and fall through to the constant.
Users add entries as they pin specific models.

## Drive-by: ``/model`` dispatcher bug

User reported:
```
you › /model deepseek-v4-pro
Model switched to: deepseek-v4-pro
Unknown command '/model'. Type /help for help.
```

Root cause: ``main._handle_slash`` had two independent ``if command ==
...`` chains. ``/model`` matched the first; execution continued past
into the second chain whose ``else`` fired the false 'Unknown command'.
Fixed by collapsing into one ``if``/``elif``/``else`` chain.

## Test plan

- [x] 13 unit tests in ``test_output_max_tokens_resolver.py`` — full
      precedence ladder, optional router param, failure-safe routing,
      AnthropicProvider table coverage, case-insensitive lookup
- [x] 4 unit tests in ``test_slash_model.py`` — ``/model`` no longer
      false-positives, genuine unknowns still caught (regression guard)
- [x] Full suite: 1298 passed, 1 skipped (was 1281 + 17 new)
- [ ] Manual: ``loom chat`` → ``/model claude-opus-4-7`` → verify clean
      output, no 'Unknown command' line
- [ ] Manual: comment out ``[cognition.output_max_tokens_overrides]``
      in local loom.toml, run a session against opus, confirm reasoning
      uses 32K cap (provider native) instead of 8K fallback

## Follow-ups

- New models added to Anthropic / MiniMax / DeepSeek require updating
  ``NATIVE_OUTPUT_LIMITS`` in ``providers.py``. Consider a lightweight
  GitHub Action that pings provider docs and opens a PR when a new
  model name appears (out of scope here).
- OpenRouter / Ollama / LMStudio model tables — left empty until users
  pin specific models. Could be populated from a community-maintained
  list later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)