### PR TITLE
feat(telemetry): agent_health follow-up — progressive disclosure + design polish

### DIFF
--- a/loom/core/infra/telemetry.py
+++ b/loom/core/infra/telemetry.py
@@ -453,7 +453,7 @@ class ContextLayoutDimension(DimensionTracker):
 # ── Dimension: runtime_identity ───────────────────────────────────────────
 
 class RuntimeIdentityDimension(DimensionTracker):
-    """Exposes current model, tier, and training cutoff to the agent."""
+    """Exposes current model and tier to the agent."""
 
     name = "runtime_identity"
 
@@ -461,26 +461,21 @@ class RuntimeIdentityDimension(DimensionTracker):
         self._model: str = "unknown"
         self._tier: int = 1
         self._tier_models: dict[int, str] = {}
-        self._training_cutoff: str = "unknown"
 
     def update(self, *, model: str | None = None, tier: int | None = None,
-               tier_models: dict[int, str] | None = None,
-               training_cutoff: str | None = None) -> None:
+               tier_models: dict[int, str] | None = None) -> None:
         if model is not None:
             self._model = model
         if tier is not None:
             self._tier = tier
         if tier_models is not None:
             self._tier_models = tier_models
-        if training_cutoff is not None:
-            self._training_cutoff = training_cutoff
 
     def snapshot(self) -> dict[str, Any]:
         return {
             "model": self._model,
             "tier": self._tier,
             "tier_models": {str(k): v for k, v in self._tier_models.items()},
-            "training_cutoff": self._training_cutoff,
         }
 
     def render_summary(self) -> str:
@@ -492,8 +487,7 @@ class RuntimeIdentityDimension(DimensionTracker):
             f"## runtime_identity\n"
             f"- model: {self._model}\n"
             f"- tier: {self._tier}\n"
-            f"- tier models: {tms or '(not configured)'}\n"
-            f"- training cutoff: {self._training_cutoff}"
+            f"- tier models: {tms or '(not configured)'}"
         )
 
 
@@ -542,13 +536,12 @@ class ContextBudgetDimension(DimensionTracker):
         return self._budget is not None and self._budget.should_compress()
 
     def describe_anomaly(self) -> str | None:
-        if not self.has_anomaly():
-            return None
-        if self._budget is None:
+        if not self.has_anomaly() or self._budget is None:
             return None
         return (
             f"Context at {self._budget.usage_fraction:.0%} — "
-            f"consider compression soon."
+            f"harness will auto-compact at start of next turn. "
+            f"Avoid starting long tool chains this turn."
         )
 
 
@@ -573,12 +566,7 @@ class SessionTurnsDimension(DimensionTracker):
         return f"turns: {self._turns}"
 
     def render_detail(self) -> str:
-        t = self._turns
-        return (
-            f"## session_turns\n"
-            f"- current turn: {t}\n"
-            f"- session stage: {'early' if t < 5 else 'mid' if t < 20 else 'deep'}"
-        )
+        return f"## session_turns\n- current turn: {self._turns}"
 
 
 # ── Dimension: loaded_skills ──────────────────────────────────────────────

--- a/loom/core/infra/telemetry.py
+++ b/loom/core/infra/telemetry.py
@@ -541,7 +541,8 @@ class ContextBudgetDimension(DimensionTracker):
         return (
             f"Context at {self._budget.usage_fraction:.0%} — "
             f"harness will auto-compact at start of next turn. "
-            f"Avoid starting long tool chains this turn."
+            f"Finish the current tool batch, then avoid starting "
+            f"new long chains until after compaction."
         )
 
 

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -3030,9 +3030,12 @@ class LoomSession:
         active = self._active_tier()
         if active == old_tier:
             return None
-        # Issue #279: update runtime_identity on tier switch
-        if self._telemetry is not None:
-            _ri = self._telemetry.get("runtime_identity")
+        # Issue #279: update runtime_identity on tier switch.
+        # Use getattr — _set_sticky_tier is unit-tested with a SimpleNamespace
+        # self that does not always carry a _telemetry attribute.
+        _telemetry = getattr(self, "_telemetry", None)
+        if _telemetry is not None:
+            _ri = _telemetry.get("runtime_identity")
             if _ri is not None:
                 _ri.update(model=self._tier_models.get(active, self._model),
                            tier=active)

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -1103,28 +1103,30 @@ def make_memory_health_tool(governor: "MemoryGovernor") -> ToolDefinition:
 
 def make_agent_health_tool(tracker: "AgentTelemetryTracker") -> ToolDefinition:
     """
-    Create a SAFE ``agent_health`` tool (Issue #142).
+    Create a SAFE ``agent_health`` tool (Issue #142, #285).
 
     Wraps ``AgentTelemetryTracker`` so the agent can pull its own
     observability state on demand. Keep it pull-only: anomalies are already
     pushed at turn boundaries — this tool is for the cases where the agent
     wants to look without being prompted.
 
-    Args:
-        dimension: optional — one of ``tool_call``, ``context_layout``,
-                   ``memory_compression``. Returns that dimension's detail.
-        minimal:   optional bool — if true, returns the one-line summary
-                   (cheap check before drilling into a specific dimension).
+    Progressive disclosure (Issue #285):
+      - default            → one-line summary across all dimensions (cheap)
+      - ``dimension=X``    → detail for one dimension (drill-down)
+      - ``full=true``      → full detail across all dimensions (expensive)
+
+    Anomalies (if any) are appended in all modes so the agent never needs a
+    second call to decide whether to act.
     """
     async def _agent_health(call: ToolCall) -> ToolResult:
         dimension = call.args.get("dimension")
-        minimal = bool(call.args.get("minimal", False))
-        if minimal:
-            output = tracker.report_minimal() or "(no telemetry data yet)"
-        else:
+        full = bool(call.args.get("full", False))
+        if dimension:
             output = tracker.report_detail(dimension) or "(no telemetry data yet)"
-        # Surface current anomalies inline so the agent doesn't need two calls
-        # to decide whether to act.
+        elif full:
+            output = tracker.report_detail() or "(no telemetry data yet)"
+        else:
+            output = tracker.report_minimal() or "(no telemetry data yet)"
         alert = tracker.anomaly_report()
         if alert:
             output = f"{output}\n\n{alert}"
@@ -1139,11 +1141,13 @@ def make_agent_health_tool(tracker: "AgentTelemetryTracker") -> ToolDefinition:
         name="agent_health",
         description=(
             "Inspect your own observability telemetry: tool call success/latency, "
-            "context token layout, memory-compression yield, runtime identity, context budget, session turns, and loaded skills. Call with "
-            "`dimension=<tool_call|context_layout|memory_compression|runtime_identity|context_budget|session_turns|loaded_skills>` to drill "
-            "down, or `minimal=true` for a one-line composite summary. Use when "
-            "you want to self-check before a risky action, or when investigating "
-            "suspected behavioral drift."
+            "context token layout, memory-compression yield, runtime identity, "
+            "context budget, session turns, and loaded skills. "
+            "Default is a one-line summary across all dimensions. "
+            "Pass `dimension=<name>` to drill into one, or `full=true` to dump "
+            "every dimension's detail at once (expensive — only use when "
+            "investigating). Use this to self-check before a risky action or "
+            "when suspecting behavioral drift."
         ),
         trust_level=TrustLevel.SAFE,
         input_schema={
@@ -1152,11 +1156,11 @@ def make_agent_health_tool(tracker: "AgentTelemetryTracker") -> ToolDefinition:
                 "dimension": {
                     "type": "string",
                     "enum": ["tool_call", "context_layout", "memory_compression", "runtime_identity", "context_budget", "session_turns", "loaded_skills"],
-                    "description": "Specific dimension to inspect. Omit for full report.",
+                    "description": "Specific dimension to inspect.",
                 },
-                "minimal": {
+                "full": {
                     "type": "boolean",
-                    "description": "One-line summary across all dimensions.",
+                    "description": "Dump every dimension's full detail. Default false (summary only).",
                     "default": False,
                 },
             },

--- a/tests/test_telemetry_279.py
+++ b/tests/test_telemetry_279.py
@@ -63,6 +63,7 @@ class TestContextBudgetDimension:
         assert msg is not None
         assert "auto-compact" in msg
         assert "next turn" in msg
+        assert "current tool batch" in msg
 
     def test_no_anomaly_when_under_threshold(self):
         budget = ContextBudget(total_tokens=100000)

--- a/tests/test_telemetry_279.py
+++ b/tests/test_telemetry_279.py
@@ -59,7 +59,10 @@ class TestContextBudgetDimension:
         budget.record_response(input_tokens=85000, output_tokens=1000)
         dim = ContextBudgetDimension(budget=budget)
         assert dim.has_anomaly() is True
-        assert dim.describe_anomaly() is not None
+        msg = dim.describe_anomaly()
+        assert msg is not None
+        assert "auto-compact" in msg
+        assert "next turn" in msg
 
     def test_no_anomaly_when_under_threshold(self):
         budget = ContextBudget(total_tokens=100000)
@@ -90,13 +93,10 @@ class TestSessionTurnsDimension:
         assert dim.snapshot()["turns"] == 2
         assert dim.snapshot()["turns"] == 3
 
-    def test_stage_label(self):
-        dim = SessionTurnsDimension(turn_index_fn=lambda: 0)
-        assert "early" in dim.render_detail()
-        dim5 = SessionTurnsDimension(turn_index_fn=lambda: 5)
-        assert "mid" in dim5.render_detail()
-        dim20 = SessionTurnsDimension(turn_index_fn=lambda: 20)
-        assert "deep" in dim20.render_detail()
+    def test_detail_shows_current_turn(self):
+        dim = SessionTurnsDimension(turn_index_fn=lambda: 7)
+        detail = dim.render_detail()
+        assert "current turn: 7" in detail
 
 
 class TestLoadedSkillsDimension:


### PR DESCRIPTION
## Summary

收尾 #285 列的設計尾巴。四個改動都是輕量收斂，沒擴大範圍。

**Closes #285**

## 改了什麼

### A. `runtime_identity.training_cutoff` 移除
空殼欄位永遠是 `\"unknown\"`，agent 看到會做出錯誤判斷比沒有更糟。下次接 provider metadata 時再加（如果有需要）。

### B. `context_budget` anomaly 訊息改 actionable
**Before:** `\"Context at 85% — consider compression soon.\"`（agent 看了沒事可做，compaction 是 harness 自動的）

**After:** `\"Context at 85% — harness will auto-compact at start of next turn. Avoid starting long tool chains this turn.\"`

把「下回合自動發生」+「這回合該避免什麼」講清楚，agent 拿到才能行動。

### C. `session_turns` stage label 移除
原本 `render_detail` 有 early/mid/deep 三段，門檻 5/20 是 hardcode magic number。turns 數字本身夠 agent 判斷，拿掉這層多餘抽象。

### D. ⭐ `agent_health` progressive disclosure
這是這批裡最重要的一條。原本無參數呼叫會吐 7 維 detail（~1k+ tokens），違背 self-check 要便宜的初衷。

| 呼叫方式 | 行為 |
|---------|------|
| `agent_health()` | one-line summary across all dimensions（**新 default**）|
| `agent_health(dimension=\"X\")` | 該維度 detail（drill-down，不變）|
| `agent_health(full=true)` | 全部維度 detail（**新增**，原本的 default 行為）|

舊的 `minimal=true` 拿掉 — 已是新 default，留著反而誤導。

呼應已和維護者確認的 progressive disclosure 通則：**任何 context-yielding 工具，default 是 summary，full 要顯式參數**。

### E. 順手修：`_set_sticky_tier` regression（#282 帶進）
`TestSetStickyTier::test_set_default_tier_normalizes_to_none` 在 master 是 failing 的 — unit test 用 `SimpleNamespace` mock `self`，post-#282 的 `self._telemetry` 引用造成 `AttributeError`。

改用 `getattr(self, \"_telemetry\", None)` 防禦。同一塊區域順手修掉，省一個 hotfix PR。

## Test plan

- [x] `pytest tests/test_telemetry.py tests/test_telemetry_279.py` — 35 passed（含更新的 anomaly message 斷言、移除的 stage_label 測試、新的 detail-shows-current-turn 測試）
- [x] `pytest tests/` 全跑 — **1342 passed, 1 skipped**（master 上原本是 1 failed + 1341 passed，本 PR 順手修綠）
- [ ] 手動驗證：CLI 跑一次 `agent_health()` 應該只看到 7 行 summary；`agent_health(full=true)` 才會看到完整 detail dump

## 不在本 PR 範圍

- `recall_health` / `tool_failure_accum` 等新維度 — #279 後續清單
- footer 反向顯示 agent-side 訊號 — #284（瞬時 hint 設計）
- 其他 context 工具的 progressive disclosure audit — 通則已建立，逐個 follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)