### PR TITLE
feat(memory): LLM-assisted domain classifier — P1-C (#281)

### DIFF
--- a/loom/core/memory/classifier.py
+++ b/loom/core/memory/classifier.py
@@ -20,12 +20,19 @@ disagreement is a strict comparison.
 
 from __future__ import annotations
 
+import json
+import logging
+import time
+
 from loom.core.memory.ontology import (
     DOMAIN_KNOWLEDGE,
     DOMAIN_PROJECT,
     DOMAIN_SELF,
     DOMAIN_USER,
+    DOMAINS,
 )
+
+logger = logging.getLogger(__name__)
 
 
 # Lower-cased key prefix → domain.  Order matters only for documentation;
@@ -74,16 +81,6 @@ def infer_domain(key: str | None) -> str:
 # (MiniMax-M2.7 by default). Live `governed_upsert` writes still go through
 # the heuristic ``infer_domain`` above for zero per-write LLM cost.
 # ---------------------------------------------------------------------------
-
-import json
-import logging
-import time
-from typing import Callable
-
-from loom.core.memory.ontology import DOMAINS
-
-logger = logging.getLogger(__name__)
-
 
 _LLM_SYSTEM = """You classify Loom memory facts along the `domain` axis of \
 Memory Ontology v0.1. Return one label per fact from this closed set:

--- a/loom/core/memory/classifier.py
+++ b/loom/core/memory/classifier.py
@@ -66,3 +66,169 @@ def infer_domain(key: str | None) -> str:
         if k.startswith(prefix):
             return domain
     return DOMAIN_KNOWLEDGE
+
+
+# ---------------------------------------------------------------------------
+# LLM-assisted classifier — used by the P1-C migration script to relabel
+# the legacy default-domain rows in bulk via Loom's existing LLM router
+# (MiniMax-M2.7 by default). Live `governed_upsert` writes still go through
+# the heuristic ``infer_domain`` above for zero per-write LLM cost.
+# ---------------------------------------------------------------------------
+
+import json
+import logging
+import time
+from typing import Callable
+
+from loom.core.memory.ontology import DOMAINS
+
+logger = logging.getLogger(__name__)
+
+
+_LLM_SYSTEM = """You classify Loom memory facts along the `domain` axis of \
+Memory Ontology v0.1. Return one label per fact from this closed set:
+
+  - self      : agent identity, principles, values, self-awareness
+  - user      : user preferences, relationship, known/unknown territory
+  - project   : architecture decisions, config, workflow, code structure
+  - knowledge : external knowledge, tool usage, research, third-party facts
+
+Heuristics:
+  * "I am / I prefer / my purpose" → self
+  * "user wants / user prefers / about user" → user
+  * "this repo / this project / loom config / file X does Y" → project
+  * "Tool X works like / library Y / external API behavior" → knowledge
+
+Output strict JSON only — no prose, no markdown fences:
+  {"results": [{"i": 0, "d": "self"}, {"i": 1, "d": "knowledge"}, ...]}
+
+`i` is the input index (0-based). `d` must be one of the four labels."""
+
+
+def _build_user_prompt(items: list[tuple[str, str]]) -> str:
+    """Render (key, value) items as a numbered list for the LLM."""
+    lines = ["Classify each fact below. Reply with strict JSON only.\n"]
+    for i, (key, value) in enumerate(items):
+        # Trim long values — domain is recoverable from the first 240 chars
+        snippet = value if len(value) <= 240 else value[:237] + "..."
+        lines.append(f"[{i}] key={key!r}\n    value={snippet!r}")
+    return "\n".join(lines)
+
+
+def _parse_llm_response(raw: str, n: int) -> list[str]:
+    """Parse the LLM's JSON list. Falls back to ``DOMAIN_KNOWLEDGE`` for any
+    index the model omitted, returned in an unknown label, or otherwise broke."""
+    out = [DOMAIN_KNOWLEDGE] * n
+    if not raw:
+        return out
+    text = raw.strip()
+    # Strip code fences if the model ignored instructions.
+    if text.startswith("```"):
+        text = text.strip("`").lstrip("json").strip()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        # Some models prepend reasoning — try to slice from first '{'.
+        first = text.find("{")
+        if first >= 0:
+            try:
+                data = json.loads(text[first:])
+            except json.JSONDecodeError:
+                logger.warning("LLM domain classifier: JSON parse failed, falling back")
+                return out
+        else:
+            return out
+
+    for item in data.get("results", []):
+        try:
+            i = int(item["i"])
+            d = str(item["d"]).strip().lower()
+        except (KeyError, TypeError, ValueError):
+            continue
+        if 0 <= i < n and d in DOMAINS:
+            out[i] = d
+    return out
+
+
+class LLMDomainClassifier:
+    """Batch domain classification via Loom's existing :class:`LLMRouter`.
+
+    Designed for the P1-C one-shot migration — not wired into the live
+    write path (the heuristic :func:`infer_domain` covers that with no
+    LLM cost). Use the router that's already configured for the running
+    Loom installation; defaults to ``minimax-m2.7`` since that's Loom's
+    standard daily model.
+    """
+
+    def __init__(
+        self,
+        router,
+        model: str = "minimax-m2.7",
+        batch_size: int = 30,
+        concurrency: int = 5,
+    ):
+        self._router = router
+        self._model = model
+        self._batch_size = batch_size
+        self._concurrency = max(1, concurrency)
+
+    async def classify_batch(
+        self,
+        items: list[tuple[str, str]],
+        progress: "Callable[[int, int, float], None] | None" = None,
+    ) -> list[str]:
+        """Return one domain label per (key, value) pair.
+
+        Items are chunked at ``batch_size`` and chunks run concurrently up
+        to ``concurrency`` in flight. Any chunk that fails (network, parse,
+        etc.) is filled with ``DOMAIN_KNOWLEDGE`` — callers can re-run the
+        migration later for only those still-default rows.
+
+        If ``progress`` is supplied it's called after every batch with
+        ``(done, total, batch_seconds)`` — note ``done`` reflects completion
+        order, not source order.
+        """
+        if not items:
+            return []
+        import asyncio
+
+        total = len(items)
+        chunks: list[tuple[int, list[tuple[str, str]]]] = []
+        for offset in range(0, total, self._batch_size):
+            chunks.append((offset, items[offset : offset + self._batch_size]))
+
+        results: list[str] = [DOMAIN_KNOWLEDGE] * total
+        sem = asyncio.Semaphore(self._concurrency)
+        completed = 0
+
+        async def _one(offset: int, chunk: list[tuple[str, str]]) -> None:
+            nonlocal completed
+            async with sem:
+                t0 = time.monotonic()
+                try:
+                    domains = await self._classify_chunk(chunk)
+                except Exception as exc:
+                    logger.warning(
+                        "LLMDomainClassifier batch %d-%d failed (%s) — "
+                        "using DEFAULT_DOMAIN for these rows; safe to re-run",
+                        offset, offset + len(chunk), exc,
+                    )
+                    domains = [DOMAIN_KNOWLEDGE] * len(chunk)
+                for i, d in enumerate(domains):
+                    results[offset + i] = d
+                completed += len(chunk)
+                if progress is not None:
+                    progress(completed, total, time.monotonic() - t0)
+
+        await asyncio.gather(*(_one(o, c) for o, c in chunks))
+        return results
+
+    async def _classify_chunk(self, chunk: list[tuple[str, str]]) -> list[str]:
+        messages = [
+            {"role": "system", "content": _LLM_SYSTEM},
+            {"role": "user", "content": _build_user_prompt(chunk)},
+        ]
+        response = await self._router.chat(
+            model=self._model, messages=messages, max_tokens=2048,
+        )
+        return _parse_llm_response(response.text or "", len(chunk))

--- a/tests/test_memory_ontology.py
+++ b/tests/test_memory_ontology.py
@@ -13,7 +13,11 @@ from __future__ import annotations
 import pytest
 import pytest_asyncio
 
-from loom.core.memory.classifier import infer_domain
+from loom.core.memory.classifier import (
+    LLMDomainClassifier,
+    _parse_llm_response,
+    infer_domain,
+)
 from loom.core.memory.governance import MemoryGovernor
 from loom.core.memory.episodic import EpisodicMemory
 from loom.core.memory.ontology import (
@@ -113,6 +117,91 @@ class TestClassifier:
     def test_infer_domain_is_case_insensitive(self):
         assert infer_domain("USER:prefers:bar") == DOMAIN_USER
         assert infer_domain("Project:Loom:Foo") == DOMAIN_PROJECT
+
+
+class TestLLMResponseParsing:
+    def test_clean_json(self):
+        raw = '{"results": [{"i": 0, "d": "self"}, {"i": 1, "d": "user"}]}'
+        assert _parse_llm_response(raw, 2) == [DOMAIN_SELF, DOMAIN_USER]
+
+    def test_strips_markdown_fences(self):
+        raw = '```json\n{"results": [{"i": 0, "d": "project"}]}\n```'
+        assert _parse_llm_response(raw, 1) == [DOMAIN_PROJECT]
+
+    def test_recovers_from_leading_prose(self):
+        raw = 'Here you go: {"results": [{"i": 0, "d": "user"}]}'
+        assert _parse_llm_response(raw, 1) == [DOMAIN_USER]
+
+    def test_invalid_json_falls_back_to_default(self):
+        raw = "this is not json"
+        assert _parse_llm_response(raw, 3) == [DOMAIN_KNOWLEDGE] * 3
+
+    def test_empty_response_falls_back(self):
+        assert _parse_llm_response("", 2) == [DOMAIN_KNOWLEDGE] * 2
+
+    def test_partial_results_filled_with_default(self):
+        # Model answered for index 0 only, index 1 should stay default
+        raw = '{"results": [{"i": 0, "d": "self"}]}'
+        assert _parse_llm_response(raw, 2) == [DOMAIN_SELF, DOMAIN_KNOWLEDGE]
+
+    def test_unknown_domain_in_response_dropped(self):
+        raw = '{"results": [{"i": 0, "d": "garbage"}, {"i": 1, "d": "self"}]}'
+        assert _parse_llm_response(raw, 2) == [DOMAIN_KNOWLEDGE, DOMAIN_SELF]
+
+    def test_out_of_range_index_ignored(self):
+        # Model invented index 99 — must not crash, must not mutate
+        raw = '{"results": [{"i": 99, "d": "self"}, {"i": 0, "d": "user"}]}'
+        assert _parse_llm_response(raw, 2) == [DOMAIN_USER, DOMAIN_KNOWLEDGE]
+
+
+class TestLLMClassifierBatching:
+    """Verify the classifier orchestrates router calls and concurrency
+    correctly without actually hitting an LLM."""
+
+    @pytest.mark.asyncio
+    async def test_concurrency_caps_in_flight_calls(self):
+        import asyncio
+
+        max_in_flight = 0
+        in_flight = 0
+
+        class FakeRouter:
+            async def chat(self, model, messages, max_tokens):
+                nonlocal max_in_flight, in_flight
+                in_flight += 1
+                max_in_flight = max(max_in_flight, in_flight)
+                await asyncio.sleep(0.05)
+                in_flight -= 1
+
+                class R:
+                    text = '{"results": [{"i": 0, "d": "self"}]}'
+                return R()
+
+        clf = LLMDomainClassifier(FakeRouter(), batch_size=1, concurrency=3)
+        items = [(f"k{i}", f"v{i}") for i in range(10)]
+        out = await clf.classify_batch(items)
+        assert len(out) == 10
+        assert max_in_flight <= 3
+
+    @pytest.mark.asyncio
+    async def test_chunk_failure_falls_back_to_default(self):
+        class FailingRouter:
+            calls = 0
+
+            async def chat(self, model, messages, max_tokens):
+                FailingRouter.calls += 1
+                if FailingRouter.calls == 1:
+                    raise RuntimeError("simulated network blip")
+
+                class R:
+                    text = '{"results": [{"i": 0, "d": "self"}]}'
+                return R()
+
+        clf = LLMDomainClassifier(FailingRouter(), batch_size=1, concurrency=1)
+        items = [("k1", "v1"), ("k2", "v2")]
+        out = await clf.classify_batch(items)
+        # First chunk fell back to DEFAULT_DOMAIN, second succeeded
+        assert out == [DOMAIN_KNOWLEDGE, DOMAIN_SELF]
 
 
 class TestDataclassNormalization:


### PR DESCRIPTION
## Summary

P1-C of Memory System v2. Adds **LLM-assisted domain classifier** for the one-shot legacy-data backfill — uses Loom's existing `LLMRouter` (defaults to `minimax-m2.7`), so no per-write runtime LLM cost. Live `governed_upsert` continues to use the zero-cost heuristic `infer_domain` from P1-B for new writes.

This PR is the reusable code only — the migration script (`scripts/p1c_migrate_domains.py`) is local-only by gitignore convention since it's a one-shot tool. The reusable classifier API + prompt lives in `loom/core/memory/classifier.py`.

## Changes

- `LLMDomainClassifier.classify_batch(items, progress=)` — chunks at `batch_size`, runs up to `concurrency` chunks in parallel via `asyncio.Semaphore`, fills `DOMAIN_KNOWLEDGE` on chunk failure so a re-run targets only still-default rows
- `_parse_llm_response` — strict JSON first, falls back to slicing from first `{` for reasoning models that prepend prose; drops unknown labels and out-of-range indices instead of raising
- Prompt designed for 30 facts/call: closed-set labels, embedded heuristics, explicit "JSON only" instruction

## Real-world result on `~/.loom/memory.db`

```
5017 default-knowledge rows reclassified in 21min @ 4 rows/s
distribution: knowledge 3144 / project 1505 / self 194 / user 187
92 rows aged >30d → temporal=archived
4 batches (~120 rows / 2.4%) hit JSON parse failures, kept default
```

Spot-check on 20 random rows showed ~85-90% classification quality. Borderline cases (self vs project for agent SOPs, knowledge vs project for Loom internal architecture) skewed toward `knowledge` — safe under-classification, not corruption.

## Test plan

- [x] `_parse_llm_response`: clean JSON / markdown fences / leading prose / malformed / empty / partial / unknown labels / out-of-range indices (8 cases)
- [x] `LLMDomainClassifier`: concurrency cap enforcement, chunk-failure fallback (2 cases, FakeRouter — no real LLM)
- [x] Full `test_memory_ontology.py`: 53 passed (43 from P1-A+B + 10 new)
- [x] Live DB applied via diff: 1929 rows updated, 1 explicit-domain row preserved, safety backup at `~/.loom/backups/memory.pre-p1c-apply-*.db`

## Out of scope / next

- **P2** — `MemoryLifecycle` module: `(domain, temporal)` half-life table, cron-driven decay cycle, replaces the two hardcoded 90-day half-lives in `semantic.py` + `governance.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)