### PR TITLE
feat(memory): three-axis fact ontology — P1-A schema + P1-B API (#281)

### DIFF
--- a/loom/core/memory/classifier.py
+++ b/loom/core/memory/classifier.py
@@ -1,0 +1,68 @@
+"""
+Domain classifier — heuristic prefix-based domain inference for memory facts.
+
+When a caller (memorize tool, session compressor, dreaming) doesn't know
+the right domain, the governor calls :func:`infer_domain` to upgrade the
+default ``knowledge`` to a more specific axis based on the entry's key /
+value shape.
+
+The heuristic looks at:
+
+  1. Key namespace prefixes (``user:`` / ``project:`` / ``loom:identity:`` etc.)
+  2. Subject prefixes for relational triples
+  3. Source tier (``user_explicit`` → user-aimed unless key says otherwise)
+
+This is intentionally **rule-based, not LLM-based**. P1-C will add an
+LLM-assisted batch classifier for legacy data migration — that classifier
+shares the canonical DOMAINS enum with this module so heuristic-vs-LLM
+disagreement is a strict comparison.
+"""
+
+from __future__ import annotations
+
+from loom.core.memory.ontology import (
+    DOMAIN_KNOWLEDGE,
+    DOMAIN_PROJECT,
+    DOMAIN_SELF,
+    DOMAIN_USER,
+)
+
+
+# Lower-cased key prefix → domain.  Order matters only for documentation;
+# matching is exact-prefix, so longer namespaces are checked first below.
+_KEY_PREFIX_RULES: tuple[tuple[str, str], ...] = (
+    # Self — agent identity / principles / self-awareness
+    ("loom:identity", DOMAIN_SELF),
+    ("loom:self", DOMAIN_SELF),
+    ("agent:identity", DOMAIN_SELF),
+    ("self:", DOMAIN_SELF),
+    ("identity:", DOMAIN_SELF),
+    # User
+    ("user:", DOMAIN_USER),
+    ("u:", DOMAIN_USER),
+    # Project — code architecture, config, workflow
+    ("project:", DOMAIN_PROJECT),
+    ("loom:config", DOMAIN_PROJECT),
+    ("loom:arch", DOMAIN_PROJECT),
+    ("repo:", DOMAIN_PROJECT),
+    ("config:", DOMAIN_PROJECT),
+    # Knowledge — explicit knowledge namespace
+    ("knowledge:", DOMAIN_KNOWLEDGE),
+    ("fact:knowledge", DOMAIN_KNOWLEDGE),
+    ("skill:", DOMAIN_KNOWLEDGE),
+)
+
+
+def infer_domain(key: str | None) -> str:
+    """Best-effort domain inference from a fact key.
+
+    Returns one of the four DOMAINS values. When no rule matches, returns
+    ``DOMAIN_KNOWLEDGE`` — the safe default per Memory Ontology v0.1.
+    """
+    if not key:
+        return DOMAIN_KNOWLEDGE
+    k = key.lower().lstrip()
+    for prefix, domain in _KEY_PREFIX_RULES:
+        if k.startswith(prefix):
+            return domain
+    return DOMAIN_KNOWLEDGE

--- a/loom/core/memory/facade.py
+++ b/loom/core/memory/facade.py
@@ -77,6 +77,8 @@ class MemoryFacade:
         query: str,
         kind: Literal["semantic", "skill", "all"] = "all",
         limit: int = 5,
+        domain: str | None = None,
+        temporal: str | None = None,
     ) -> list["MemorySearchResult"]:
         """BM25 + embedding ranked retrieval across semantic + procedural memory.
 
@@ -88,8 +90,14 @@ class MemoryFacade:
         backend to hit: ``"semantic"`` facts only, ``"skill"`` for
         procedural skills only, or ``"all"`` (default).  Renamed to
         avoid shadowing the ``type`` builtin.
+
+        ``domain`` and ``temporal`` are optional Memory-Ontology filters
+        (issue #281) — see :meth:`MemorySearch.recall` for semantics.
         """
-        return await self.search_index.recall(query, type=kind, limit=limit)
+        return await self.search_index.recall(
+            query, type=kind, limit=limit,
+            domain=domain, temporal=temporal,
+        )
 
     async def get_fact(self, key: str) -> "SemanticEntry | None":
         """Direct semantic-memory lookup by exact key."""

--- a/loom/core/memory/governance.py
+++ b/loom/core/memory/governance.py
@@ -24,11 +24,13 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, UTC
 from typing import TYPE_CHECKING
 
+from loom.core.memory.classifier import infer_domain
 from loom.core.memory.contradiction import (
     ContradictionDetector,
     Resolution,
 )
 from loom.core.memory.health import MemoryHealthTracker
+from loom.core.memory.ontology import DEFAULT_DOMAIN
 from loom.core.memory.semantic import SemanticEntry, classify_source
 
 if TYPE_CHECKING:
@@ -153,6 +155,15 @@ class MemoryGovernor:
         # (but don't lower an explicitly-set high confidence)
         adjusted = max(entry.confidence, tier_confidence)
         entry.confidence = adjusted
+
+        # Memory Ontology v0.1 (issue #281): if domain is the safe default,
+        # try to upgrade it via the heuristic classifier. We only override
+        # when the classifier finds a more specific axis — explicit
+        # ``knowledge`` from the caller is preserved as-is.
+        if entry.domain == DEFAULT_DOMAIN:
+            inferred = infer_domain(entry.key)
+            if inferred != DEFAULT_DOMAIN:
+                entry.domain = inferred
 
         # Contradiction check
         contradictions = await self._detector.detect(entry)

--- a/loom/core/memory/ontology.py
+++ b/loom/core/memory/ontology.py
@@ -1,0 +1,71 @@
+"""
+Memory ontology — single source of truth for fact classification axes.
+
+Every semantic / relational fact is classified along three axes:
+
+  - source    : trust tier (existing — see semantic.classify_source)
+  - domain    : semantic territory (this module — DOMAINS)
+  - temporal  : lifecycle state    (this module — TEMPORALS)
+
+Reference: outputs/doc/memory_ontology_draft_2026-05-03.md
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+
+# ---------------------------------------------------------------------------
+# Domain — semantic territory of a fact
+# ---------------------------------------------------------------------------
+
+DOMAIN_SELF: Final = "self"            # Agent identity, principles, self-awareness
+DOMAIN_USER: Final = "user"            # User preferences, relationship, known/unknown
+DOMAIN_PROJECT: Final = "project"      # Architecture decisions, config, workflow
+DOMAIN_KNOWLEDGE: Final = "knowledge"  # External knowledge, tool usage, research
+
+DOMAINS: Final = frozenset({
+    DOMAIN_SELF,
+    DOMAIN_USER,
+    DOMAIN_PROJECT,
+    DOMAIN_KNOWLEDGE,
+})
+
+DEFAULT_DOMAIN: Final = DOMAIN_KNOWLEDGE
+
+
+# ---------------------------------------------------------------------------
+# Temporal — lifecycle state of a fact
+# ---------------------------------------------------------------------------
+
+TEMPORAL_EPHEMERAL: Final = "ephemeral"  # Session-scoped, dies on session end
+TEMPORAL_RECENT: Final = "recent"        # Active within recent window (~7d)
+TEMPORAL_MILESTONE: Final = "milestone"  # Permanent anchor, never auto-decays
+TEMPORAL_ARCHIVED: Final = "archived"    # Long-untouched, near-decay
+
+TEMPORALS: Final = frozenset({
+    TEMPORAL_EPHEMERAL,
+    TEMPORAL_RECENT,
+    TEMPORAL_MILESTONE,
+    TEMPORAL_ARCHIVED,
+})
+
+DEFAULT_TEMPORAL: Final = TEMPORAL_RECENT
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def normalize_domain(value: str | None) -> str:
+    """Return a valid domain — falls back to DEFAULT_DOMAIN for unknown/None."""
+    if value and value in DOMAINS:
+        return value
+    return DEFAULT_DOMAIN
+
+
+def normalize_temporal(value: str | None) -> str:
+    """Return a valid temporal — falls back to DEFAULT_TEMPORAL for unknown/None."""
+    if value and value in TEMPORALS:
+        return value
+    return DEFAULT_TEMPORAL

--- a/loom/core/memory/relational.py
+++ b/loom/core/memory/relational.py
@@ -139,9 +139,10 @@ class RelationalMemory:
         Pass neither to return all entries.
         """
         base = f"SELECT {_SELECT_COLS} FROM relational_entries"
+        params: tuple[str, ...]
         if subject and predicate:
             sql = f"{base} WHERE subject = ? AND predicate = ? ORDER BY updated_at DESC"
-            params: tuple = (subject, predicate)
+            params = (subject, predicate)
         elif subject:
             sql = f"{base} WHERE subject = ? ORDER BY updated_at DESC"
             params = (subject,)

--- a/loom/core/memory/relational.py
+++ b/loom/core/memory/relational.py
@@ -25,6 +25,13 @@ from typing import Any
 
 import aiosqlite
 
+from loom.core.memory.ontology import (
+    DEFAULT_DOMAIN,
+    DEFAULT_TEMPORAL,
+    normalize_domain,
+    normalize_temporal,
+)
+
 
 # ---------------------------------------------------------------------------
 # Data class
@@ -42,6 +49,20 @@ class RelationalEntry:
     id:        str = field(default_factory=lambda: str(uuid.uuid4()))
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    # Memory Ontology v0.1 (issue #281)
+    domain:    str = DEFAULT_DOMAIN
+    temporal:  str = DEFAULT_TEMPORAL
+    last_accessed_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        self.domain = normalize_domain(self.domain)
+        self.temporal = normalize_temporal(self.temporal)
+
+
+_SELECT_COLS = (
+    "id, subject, predicate, object, confidence, source, metadata, "
+    "created_at, updated_at, domain, temporal, last_accessed_at"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -66,14 +87,16 @@ class RelationalMemory:
             """
             INSERT INTO relational_entries
                 (id, subject, predicate, object, confidence, source, metadata,
-                 created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 created_at, updated_at, domain, temporal, last_accessed_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(subject, predicate) DO UPDATE SET
                 object     = excluded.object,
                 confidence = excluded.confidence,
                 source     = excluded.source,
                 metadata   = excluded.metadata,
-                updated_at = excluded.updated_at
+                updated_at = excluded.updated_at,
+                domain     = excluded.domain,
+                temporal   = excluded.temporal
             """,
             (
                 entry.id,
@@ -85,6 +108,9 @@ class RelationalMemory:
                 json.dumps(entry.metadata, ensure_ascii=False),
                 entry.created_at.isoformat(),
                 now,
+                entry.domain,
+                entry.temporal,
+                entry.last_accessed_at.isoformat() if entry.last_accessed_at else None,
             ),
         )
         await self._db.commit()
@@ -92,9 +118,8 @@ class RelationalMemory:
     async def get(self, subject: str, predicate: str) -> RelationalEntry | None:
         """Return the entry for (subject, predicate), or None."""
         cursor = await self._db.execute(
-            "SELECT id, subject, predicate, object, confidence, source, metadata, "
-            "created_at, updated_at "
-            "FROM relational_entries WHERE subject = ? AND predicate = ?",
+            f"SELECT {_SELECT_COLS} FROM relational_entries "
+            "WHERE subject = ? AND predicate = ?",
             (subject, predicate),
         )
         row = await cursor.fetchone()
@@ -113,32 +138,18 @@ class RelationalMemory:
         Pass both for an exact lookup (same as ``get()`` but returns a list).
         Pass neither to return all entries.
         """
+        base = f"SELECT {_SELECT_COLS} FROM relational_entries"
         if subject and predicate:
-            sql = (
-                "SELECT id, subject, predicate, object, confidence, source, metadata, "
-                "created_at, updated_at FROM relational_entries "
-                "WHERE subject = ? AND predicate = ? ORDER BY updated_at DESC"
-            )
-            params = (subject, predicate)
+            sql = f"{base} WHERE subject = ? AND predicate = ? ORDER BY updated_at DESC"
+            params: tuple = (subject, predicate)
         elif subject:
-            sql = (
-                "SELECT id, subject, predicate, object, confidence, source, metadata, "
-                "created_at, updated_at FROM relational_entries "
-                "WHERE subject = ? ORDER BY updated_at DESC"
-            )
+            sql = f"{base} WHERE subject = ? ORDER BY updated_at DESC"
             params = (subject,)
         elif predicate:
-            sql = (
-                "SELECT id, subject, predicate, object, confidence, source, metadata, "
-                "created_at, updated_at FROM relational_entries "
-                "WHERE predicate = ? ORDER BY updated_at DESC"
-            )
+            sql = f"{base} WHERE predicate = ? ORDER BY updated_at DESC"
             params = (predicate,)
         else:
-            sql = (
-                "SELECT id, subject, predicate, object, confidence, source, metadata, "
-                "created_at, updated_at FROM relational_entries ORDER BY updated_at DESC"
-            )
+            sql = f"{base} ORDER BY updated_at DESC"
             params = ()
 
         cursor = await self._db.execute(sql, params)
@@ -171,4 +182,7 @@ class RelationalMemory:
             metadata=json.loads(row[6]),
             created_at=datetime.fromisoformat(row[7]),
             updated_at=datetime.fromisoformat(row[8]),
+            domain=row[9],
+            temporal=row[10],
+            last_accessed_at=datetime.fromisoformat(row[11]) if row[11] else None,
         )

--- a/loom/core/memory/search.py
+++ b/loom/core/memory/search.py
@@ -31,7 +31,11 @@ logger = logging.getLogger(__name__)
 
 from loom.core.memory.embeddings import cosine_similarity
 from loom.core.memory.procedural import ProceduralMemory
-from loom.core.memory.semantic import SemanticMemory
+from loom.core.memory.semantic import (
+    SemanticMemory,
+    _SELECT_COLS as _SEMANTIC_SELECT_COLS,
+    _row_to_entry as _semantic_row_to_entry,
+)
 
 
 def _sanitize_fts(query: str) -> str:
@@ -213,7 +217,7 @@ class MemorySearch:
         where, axis_params = _axis_filter_sql(domain, temporal)
         cursor = await self._semantic._db.execute(
             f"""
-            SELECT id, key, value, confidence, source, metadata, created_at, updated_at,
+            SELECT {_SEMANTIC_SELECT_COLS},
                    1.0 - vec_distance_cosine(embedding, ?) AS score
             FROM semantic_entries
             WHERE embedding IS NOT NULL{where}
@@ -223,18 +227,12 @@ class MemorySearch:
             (json.dumps(query_vec), *axis_params, json.dumps(query_vec), limit)
         )
         rows = await cursor.fetchall()
-        
-        from loom.core.memory.semantic import SemanticEntry
 
         results: list[MemorySearchResult] = []
         for r in rows:
-            entry = SemanticEntry(
-                id=r[0], key=r[1], value=r[2], confidence=r[3],
-                source=r[4], metadata=json.loads(r[5]),
-                created_at=datetime.fromisoformat(r[6]),
-                updated_at=datetime.fromisoformat(r[7]),
-            )
-            score = r[8]
+            # _SELECT_COLS produces 11 columns; index 11 holds the score.
+            entry = _semantic_row_to_entry(r[:11])
+            score = r[11]
             if score > 0.0:
                 results.append(
                     MemorySearchResult(
@@ -307,12 +305,16 @@ class MemorySearch:
             return []
 
         where, axis_params = _axis_filter_sql(domain, temporal, prefix="e.")
+        # SELECT mirrors _SEMANTIC_SELECT_COLS aliased onto the joined table
+        # so _semantic_row_to_entry can parse rows uniformly with the
+        # embedding path.
+        select_cols = ", ".join(f"e.{c.strip()}" for c in _SEMANTIC_SELECT_COLS.split(","))
         # FTS5 returns negative scores for bm25 by default, smaller = better.
         # We order by rank and return absolute values for positive compatibility.
         cursor = await self._semantic._db.execute(
             f"""
             SELECT
-                e.id, e.key, e.value, e.confidence, e.source, e.metadata, e.created_at, e.updated_at,
+                {select_cols},
                 bm25(semantic_fts) AS fts_score
             FROM semantic_fts
             JOIN semantic_entries e ON semantic_fts.rowid = e.rowid
@@ -324,17 +326,11 @@ class MemorySearch:
         )
         rows = await cursor.fetchall()
 
-        from loom.core.memory.semantic import SemanticEntry
         results: list[MemorySearchResult] = []
         for r in rows:
-            entry = SemanticEntry(
-                id=r[0], key=r[1], value=r[2], confidence=r[3],
-                source=r[4], metadata=json.loads(r[5]),
-                created_at=datetime.fromisoformat(r[6]),
-                updated_at=datetime.fromisoformat(r[7]),
-            )
+            entry = _semantic_row_to_entry(r[:11])
             # Convert negative rank to positive score
-            score = abs(r[8]) if r[8] else 0.0
+            score = abs(r[11]) if r[11] else 0.0
             results.append(
                 MemorySearchResult(
                     type="semantic",

--- a/loom/core/memory/search.py
+++ b/loom/core/memory/search.py
@@ -40,6 +40,29 @@ def _sanitize_fts(query: str) -> str:
     return " ".join(f'"{t}"' for t in query.replace('"', " ").split() if t)
 
 
+def _axis_filter_sql(
+    domain: str | None,
+    temporal: str | None,
+    prefix: str = "",
+) -> tuple[str, tuple[str, ...]]:
+    """Build a SQL fragment + params for optional (domain, temporal) filters.
+
+    Returns ``("", ())`` when both axes are None — callers can splice the
+    fragment after an existing ``WHERE`` clause without needing to branch
+    on whether any filter was supplied. ``prefix`` is prepended to the
+    column names for queries that join multiple tables (e.g. ``"e."``).
+    """
+    parts: list[str] = []
+    params: list[str] = []
+    if domain:
+        parts.append(f"AND {prefix}domain = ?")
+        params.append(domain)
+    if temporal:
+        parts.append(f"AND {prefix}temporal = ?")
+        params.append(temporal)
+    return (" " + " ".join(parts) if parts else ""), tuple(params)
+
+
 # ---------------------------------------------------------------------------
 # Result type
 # ---------------------------------------------------------------------------
@@ -95,6 +118,8 @@ class MemorySearch:
         query: str,
         type: MemoryType = "all",
         limit: int = 5,
+        domain: str | None = None,
+        temporal: str | None = None,
     ) -> list[MemorySearchResult]:
         """
         Return the top-*limit* memory entries most relevant to *query*.
@@ -106,9 +131,13 @@ class MemorySearch:
 
         Parameters
         ----------
-        query:  Natural-language search query.
-        type:   Which memory store(s) to search: "semantic", "skill", or "all".
-        limit:  Maximum number of results to return (across all types).
+        query:    Natural-language search query.
+        type:     Which memory store(s) to search: "semantic", "skill", or "all".
+        limit:    Maximum number of results to return (across all types).
+        domain:   Optional Memory-Ontology axis filter (issue #281). When set,
+                  only semantic entries with this domain are returned. Skills
+                  are unaffected — domain/temporal apply to facts, not skills.
+        temporal: Optional temporal axis filter (same semantics as ``domain``).
         """
         if not query.strip():
             return []
@@ -118,15 +147,20 @@ class MemorySearch:
         # configured.  Any exception (network, API error) falls through to BM25.
         if self._semantic.has_embeddings and type in ("semantic", "all"):
             try:
-                emb_results = await self._search_semantic_embedding(query, limit)
+                emb_results = await self._search_semantic_embedding(
+                    query, limit, domain=domain, temporal=temporal,
+                )
                 if emb_results:
                     # Skills are not embedding-indexed; mix in BM25 skill results
                     if type == "all":
                         skill_results = await self._search_skills(query, limit)
                         combined = emb_results + skill_results
                         combined.sort(key=lambda r: r.score, reverse=True)
-                        return combined[:limit]
-                    return emb_results
+                        ranked = combined[:limit]
+                    else:
+                        ranked = emb_results
+                    await self._mark_accessed(ranked)
+                    return ranked
             except Exception as exc:
                 logger.warning(
                     "Embedding search failed, degrading to BM25: %s", exc,
@@ -137,7 +171,11 @@ class MemorySearch:
         # ── Tier 2: BM25 keyword search ───────────────────────────────────────
         results: list[MemorySearchResult] = []
         if type in ("semantic", "all"):
-            results.extend(await self._search_semantic(query, limit))
+            results.extend(
+                await self._search_semantic(
+                    query, limit, domain=domain, temporal=temporal,
+                )
+            )
         if type in ("skill", "all"):
             results.extend(await self._search_skills(query, limit))
 
@@ -148,10 +186,19 @@ class MemorySearch:
         if not ranked:
             ranked = await self._recent_fallback(type, limit)
 
+        await self._mark_accessed(ranked)
         return ranked
 
+    async def _mark_accessed(self, results: list[MemorySearchResult]) -> None:
+        """Bump last_accessed_at for semantic hits (Memory Ontology v0.1)."""
+        keys = [r.key for r in results if r.type == "semantic"]
+        if keys:
+            await self._semantic.mark_accessed(keys)
+
     async def _search_semantic_embedding(
-        self, query: str, limit: int
+        self, query: str, limit: int,
+        domain: str | None = None,
+        temporal: str | None = None,
     ) -> list[MemorySearchResult]:
         """Rank semantic entries by cosine similarity using sqlite-vec."""
         provider = self._semantic._embeddings
@@ -163,16 +210,17 @@ class MemorySearch:
             return []
         query_vec = query_vectors[0]
 
+        where, axis_params = _axis_filter_sql(domain, temporal)
         cursor = await self._semantic._db.execute(
-            """
+            f"""
             SELECT id, key, value, confidence, source, metadata, created_at, updated_at,
                    1.0 - vec_distance_cosine(embedding, ?) AS score
             FROM semantic_entries
-            WHERE embedding IS NOT NULL
+            WHERE embedding IS NOT NULL{where}
             ORDER BY vec_distance_cosine(embedding, ?) ASC
             LIMIT ?
             """,
-            (json.dumps(query_vec), json.dumps(query_vec), limit)
+            (json.dumps(query_vec), *axis_params, json.dumps(query_vec), limit)
         )
         rows = await cursor.fetchall()
         
@@ -246,28 +294,33 @@ class MemorySearch:
 
     # ------------------------------------------------------------------
 
-    async def _search_semantic(self, query: str, limit: int) -> list[MemorySearchResult]:
+    async def _search_semantic(
+        self, query: str, limit: int,
+        domain: str | None = None,
+        temporal: str | None = None,
+    ) -> list[MemorySearchResult]:
         if not query.strip():
             return []
-            
+
         safe_query = _sanitize_fts(query)
         if not safe_query:
             return []
 
+        where, axis_params = _axis_filter_sql(domain, temporal, prefix="e.")
         # FTS5 returns negative scores for bm25 by default, smaller = better.
         # We order by rank and return absolute values for positive compatibility.
         cursor = await self._semantic._db.execute(
-            """
+            f"""
             SELECT
                 e.id, e.key, e.value, e.confidence, e.source, e.metadata, e.created_at, e.updated_at,
                 bm25(semantic_fts) AS fts_score
             FROM semantic_fts
             JOIN semantic_entries e ON semantic_fts.rowid = e.rowid
-            WHERE semantic_fts MATCH ?
+            WHERE semantic_fts MATCH ?{where}
             ORDER BY rank
             LIMIT ?
             """,
-            (safe_query, limit)
+            (safe_query, *axis_params, limit)
         )
         rows = await cursor.fetchall()
 

--- a/loom/core/memory/semantic.py
+++ b/loom/core/memory/semantic.py
@@ -19,6 +19,13 @@ logger = logging.getLogger(__name__)
 
 import aiosqlite
 
+from loom.core.memory.ontology import (
+    DEFAULT_DOMAIN,
+    DEFAULT_TEMPORAL,
+    normalize_domain,
+    normalize_temporal,
+)
+
 if TYPE_CHECKING:
     from loom.core.memory.embeddings import EmbeddingProvider
 
@@ -109,10 +116,41 @@ class SemanticEntry:
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    # Memory Ontology v0.1 (issue #281)
+    domain: str = DEFAULT_DOMAIN
+    temporal: str = DEFAULT_TEMPORAL
+    last_accessed_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        self.domain = normalize_domain(self.domain)
+        self.temporal = normalize_temporal(self.temporal)
 
     def effective_confidence(self, half_life_days: float = _DEFAULT_HALF_LIFE_DAYS) -> float:
         """Time-decayed confidence score."""
         return _effective_confidence(self.confidence, self.updated_at, half_life_days)
+
+
+_SELECT_COLS = (
+    "id, key, value, confidence, source, metadata, created_at, updated_at, "
+    "domain, temporal, last_accessed_at"
+)
+
+
+def _row_to_entry(row: tuple) -> SemanticEntry:
+    """Build a SemanticEntry from a row that follows ``_SELECT_COLS`` ordering."""
+    return SemanticEntry(
+        id=row[0],
+        key=row[1],
+        value=row[2],
+        confidence=row[3],
+        source=row[4],
+        metadata=json.loads(row[5]),
+        created_at=datetime.fromisoformat(row[6]),
+        updated_at=datetime.fromisoformat(row[7]),
+        domain=row[8],
+        temporal=row[9],
+        last_accessed_at=datetime.fromisoformat(row[10]) if row[10] else None,
+    )
 
 
 class SemanticMemory:
@@ -166,14 +204,17 @@ class SemanticMemory:
         await self._db.execute(
             """
             INSERT INTO semantic_entries
-                (id, key, value, confidence, source, metadata, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                (id, key, value, confidence, source, metadata, created_at, updated_at,
+                 domain, temporal, last_accessed_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(key) DO UPDATE SET
                 value      = excluded.value,
                 confidence = excluded.confidence,
                 source     = excluded.source,
                 metadata   = excluded.metadata,
-                updated_at = excluded.updated_at
+                updated_at = excluded.updated_at,
+                domain     = excluded.domain,
+                temporal   = excluded.temporal
             """,
             (
                 entry.id,
@@ -184,6 +225,9 @@ class SemanticMemory:
                 json.dumps(merged_metadata, ensure_ascii=False),
                 entry.created_at.isoformat(),
                 now,
+                entry.domain,
+                entry.temporal,
+                entry.last_accessed_at.isoformat() if entry.last_accessed_at else None,
             ),
         )
         await self._db.commit()
@@ -228,36 +272,20 @@ class SemanticMemory:
 
     async def get(self, key: str) -> SemanticEntry | None:
         cursor = await self._db.execute(
-            "SELECT id, key, value, confidence, source, metadata, created_at, updated_at "
-            "FROM semantic_entries WHERE key = ?",
+            f"SELECT {_SELECT_COLS} FROM semantic_entries WHERE key = ?",
             (key,),
         )
         row = await cursor.fetchone()
-        if not row:
-            return None
-        return SemanticEntry(
-            id=row[0], key=row[1], value=row[2], confidence=row[3],
-            source=row[4], metadata=json.loads(row[5]),
-            created_at=datetime.fromisoformat(row[6]),
-            updated_at=datetime.fromisoformat(row[7]),
-        )
+        return _row_to_entry(row) if row else None
 
     async def list_recent(self, limit: int = 20) -> list[SemanticEntry]:
         cursor = await self._db.execute(
-            "SELECT id, key, value, confidence, source, metadata, created_at, updated_at "
-            "FROM semantic_entries ORDER BY updated_at DESC LIMIT ?",
+            f"SELECT {_SELECT_COLS} FROM semantic_entries "
+            "ORDER BY updated_at DESC LIMIT ?",
             (limit,),
         )
         rows = await cursor.fetchall()
-        return [
-            SemanticEntry(
-                id=r[0], key=r[1], value=r[2], confidence=r[3],
-                source=r[4], metadata=json.loads(r[5]),
-                created_at=datetime.fromisoformat(r[6]),
-                updated_at=datetime.fromisoformat(r[7]),
-            )
-            for r in rows
-        ]
+        return [_row_to_entry(r) for r in rows]
 
     async def get_random(self, limit: int = 15) -> list[SemanticEntry]:
         """
@@ -268,20 +296,11 @@ class SemanticMemory:
         for typical Loom memory sizes (< 50k rows).
         """
         cursor = await self._db.execute(
-            "SELECT id, key, value, confidence, source, metadata, created_at, updated_at "
-            "FROM semantic_entries ORDER BY RANDOM() LIMIT ?",
+            f"SELECT {_SELECT_COLS} FROM semantic_entries ORDER BY RANDOM() LIMIT ?",
             (limit,),
         )
         rows = await cursor.fetchall()
-        return [
-            SemanticEntry(
-                id=r[0], key=r[1], value=r[2], confidence=r[3],
-                source=r[4], metadata=json.loads(r[5]),
-                created_at=datetime.fromisoformat(r[6]),
-                updated_at=datetime.fromisoformat(r[7]),
-            )
-            for r in rows
-        ]
+        return [_row_to_entry(r) for r in rows]
 
     async def list_with_embeddings(
         self, limit: int = 500
@@ -292,41 +311,27 @@ class SemanticMemory:
         Used by MemorySearch for cosine-similarity ranking.
         """
         cursor = await self._db.execute(
-            "SELECT id, key, value, confidence, source, metadata, "
-            "created_at, updated_at, embedding "
-            "FROM semantic_entries ORDER BY updated_at DESC LIMIT ?",
+            f"SELECT {_SELECT_COLS}, embedding FROM semantic_entries "
+            "ORDER BY updated_at DESC LIMIT ?",
             (limit,),
         )
         rows = await cursor.fetchall()
         result: list[tuple[SemanticEntry, list[float] | None]] = []
         for r in rows:
-            entry = SemanticEntry(
-                id=r[0], key=r[1], value=r[2], confidence=r[3],
-                source=r[4], metadata=json.loads(r[5]),
-                created_at=datetime.fromisoformat(r[6]),
-                updated_at=datetime.fromisoformat(r[7]),
-            )
-            vector: list[float] | None = json.loads(r[8]) if r[8] else None
+            entry = _row_to_entry(r[:11])
+            vector: list[float] | None = json.loads(r[11]) if r[11] else None
             result.append((entry, vector))
         return result
 
     async def search(self, query: str, limit: int = 10) -> list[SemanticEntry]:
         """Simple substring search — full-text search can be added later."""
         cursor = await self._db.execute(
-            "SELECT id, key, value, confidence, source, metadata, created_at, updated_at "
-            "FROM semantic_entries WHERE value LIKE ? ORDER BY confidence DESC LIMIT ?",
+            f"SELECT {_SELECT_COLS} FROM semantic_entries "
+            "WHERE value LIKE ? ORDER BY confidence DESC LIMIT ?",
             (f"%{query}%", limit),
         )
         rows = await cursor.fetchall()
-        return [
-            SemanticEntry(
-                id=r[0], key=r[1], value=r[2], confidence=r[3],
-                source=r[4], metadata=json.loads(r[5]),
-                created_at=datetime.fromisoformat(r[6]),
-                updated_at=datetime.fromisoformat(r[7]),
-            )
-            for r in rows
-        ]
+        return [_row_to_entry(r) for r in rows]
 
     async def list_by_prefix(self, prefix: str, limit: int = 10) -> list[SemanticEntry]:
         """Return entries whose key starts with *prefix*, newest first.
@@ -335,20 +340,12 @@ class SemanticMemory:
         ``skill:<name>:evolution_hint:*`` without full-text search overhead.
         """
         cursor = await self._db.execute(
-            "SELECT id, key, value, confidence, source, metadata, created_at, updated_at "
-            "FROM semantic_entries WHERE key LIKE ? ORDER BY updated_at DESC LIMIT ?",
+            f"SELECT {_SELECT_COLS} FROM semantic_entries "
+            "WHERE key LIKE ? ORDER BY updated_at DESC LIMIT ?",
             (f"{prefix}%", limit),
         )
         rows = await cursor.fetchall()
-        return [
-            SemanticEntry(
-                id=r[0], key=r[1], value=r[2], confidence=r[3],
-                source=r[4], metadata=json.loads(r[5]),
-                created_at=datetime.fromisoformat(r[6]),
-                updated_at=datetime.fromisoformat(r[7]),
-            )
-            for r in rows
-        ]
+        return [_row_to_entry(r) for r in rows]
 
     async def prune_decayed(
         self,
@@ -420,4 +417,23 @@ class SemanticMemory:
         )
         await self._db.commit()
         return (cursor.rowcount or 0) > 0
+
+    async def mark_accessed(self, keys: list[str]) -> None:
+        """Bump ``last_accessed_at`` for the given keys (Memory Ontology v0.1).
+
+        Called by :class:`MemorySearch` after a successful recall so the
+        decay cycle can distinguish facts that are still in active use from
+        those drifting toward archived state. Silent no-op for empty keys
+        list — recall hot path stays cheap.
+        """
+        if not keys:
+            return
+        now = datetime.now(UTC).isoformat()
+        placeholders = ",".join("?" * len(keys))
+        await self._db.execute(
+            f"UPDATE semantic_entries SET last_accessed_at = ? "
+            f"WHERE key IN ({placeholders})",
+            (now, *keys),
+        )
+        await self._db.commit()
 

--- a/loom/core/memory/store.py
+++ b/loom/core/memory/store.py
@@ -27,15 +27,20 @@ CREATE TABLE IF NOT EXISTS episodic_entries (
 );
 
 CREATE TABLE IF NOT EXISTS semantic_entries (
-    id          TEXT PRIMARY KEY,
-    key         TEXT UNIQUE NOT NULL,
-    value       TEXT NOT NULL,
-    confidence  REAL NOT NULL DEFAULT 1.0,
-    source      TEXT,
-    metadata    TEXT NOT NULL DEFAULT '{}',
-    created_at  TEXT NOT NULL,
-    updated_at  TEXT NOT NULL,
-    embedding   TEXT            -- JSON float array; NULL until first embed
+    id              TEXT PRIMARY KEY,
+    key             TEXT UNIQUE NOT NULL,
+    value           TEXT NOT NULL,
+    confidence      REAL NOT NULL DEFAULT 1.0,
+    source          TEXT,
+    metadata        TEXT NOT NULL DEFAULT '{}',
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL,
+    embedding       TEXT,                                              -- JSON float array; NULL until first embed
+    -- Memory Ontology v0.1 (issue #281): three-axis classification.
+    -- See loom/core/memory/ontology.py for canonical values.
+    domain          TEXT NOT NULL DEFAULT 'knowledge',
+    temporal        TEXT NOT NULL DEFAULT 'recent',
+    last_accessed_at TEXT                                              -- ISO timestamp; updated on recall hit
 );
 
 CREATE TABLE IF NOT EXISTS skill_genomes (
@@ -66,15 +71,19 @@ CREATE TABLE IF NOT EXISTS audit_log (
 );
 
 CREATE TABLE IF NOT EXISTS relational_entries (
-    id          TEXT PRIMARY KEY,
-    subject     TEXT NOT NULL,
-    predicate   TEXT NOT NULL,
-    object      TEXT NOT NULL,
-    confidence  REAL NOT NULL DEFAULT 1.0,
-    source      TEXT NOT NULL DEFAULT 'agent',
-    metadata    TEXT NOT NULL DEFAULT '{}',
-    created_at  TEXT NOT NULL,
-    updated_at  TEXT NOT NULL,
+    id              TEXT PRIMARY KEY,
+    subject         TEXT NOT NULL,
+    predicate       TEXT NOT NULL,
+    object          TEXT NOT NULL,
+    confidence      REAL NOT NULL DEFAULT 1.0,
+    source          TEXT NOT NULL DEFAULT 'agent',
+    metadata        TEXT NOT NULL DEFAULT '{}',
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL,
+    -- Memory Ontology v0.1 (issue #281): three-axis classification.
+    domain          TEXT NOT NULL DEFAULT 'knowledge',
+    temporal        TEXT NOT NULL DEFAULT 'recent',
+    last_accessed_at TEXT,
     UNIQUE(subject, predicate)
 );
 
@@ -262,6 +271,14 @@ class SQLiteStore:
                 # Issue #120 PR 4: fast-track flag bypasses shadow phase when Grader
                 # proves ≥20% pass-rate improvement over the previous version.
                 "ALTER TABLE skill_candidates ADD COLUMN fast_track INTEGER NOT NULL DEFAULT 0",
+                # Memory Ontology v0.1 (issue #281): three-axis classification on
+                # semantic + relational facts. See loom/core/memory/ontology.py.
+                "ALTER TABLE semantic_entries ADD COLUMN domain TEXT NOT NULL DEFAULT 'knowledge'",
+                "ALTER TABLE semantic_entries ADD COLUMN temporal TEXT NOT NULL DEFAULT 'recent'",
+                "ALTER TABLE semantic_entries ADD COLUMN last_accessed_at TEXT",
+                "ALTER TABLE relational_entries ADD COLUMN domain TEXT NOT NULL DEFAULT 'knowledge'",
+                "ALTER TABLE relational_entries ADD COLUMN temporal TEXT NOT NULL DEFAULT 'recent'",
+                "ALTER TABLE relational_entries ADD COLUMN last_accessed_at TEXT",
             ]:
                 try:
                     await db.execute(_migration)
@@ -273,6 +290,12 @@ class SQLiteStore:
                 "CREATE INDEX IF NOT EXISTS idx_session_log_role ON session_log(session_id, role)",
                 "CREATE INDEX IF NOT EXISTS idx_episodic_session_uncompressed "
                 "ON episodic_entries(session_id) WHERE compressed_at IS NULL",
+                # Memory Ontology v0.1 (issue #281): filter by (domain, temporal)
+                # is the primary recall path for axis-aware queries.
+                "CREATE INDEX IF NOT EXISTS idx_semantic_domain_temporal "
+                "ON semantic_entries(domain, temporal)",
+                "CREATE INDEX IF NOT EXISTS idx_relational_domain_temporal "
+                "ON relational_entries(domain, temporal)",
             ]:
                 try:
                     await db.execute(_index_sql)

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -858,10 +858,14 @@ def make_recall_tool(memory: "MemoryFacade") -> ToolDefinition:
     The tool performs BM25-ranked retrieval across semantic facts and
     skills via :meth:`MemoryFacade.search`.
     """
+    from loom.core.memory.ontology import DOMAINS, TEMPORALS
+
     async def _recall(call: ToolCall) -> ToolResult:
         query = call.args.get("query", "").strip()
         mem_type = call.args.get("type", "all")
         limit = min(max(int(call.args.get("limit", 5)), 1), 10)
+        domain = (call.args.get("domain") or "").strip().lower() or None
+        temporal = (call.args.get("temporal") or "").strip().lower() or None
 
         if not query:
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
@@ -869,8 +873,17 @@ def make_recall_tool(memory: "MemoryFacade") -> ToolDefinition:
 
         if mem_type not in ("semantic", "skill", "all"):
             mem_type = "all"
+        # Drop unknown axis filters silently rather than 400 — keeps the
+        # recall hot path forgiving.
+        if domain and domain not in DOMAINS:
+            domain = None
+        if temporal and temporal not in TEMPORALS:
+            temporal = None
 
-        results = await memory.search(query, kind=mem_type, limit=limit)  # type: ignore[arg-type]
+        results = await memory.search(  # type: ignore[arg-type]
+            query, kind=mem_type, limit=limit,
+            domain=domain, temporal=temporal,
+        )
 
         if not results:
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
@@ -911,6 +924,22 @@ def make_recall_tool(memory: "MemoryFacade") -> ToolDefinition:
                     "type": "integer",
                     "description": "Max results to return (1–10, default 5)",
                 },
+                "domain": {
+                    "type": "string",
+                    "enum": ["self", "user", "project", "knowledge"],
+                    "description": (
+                        "Optional Memory-Ontology axis filter — return only "
+                        "facts in this domain. Skills are unaffected."
+                    ),
+                },
+                "temporal": {
+                    "type": "string",
+                    "enum": ["ephemeral", "recent", "milestone", "archived"],
+                    "description": (
+                        "Optional temporal filter — e.g. 'milestone' to find "
+                        "permanent anchors only."
+                    ),
+                },
             },
             "required": ["query"],
         },
@@ -944,6 +973,11 @@ def make_memorize_tool(
         stay silent (PR-C4 design: governor only speaks when it stops
         something).
     """
+    from loom.core.memory.ontology import (
+        DEFAULT_TEMPORAL,
+        normalize_domain,
+        normalize_temporal,
+    )
     from loom.core.memory.semantic import SemanticEntry
 
     async def _memorize(call: ToolCall) -> ToolResult:
@@ -951,12 +985,24 @@ def make_memorize_tool(
         value = call.args.get("value", "").strip()
         confidence = float(call.args.get("confidence", 0.8))
         confidence = max(0.0, min(1.0, confidence))
+        # Memory Ontology v0.1 (issue #281): three-axis classification.
+        # `domain` is optional in the schema — if missing, governor will
+        # apply the heuristic classifier (loom/core/memory/classifier.py).
+        domain_raw = (call.args.get("domain") or "").strip().lower() or None
+        temporal_raw = (call.args.get("temporal") or DEFAULT_TEMPORAL).strip().lower()
 
         if not key or not value:
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
                               success=False, error="Both 'key' and 'value' are required")
 
-        entry = SemanticEntry(key=key, value=value, confidence=confidence, source="memorize")
+        entry = SemanticEntry(
+            key=key,
+            value=value,
+            confidence=confidence,
+            source="memorize",
+            domain=normalize_domain(domain_raw),
+            temporal=normalize_temporal(temporal_raw),
+        )
         gov_result = await memory.memorize(entry)
 
         if not gov_result.written:
@@ -1051,6 +1097,25 @@ def make_memorize_tool(
                 "confidence": {
                     "type": "number",
                     "description": "Confidence score 0–1 (default 0.8)",
+                },
+                "domain": {
+                    "type": "string",
+                    "enum": ["self", "user", "project", "knowledge"],
+                    "description": (
+                        "Semantic territory of the fact: 'self' (agent identity / "
+                        "principles), 'user' (preferences / relationship), 'project' "
+                        "(architecture / config / workflow), 'knowledge' (external "
+                        "facts / tool usage). Optional — if omitted, inferred from key."
+                    ),
+                },
+                "temporal": {
+                    "type": "string",
+                    "enum": ["ephemeral", "recent", "milestone", "archived"],
+                    "description": (
+                        "Lifecycle state: 'ephemeral' (session-scoped), 'recent' "
+                        "(default — active within ~7d), 'milestone' (permanent "
+                        "anchor; use sparingly), 'archived' (rare on write)."
+                    ),
                 },
             },
             "required": ["key", "value"],

--- a/tests/test_memory_ontology.py
+++ b/tests/test_memory_ontology.py
@@ -1,0 +1,285 @@
+"""
+Tests for Memory Ontology v0.1 (issue #281):
+  - ontology.normalize_domain / normalize_temporal — invalid → default
+  - classifier.infer_domain — prefix-rule matching
+  - SemanticEntry / RelationalEntry — dataclass normalization
+  - governed_upsert — auto-classify when domain is the safe default
+  - MemorySearch.recall — domain/temporal filter
+  - SemanticMemory.mark_accessed — last_accessed_at update
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from loom.core.memory.classifier import infer_domain
+from loom.core.memory.governance import MemoryGovernor
+from loom.core.memory.episodic import EpisodicMemory
+from loom.core.memory.ontology import (
+    DEFAULT_DOMAIN,
+    DEFAULT_TEMPORAL,
+    DOMAIN_KNOWLEDGE,
+    DOMAIN_PROJECT,
+    DOMAIN_SELF,
+    DOMAIN_USER,
+    DOMAINS,
+    TEMPORAL_MILESTONE,
+    TEMPORAL_RECENT,
+    TEMPORALS,
+    normalize_domain,
+    normalize_temporal,
+)
+from loom.core.memory.procedural import ProceduralMemory
+from loom.core.memory.relational import RelationalEntry, RelationalMemory
+from loom.core.memory.search import MemorySearch
+from loom.core.memory.semantic import SemanticEntry, SemanticMemory
+from loom.core.memory.store import SQLiteStore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = SQLiteStore(str(tmp_path / "ontology.db"))
+    await s.initialize()
+    return s
+
+
+@pytest_asyncio.fixture
+async def db_conn(store):
+    async with store.connect() as db:
+        yield db
+
+
+@pytest_asyncio.fixture
+async def memories(db_conn):
+    semantic = SemanticMemory(db_conn)
+    relational = RelationalMemory(db_conn)
+    procedural = ProceduralMemory(db_conn)
+    episodic = EpisodicMemory(db_conn)
+    return semantic, relational, procedural, episodic
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests
+# ---------------------------------------------------------------------------
+
+class TestOntologyNormalizers:
+    def test_domains_are_closed_set(self):
+        assert DOMAINS == {DOMAIN_SELF, DOMAIN_USER, DOMAIN_PROJECT, DOMAIN_KNOWLEDGE}
+
+    def test_temporals_are_closed_set(self):
+        assert "ephemeral" in TEMPORALS
+        assert "recent" in TEMPORALS
+        assert "milestone" in TEMPORALS
+        assert "archived" in TEMPORALS
+        assert len(TEMPORALS) == 4
+
+    @pytest.mark.parametrize("good", list(DOMAINS))
+    def test_normalize_domain_passes_known_values(self, good):
+        assert normalize_domain(good) == good
+
+    @pytest.mark.parametrize("bad", ["", None, "weird", "SELF", "Knowledge"])
+    def test_normalize_domain_falls_back_for_unknown(self, bad):
+        assert normalize_domain(bad) == DEFAULT_DOMAIN
+
+    @pytest.mark.parametrize("good", list(TEMPORALS))
+    def test_normalize_temporal_passes_known_values(self, good):
+        assert normalize_temporal(good) == good
+
+    @pytest.mark.parametrize("bad", ["", None, "soon", "RECENT"])
+    def test_normalize_temporal_falls_back_for_unknown(self, bad):
+        assert normalize_temporal(bad) == DEFAULT_TEMPORAL
+
+
+class TestClassifier:
+    @pytest.mark.parametrize("key,expected", [
+        ("loom:identity:establishment_date", DOMAIN_SELF),
+        ("user:prefers:concise", DOMAIN_USER),
+        ("project:loom:db_schema", DOMAIN_PROJECT),
+        ("loom:config:model_default", DOMAIN_PROJECT),
+        ("knowledge:gitnexus:cypher_syntax", DOMAIN_KNOWLEDGE),
+        ("skill:code_weaver:v1", DOMAIN_KNOWLEDGE),
+        ("random_key_with_no_namespace", DOMAIN_KNOWLEDGE),
+        ("", DOMAIN_KNOWLEDGE),
+        (None, DOMAIN_KNOWLEDGE),
+    ])
+    def test_infer_domain_known_prefixes(self, key, expected):
+        assert infer_domain(key) == expected
+
+    def test_infer_domain_is_case_insensitive(self):
+        assert infer_domain("USER:prefers:bar") == DOMAIN_USER
+        assert infer_domain("Project:Loom:Foo") == DOMAIN_PROJECT
+
+
+class TestDataclassNormalization:
+    def test_semantic_entry_normalizes_invalid_domain(self):
+        e = SemanticEntry(key="k", value="v", domain="nonsense")
+        assert e.domain == DEFAULT_DOMAIN
+
+    def test_semantic_entry_preserves_valid_domain(self):
+        e = SemanticEntry(key="k", value="v", domain=DOMAIN_SELF)
+        assert e.domain == DOMAIN_SELF
+
+    def test_semantic_entry_normalizes_invalid_temporal(self):
+        e = SemanticEntry(key="k", value="v", temporal="bogus")
+        assert e.temporal == DEFAULT_TEMPORAL
+
+    def test_relational_entry_normalizes(self):
+        e = RelationalEntry(
+            subject="user", predicate="prefers", object="x",
+            domain="???", temporal="?",
+        )
+        assert e.domain == DEFAULT_DOMAIN
+        assert e.temporal == DEFAULT_TEMPORAL
+
+
+# ---------------------------------------------------------------------------
+# Round-trip tests — schema actually persists and returns the new fields
+# ---------------------------------------------------------------------------
+
+class TestSemanticPersistence:
+    @pytest.mark.asyncio
+    async def test_upsert_persists_domain_and_temporal(self, memories):
+        semantic, *_ = memories
+        await semantic.upsert(SemanticEntry(
+            key="loom:identity:foo", value="hello",
+            domain=DOMAIN_SELF, temporal=TEMPORAL_MILESTONE,
+        ))
+        got = await semantic.get("loom:identity:foo")
+        assert got is not None
+        assert got.domain == DOMAIN_SELF
+        assert got.temporal == TEMPORAL_MILESTONE
+
+    @pytest.mark.asyncio
+    async def test_upsert_uses_defaults_when_omitted(self, memories):
+        semantic, *_ = memories
+        await semantic.upsert(SemanticEntry(key="k", value="v"))
+        got = await semantic.get("k")
+        assert got.domain == DEFAULT_DOMAIN
+        assert got.temporal == DEFAULT_TEMPORAL
+        assert got.last_accessed_at is None
+
+    @pytest.mark.asyncio
+    async def test_mark_accessed_updates_last_accessed_at(self, memories):
+        semantic, *_ = memories
+        await semantic.upsert(SemanticEntry(key="k", value="v"))
+        assert (await semantic.get("k")).last_accessed_at is None
+        await semantic.mark_accessed(["k"])
+        got = await semantic.get("k")
+        assert got.last_accessed_at is not None
+
+    @pytest.mark.asyncio
+    async def test_mark_accessed_empty_list_is_noop(self, memories):
+        semantic, *_ = memories
+        await semantic.mark_accessed([])  # must not raise
+
+
+class TestRelationalPersistence:
+    @pytest.mark.asyncio
+    async def test_relational_round_trip(self, memories):
+        _, relational, *_ = memories
+        await relational.upsert(RelationalEntry(
+            subject="user", predicate="prefers", object="brevity",
+            domain=DOMAIN_USER, temporal=TEMPORAL_MILESTONE,
+        ))
+        got = await relational.get("user", "prefers")
+        assert got.domain == DOMAIN_USER
+        assert got.temporal == TEMPORAL_MILESTONE
+
+
+# ---------------------------------------------------------------------------
+# Governance: classifier upgrades default domain when key has a known prefix
+# ---------------------------------------------------------------------------
+
+class TestGovernorClassifier:
+    @pytest.mark.asyncio
+    async def test_governor_upgrades_default_domain_via_classifier(
+        self, db_conn, memories
+    ):
+        semantic, relational, procedural, episodic = memories
+        gov = MemoryGovernor(
+            semantic=semantic, procedural=procedural,
+            relational=relational, episodic=episodic, db=db_conn,
+        )
+        # Default domain on the entry, but key has a `user:` prefix —
+        # governor should rewrite to DOMAIN_USER before persisting.
+        entry = SemanticEntry(
+            key="user:prefers:concise",
+            value="user wants short responses",
+            source="memorize",
+        )
+        assert entry.domain == DEFAULT_DOMAIN
+        await gov.governed_upsert(entry)
+
+        got = await semantic.get("user:prefers:concise")
+        assert got.domain == DOMAIN_USER
+
+    @pytest.mark.asyncio
+    async def test_governor_preserves_explicit_non_default_domain(
+        self, db_conn, memories
+    ):
+        semantic, relational, procedural, episodic = memories
+        gov = MemoryGovernor(
+            semantic=semantic, procedural=procedural,
+            relational=relational, episodic=episodic, db=db_conn,
+        )
+        # Caller explicitly set DOMAIN_SELF — classifier must not override
+        # even though key prefix says ``user:``.
+        entry = SemanticEntry(
+            key="user:weird_key",
+            value="agent thinks this is about itself",
+            source="memorize",
+            domain=DOMAIN_SELF,
+        )
+        await gov.governed_upsert(entry)
+        got = await semantic.get("user:weird_key")
+        assert got.domain == DOMAIN_SELF
+
+
+# ---------------------------------------------------------------------------
+# Recall: domain / temporal filter and last_accessed_at side-effect
+# ---------------------------------------------------------------------------
+
+class TestRecallAxisFilter:
+    @pytest_asyncio.fixture
+    async def populated(self, memories):
+        semantic, _, procedural, _ = memories
+        for key, value, domain, temporal in [
+            ("user:prefers", "concise responses", DOMAIN_USER, TEMPORAL_RECENT),
+            ("project:db", "uses sqlite wal", DOMAIN_PROJECT, TEMPORAL_RECENT),
+            ("project:milestone", "release v1 launched", DOMAIN_PROJECT, TEMPORAL_MILESTONE),
+            ("knowledge:tool", "gitnexus indexes code", DOMAIN_KNOWLEDGE, TEMPORAL_RECENT),
+        ]:
+            await semantic.upsert(SemanticEntry(
+                key=key, value=value, domain=domain, temporal=temporal,
+            ))
+        return MemorySearch(semantic=semantic, procedural=procedural)
+
+    @pytest.mark.asyncio
+    async def test_recall_filters_by_domain(self, populated):
+        # Query word "uses" appears in the project entry; without filter
+        # we'd also pick up unrelated results. With domain=user, that
+        # entry must not appear because it's project-domain.
+        results = await populated.recall("responses", domain=DOMAIN_USER, limit=5)
+        assert all(r.type != "semantic" or r.key.startswith("user:") for r in results)
+
+    @pytest.mark.asyncio
+    async def test_recall_filters_by_temporal_milestone(self, populated):
+        results = await populated.recall(
+            "release", temporal=TEMPORAL_MILESTONE, type="semantic", limit=5,
+        )
+        assert results, "milestone entry should match"
+        assert all(r.key == "project:milestone" for r in results)
+
+    @pytest.mark.asyncio
+    async def test_recall_marks_accessed_on_hit(self, populated, memories):
+        semantic, *_ = memories
+        before = await semantic.get("user:prefers")
+        assert before.last_accessed_at is None
+        await populated.recall("concise", type="semantic", limit=5)
+        after = await semantic.get("user:prefers")
+        assert after.last_accessed_at is not None


### PR DESCRIPTION
## Summary

Phase 1 of the Memory System v2 refactor (issue #281). Lays the **schema foundation** so every fact is classified along three orthogonal axes — **source × domain × temporal**. Downstream work (decay rewrite, active hooks, themed dreams) builds on this without touching the wire format again.

Reference design: [`outputs/doc/memory_ontology_draft_2026-05-03.md`](../blob/feat/memory-ontology-p1/outputs/doc/memory_ontology_draft_2026-05-03.md) — Decisions locked, no approval queue, hooks scoped to G + A only.

### P1-A — schema
- `loom/core/memory/ontology.py` (new) — closed `DOMAINS` / `TEMPORALS` enums + normalize_* fallbacks; single source of truth
- `semantic_entries` / `relational_entries`: add `domain` (default `'knowledge'`), `temporal` (default `'recent'`), `last_accessed_at`
- New `idx_{semantic,relational}_domain_temporal` — primary axis-aware recall path
- Dataclass `__post_init__` normalizes invalid inputs so the table can't be poisoned
- DRY 6 duplicated SELECTs in `semantic.py` via `_SELECT_COLS` + `_row_to_entry()` helper

### P1-B — API
- `loom/core/memory/classifier.py` (new) — heuristic prefix-based domain inference (LLM upgrade comes in P1-C)
- `memorize` tool: schema gains optional `domain` / `temporal` enums
- `recall` tool: same axis filters; unknown values silently dropped
- `governed_upsert`: when entry.domain is the safe default AND the classifier finds a more specific axis → upgrade. **Explicit non-default domains from the caller are preserved** — agent intent always wins
- `MemorySearch.recall(domain=, temporal=)` — applied to both BM25 and embedding paths via `_axis_filter_sql` helper
- `SemanticMemory.mark_accessed(keys)` — bulk update `last_accessed_at`; called automatically after every recall hit (so the future decay cycle can distinguish *in active use* from *drifting to archive*)
- `MemoryFacade.search` forwards new kwargs

## Backward compatibility

- All existing `SemanticEntry` / `RelationalEntry` constructors compile unchanged — new fields have defaults
- `ALTER`s run idempotently with `DEFAULT` values; existing rows fill in as `('knowledge', 'recent', NULL)` on first migration
- `last_accessed_at` is purely additive — no read path depends on it yet (that's the decay rewrite)

## Test plan

- [x] 43 new tests in `tests/test_memory_ontology.py`:
  - Pure enum / normalizer behaviour (closed sets, fallback)
  - Classifier prefix rules incl. case-insensitive
  - Dataclass `__post_init__` on Semantic + Relational
  - Round-trip persistence of all three new columns
  - Governor classifier upgrade for default domain
  - Governor preserves explicit non-default domain (does NOT override)
  - `recall(domain=...)` excludes other-domain hits
  - `recall(temporal=milestone)` returns only milestones
  - `mark_accessed` updates `last_accessed_at`; empty list is no-op
  - Recall side-effect: bumps `last_accessed_at` on hit
- [x] Full suite: **1399 passed, 1 skipped** (baseline 1356)
- [ ] Local DB migration sanity check (deferred — user will validate against `~/.loom/memory.db` after merge per agreement: 確認沒有問題才對 db 對刀)

## Out of scope

Tracked separately, will land on top of this:
- **P1-C** — LLM-assisted batch reclassification of legacy rows
- **P2** — `MemoryLifecycle` module: domain×temporal decay table, cron-driven cycle, replaces two hardcoded 90-day half-lives
- **P3** — Memory Pulse hooks (Session brief + contradiction triggers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)