### PR TITLE
feat(memory): MemoryLifecycle — domain×temporal decay table — P2 (#281, fixes #299)

### DIFF
--- a/loom/core/memory/governance.py
+++ b/loom/core/memory/governance.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import json
 import logging
-import math
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, UTC
@@ -77,15 +76,27 @@ class AdmissionResult:
 
 @dataclass
 class DecayCycleResult:
-    """Summary of a periodic decay/prune cycle."""
+    """Summary of a periodic decay/prune cycle.
+
+    Memory Lifecycle (issue #281 P2) introduces a two-stage transition:
+    rows can be **archived** (demoted to second-chance state) before being
+    **deleted**. ``*_pruned`` totals archived + deleted so legacy callers
+    keep a single number; ``*_archived`` is exposed for richer reporting.
+    """
     semantic_pruned: int
     episodic_pruned: int
     relational_pruned: int
     total_examined: int
+    semantic_archived: int = 0
+    relational_archived: int = 0
 
     @property
     def total_pruned(self) -> int:
         return self.semantic_pruned + self.episodic_pruned + self.relational_pruned
+
+    @property
+    def total_archived(self) -> int:
+        return self.semantic_archived + self.relational_archived
 
 
 # ---------------------------------------------------------------------------
@@ -128,7 +139,10 @@ class MemoryGovernor:
         self._admission_threshold: float = cfg.get("admission_threshold", 0.5)
         self._episodic_ttl_days: int = cfg.get("episodic_ttl_days", 30)
         self._semantic_decay_threshold: float = cfg.get("semantic_decay_threshold", 0.1)
-        self._relational_decay_factor: float = cfg.get("relational_decay_factor", 1.5)
+        # Note: ``relational_decay_factor`` is no longer used — Memory
+        # Lifecycle (issue #281 P2) computes per-domain half-lives directly.
+        # Config key stays accepted (and ignored) for backward compatibility
+        # with existing loom.toml entries.
         self._governance_log_write_warning_emitted = False
 
         # Issue #133: memory health tracking for agent self-observability
@@ -331,32 +345,35 @@ class MemoryGovernor:
     async def run_decay_cycle(self) -> DecayCycleResult:
         """Execute periodic decay across all memory types.
 
-        Called at session shutdown (after compression).
+        Called at session shutdown (after compression). Memory Lifecycle
+        (issue #281 P2) drives the semantic + relational paths via a single
+        ``(domain, temporal)`` half-life table; episodic TTL stays here
+        because it's a flat age cutoff, not effective_confidence.
 
-        - **Semantic**: prune entries whose effective_confidence < threshold
-        - **Episodic**: delete entries older than TTL days
-        - **Relational**: decay dreaming-sourced triples with higher factor
+        Fixes issue #299 — relational triples from every source are now
+        examined, not just ``source='dreaming'``.
         """
-        total_examined = 0
+        from loom.core.memory.lifecycle import MemoryLifecycle
 
-        # ── Semantic decay ──────────────────────────────────────────────
-        sem_result = await self._semantic.prune_decayed(
-            threshold=self._semantic_decay_threshold,
-        )
-        semantic_pruned = sem_result.get("pruned", 0)
-        total_examined += sem_result.get("examined", 0)
+        cycle = MemoryLifecycle(self._db, threshold=self._semantic_decay_threshold)
+        lifecycle_result = await cycle.run()
 
-        # ── Episodic TTL ────────────────────────────────────────────────
+        # ── Episodic TTL (still a flat age check, not lifecycle-managed) ──
         episodic_pruned = await self._prune_episodic_ttl()
 
-        # ── Relational decay ────────────────────────────────────────────
-        relational_pruned = await self._prune_relational_decay()
-
         result = DecayCycleResult(
-            semantic_pruned=semantic_pruned,
+            semantic_pruned=(
+                lifecycle_result.semantic_archived + lifecycle_result.semantic_deleted
+            ),
             episodic_pruned=episodic_pruned,
-            relational_pruned=relational_pruned,
-            total_examined=total_examined,
+            relational_pruned=(
+                lifecycle_result.relational_archived + lifecycle_result.relational_deleted
+            ),
+            total_examined=(
+                lifecycle_result.semantic_examined + lifecycle_result.relational_examined
+            ),
+            semantic_archived=lifecycle_result.semantic_archived,
+            relational_archived=lifecycle_result.relational_archived,
         )
 
         if result.total_pruned > 0:
@@ -364,10 +381,12 @@ class MemoryGovernor:
                 "governance:decay",
                 f"Pruned {result.total_pruned} entries",
                 {
-                    "semantic": semantic_pruned,
+                    "semantic_archived": lifecycle_result.semantic_archived,
+                    "semantic_deleted":  lifecycle_result.semantic_deleted,
+                    "relational_archived": lifecycle_result.relational_archived,
+                    "relational_deleted":  lifecycle_result.relational_deleted,
                     "episodic": episodic_pruned,
-                    "relational": relational_pruned,
-                    "examined": total_examined,
+                    "examined": result.total_examined,
                 },
             )
 
@@ -388,56 +407,6 @@ class MemoryGovernor:
         except Exception as exc:
             logger.debug("Episodic TTL prune failed: %s", exc)
             return 0
-
-    async def _prune_relational_decay(self) -> int:
-        """Prune dreaming-sourced relational triples with accelerated decay.
-
-        Dreaming triples use a shorter effective half-life:
-        base_half_life / relational_decay_factor.
-
-        Only triples with source='dreaming' are subject to accelerated decay.
-        """
-        base_half_life = 90.0  # days
-        effective_half_life = base_half_life / self._relational_decay_factor
-
-        try:
-            cursor = await self._db.execute(
-                "SELECT id, confidence, updated_at FROM relational_entries "
-                "WHERE source = 'dreaming'"
-            )
-            rows = await cursor.fetchall()
-        except Exception as exc:
-            logger.debug("Relational decay query failed: %s", exc)
-            return 0
-
-        to_prune: list[str] = []
-        for row_id, confidence, updated_at_str in rows:
-            try:
-                updated_at = datetime.fromisoformat(updated_at_str)
-                days = (datetime.now(UTC) - updated_at).total_seconds() / 86400.0
-                decayed = confidence * math.pow(2.0, -days / effective_half_life)
-                if decayed < self._semantic_decay_threshold:
-                    to_prune.append(row_id)
-            except Exception as exc:
-                logger.debug(
-                    "Relational decay: skipping row %s (parse error): %s",
-                    row_id, exc,
-                )
-                continue
-
-        if to_prune:
-            try:
-                placeholders = ",".join("?" * len(to_prune))
-                await self._db.execute(
-                    f"DELETE FROM relational_entries WHERE id IN ({placeholders})",
-                    to_prune,
-                )
-                await self._db.commit()
-            except Exception as exc:
-                logger.debug("Relational decay delete failed: %s", exc)
-                return 0
-
-        return len(to_prune)
 
     # ------------------------------------------------------------------
     # Audit logging

--- a/loom/core/memory/lifecycle.py
+++ b/loom/core/memory/lifecycle.py
@@ -1,0 +1,294 @@
+"""
+Memory Lifecycle — single source of truth for fact decay & state transitions.
+
+Replaces two scattered hardcoded half-lives (``semantic._DEFAULT_HALF_LIFE_DAYS``
+and ``governance._prune_relational_decay``'s ``base_half_life``) with a
+``(domain × temporal) → half_life_days`` table, and fixes issue #299
+(non-dreaming relational triples never being cleaned).
+
+State transitions per cycle (single threshold, two-stage):
+
+  1. ``temporal == 'archived'`` AND eff_conf < threshold → DELETE
+  2. ``temporal == 'recent'``    AND eff_conf < threshold → demote to archived
+  3. ``temporal == 'milestone'`` → never (half-life = infinity for self/user/project;
+                                         365d for knowledge — slowest decay class)
+  4. ``temporal == 'ephemeral'`` → not handled here; session compressor expires them
+
+Step 1 runs first so a row newly-demoted in step 2 doesn't get deleted in
+the same cycle — its archived life starts fresh next pass.
+
+``last_accessed_at`` (set by :meth:`MemorySearch._mark_accessed` on every
+recall hit) is the time anchor when more recent than ``updated_at``, so a
+fact still in active use never decays — N1 from PR #303 review.
+
+Reference: outputs/doc/memory_ontology_draft_2026-05-03.md §3
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from datetime import datetime, UTC
+from typing import TYPE_CHECKING
+
+from loom.core.memory.ontology import (
+    DOMAIN_KNOWLEDGE,
+    DOMAIN_PROJECT,
+    DOMAIN_SELF,
+    DOMAIN_USER,
+    TEMPORAL_ARCHIVED,
+    TEMPORAL_MILESTONE,
+    TEMPORAL_RECENT,
+)
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Half-life table — single source of truth (issue #281 / Phase 0 §3)
+# ---------------------------------------------------------------------------
+#
+# Adjusted from initial Phase 0 draft after PR #303 review N1: knowledge/recent
+# was 60d, raised to 90d so legacy LLM-classified rows don't decay aggressively
+# while we wait for explicit re-classification on touch.
+
+_INF = math.inf
+
+_HALF_LIFE_TABLE: dict[tuple[str, str], float] = {
+    # recent — actively used facts
+    (DOMAIN_SELF,      TEMPORAL_RECENT):    180.0,
+    (DOMAIN_USER,      TEMPORAL_RECENT):     90.0,
+    (DOMAIN_PROJECT,   TEMPORAL_RECENT):     90.0,
+    (DOMAIN_KNOWLEDGE, TEMPORAL_RECENT):     90.0,  # was 60 — N1 concession
+    # milestone — permanent anchors; only knowledge can ever expire
+    (DOMAIN_SELF,      TEMPORAL_MILESTONE): _INF,
+    (DOMAIN_USER,      TEMPORAL_MILESTONE): _INF,
+    (DOMAIN_PROJECT,   TEMPORAL_MILESTONE): _INF,
+    (DOMAIN_KNOWLEDGE, TEMPORAL_MILESTONE): 365.0,
+    # archived — second-chance state; shorter half-lives so unused rows
+    # progress to delete in a reasonable window
+    (DOMAIN_SELF,      TEMPORAL_ARCHIVED):   30.0,
+    (DOMAIN_USER,      TEMPORAL_ARCHIVED):   30.0,
+    (DOMAIN_PROJECT,   TEMPORAL_ARCHIVED):   30.0,
+    (DOMAIN_KNOWLEDGE, TEMPORAL_ARCHIVED):   14.0,
+}
+
+# Fallback used when a row's domain/temporal value is somehow outside the
+# closed enums (shouldn't happen — dataclass __post_init__ normalizes).
+_FALLBACK_HALF_LIFE = 90.0
+
+
+def half_life_for(domain: str, temporal: str) -> float:
+    """Return the half-life in days for a (domain, temporal) pair.
+
+    ``math.inf`` means "never decays" — used by milestone-class facts in
+    every domain except knowledge.
+    """
+    return _HALF_LIFE_TABLE.get((domain, temporal), _FALLBACK_HALF_LIFE)
+
+
+def effective_confidence(
+    confidence: float,
+    updated_at: datetime,
+    last_accessed_at: datetime | None,
+    domain: str,
+    temporal: str,
+) -> float:
+    """Time-decayed confidence using the (domain, temporal) half-life.
+
+    The decay clock starts from ``max(updated_at, last_accessed_at)`` —
+    a fact that's been recalled recently doesn't decay even if it hasn't
+    been re-written. Returns at least 0.01 so a fully-decayed fact stays
+    visible to audits.
+    """
+    half = half_life_for(domain, temporal)
+    if half == _INF:
+        return confidence
+    anchor = updated_at
+    if last_accessed_at is not None and last_accessed_at > anchor:
+        anchor = last_accessed_at
+    days = (datetime.now(UTC) - anchor).total_seconds() / 86400.0
+    decayed = confidence * math.pow(2.0, -days / half)
+    return max(0.01, round(decayed, 4))
+
+
+# ---------------------------------------------------------------------------
+# Cycle result
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LifecycleResult:
+    """Per-table summary of one ``MemoryLifecycle.run()`` invocation."""
+    semantic_examined:   int = 0
+    semantic_archived:   int = 0
+    semantic_deleted:    int = 0
+    relational_examined: int = 0
+    relational_archived: int = 0
+    relational_deleted:  int = 0
+    dry_run: bool = False
+
+    @property
+    def total_archived(self) -> int:
+        return self.semantic_archived + self.relational_archived
+
+    @property
+    def total_deleted(self) -> int:
+        return self.semantic_deleted + self.relational_deleted
+
+
+# ---------------------------------------------------------------------------
+# MemoryLifecycle
+# ---------------------------------------------------------------------------
+
+class MemoryLifecycle:
+    """Run decay + state-transition cycle across semantic + relational tables.
+
+    Single ``threshold`` (default 0.1) — both archive and delete steps use
+    the same effective_confidence cutoff. Two-stage transition (recent →
+    archived → deleted) gives a fact a structurally-meaningful "second
+    chance" window before disappearing.
+    """
+
+    def __init__(
+        self,
+        db: "aiosqlite.Connection",
+        threshold: float = 0.1,
+    ) -> None:
+        self._db = db
+        self._threshold = threshold
+
+    async def run(self, dry_run: bool = False) -> LifecycleResult:
+        """Run one full lifecycle cycle. Returns counts; never raises."""
+        result = LifecycleResult(dry_run=dry_run)
+
+        # Order matters: deletes (already-archived rows still decayed)
+        # run BEFORE demotes (recent rows newly below threshold). This
+        # prevents a row from being demoted-then-deleted in the same pass —
+        # newly-demoted rows get a fresh archived-state half-life window
+        # to be re-accessed before the next cycle considers them again.
+        sem_e, sem_d = await self._process_table_delete(
+            "semantic_entries", dry_run=dry_run,
+        )
+        sem_arch_e, sem_a = await self._process_table_demote(
+            "semantic_entries", dry_run=dry_run,
+        )
+        result.semantic_examined = sem_e + sem_arch_e
+        result.semantic_deleted = sem_d
+        result.semantic_archived = sem_a
+
+        rel_e, rel_d = await self._process_table_delete(
+            "relational_entries", dry_run=dry_run, key_col="id",
+        )
+        rel_arch_e, rel_a = await self._process_table_demote(
+            "relational_entries", dry_run=dry_run, key_col="id",
+        )
+        result.relational_examined = rel_e + rel_arch_e
+        result.relational_deleted = rel_d
+        result.relational_archived = rel_a
+
+        return result
+
+    # -- private --------------------------------------------------------------
+
+    async def _process_table_delete(
+        self,
+        table: str,
+        dry_run: bool,
+        key_col: str = "key",
+    ) -> tuple[int, int]:
+        """Delete archived rows that have decayed past threshold.
+
+        Returns (examined, deleted)."""
+        cursor = await self._db.execute(
+            f"SELECT {key_col}, confidence, updated_at, last_accessed_at, "
+            f"domain, temporal FROM {table} WHERE temporal = ?",
+            (TEMPORAL_ARCHIVED,),
+        )
+        rows = await cursor.fetchall()
+        if not rows:
+            return 0, 0
+
+        to_delete: list = []
+        for row in rows:
+            try:
+                eff = effective_confidence(
+                    confidence=row[1],
+                    updated_at=datetime.fromisoformat(row[2]),
+                    last_accessed_at=(
+                        datetime.fromisoformat(row[3]) if row[3] else None
+                    ),
+                    domain=row[4],
+                    temporal=row[5],
+                )
+            except Exception as exc:
+                logger.debug("lifecycle: skip %s row %r (%s)", table, row[0], exc)
+                continue
+            if eff < self._threshold:
+                to_delete.append(row[0])
+
+        if to_delete and not dry_run:
+            placeholders = ",".join("?" * len(to_delete))
+            await self._db.execute(
+                f"DELETE FROM {table} WHERE {key_col} IN ({placeholders})",
+                to_delete,
+            )
+            await self._db.commit()
+
+        return len(rows), len(to_delete)
+
+    async def _process_table_demote(
+        self,
+        table: str,
+        dry_run: bool,
+        key_col: str = "key",
+    ) -> tuple[int, int]:
+        """Demote recent rows whose effective_confidence has fallen below
+        threshold to ``temporal='archived'``. Milestone rows are skipped
+        because their half-life is infinity (or 365d for knowledge —
+        which delays the demote rather than skipping it).
+
+        Returns (examined, demoted)."""
+        cursor = await self._db.execute(
+            f"SELECT {key_col}, confidence, updated_at, last_accessed_at, "
+            f"domain, temporal FROM {table} "
+            f"WHERE temporal IN (?, ?)",
+            (TEMPORAL_RECENT, TEMPORAL_MILESTONE),
+        )
+        rows = await cursor.fetchall()
+        if not rows:
+            return 0, 0
+
+        to_demote: list = []
+        for row in rows:
+            try:
+                eff = effective_confidence(
+                    confidence=row[1],
+                    updated_at=datetime.fromisoformat(row[2]),
+                    last_accessed_at=(
+                        datetime.fromisoformat(row[3]) if row[3] else None
+                    ),
+                    domain=row[4],
+                    temporal=row[5],
+                )
+            except Exception as exc:
+                logger.debug("lifecycle: skip %s row %r (%s)", table, row[0], exc)
+                continue
+            # Milestone rows demote only if knowledge — others have inf half-life
+            # so eff stays at original confidence (well above threshold).
+            if eff < self._threshold and row[5] != TEMPORAL_MILESTONE:
+                to_demote.append(row[0])
+
+        if to_demote and not dry_run:
+            placeholders = ",".join("?" * len(to_demote))
+            await self._db.execute(
+                f"UPDATE {table} SET temporal = ? "
+                f"WHERE {key_col} IN ({placeholders})",
+                (TEMPORAL_ARCHIVED, *to_demote),
+            )
+            await self._db.commit()
+
+        return len(rows), len(to_demote)

--- a/loom/core/memory/lifecycle.py
+++ b/loom/core/memory/lifecycle.py
@@ -56,18 +56,19 @@ logger = logging.getLogger(__name__)
 # was 60d, raised to 90d so legacy LLM-classified rows don't decay aggressively
 # while we wait for explicit re-classification on touch.
 
-_INF = math.inf
-
 _HALF_LIFE_TABLE: dict[tuple[str, str], float] = {
     # recent — actively used facts
     (DOMAIN_SELF,      TEMPORAL_RECENT):    180.0,
     (DOMAIN_USER,      TEMPORAL_RECENT):     90.0,
     (DOMAIN_PROJECT,   TEMPORAL_RECENT):     90.0,
     (DOMAIN_KNOWLEDGE, TEMPORAL_RECENT):     90.0,  # was 60 — N1 concession
-    # milestone — permanent anchors; only knowledge can ever expire
-    (DOMAIN_SELF,      TEMPORAL_MILESTONE): _INF,
-    (DOMAIN_USER,      TEMPORAL_MILESTONE): _INF,
-    (DOMAIN_PROJECT,   TEMPORAL_MILESTONE): _INF,
+    # milestone — permanent anchors. self/user/project never expire (inf
+    # half-life ⇒ effective_confidence stays at original value forever).
+    # knowledge/milestone has 365d so an outdated external fact eventually
+    # transitions through archived → deleted via the normal threshold path.
+    (DOMAIN_SELF,      TEMPORAL_MILESTONE): math.inf,
+    (DOMAIN_USER,      TEMPORAL_MILESTONE): math.inf,
+    (DOMAIN_PROJECT,   TEMPORAL_MILESTONE): math.inf,
     (DOMAIN_KNOWLEDGE, TEMPORAL_MILESTONE): 365.0,
     # archived — second-chance state; shorter half-lives so unused rows
     # progress to delete in a reasonable window
@@ -91,6 +92,14 @@ def half_life_for(domain: str, temporal: str) -> float:
     return _HALF_LIFE_TABLE.get((domain, temporal), _FALLBACK_HALF_LIFE)
 
 
+def _decay_factor(half_life: float, days: float) -> float:
+    """Standalone helper for tests/auditing — exposes the math separately
+    from the time-anchor logic in :func:`effective_confidence`."""
+    if half_life == math.inf:
+        return 1.0
+    return math.pow(2.0, -days / half_life)
+
+
 def effective_confidence(
     confidence: float,
     updated_at: datetime,
@@ -106,13 +115,13 @@ def effective_confidence(
     visible to audits.
     """
     half = half_life_for(domain, temporal)
-    if half == _INF:
+    if half == math.inf:
         return confidence
     anchor = updated_at
     if last_accessed_at is not None and last_accessed_at > anchor:
         anchor = last_accessed_at
     days = (datetime.now(UTC) - anchor).total_seconds() / 86400.0
-    decayed = confidence * math.pow(2.0, -days / half)
+    decayed = confidence * _decay_factor(half, days)
     return max(0.01, round(decayed, 4))
 
 
@@ -160,6 +169,27 @@ class MemoryLifecycle:
     ) -> None:
         self._db = db
         self._threshold = threshold
+
+    async def run_for_table(
+        self,
+        table: str,
+        dry_run: bool = False,
+        key_col: str = "key",
+    ) -> tuple[int, int, int]:
+        """Run delete + demote on a single table. Public entry point used
+        by :meth:`SemanticMemory.prune_decayed` so the legacy ``memory_prune``
+        CLI tool stays narrowly-scoped to one table without reaching into
+        ``MemoryLifecycle``'s private helpers.
+
+        Returns ``(examined, archived, deleted)``.
+        """
+        examined_d, deleted = await self._process_table_delete(
+            table, dry_run=dry_run, key_col=key_col,
+        )
+        examined_a, archived = await self._process_table_demote(
+            table, dry_run=dry_run, key_col=key_col,
+        )
+        return examined_d + examined_a, archived, deleted
 
     async def run(self, dry_run: bool = False) -> LifecycleResult:
         """Run one full lifecycle cycle. Returns counts; never raises."""
@@ -246,10 +276,14 @@ class MemoryLifecycle:
         dry_run: bool,
         key_col: str = "key",
     ) -> tuple[int, int]:
-        """Demote recent rows whose effective_confidence has fallen below
-        threshold to ``temporal='archived'``. Milestone rows are skipped
-        because their half-life is infinity (or 365d for knowledge —
-        which delays the demote rather than skipping it).
+        """Demote rows whose effective_confidence has fallen below threshold
+        to ``temporal='archived'``. Both ``recent`` and ``milestone`` rows
+        are examined — but ``effective_confidence`` returns the original
+        confidence unchanged for self/user/project milestone (inf half-life),
+        so they never cross the threshold and never get demoted. Only
+        ``knowledge/milestone`` (365d half-life) can eventually demote,
+        which is the design intent — outdated external knowledge expires
+        through the normal pipeline instead of accumulating forever.
 
         Returns (examined, demoted)."""
         cursor = await self._db.execute(
@@ -277,9 +311,7 @@ class MemoryLifecycle:
             except Exception as exc:
                 logger.debug("lifecycle: skip %s row %r (%s)", table, row[0], exc)
                 continue
-            # Milestone rows demote only if knowledge — others have inf half-life
-            # so eff stays at original confidence (well above threshold).
-            if eff < self._threshold and row[5] != TEMPORAL_MILESTONE:
+            if eff < self._threshold:
                 to_demote.append(row[0])
 
         if to_demote and not dry_run:

--- a/loom/core/memory/relational.py
+++ b/loom/core/memory/relational.py
@@ -58,6 +58,22 @@ class RelationalEntry:
         self.domain = normalize_domain(self.domain)
         self.temporal = normalize_temporal(self.temporal)
 
+    def effective_confidence(self) -> float:
+        """Time-decayed confidence using the (domain, temporal) half-life.
+
+        Issue #299 — relational triples now decay across all sources, not
+        just ``source='dreaming'``. See :mod:`loom.core.memory.lifecycle`
+        for the half-life table.
+        """
+        from loom.core.memory.lifecycle import effective_confidence
+        return effective_confidence(
+            confidence=self.confidence,
+            updated_at=self.updated_at,
+            last_accessed_at=self.last_accessed_at,
+            domain=self.domain,
+            temporal=self.temporal,
+        )
+
 
 _SELECT_COLS = (
     "id, subject, predicate, object, confidence, source, metadata, "

--- a/loom/core/memory/semantic.py
+++ b/loom/core/memory/semantic.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import logging
-import math
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, UTC
@@ -94,16 +93,10 @@ def classify_source(source: str | None) -> tuple[str, float]:
     return "unknown", TRUST_TIERS["unknown"]
 
 
-_DEFAULT_HALF_LIFE_DAYS = 90.0  # confidence halves after this many days of no update
-
-
-def _effective_confidence(confidence: float, updated_at: datetime,
-                           half_life_days: float = _DEFAULT_HALF_LIFE_DAYS) -> float:
-    """Exponential decay: confidence * 2^(-days_since_update / half_life).
-    Returns at least 0.01 so a stale entry is never completely invisible."""
-    days = (datetime.now(UTC) - updated_at).total_seconds() / 86400.0
-    decayed = confidence * math.pow(2.0, -days / half_life_days)
-    return max(0.01, round(decayed, 4))
+# Memory Lifecycle (issue #281 P2): half-life is now (domain × temporal)
+# in loom/core/memory/lifecycle.py. The legacy ``_DEFAULT_HALF_LIFE_DAYS``
+# constant + module-level ``_effective_confidence`` helper were removed —
+# all callers go through ``MemoryLifecycle`` or the dataclass method below.
 
 
 @dataclass
@@ -125,9 +118,19 @@ class SemanticEntry:
         self.domain = normalize_domain(self.domain)
         self.temporal = normalize_temporal(self.temporal)
 
-    def effective_confidence(self, half_life_days: float = _DEFAULT_HALF_LIFE_DAYS) -> float:
-        """Time-decayed confidence score."""
-        return _effective_confidence(self.confidence, self.updated_at, half_life_days)
+    def effective_confidence(self) -> float:
+        """Time-decayed confidence using the (domain, temporal) half-life.
+
+        See :mod:`loom.core.memory.lifecycle` for the half-life table.
+        """
+        from loom.core.memory.lifecycle import effective_confidence
+        return effective_confidence(
+            confidence=self.confidence,
+            updated_at=self.updated_at,
+            last_accessed_at=self.last_accessed_at,
+            domain=self.domain,
+            temporal=self.temporal,
+        )
 
 
 _SELECT_COLS = (
@@ -352,40 +355,41 @@ class SemanticMemory:
         threshold: float = 0.1,
         dry_run: bool = False,
     ) -> dict:
-        """
-        Delete semantic entries whose effective_confidence has decayed below *threshold*.
+        """Run one decay+demote cycle on the semantic table only.
 
-        Effective confidence = stored_confidence × 2^(-days_since_update / half_life).
-        A 90-day half-life means:
-          - confidence=0.8 → drops below 0.1 after ~282 days of no update
-          - confidence=1.0 → drops below 0.1 after ~299 days of no update
+        Delegates to :class:`MemoryLifecycle` — half-life is determined per
+        ``(domain, temporal)`` (see ``lifecycle._HALF_LIFE_TABLE``) rather
+        than the legacy single-90d value. Two-stage transition: rows with
+        ``temporal='recent'`` whose effective_confidence has fallen below
+        ``threshold`` are demoted to ``archived`` (preserved for second-
+        chance recall); rows already ``archived`` and still below threshold
+        are deleted.
 
-        Returns a dict: {examined, pruned, threshold, dry_run}
-        If dry_run=True the query runs but nothing is deleted.
+        Returns the same dict shape callers expect (``examined`` / ``pruned``
+        / ``retained``), where ``pruned`` totals archived + deleted so the
+        ``memory_prune`` tool's output stays meaningful.
         """
-        cursor = await self._db.execute(
-            "SELECT key, confidence, updated_at FROM semantic_entries"
+        from loom.core.memory.lifecycle import MemoryLifecycle
+
+        cycle = MemoryLifecycle(self._db, threshold=threshold)
+        # Run only the semantic side. Implementation invokes both private
+        # methods on the semantic_entries table — keeps relational decay
+        # owned by MemoryGovernor.run_decay_cycle.
+        examined_d, deleted = await cycle._process_table_delete(
+            "semantic_entries", dry_run=dry_run,
         )
-        rows = await cursor.fetchall()
-
-        to_prune: list[str] = []
-        for key, confidence, updated_at_str in rows:
-            updated_at = datetime.fromisoformat(updated_at_str)
-            if _effective_confidence(confidence, updated_at) < threshold:
-                to_prune.append(key)
-
-        if not dry_run and to_prune:
-            placeholders = ",".join("?" * len(to_prune))
-            await self._db.execute(
-                f"DELETE FROM semantic_entries WHERE key IN ({placeholders})",
-                to_prune,
-            )
-            await self._db.commit()
+        examined_a, archived = await cycle._process_table_demote(
+            "semantic_entries", dry_run=dry_run,
+        )
+        examined = examined_d + examined_a
+        pruned = archived + deleted
 
         return {
-            "examined": len(rows),
-            "pruned": len(to_prune),
-            "retained": len(rows) - len(to_prune),
+            "examined": examined,
+            "pruned": pruned,
+            "archived": archived,
+            "deleted": deleted,
+            "retained": examined - pruned,
             "threshold": threshold,
             "dry_run": dry_run,
         }

--- a/loom/core/memory/semantic.py
+++ b/loom/core/memory/semantic.py
@@ -372,16 +372,9 @@ class SemanticMemory:
         from loom.core.memory.lifecycle import MemoryLifecycle
 
         cycle = MemoryLifecycle(self._db, threshold=threshold)
-        # Run only the semantic side. Implementation invokes both private
-        # methods on the semantic_entries table — keeps relational decay
-        # owned by MemoryGovernor.run_decay_cycle.
-        examined_d, deleted = await cycle._process_table_delete(
+        examined, archived, deleted = await cycle.run_for_table(
             "semantic_entries", dry_run=dry_run,
         )
-        examined_a, archived = await cycle._process_table_demote(
-            "semantic_entries", dry_run=dry_run,
-        )
-        examined = examined_d + examined_a
         pruned = archived + deleted
 
         return {

--- a/tests/test_memory_lifecycle.py
+++ b/tests/test_memory_lifecycle.py
@@ -1,0 +1,323 @@
+"""
+Tests for Memory Lifecycle (issue #281 P2):
+
+  - half_life_for / effective_confidence — pure-function math
+  - last_accessed_at refresh keeps a fact alive even when stale
+  - State transitions: recent → archived → deleted (two-stage)
+  - Milestone facts never decay (except knowledge / 365d)
+  - Relational decay covers all sources (fixes #299)
+  - DecayCycleResult preserves legacy contract
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta, UTC
+
+import pytest
+import pytest_asyncio
+
+from loom.core.memory.episodic import EpisodicMemory
+from loom.core.memory.governance import MemoryGovernor
+from loom.core.memory.lifecycle import (
+    MemoryLifecycle,
+    effective_confidence,
+    half_life_for,
+)
+from loom.core.memory.ontology import (
+    DOMAIN_KNOWLEDGE,
+    DOMAIN_PROJECT,
+    DOMAIN_SELF,
+    DOMAIN_USER,
+    TEMPORAL_ARCHIVED,
+    TEMPORAL_MILESTONE,
+    TEMPORAL_RECENT,
+)
+from loom.core.memory.procedural import ProceduralMemory
+from loom.core.memory.relational import RelationalEntry, RelationalMemory
+from loom.core.memory.semantic import SemanticEntry, SemanticMemory
+from loom.core.memory.store import SQLiteStore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def db_conn(tmp_path):
+    s = SQLiteStore(str(tmp_path / "lifecycle.db"))
+    await s.initialize()
+    async with s.connect() as db:
+        yield db
+
+
+@pytest_asyncio.fixture
+async def memories(db_conn):
+    return (
+        SemanticMemory(db_conn),
+        RelationalMemory(db_conn),
+        ProceduralMemory(db_conn),
+        EpisodicMemory(db_conn),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests
+# ---------------------------------------------------------------------------
+
+class TestHalfLifeTable:
+    def test_self_recent_180d(self):
+        assert half_life_for(DOMAIN_SELF, TEMPORAL_RECENT) == 180.0
+
+    def test_user_project_knowledge_recent_90d(self):
+        # Per N1 concession: knowledge/recent raised to 90 (was 60)
+        assert half_life_for(DOMAIN_USER, TEMPORAL_RECENT) == 90.0
+        assert half_life_for(DOMAIN_PROJECT, TEMPORAL_RECENT) == 90.0
+        assert half_life_for(DOMAIN_KNOWLEDGE, TEMPORAL_RECENT) == 90.0
+
+    def test_milestone_inf_except_knowledge(self):
+        assert half_life_for(DOMAIN_SELF, TEMPORAL_MILESTONE) == math.inf
+        assert half_life_for(DOMAIN_USER, TEMPORAL_MILESTONE) == math.inf
+        assert half_life_for(DOMAIN_PROJECT, TEMPORAL_MILESTONE) == math.inf
+        assert half_life_for(DOMAIN_KNOWLEDGE, TEMPORAL_MILESTONE) == 365.0
+
+    def test_archived_short(self):
+        assert half_life_for(DOMAIN_SELF, TEMPORAL_ARCHIVED) == 30.0
+        assert half_life_for(DOMAIN_KNOWLEDGE, TEMPORAL_ARCHIVED) == 14.0
+
+    def test_unknown_pair_falls_back_90d(self):
+        assert half_life_for("ghost", "void") == 90.0
+
+
+class TestEffectiveConfidence:
+    def test_fresh_entry_has_full_confidence(self):
+        now = datetime.now(UTC)
+        eff = effective_confidence(
+            confidence=1.0, updated_at=now, last_accessed_at=None,
+            domain=DOMAIN_PROJECT, temporal=TEMPORAL_RECENT,
+        )
+        assert eff > 0.99
+
+    def test_one_half_life_halves_confidence(self):
+        old = datetime.now(UTC) - timedelta(days=90)
+        eff = effective_confidence(
+            confidence=1.0, updated_at=old, last_accessed_at=None,
+            domain=DOMAIN_PROJECT, temporal=TEMPORAL_RECENT,
+        )
+        # 90d half-life on 90d-old entry → ~0.5
+        assert 0.49 < eff < 0.51
+
+    def test_milestone_self_never_decays(self):
+        ancient = datetime.now(UTC) - timedelta(days=10_000)
+        eff = effective_confidence(
+            confidence=0.8, updated_at=ancient, last_accessed_at=None,
+            domain=DOMAIN_SELF, temporal=TEMPORAL_MILESTONE,
+        )
+        assert eff == 0.8  # half-life is inf — no decay applied
+
+    def test_last_accessed_keeps_fact_alive(self):
+        old = datetime.now(UTC) - timedelta(days=200)
+        recent_access = datetime.now(UTC) - timedelta(days=5)
+        eff_with_access = effective_confidence(
+            confidence=1.0, updated_at=old, last_accessed_at=recent_access,
+            domain=DOMAIN_PROJECT, temporal=TEMPORAL_RECENT,
+        )
+        eff_without_access = effective_confidence(
+            confidence=1.0, updated_at=old, last_accessed_at=None,
+            domain=DOMAIN_PROJECT, temporal=TEMPORAL_RECENT,
+        )
+        assert eff_with_access > eff_without_access
+        assert eff_with_access > 0.95  # recent access → ~no decay
+        assert eff_without_access < 0.3  # 200d on 90d half-life → much decay
+
+    def test_floor_is_001(self):
+        ancient = datetime.now(UTC) - timedelta(days=100_000)
+        eff = effective_confidence(
+            confidence=1.0, updated_at=ancient, last_accessed_at=None,
+            domain=DOMAIN_KNOWLEDGE, temporal=TEMPORAL_ARCHIVED,
+        )
+        assert eff >= 0.01
+
+
+# ---------------------------------------------------------------------------
+# State transition tests
+# ---------------------------------------------------------------------------
+
+class TestSemanticTransitions:
+    @pytest.mark.asyncio
+    async def test_fresh_recent_row_untouched(self, db_conn, memories):
+        semantic, *_ = memories
+        await semantic.upsert(SemanticEntry(
+            key="fresh", value="just written",
+            domain=DOMAIN_PROJECT, temporal=TEMPORAL_RECENT,
+        ))
+        result = await MemoryLifecycle(db_conn).run()
+        assert result.semantic_archived == 0
+        assert result.semantic_deleted == 0
+        assert (await semantic.get("fresh")).temporal == TEMPORAL_RECENT
+
+    @pytest.mark.asyncio
+    async def test_old_recent_row_demoted_to_archived(self, db_conn, memories):
+        semantic, *_ = memories
+        # Hand-write an entry with a 1000d-old updated_at — well past
+        # archive threshold for any (domain, recent) half-life.
+        old = (datetime.now(UTC) - timedelta(days=1000)).isoformat()
+        await db_conn.execute(
+            "INSERT INTO semantic_entries (id, key, value, confidence, source, "
+            "metadata, created_at, updated_at, domain, temporal) "
+            "VALUES (?, ?, ?, ?, ?, '{}', ?, ?, ?, ?)",
+            ("id1", "stale", "old fact", 1.0, "test", old, old,
+             DOMAIN_PROJECT, TEMPORAL_RECENT),
+        )
+        await db_conn.commit()
+
+        result = await MemoryLifecycle(db_conn).run()
+        assert result.semantic_archived == 1
+        assert result.semantic_deleted == 0
+        got = await semantic.get("stale")
+        assert got.temporal == TEMPORAL_ARCHIVED
+
+    @pytest.mark.asyncio
+    async def test_old_archived_row_deleted(self, db_conn, memories):
+        semantic, *_ = memories
+        # Already-archived row that's also too old → DELETE
+        old = (datetime.now(UTC) - timedelta(days=1000)).isoformat()
+        await db_conn.execute(
+            "INSERT INTO semantic_entries (id, key, value, confidence, source, "
+            "metadata, created_at, updated_at, domain, temporal) "
+            "VALUES (?, ?, ?, ?, ?, '{}', ?, ?, ?, ?)",
+            ("id2", "doomed", "very old", 1.0, "test", old, old,
+             DOMAIN_KNOWLEDGE, TEMPORAL_ARCHIVED),
+        )
+        await db_conn.commit()
+
+        result = await MemoryLifecycle(db_conn).run()
+        assert result.semantic_deleted == 1
+        assert (await semantic.get("doomed")) is None
+
+    @pytest.mark.asyncio
+    async def test_milestone_self_survives_extreme_age(self, db_conn, memories):
+        semantic, *_ = memories
+        ancient = (datetime.now(UTC) - timedelta(days=10_000)).isoformat()
+        await db_conn.execute(
+            "INSERT INTO semantic_entries (id, key, value, confidence, source, "
+            "metadata, created_at, updated_at, domain, temporal) "
+            "VALUES (?, ?, ?, ?, ?, '{}', ?, ?, ?, ?)",
+            ("id3", "core", "agent identity", 1.0, "manual", ancient, ancient,
+             DOMAIN_SELF, TEMPORAL_MILESTONE),
+        )
+        await db_conn.commit()
+
+        result = await MemoryLifecycle(db_conn).run()
+        assert result.semantic_archived == 0
+        assert result.semantic_deleted == 0
+        assert (await semantic.get("core")) is not None
+
+    @pytest.mark.asyncio
+    async def test_demote_does_not_double_into_delete_same_cycle(
+        self, db_conn, memories,
+    ):
+        """A row demoted in this cycle must not be deleted in the same pass.
+        Otherwise the second-chance archived state is meaningless."""
+        semantic, *_ = memories
+        old = (datetime.now(UTC) - timedelta(days=1000)).isoformat()
+        await db_conn.execute(
+            "INSERT INTO semantic_entries (id, key, value, confidence, source, "
+            "metadata, created_at, updated_at, domain, temporal) "
+            "VALUES (?, ?, ?, ?, ?, '{}', ?, ?, ?, ?)",
+            ("id4", "borderline", "old", 1.0, "test", old, old,
+             DOMAIN_PROJECT, TEMPORAL_RECENT),
+        )
+        await db_conn.commit()
+
+        result = await MemoryLifecycle(db_conn).run()
+        # First cycle: row was recent → archived, NOT deleted
+        assert result.semantic_archived == 1
+        assert result.semantic_deleted == 0
+        assert (await semantic.get("borderline")).temporal == TEMPORAL_ARCHIVED
+
+
+class TestRelationalCoverage:
+    """Issue #299 fix: relational decay must not be limited to
+    ``source='dreaming'``."""
+
+    @pytest.mark.asyncio
+    async def test_non_dreaming_source_is_examined(self, db_conn, memories):
+        _, relational, *_ = memories
+        old = (datetime.now(UTC) - timedelta(days=1000)).isoformat()
+        for sub, src in [("a", "user"), ("b", "agent"), ("c", "skill_eval")]:
+            await db_conn.execute(
+                "INSERT INTO relational_entries (id, subject, predicate, object, "
+                "confidence, source, metadata, created_at, updated_at, "
+                "domain, temporal) "
+                "VALUES (?, ?, 'rel', 'x', ?, ?, '{}', ?, ?, ?, ?)",
+                (f"id_{sub}", sub, 1.0, src, old, old,
+                 DOMAIN_PROJECT, TEMPORAL_RECENT),
+            )
+        await db_conn.commit()
+
+        result = await MemoryLifecycle(db_conn).run()
+        # All three should have been demoted to archived, regardless of source
+        assert result.relational_examined == 3
+        assert result.relational_archived == 3
+
+
+class TestDryRun:
+    @pytest.mark.asyncio
+    async def test_dry_run_changes_nothing(self, db_conn, memories):
+        semantic, *_ = memories
+        old = (datetime.now(UTC) - timedelta(days=1000)).isoformat()
+        await db_conn.execute(
+            "INSERT INTO semantic_entries (id, key, value, confidence, source, "
+            "metadata, created_at, updated_at, domain, temporal) "
+            "VALUES (?, ?, ?, ?, ?, '{}', ?, ?, ?, ?)",
+            ("id5", "doomed", "old", 1.0, "test", old, old,
+             DOMAIN_KNOWLEDGE, TEMPORAL_ARCHIVED),
+        )
+        await db_conn.commit()
+
+        result = await MemoryLifecycle(db_conn).run(dry_run=True)
+        assert result.semantic_deleted == 1  # would delete
+        # ...but DB unchanged
+        assert (await semantic.get("doomed")) is not None
+
+
+# ---------------------------------------------------------------------------
+# Integration: governance.run_decay_cycle preserves legacy contract
+# ---------------------------------------------------------------------------
+
+class TestGovernanceIntegration:
+    @pytest.mark.asyncio
+    async def test_run_decay_cycle_returns_archived_and_pruned(
+        self, db_conn, memories,
+    ):
+        semantic, relational, procedural, episodic = memories
+        old = (datetime.now(UTC) - timedelta(days=1000)).isoformat()
+        # one to archive, one already-archived to delete
+        await db_conn.execute(
+            "INSERT INTO semantic_entries (id, key, value, confidence, source, "
+            "metadata, created_at, updated_at, domain, temporal) "
+            "VALUES (?, ?, ?, ?, ?, '{}', ?, ?, ?, ?)",
+            ("a", "to_archive", "old", 1.0, "test", old, old,
+             DOMAIN_PROJECT, TEMPORAL_RECENT),
+        )
+        await db_conn.execute(
+            "INSERT INTO semantic_entries (id, key, value, confidence, source, "
+            "metadata, created_at, updated_at, domain, temporal) "
+            "VALUES (?, ?, ?, ?, ?, '{}', ?, ?, ?, ?)",
+            ("b", "to_delete", "very old", 1.0, "test", old, old,
+             DOMAIN_KNOWLEDGE, TEMPORAL_ARCHIVED),
+        )
+        await db_conn.commit()
+
+        gov = MemoryGovernor(
+            semantic=semantic, procedural=procedural,
+            relational=relational, episodic=episodic, db=db_conn,
+        )
+        result = await gov.run_decay_cycle()
+
+        assert result.semantic_archived == 1
+        # semantic_pruned = archived + deleted (legacy contract)
+        assert result.semantic_pruned == 2
+        assert result.total_pruned >= 2
+        assert result.total_archived == 1

--- a/tests/test_memory_lifecycle.py
+++ b/tests/test_memory_lifecycle.py
@@ -196,6 +196,35 @@ class TestSemanticTransitions:
         assert (await semantic.get("doomed")) is None
 
     @pytest.mark.asyncio
+    async def test_knowledge_milestone_demotes_when_truly_stale(
+        self, db_conn, memories,
+    ):
+        """B1 from PR #304 review: knowledge/milestone has 365d half-life,
+        so a *very* old knowledge/milestone fact must eventually transition
+        through archived → deleted via the normal pipeline. Earlier code
+        excluded ALL milestones from demote, breaking this design intent."""
+        semantic, *_ = memories
+        # 5000d is enough for 365d half-life to drop confidence well below
+        # the 0.1 threshold (1.0 * 2^(-5000/365) ≈ 1e-4).
+        ancient = (datetime.now(UTC) - timedelta(days=5000)).isoformat()
+        await db_conn.execute(
+            "INSERT INTO semantic_entries (id, key, value, confidence, source, "
+            "metadata, created_at, updated_at, domain, temporal) "
+            "VALUES (?, ?, ?, ?, ?, '{}', ?, ?, ?, ?)",
+            ("kmile", "stale_external", "outdated knowledge", 1.0, "manual",
+             ancient, ancient, DOMAIN_KNOWLEDGE, TEMPORAL_MILESTONE),
+        )
+        await db_conn.commit()
+
+        result = await MemoryLifecycle(db_conn).run()
+        assert result.semantic_archived == 1, (
+            "knowledge/milestone with 365d half-life MUST be demotable "
+            "once eff_conf < threshold — otherwise the 365d entry in "
+            "_HALF_LIFE_TABLE is meaningless"
+        )
+        assert (await semantic.get("stale_external")).temporal == TEMPORAL_ARCHIVED
+
+    @pytest.mark.asyncio
     async def test_milestone_self_survives_extreme_age(self, db_conn, memories):
         semantic, *_ = memories
         ancient = (datetime.now(UTC) - timedelta(days=10_000)).isoformat()


### PR DESCRIPTION
## Summary

Phase 2 of Memory System v2. **Single source of truth for fact decay** — replaces two scattered hardcoded 90-day half-lives (`semantic._DEFAULT_HALF_LIFE_DAYS` + `governance._prune_relational_decay`'s `base_half_life`) with a `(domain × temporal) → days` table. Also closes #299 — relational triples now decay across all sources, not just `source='dreaming'`.

Reference: [`outputs/doc/memory_ontology_draft_2026-05-03.md §3`](../blob/master/outputs/doc/memory_ontology_draft_2026-05-03.md).

## Half-life table

|  | self | user | project | knowledge |
|---|---|---|---|---|
| recent | 180d | 90d | 90d | **90d** |
| milestone | ∞ | ∞ | ∞ | 365d |
| archived | 30d | 30d | 30d | 14d |
| ephemeral | session-scoped — not handled here |

`knowledge/recent` raised from the 60d Phase 0 draft to 90d per PR #303 review N1: legacy LLM-classified rows include some misclassifications, the longer half-life is a conservative buffer until they get re-touched.

## Two-stage state machine

```
recent  →  archived  →  deleted
milestone (self/user/project)  — never demoted (∞ half-life)
milestone (knowledge)          — eventually demoted (365d)
```

Each cycle runs the **delete pass first**, then the demote pass. A row demoted in cycle T can't be deleted in cycle T — it gets a fresh archived-state window before reconsideration. Combined with `mark_accessed` from PR #301 (bumps `last_accessed_at` on every recall hit), facts in active use never decay regardless of age.

## What changed

| File | Diff |
|---|---|
| `loom/core/memory/lifecycle.py` | **NEW** — `half_life_for`, `effective_confidence`, `MemoryLifecycle` class |
| `loom/core/memory/semantic.py` | Removed `_DEFAULT_HALF_LIFE_DAYS` + `_effective_confidence` helper; `SemanticEntry.effective_confidence()` drops `half_life_days` param, delegates to lifecycle; `prune_decayed` now goes through lifecycle (archives + deletes), returns legacy dict shape plus new `archived`/`deleted` fields |
| `loom/core/memory/relational.py` | `RelationalEntry.effective_confidence()` added |
| `loom/core/memory/governance.py` | `run_decay_cycle` delegates semantic+relational to lifecycle; `_prune_relational_decay` deleted (#299 fix); `DecayCycleResult` gains `semantic_archived` / `relational_archived` |

## Tests

- `tests/test_memory_lifecycle.py` — 18 new tests cover half-life table values, `effective_confidence` math (fresh / one-half-life / floor / inf), `last_accessed_at` keeping stale facts alive (the N1 mechanism), all four state transitions, the demote-then-delete-in-same-cycle prevention, relational all-source coverage (#299 regression), `dry_run`, and `governance.run_decay_cycle` legacy contract preservation
- Full suite: **1427 passed** (was 1409), 1 skipped

## Backward compatibility

- `SemanticEntry.effective_confidence()` — old `half_life_days` arg removed. Searched the codebase: no callers passed it; safe.
- `SemanticMemory.prune_decayed` — same `(threshold, dry_run)` signature, same dict keys (`examined / pruned / retained`); adds `archived` / `deleted` for richer reporting
- `DecayCycleResult` — adds two fields with defaults; existing code reading `total_pruned` / `*_pruned` is untouched
- `loom.toml [memory.governance].relational_decay_factor` — config key still accepted (silently ignored), no migration needed

## Out of scope / next

- **P3** — cron trigger from autonomy daemon. Lifecycle is ready; only the trigger remains.
- **Memory Pulse hooks** (Session brief + contradiction) — separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)