### PR TITLE
feat(legitimacy): 唯讀 bash 視為 probe + probe_file 工具

### DIFF
--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -19,7 +19,7 @@ _log = logging.getLogger(__name__)
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, UTC
-from typing import Any, Awaitable, Callable
+from typing import Any, Awaitable, Callable, ClassVar
 
 from .permissions import ToolCapability, TrustLevel
 
@@ -380,6 +380,11 @@ class LegitimacyGuardMiddleware(Middleware):
     intentionally leaves ``_session_trusted`` intact.
     """
 
+    # Read-only shell commands that count as file probes (Issue #283).
+    _READONLY_COMMANDS: ClassVar[frozenset[str]] = frozenset({
+        "grep", "head", "cat", "awk", "sed", "tail", "wc",
+    })
+
     def __init__(self) -> None:
         self.has_probed: bool = False
         # Only file-writing tools belong here.  exec tools (run_bash) and MCP
@@ -401,6 +406,18 @@ class LegitimacyGuardMiddleware(Middleware):
         ) = None
 
     @staticmethod
+    def _is_readonly_bash(call: ToolCall) -> bool:
+        command = (call.args.get('command', '') or '').strip()
+        if not command:
+            return False
+        first_word = command.split()[0] if command else ''
+        if first_word not in LegitimacyGuardMiddleware._READONLY_COMMANDS:
+            return False
+        if first_word == 'sed' and '-n' not in command:
+            return False
+        return True
+
+    @staticmethod
     def _is_probe(call: ToolCall) -> bool:
         """Issue #167: capability flag OR SAFE trust counts as a probe."""
         if call.capabilities & ToolCapability.READ_PROBE:
@@ -412,6 +429,10 @@ class LegitimacyGuardMiddleware(Middleware):
         self.has_probed = False
 
     async def process(self, call: ToolCall, next: ToolHandler) -> ToolResult:
+        # Issue #283: read-only bash commands count as probes
+        if call.tool_name == 'run_bash' and self._is_readonly_bash(call):
+            self.has_probed = True
+
         if self._is_probe(call):
             self.has_probed = True
 

--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -410,7 +410,7 @@ class LegitimacyGuardMiddleware(Middleware):
         command = (call.args.get('command', '') or '').strip()
         if not command:
             return False
-        first_word = command.split()[0] if command else ''
+        first_word = command.split()[0]
         if first_word not in LegitimacyGuardMiddleware._READONLY_COMMANDS:
             return False
         if first_word == 'sed' and '-n' not in command:

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1047,6 +1047,7 @@ class LoomSession:
         # Register memory tools with injected stores
         from loom.platform.cli.tools import (
             make_agent_health_tool,
+            make_probe_file_tool,
             make_exec_escape_fn,
             make_fetch_url_tool,
             make_load_skill_tool,
@@ -1117,6 +1118,9 @@ class LoomSession:
 
         if self._telemetry is not None:
             self.registry.register(make_agent_health_tool(self._telemetry))
+
+        # Issue #283: probe_file — agent-initiated context establishment
+        self.registry.register(make_probe_file_tool())
 
         # Issue #56: Register load_skill tool with outcome tracker
         from loom.core.memory.skill_outcome import SkillOutcomeTracker

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -3167,7 +3167,7 @@ def make_request_model_tier_tool(session: Any) -> ToolDefinition:
             },
             "required": ["tier", "reason"],
         },
-        executor=None,
+        executor=_executor,
         tags=["cognition", "tier"],
         impact_scope="agent",
     )

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -1167,6 +1167,51 @@ def make_agent_health_tool(tracker: "AgentTelemetryTracker") -> ToolDefinition:
     )
 
 
+
+def make_probe_file_tool() -> ToolDefinition:
+    """
+    Create a SAFE ``probe_file`` tool (Issue #283).
+
+    Lets the agent explicitly mark a file as probed when using
+    non-``read_file`` means (grep, head, sed -n, etc.) to inspect
+    its contents.  Calling this tool sets ``has_probed`` in
+    LegitimacyGuardMiddleware, preventing spurious trajectory anomaly
+    warnings on subsequent ``run_bash`` writes to the same file.
+    """
+
+    async def _probe_file(call: ToolCall) -> ToolResult:
+        path = call.args.get("path", "")
+        return ToolResult(
+            call_id=call.id,
+            tool_name="probe_file",
+            success=True,
+            text=f"File marked as probed: {path}",
+        )
+
+    return ToolDefinition(
+        name="probe_file",
+        description=(
+            "Mark a file as probed. Use after inspecting a file with grep, head, "
+            "or other non-read_file means.  This prevents LegitimacyGuard from "
+            "flagging subsequent writes as trajectory anomalies."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the file that was probed.",
+                },
+            },
+            "required": ["path"],
+        },
+        executor=_probe_file,
+        trust_level=TrustLevel.SAFE,
+        tags=["io", "guard"],
+        impact_scope="file",
+    )
+
+
 def make_relate_tool(memory: "MemoryFacade") -> ToolDefinition:
     """
     Create a GUARDED ``relate`` tool bound to the given MemoryFacade.
@@ -3122,7 +3167,7 @@ def make_request_model_tier_tool(session: Any) -> ToolDefinition:
             },
             "required": ["tier", "reason"],
         },
-        executor=_executor,
+        executor=None,
         tags=["cognition", "tier"],
         impact_scope="agent",
     )

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -1189,7 +1189,7 @@ def make_probe_file_tool() -> ToolDefinition:
             call_id=call.id,
             tool_name="probe_file",
             success=True,
-            text=f"File marked as probed: {path}",
+            output=f"File marked as probed: {path}",
         )
 
     return ToolDefinition(

--- a/tests/test_legitimacy.py
+++ b/tests/test_legitimacy.py
@@ -299,3 +299,79 @@ async def test_circuit_breaker_resets_on_allow(perm_ctx, registry, handler):
     res3 = await bmw.process(call, handler)
     assert res3.success
     assert perm_ctx.recent_denies == 0
+
+
+@pytest.mark.asyncio
+async def test_readonly_bash_counts_as_probe(handler):
+    """Issue #283: grep, head, cat, etc. set has_probed."""
+    guard = LegitimacyGuardMiddleware()
+
+    call_grep = make_call(
+        "run_bash", TrustLevel.GUARDED,
+        {"command": "grep -n 'class ' file.py"},
+        capabilities=ToolCapability.EXEC,
+    )
+    await guard.process(call_grep, handler)
+    assert guard.has_probed
+
+
+@pytest.mark.asyncio
+async def test_sed_minus_n_counts_as_probe(handler):
+    """sed -n is read-only and should count as a probe."""
+    guard = LegitimacyGuardMiddleware()
+
+    call_sed = make_call(
+        "run_bash", TrustLevel.GUARDED,
+        {"command": "sed -n '100,120p' file.py"},
+        capabilities=ToolCapability.EXEC,
+    )
+    await guard.process(call_sed, handler)
+    assert guard.has_probed
+
+
+@pytest.mark.asyncio
+async def test_sed_without_n_does_not_count(handler):
+    """sed without -n is mutating (sed -i ...), NOT a probe."""
+    guard = LegitimacyGuardMiddleware()
+
+    call_sed = make_call(
+        "run_bash", TrustLevel.GUARDED,
+        {"command": "sed -i 's/old/new/' file.py"},
+        capabilities=ToolCapability.EXEC,
+    )
+    await guard.process(call_sed, handler)
+    assert not guard.has_probed
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_does_not_count(handler):
+    """Arbitrary commands like python3 are not whitelisted."""
+    guard = LegitimacyGuardMiddleware()
+
+    call_py = make_call(
+        "run_bash", TrustLevel.GUARDED,
+        {"command": "python3 -c 'print(1)'"},
+        capabilities=ToolCapability.EXEC,
+    )
+    await guard.process(call_py, handler)
+    assert not guard.has_probed
+
+
+@pytest.mark.asyncio
+async def test_readonly_bash_permits_write(handler):
+    """After a read-only bash, write_file should be allowed."""
+    guard = LegitimacyGuardMiddleware()
+
+    call_grep = make_call(
+        "run_bash", TrustLevel.GUARDED,
+        {"command": "grep class file.py"},
+        capabilities=ToolCapability.EXEC,
+    )
+    await guard.process(call_grep, handler)
+
+    call_write = make_call(
+        "write_file", TrustLevel.GUARDED,
+        {"path": "file.py", "content": "x"},
+    )
+    res = await guard.process(call_write, handler)
+    assert res.success

--- a/tests/test_legitimacy.py
+++ b/tests/test_legitimacy.py
@@ -375,3 +375,17 @@ async def test_readonly_bash_permits_write(handler):
     )
     res = await guard.process(call_write, handler)
     assert res.success
+
+
+@pytest.mark.asyncio
+async def test_probe_file_tool_executes_successfully():
+    """probe_file executor must build a valid ToolResult — would catch the
+    `text=` vs `output=` typo that initially shipped in #287.
+    """
+    from loom.platform.cli.tools import make_probe_file_tool
+
+    td = make_probe_file_tool()
+    call = make_call("probe_file", TrustLevel.SAFE, {"path": "/tmp/foo.py"})
+    res = await td.executor(call)
+    assert res.success
+    assert "/tmp/foo.py" in res.output


### PR DESCRIPTION
## LegitimacyGuard 擴充：承認唯讀 bash 為有效 probe

**Fixes:** #283
**Type:** enhancement

### 改了什麼

`run_bash` 中唯讀操作（grep/head/cat/awk/sed -n/tail/wc）現在會被 `LegitimacyGuardMiddleware` 視為有效的 file probe，不再觸發 `trajectory_anomaly` 誤報。同步新增 `probe_file(path)` SAFE 工具供 Agent 主動標記已探查檔案。

### 怎麼改的

1. **`middleware.py`** — `LegitimacyGuardMiddleware`：
   - 新增 `_READONLY_COMMANDS` whitelist（grep/head/cat/awk/sed/tail/wc）
   - 新增 `_is_readonly_bash()` static method 解析命令
   - `process()` 中：唯讀 bash 自動設定 `has_probed=True`
   - 刻意排除 `ls/find/stat/file`（只查 metadata，不查內容）

2. **`tools.py`** — 新增 `make_probe_file_tool()`：
   - SAFE trust level
   - 接受 `path` 參數
   - 回傳簡單確認訊息
   - 工具本身的 SAFE trust 就讓它被 guard 視為 probe

3. **`session.py`** — import + 註冊 `probe_file`

4. **`test_legitimacy.py`** — 5 個新測試：
   - `grep` 被視為 probe
   - `sed -n` 被視為 probe
   - `sed`（無 -n）不被視為 probe
   - 未知命令不被視為 probe
   - 唯讀 bash 後 write_file 放行

### 測試

```
pytest tests/test_legitimacy.py tests/test_session.py::TestLoomSessionStartup -v
21 passed
```
