### PR TITLE
fix(cli): refresh footer model badge on /model switch (+ finish TUI dispatcher fix)

### DIFF
--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -559,6 +559,11 @@ async def _chat(
             # user is reading).
             app.footer.token_pct = session.budget.usage_fraction * 100
             app.footer.persona = session.current_personality
+            # Belt-and-suspenders for /model: slash handlers update
+            # footer.model immediately on switch, but a future code path
+            # could change session.model without going through them. Keep
+            # the badge aligned with reality at every turn edge.
+            app.footer.model = session.model
             try:
                 snapshot = session._build_grants_snapshot()
                 app.footer.grants_active = snapshot.active_count
@@ -756,6 +761,13 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
             ok = session.set_model(arg)
             if ok:
                 console.print(f"[loom.muted]Model switched to: [bold]{arg}[/bold][/loom.muted]")
+                # Footer was set once at startup (build_loom_app) and never
+                # refreshed for runtime model switches — user saw the success
+                # line above but the bottom badge kept showing the old name
+                # until the next turn boundary's stat refresh.
+                if (loom_app := getattr(session, "_loom_app", None)) is not None:
+                    loom_app.footer.model = arg
+                    loom_app.invalidate()
             else:
                 console.print(
                     f"[loom.error]Could not switch to '{arg}'.[/loom.error] "
@@ -1362,6 +1374,10 @@ async def _handle_slash_tui(cmd: str, session: "LoomSession", app: Any) -> None:
             ok = session.set_model(arg)
             if ok:
                 app.notify(f"Model switched to: {arg}")
+                # Mirror the change into the footer badge so the bottom
+                # region stops showing the old model until next turn.
+                app.footer.model = arg
+                app.invalidate()
             else:
                 app.notify(
                     f"Cannot switch to '{arg}' — prefix not recognised or provider "
@@ -1369,7 +1385,7 @@ async def _handle_slash_tui(cmd: str, session: "LoomSession", app: Any) -> None:
                     severity="error",
                 )
 
-    if command == "/personality":
+    elif command == "/personality":
         if not arg:
             p = session.current_personality
             avail = session._stack.available_personalities()

--- a/tests/test_slash_model.py
+++ b/tests/test_slash_model.py
@@ -103,3 +103,62 @@ class TestSlashModel:
 
         joined = "\n".join(capture_console)
         assert "Unknown command" in joined
+
+
+class TestFooterSyncOnModelSwitch:
+    """The footer's model badge must reflect the new model immediately on
+    a successful ``/model`` switch — not wait until next turn boundary."""
+
+    async def test_footer_updated_after_successful_switch(
+        self, capture_console
+    ) -> None:
+        from types import SimpleNamespace as _NS
+
+        # Stand-in LoomApp with the surface the slash handler touches.
+        invalidate_calls: list[bool] = []
+        loom_app = _NS(
+            footer=_NS(model="minimax-m2.7"),
+            invalidate=lambda: invalidate_calls.append(True),
+        )
+
+        session = _stub_session()
+        session._loom_app = loom_app
+
+        await cli_main._handle_slash("/model claude-opus-4-7", session)
+
+        assert loom_app.footer.model == "claude-opus-4-7", (
+            "footer.model not refreshed after /model switch"
+        )
+        assert invalidate_calls, "app.invalidate() was not called — UI won't redraw"
+
+    async def test_footer_unchanged_on_failed_switch(
+        self, capture_console
+    ) -> None:
+        """A failed switch must NOT alter the footer (would be misleading)."""
+        from types import SimpleNamespace as _NS
+
+        loom_app = _NS(
+            footer=_NS(model="minimax-m2.7"),
+            invalidate=lambda: None,
+        )
+
+        session = _stub_session(switch_ok=False)
+        session._loom_app = loom_app
+
+        await cli_main._handle_slash("/model gibberish-model", session)
+
+        assert loom_app.footer.model == "minimax-m2.7", (
+            "footer.model changed on failed switch — UI now lies about the active model"
+        )
+
+    async def test_no_loom_app_does_not_crash(
+        self, capture_console
+    ) -> None:
+        """Sessions used outside the persistent app (tests, scripts) have
+        no ``_loom_app`` — slash handler must tolerate that gracefully."""
+        session = _stub_session()
+        # Explicitly absent — getattr default branch fires
+        assert not hasattr(session, "_loom_app")
+
+        # Just shouldn't raise.
+        await cli_main._handle_slash("/model some-model", session)


### PR DESCRIPTION
Tight follow-up to #274.

## Bug

After ``/model claude-opus-4-7`` the success line prints fine in
scrollback, but the **footer badge at the bottom keeps showing the old
model** until the next turn boundary's stats refresh kicks in. Looks
like the switch didn't take.

## Three fixes in this PR

### 1. Plain CLI immediate refresh

In ``_handle_slash`` after a successful ``set_model``:

```python
if (loom_app := getattr(session, "_loom_app", None)) is not None:
    loom_app.footer.model = arg
    loom_app.invalidate()
```

``getattr`` default keeps it safe for sessions used outside the
persistent app (test fixtures, scripts).

### 2. TUI handler — same fix + finish dispatcher cleanup

``_handle_slash_tui`` still had the **two-independent-``if``-chains**
bug that #274 fixed in plain CLI. Same symptom: ``/model`` matched the
first chain at L1354, fell through to the second chain's ``else``, and
``app.notify("Unknown command '/model'…")`` fired on TUI too.

Fixed by changing the leading ``if`` of the second chain to ``elif``,
mirroring #274's plain-CLI fix.

Also wires the same ``app.footer.model = arg + app.invalidate()`` pair
into the TUI success path.

### 3. Belt-and-suspenders at turn-boundary

L560 already refreshes ``persona`` / ``token_pct`` / grants on every
turn edge. Adds ``app.footer.model = session.model`` to the same block
so any **future** code path that mutates model without going through
the slash command (programmatic switch, recovery flow, etc.) still
converges the footer with reality at the next turn boundary.

## Test plan

- [x] 3 new tests in ``test_slash_model.py``:
  - footer write **AND** invalidate() both called on success
  - footer unchanged on failed switch (no misleading state)
  - graceful no-op when ``_loom_app`` not attached
- [x] Full suite: 1301 passed, 1 skipped (was 1298 + 3 new)
- [ ] Manual: ``loom chat`` → ``/model claude-opus-4-7`` → footer badge
  flips immediately, no waiting for next turn
- [ ] Manual: ``loom chat`` → ``/model gibberish`` → footer stays on
  the original model (no false update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)