### PR TITLE
feat(legitimacy): per-file probe tracking — make trajectory_anomaly real

### DIFF
--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -11,6 +11,7 @@ Execution order (outermost → innermost):
 
 import asyncio
 import logging
+import os
 import time
 import traceback
 import uuid
@@ -385,8 +386,22 @@ class LegitimacyGuardMiddleware(Middleware):
         "grep", "head", "cat", "awk", "sed", "tail", "wc",
     })
 
+    # Shell metacharacters that defeat single-path bash extraction (#288).
+    _BASH_AMBIGUOUS_CHARS: ClassVar[frozenset[str]] = frozenset("|<>;&")
+
     def __init__(self) -> None:
-        self.has_probed: bool = False
+        # Issue #288: probe tracking is now per-file. _probed_files accumulates
+        # paths the agent has actually inspected this session; _unscoped_probed
+        # is the soft fallback for cases where the probe channel can't pin
+        # down a single path (READ_PROBE-flagged tools, bash pipelines, etc.)
+        # and is the moral successor of the old `has_probed` boolean for
+        # those non-file-scoped probes.
+        self._probed_files: set[str] = set()
+        self._unscoped_probed: bool = False
+        # Per-turn flag, kept ONLY for trajectory_anomaly Layer 2 — that
+        # check wants to know "did the agent do any probing this turn"
+        # before an EXEC call, not session-level history.
+        self._probed_this_turn: bool = False
         # Only file-writing tools belong here.  exec tools (run_bash) and MCP
         # generative tools are handled by BlastRadiusMiddleware.
         self.strict_guard_tools: set[str] = {
@@ -405,6 +420,86 @@ class LegitimacyGuardMiddleware(Middleware):
             Callable[[str, str], None] | None
         ) = None
 
+    @property
+    def has_probed(self) -> bool:
+        """Backward-compat: per-turn probe flag. Reads as True when any
+        probe (file-scoped or unscoped) fired this turn."""
+        return self._probed_this_turn
+
+    @staticmethod
+    def _normalize_path(path: str) -> str:
+        if not path:
+            return ""
+        return os.path.normpath(os.path.expanduser(path.strip()))
+
+    @classmethod
+    def _extract_bash_path(cls, command: str) -> str | None:
+        """Best-effort: pull a single file path from a known read-only bash
+        invocation. Returns None when the parser can't pin one down — that
+        case falls back to ``_unscoped_probed`` and the agent must use
+        ``probe_file()`` if they need a per-file mark.
+
+        Bails on shell metacharacters (pipe/redirect/chain) and on glob
+        patterns. The point isn't to be a shell — it's to catch the
+        common forms (``grep PAT file``, ``head -n 100 file``,
+        ``sed -n '1,20p' file``) cleanly.
+        """
+        import shlex
+        if any(c in command for c in cls._BASH_AMBIGUOUS_CHARS):
+            return None
+        try:
+            parts = shlex.split(command)
+        except ValueError:
+            return None
+        if len(parts) < 2:
+            return None
+        # Drop flags. The remaining last token is the path candidate.
+        # `sed -n '1,20p' file.py` survives because the script is single-quoted
+        # and shlex strips the quotes — both '1,20p' and 'file.py' look like
+        # candidates, last wins (sed's file argument is always last).
+        candidates = [p for p in parts[1:] if not p.startswith("-")]
+        if not candidates:
+            return None
+        last = candidates[-1]
+        if any(c in last for c in "*?["):
+            return None
+        return last
+
+    def _probe_signal(self, call: ToolCall) -> tuple[set[str], bool]:
+        """Compute (file_paths, unscoped) for this call.
+
+        - file_paths: specific files this call probed (normalized)
+        - unscoped:   True when the call probed *something* but the
+                      file identity is unknown (READ_PROBE-flagged tools,
+                      unparseable bash, etc.)
+
+        Returning ``(set(), False)`` means "not a probe" — falls through
+        to the trajectory_anomaly path.
+        """
+        # Read-only bash with extractable path → per-file; otherwise unscoped.
+        if call.tool_name == "run_bash" and self._is_readonly_bash(call):
+            cmd = (call.args.get("command", "") or "")
+            path = self._extract_bash_path(cmd)
+            if path:
+                return ({self._normalize_path(path)}, False)
+            return (set(), True)
+
+        # READ_PROBE capability flag: tool reads but identity not file-scoped
+        # (web_search, MCP read tools).
+        if call.capabilities & ToolCapability.READ_PROBE:
+            return (set(), True)
+
+        # SAFE trust + explicit ``path`` arg: per-file probe.
+        # Covers read_file, list_dir, probe_file. SAFE tools without a
+        # ``path`` arg (agent_health, time_now) intentionally do NOT
+        # count as a probe — that was the #288 sledgehammer hole.
+        if call.trust_level == TrustLevel.SAFE:
+            path = call.args.get("path", "")
+            if path:
+                return ({self._normalize_path(path)}, False)
+
+        return (set(), False)
+
     @staticmethod
     def _is_readonly_bash(call: ToolCall) -> bool:
         command = (call.args.get('command', '') or '').strip()
@@ -417,24 +512,20 @@ class LegitimacyGuardMiddleware(Middleware):
             return False
         return True
 
-    @staticmethod
-    def _is_probe(call: ToolCall) -> bool:
-        """Issue #167: capability flag OR SAFE trust counts as a probe."""
-        if call.capabilities & ToolCapability.READ_PROBE:
-            return True
-        return call.trust_level == TrustLevel.SAFE
-
     def reset_probe(self) -> None:
-        """Reset per-turn probe state. Does NOT clear session-level trust."""
-        self.has_probed = False
+        """Clear per-turn flag. Session-level _probed_files and
+        _unscoped_probed survive — once read, always read."""
+        self._probed_this_turn = False
 
     async def process(self, call: ToolCall, next: ToolHandler) -> ToolResult:
-        # Issue #283: read-only bash commands count as probes
-        if call.tool_name == 'run_bash' and self._is_readonly_bash(call):
-            self.has_probed = True
-
-        if self._is_probe(call):
-            self.has_probed = True
+        # Issue #288: per-file probe tracking
+        paths, unscoped = self._probe_signal(call)
+        if paths:
+            self._probed_files |= paths
+            self._probed_this_turn = True
+        if unscoped:
+            self._unscoped_probed = True
+            self._probed_this_turn = True
 
         # TODO(#xx): Phase 4 - Goal Drift / Re-justification budget.
         # Enforce re-justification for guarded actions after N steps without human interaction.
@@ -445,35 +536,40 @@ class LegitimacyGuardMiddleware(Middleware):
         if is_strict and call.tool_name in self._session_trusted:
             return await next(call)
 
-        # --- Layer 1: Hard guard (write_file) ---
-        if is_strict and not self.has_probed:
-            target = call.args.get("path", "")
-            error_msg = (
-                f"LEGITIMACY GUARD: Blocked `{call.tool_name}`"
-                + (f" → '{target}'" if target else "")
-                + ". You must read the target file (or list its directory) before "
-                "writing. Call read_file or list_dir first to establish context — "
-                "writing to a path you haven't read risks overwriting unknown content."
-            )
+        # --- Layer 1: Hard guard (write_file) — per-file check ---
+        if is_strict:
+            raw_target = call.args.get("path", "")
+            target = self._normalize_path(raw_target)
+            target_probed = target and target in self._probed_files
+            if not target_probed and not self._unscoped_probed:
+                error_msg = (
+                    f"LEGITIMACY GUARD: Blocked `{call.tool_name}`"
+                    + (f" → '{raw_target}'" if raw_target else "")
+                    + ". You must read this specific file before writing it. "
+                    "Call read_file (or grep/head/sed -n on this path, or "
+                    "probe_file if you read it via a complex pipeline) first. "
+                    "Writing to a path you have not inspected risks "
+                    "overwriting unknown content."
+                )
 
-            from .lifecycle import LIFECYCLE_CTX_KEY
-            ctx = call.metadata.get(LIFECYCLE_CTX_KEY)
-            if ctx is not None:
-                ctx.authorization_result = False
-                ctx.authorization_reason = "probe-first heuristic failed"
+                from .lifecycle import LIFECYCLE_CTX_KEY
+                ctx = call.metadata.get(LIFECYCLE_CTX_KEY)
+                if ctx is not None:
+                    ctx.authorization_result = False
+                    ctx.authorization_reason = "per-file probe-first failed"
 
-            return ToolResult(
-                call_id=call.id,
-                tool_name=call.tool_name,
-                success=False,
-                error=error_msg,
-                failure_type="permission_denied"
-            )
+                return ToolResult(
+                    call_id=call.id,
+                    tool_name=call.tool_name,
+                    success=False,
+                    error=error_msg,
+                    failure_type="permission_denied"
+                )
 
         # --- Layer 2: Trajectory Anomaly (soft guard for EXEC tools) ---
         # When EXEC tools run without any prior probe this turn, flag the call
         # so BlastRadiusMiddleware can downgrade exec_auto to require confirm.
-        if not is_strict and not self.has_probed:
+        if not is_strict and not self._probed_this_turn:
             if call.capabilities & ToolCapability.EXEC:
                 call.metadata["trajectory_anomaly"] = True
                 # Issue #168: surface the soft-guard trip so operators (and log

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -1174,13 +1174,15 @@ def make_agent_health_tool(tracker: "AgentTelemetryTracker") -> ToolDefinition:
 
 def make_probe_file_tool() -> ToolDefinition:
     """
-    Create a SAFE ``probe_file`` tool (Issue #283).
+    Create a SAFE ``probe_file`` tool (Issues #283, #288).
 
-    Lets the agent explicitly mark a file as probed when using
-    non-``read_file`` means (grep, head, sed -n, etc.) to inspect
-    its contents.  Calling this tool sets ``has_probed`` in
-    LegitimacyGuardMiddleware, preventing spurious trajectory anomaly
-    warnings on subsequent ``run_bash`` writes to the same file.
+    Fallback marker for cases where LegitimacyGuard cannot infer the
+    probed file from the tool call itself — e.g. shell pipelines
+    (``cat a.py | grep foo``), variable expansion, or custom scripts
+    that print file contents. Standard ``read_file`` and simple
+    ``grep``/``head``/``sed -n`` invocations already auto-register
+    the file path; calling ``probe_file`` redundantly in those cases
+    just burns context.
     """
 
     async def _probe_file(call: ToolCall) -> ToolResult:
@@ -1195,9 +1197,12 @@ def make_probe_file_tool() -> ToolDefinition:
     return ToolDefinition(
         name="probe_file",
         description=(
-            "Mark a file as probed. Use after inspecting a file with grep, head, "
-            "or other non-read_file means.  This prevents LegitimacyGuard from "
-            "flagging subsequent writes as trajectory anomalies."
+            "Mark a specific file as probed when LegitimacyGuard cannot infer "
+            "the path from your tool call (complex bash pipelines, custom "
+            "scripts, etc.). Do NOT call this after standard read_file or "
+            "simple grep/head/sed -n invocations — those already register "
+            "the path automatically and a redundant probe_file just burns "
+            "context."
         ),
         input_schema={
             "type": "object",

--- a/tests/test_legitimacy.py
+++ b/tests/test_legitimacy.py
@@ -53,7 +53,7 @@ async def test_write_file_blocked_without_probe(handler):
     res = await guard.process(call_write, handler)
     assert not res.success
     assert res.failure_type == "permission_denied"
-    assert "read the target file" in res.error
+    assert "read this specific file" in res.error
     assert call_write.metadata[LIFECYCLE_CTX_KEY].authorization_result is False
 
 
@@ -71,18 +71,22 @@ async def test_write_file_allowed_after_read(handler):
 
 
 @pytest.mark.asyncio
-async def test_safe_tool_counts_as_probe(handler):
-    """Issue #167: any SAFE-trust tool should satisfy the probe-first heuristic
-    without an explicit READ_PROBE flag — SAFE means read-only and reversible."""
+async def test_safe_tool_without_path_does_not_probe_files(handler):
+    """Issue #288: SAFE tools that don't take a ``path`` arg (agent_health,
+    introspect_self) MUST NOT count as a file probe. The previous
+    sledgehammer behavior — any SAFE call clearing the gate for any
+    write — is the bug this issue exists to fix.
+    """
     guard = LegitimacyGuardMiddleware()
-    # A SAFE tool the old hardcoded set never knew about
     call_safe = make_call("introspect_self", TrustLevel.SAFE, {})
     await guard.process(call_safe, handler)
-    assert guard.has_probed
+    assert not guard.has_probed
+    assert not guard._probed_files
 
     call_write = make_call("write_file", TrustLevel.GUARDED, {"path": "x", "content": ""})
     res = await guard.process(call_write, handler)
-    assert res.success
+    assert not res.success
+    assert res.failure_type == "permission_denied"
 
 
 @pytest.mark.asyncio
@@ -374,6 +378,160 @@ async def test_readonly_bash_permits_write(handler):
         {"path": "file.py", "content": "x"},
     )
     res = await guard.process(call_write, handler)
+    assert res.success
+
+
+@pytest.mark.asyncio
+async def test_per_file_probe_blocks_unrelated_write(handler):
+    """Issue #288: probing foo.py does NOT clear writes to bar.py."""
+    guard = LegitimacyGuardMiddleware()
+
+    await guard.process(
+        make_call("read_file", TrustLevel.SAFE, {"path": "foo.py"}), handler
+    )
+    assert "foo.py" in guard._probed_files
+
+    res_foo = await guard.process(
+        make_call("write_file", TrustLevel.GUARDED, {"path": "foo.py", "content": "x"}),
+        handler,
+    )
+    assert res_foo.success
+
+    # Reset session_trusted to isolate the per-file check (Layer 1, not Layer 3)
+    guard._session_trusted.clear()
+
+    res_bar = await guard.process(
+        make_call("write_file", TrustLevel.GUARDED, {"path": "bar.py", "content": "x"}),
+        handler,
+    )
+    assert not res_bar.success
+    assert res_bar.failure_type == "permission_denied"
+
+
+@pytest.mark.asyncio
+async def test_probe_file_tool_marks_specific_path(handler):
+    """probe_file('x.py') marks x.py specifically, not all files."""
+    guard = LegitimacyGuardMiddleware()
+
+    await guard.process(
+        make_call("probe_file", TrustLevel.SAFE, {"path": "x.py"}), handler
+    )
+    assert "x.py" in guard._probed_files
+
+    res = await guard.process(
+        make_call("write_file", TrustLevel.GUARDED, {"path": "x.py", "content": "x"}),
+        handler,
+    )
+    assert res.success
+
+
+@pytest.mark.asyncio
+async def test_bash_path_extraction_per_file(handler):
+    """grep PAT file.py marks file.py, not other.py."""
+    guard = LegitimacyGuardMiddleware()
+
+    await guard.process(
+        make_call(
+            "run_bash", TrustLevel.GUARDED,
+            {"command": "grep class file.py"},
+            capabilities=ToolCapability.EXEC,
+        ),
+        handler,
+    )
+    assert "file.py" in guard._probed_files
+    assert not guard._unscoped_probed
+
+    res_match = await guard.process(
+        make_call("write_file", TrustLevel.GUARDED, {"path": "file.py", "content": "x"}),
+        handler,
+    )
+    assert res_match.success
+    guard._session_trusted.clear()
+
+    res_other = await guard.process(
+        make_call("write_file", TrustLevel.GUARDED, {"path": "other.py", "content": "x"}),
+        handler,
+    )
+    assert not res_other.success
+
+
+@pytest.mark.asyncio
+async def test_bash_pipeline_falls_back_to_unscoped(handler):
+    """Pipelines defeat the parser → unscoped fallback so writes still pass."""
+    guard = LegitimacyGuardMiddleware()
+
+    await guard.process(
+        make_call(
+            "run_bash", TrustLevel.GUARDED,
+            {"command": "cat a.py | grep class"},
+            capabilities=ToolCapability.EXEC,
+        ),
+        handler,
+    )
+    assert guard._unscoped_probed
+    assert not guard._probed_files
+
+    res = await guard.process(
+        make_call("write_file", TrustLevel.GUARDED, {"path": "anything.py", "content": "x"}),
+        handler,
+    )
+    assert res.success
+
+
+@pytest.mark.asyncio
+async def test_path_normalization_dot_prefix(handler):
+    """./foo.py and foo.py refer to the same file under per-file tracking."""
+    guard = LegitimacyGuardMiddleware()
+
+    await guard.process(
+        make_call("read_file", TrustLevel.SAFE, {"path": "./foo.py"}), handler
+    )
+
+    res = await guard.process(
+        make_call("write_file", TrustLevel.GUARDED, {"path": "foo.py", "content": "x"}),
+        handler,
+    )
+    assert res.success
+
+
+@pytest.mark.asyncio
+async def test_read_probe_capability_unscoped(handler):
+    """READ_PROBE-flagged tools (web_search, MCP) probe unscoped — they
+    don't read local files but the agent has done some real reading work."""
+    guard = LegitimacyGuardMiddleware()
+
+    await guard.process(
+        make_call(
+            "github:search", TrustLevel.GUARDED, {"q": "loom"},
+            capabilities=ToolCapability.NETWORK | ToolCapability.READ_PROBE,
+        ),
+        handler,
+    )
+    assert guard._unscoped_probed
+    assert guard.has_probed
+
+
+@pytest.mark.asyncio
+async def test_probed_files_persist_across_turn_reset(handler):
+    """reset_probe() clears per-turn flag but session-level _probed_files
+    survives — once read, always read."""
+    guard = LegitimacyGuardMiddleware()
+
+    await guard.process(
+        make_call("read_file", TrustLevel.SAFE, {"path": "kept.py"}), handler
+    )
+    assert "kept.py" in guard._probed_files
+
+    guard.reset_probe()
+    assert not guard.has_probed
+    assert "kept.py" in guard._probed_files  # session-level survives
+
+    # Across the turn boundary, session_trusted hasn't kicked in yet
+    # (no write succeeded), so the per-file check is what permits this:
+    res = await guard.process(
+        make_call("write_file", TrustLevel.GUARDED, {"path": "kept.py", "content": "x"}),
+        handler,
+    )
     assert res.success
 
 


### PR DESCRIPTION
## Summary

把 `LegitimacyGuardMiddleware` 從 session 級 boolean (`has_probed`) 換成 per-file set (`_probed_files`)。write_file 現在要求**那個具體檔案**這 session 內被讀過，而不是「session 內讀過任何東西」。

**Closes #288**

## 為什麼要改

舊機制下 `agent_health()` 一叫，整個 session 後續所有 write 都通行 — guard 在實務上幾乎不會觸發，「誤報少見」是因為閾值寬鬆，不是偵測精準。#287 留下的 `probe_file` 工具在舊機制下也接近冗餘（任何 SAFE 工具都已經達到一樣效果）。

本 PR 把這層擺設變成真有牙齒的約束。

## 改了什麼

### Probe 訊號分類

| 來源 | 行為 |
|---|---|
| `read_file(path)` / `list_dir(path)` / `probe_file(path)`（任何 SAFE + `path` arg） | per-file：path 加入 `_probed_files` |
| `run_bash` 唯讀 + parser 抓到 path (`grep PAT file`) | per-file |
| `run_bash` 含 pipe/redirect/chain (`cat a \| grep b`) | unscoped fallback |
| `web_search` 等 (READ_PROBE flag) | unscoped fallback |
| `agent_health`, `time_now` (SAFE 無 path) | **不**算 probe — 這就是 #288 的 sledgehammer 漏洞 |

### 三個 flag 的職責

- `_probed_files: set[str]` — session 級，累積看過的檔案
- `_unscoped_probed: bool` — session 級，soft fallback（READ_PROBE / 不可解析 bash）
- `_probed_this_turn: bool` — per-turn，**只**給 `trajectory_anomaly` Layer 2 用（那個檢查邏輯上本來就要 per-turn 語意）
- `has_probed` 變成讀 `_probed_this_turn` 的 property，外部 caller 行為不變

### Bash path 解析

best-effort 用 `shlex.split`，碰到 `|<>;&` 或 glob 直接放棄、退回 `_unscoped_probed`。設計上不追求完美，parser 失敗是預期情況 — 那正是 `probe_file` 的角色。

### `probe_file` 重新定位

Description 改寫，明說只在 LegitimacyGuard 無法從 tool call 推得 path 時用（pipeline、custom script 等）。標準 `read_file` 或單純的 `grep`/`head`/`sed -n` 已經自動標記，呼叫 `probe_file` 是冗餘且燒 token。Agent 不該學成「grep 完就 probe_file」這個 pattern。

## 行為差異 — 會 break 什麼

舊機制下：
```python
agent_health()                     # has_probed=True
# 50 turns later
write_file(\"/etc/passwd\", \"...\") # 通過
```

新機制下：
```python
agent_health()                     # NOT a file probe
write_file(\"/etc/passwd\", \"...\") # 被擋
# Error: \"You must read this specific file before writing it.\"
```

這是設計意圖內的 breaking change。`test_safe_tool_counts_as_probe` 原本斷言這個寬鬆行為，**它編碼的就是我們要修的 bug** — 改寫成 `test_safe_tool_without_path_does_not_probe_files` 斷言新的正確行為。

## Test plan

- [x] `pytest tests/test_legitimacy.py` — 27 passed（含 7 個新 per-file 測試）
- [x] `pytest tests/` 全跑 — **1355 passed, 1 skipped**
- [ ] 手動 smoke：CLI 跑一個 session，連續 `read_file('a.py')` → `write_file('a.py')` 通過；`agent_health()` → `write_file('b.py')` 被擋

## 設計取捨記錄

- **Session-level retention（不每 turn reset `_probed_files`）**：依照 #288 issue 設計：「一個 session 內讀過就算讀過」。如果這個假設後續證明太寬鬆（agent 在 turn 1 讀 foo，turn 50 寫 foo，這中間 foo 可能已被外部修改），可以未來加 staleness 閾值，例如「N turn 沒重讀就 expire」。
- **Tool-name `_session_trusted` 不動**：那是另一條 escape，#118 的人類授權快車道，跟 #288 的核心訴求正交。要收緊那條也是另一個 issue。
- **READ_PROBE → unscoped**：web_search 等遠端讀對「寫本地檔案」沒語意保證，但完全無視太緊。維持為 unscoped（會 clear 整個 gate）作為已知的軟路徑，未來想再收緊另開 issue。

🤖 Generated with [Claude Code](https://claude.com/claude-code)