### PR TITLE
feat(memory): P3-B MemoryPulse — Hook G + Hook A (#281)

### DIFF
--- a/loom/core/memory/governance.py
+++ b/loom/core/memory/governance.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     import aiosqlite
     from loom.core.memory.episodic import EpisodicMemory
     from loom.core.memory.procedural import ProceduralMemory
+    from loom.core.memory.pulse import MemoryPulse
     from loom.core.memory.relational import RelationalMemory
     from loom.core.memory.semantic import SemanticMemory
 
@@ -152,6 +153,15 @@ class MemoryGovernor:
         # Issue #133: memory health tracking for agent self-observability
         self.health = MemoryHealthTracker(db, session_id=session_id)
 
+        # Issue #281 P3 Hook A — late-bound by LoomSession.start() once the
+        # MemoryPulse is constructed (depends on _pending_pulses buffer).
+        # Optional: governor stays usable in tests / non-session contexts.
+        self._pulse: "MemoryPulse | None" = None
+
+    def set_pulse(self, pulse: "MemoryPulse | None") -> None:
+        """Wire the MemoryPulse for Hook A contradiction notices."""
+        self._pulse = pulse
+
     # ------------------------------------------------------------------
     # 1. Governed upsert
     # ------------------------------------------------------------------
@@ -191,6 +201,12 @@ class MemoryGovernor:
             # Process the most significant contradiction (highest similarity)
             main = max(contradictions, key=lambda c: c.similarity_score)
             result = self._detector.resolve(main)
+
+            # Issue #281 P3 Hook A — fire once per (key × session) regardless
+            # of resolution: even when the existing fact wins (KEEP), the
+            # agent benefits from knowing a contradicting attempt happened.
+            if self._pulse is not None:
+                await self._pulse.contradiction_inject(main)
 
             if result.resolution == Resolution.KEEP:
                 # Existing entry wins — don't write proposed

--- a/loom/core/memory/pulse.py
+++ b/loom/core/memory/pulse.py
@@ -1,0 +1,178 @@
+"""
+MemoryPulse — proactive memory hooks (Issue #281 P3, ontology §5).
+
+Two hooks (G + A) that emit short text briefs into a session-scoped buffer
+(``LoomSession._pending_pulses``), drained at the top of ``stream_turn``
+alongside judge verdicts (#196 Phase 2 pattern). Pulses surface as
+``<system-reminder>`` blocks on the agent's first LLM call of the next turn.
+
+Hook G — Session preheat
+    Once per ``start()``, query the previous active session's
+    ``domain=project AND temporal=milestone`` facts, top-3 by confidence.
+    Continuity across session boundaries without polluting context: ``None``
+    when nothing relevant exists.
+
+Hook A — Contradiction notice
+    Each ``governed_upsert`` that detects a contradiction emits a short
+    old-vs-new diff. Once-per-key gate via ``memory_meta`` so a hot key
+    being rewritten repeatedly doesn't spam the agent — gate clears at
+    session start (next session sees the contradiction once again if the
+    issue is still live).
+
+The remaining four hooks from #280 (E/H/B/D) are deferred until G+A
+have run two weeks and noise is measurable.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, UTC
+from typing import TYPE_CHECKING
+
+from loom.core.memory.ontology import (
+    DOMAIN_PROJECT,
+    TEMPORAL_MILESTONE,
+)
+
+if TYPE_CHECKING:
+    import aiosqlite
+    from loom.core.memory.contradiction import Contradiction
+    from loom.core.memory.semantic import SemanticMemory
+
+logger = logging.getLogger(__name__)
+
+
+_BRIEF_TOP_N = 3
+_GATE_KEY_PREFIX = "pulse.contradiction."
+
+
+class MemoryPulse:
+    """Owns the two active hooks (G + A). Stateless across calls — all
+    persistence goes through ``memory_meta`` or the pending buffer."""
+
+    def __init__(
+        self,
+        db: "aiosqlite.Connection",
+        semantic: "SemanticMemory",
+        session_id: str,
+        session_started_at: datetime,
+        pending_buffer: list[str],
+    ) -> None:
+        self._db = db
+        self._semantic = semantic
+        self._session_id = session_id
+        self._session_started_at = session_started_at
+        self._buffer = pending_buffer
+
+    # ------------------------------------------------------------------
+    # Hook G — Session preheat
+    # ------------------------------------------------------------------
+
+    async def session_brief(self) -> None:
+        """Append a brief summarising the previous session's milestone-class
+        project facts (top-3 by confidence). No-op when:
+          - no prior session exists
+          - no project/milestone fact has been touched since the prior
+            session started (i.e. nothing the agent recently anchored on)
+        """
+        try:
+            prev = await self._previous_active_session()
+            if prev is None:
+                return
+            _, prev_started_at = prev
+
+            cursor = await self._db.execute(
+                "SELECT key, value, confidence FROM semantic_entries "
+                "WHERE domain = ? AND temporal = ? "
+                "AND COALESCE(last_accessed_at, updated_at) >= ? "
+                "ORDER BY confidence DESC LIMIT ?",
+                (DOMAIN_PROJECT, TEMPORAL_MILESTONE,
+                 prev_started_at.isoformat(), _BRIEF_TOP_N),
+            )
+            rows = await cursor.fetchall()
+            if not rows:
+                return
+
+            lines = [f"- {row[0]}: {self._truncate(row[1])}" for row in rows]
+            brief = (
+                "Memory preheat — milestone facts active in your previous "
+                "session (top by confidence):\n" + "\n".join(lines)
+            )
+            self._buffer.append(brief)
+        except Exception as exc:
+            logger.debug("pulse: session_brief failed: %s", exc)
+
+    async def _previous_active_session(self) -> tuple[str, datetime] | None:
+        cursor = await self._db.execute(
+            "SELECT session_id, started_at FROM sessions "
+            "WHERE session_id != ? ORDER BY last_active DESC LIMIT 1",
+            (self._session_id,),
+        )
+        row = await cursor.fetchone()
+        if not row:
+            return None
+        try:
+            return row[0], datetime.fromisoformat(row[1])
+        except ValueError:
+            return None
+
+    # ------------------------------------------------------------------
+    # Hook A — Contradiction notice
+    # ------------------------------------------------------------------
+
+    async def contradiction_inject(self, contradiction: "Contradiction") -> None:
+        """Append a once-per-key contradiction notice. Gate uses
+        ``memory_meta`` keyed by the canonical fact key — if the same key
+        contradicted earlier *this session*, skip.
+        """
+        try:
+            key = contradiction.proposed.key
+            if await self._already_notified_this_session(key):
+                return
+
+            old = self._truncate(contradiction.existing.value)
+            new = self._truncate(contradiction.proposed.value)
+            notice = (
+                f"Memory contradiction on key={key!r} (resolution: "
+                f"{contradiction.resolution.value if contradiction.resolution else 'pending'}):\n"
+                f"  existing: {old}\n"
+                f"  proposed: {new}\n"
+                f"Reconcile if the new value should override the old."
+            )
+            self._buffer.append(notice)
+            await self._mark_notified(key)
+        except Exception as exc:
+            logger.debug("pulse: contradiction_inject failed: %s", exc)
+
+    async def _already_notified_this_session(self, key: str) -> bool:
+        cursor = await self._db.execute(
+            "SELECT updated_at FROM memory_meta WHERE key = ?",
+            (_GATE_KEY_PREFIX + key,),
+        )
+        row = await cursor.fetchone()
+        if not row:
+            return False
+        try:
+            ts = datetime.fromisoformat(row[0])
+        except ValueError:
+            return False
+        return ts >= self._session_started_at
+
+    async def _mark_notified(self, key: str) -> None:
+        now = datetime.now(UTC).isoformat()
+        await self._db.execute(
+            "INSERT INTO memory_meta(key, value, updated_at) VALUES (?, ?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value, "
+            "updated_at = excluded.updated_at",
+            (_GATE_KEY_PREFIX + key, self._session_id, now),
+        )
+        await self._db.commit()
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _truncate(value: str, limit: int = 160) -> str:
+        v = value.strip().replace("\n", " ")
+        return v if len(v) <= limit else v[: limit - 1] + "…"

--- a/loom/core/memory/pulse.py
+++ b/loom/core/memory/pulse.py
@@ -26,6 +26,7 @@ have run two weeks and noise is measurable.
 from __future__ import annotations
 
 import logging
+import textwrap
 from datetime import datetime, UTC
 from typing import TYPE_CHECKING
 
@@ -81,6 +82,9 @@ class MemoryPulse:
                 return
             _, prev_started_at = prev
 
+            # COALESCE: fall back to updated_at for facts never recalled
+            # (last_accessed_at is NULL) — a fact written but never read in
+            # the prior session is still relevant continuity.
             cursor = await self._db.execute(
                 "SELECT key, value, confidence FROM semantic_entries "
                 "WHERE domain = ? AND temporal = ? "
@@ -166,6 +170,11 @@ class MemoryPulse:
             "updated_at = excluded.updated_at",
             (_GATE_KEY_PREFIX + key, self._session_id, now),
         )
+        # Deliberate early commit: gate persistence must survive the rest
+        # of governed_upsert's path so a re-entrant write within the same
+        # turn doesn't bypass the once-per-(key × session) check. Caller
+        # (governance.governed_upsert) holds no other un-committed writes
+        # at this point — do not introduce any before this hook fires.
         await self._db.commit()
 
     # ------------------------------------------------------------------
@@ -174,5 +183,10 @@ class MemoryPulse:
 
     @staticmethod
     def _truncate(value: str, limit: int = 160) -> str:
+        # textwrap.shorten is whitespace-aware so CJK / mixed-script values
+        # don't get sliced mid-grapheme on the byte boundary. Falls back to
+        # raw value if already short, since shorten() collapses whitespace.
         v = value.strip().replace("\n", " ")
-        return v if len(v) <= limit else v[: limit - 1] + "…"
+        if len(v) <= limit:
+            return v
+        return textwrap.shorten(v, width=limit, placeholder="…")

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -730,6 +730,9 @@ class LoomSession:
         # Verdicts produced async land here; drained as <system-reminder>
         # at the start of the next stream_turn.
         self._pending_verdicts: list[str] = []
+        # Issue #281 P3 Hook G/A — MemoryPulse appends here, drained as
+        # <system-reminder> alongside verdicts in stream_turn.
+        self._pending_pulses: list[str] = []
         # In-flight judge background tasks — kept so stop() can cancel them
         # cleanly and so a single turn can't fire judge twice.
         self._judge_tasks: set[asyncio.Task] = set()
@@ -1384,6 +1387,20 @@ class LoomSession:
                     f.name, f.summary, f.detail,
                 )
 
+        # Issue #281 P3 — MemoryPulse: build now (db + memory ready), wire
+        # into governor for Hook A, then run Hook G so the brief lands in
+        # _pending_pulses before the agent's first turn drains the buffer.
+        from loom.core.memory.pulse import MemoryPulse
+        self._pulse = MemoryPulse(
+            db=self._db,
+            semantic=self._memory.semantic,
+            session_id=self.session_id,
+            session_started_at=datetime.now(UTC),
+            pending_buffer=self._pending_pulses,
+        )
+        self._governor.set_pulse(self._pulse)
+        await self._pulse.session_brief()
+
     # ------------------------------------------------------------------
     # HITL pause / resume / cancel
     # ------------------------------------------------------------------
@@ -1661,6 +1678,15 @@ class LoomSession:
                         "content": f"<system-reminder>\n{body}\n</system-reminder>",
                     })
                 self._pending_verdicts.clear()
+
+            # Issue #281 P3 — drain MemoryPulse hooks (G/A) the same way.
+            if self._pending_pulses:
+                for body in self._pending_pulses:
+                    self.messages.append({
+                        "role": "user",
+                        "content": f"<system-reminder>\n{body}\n</system-reminder>",
+                    })
+                self._pending_pulses.clear()
 
             await self._memory.episodic.write(
                 EpisodicEntry(

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1667,26 +1667,17 @@ class LoomSession:
             self.messages.append({"role": "user", "content": annotated})
             asyncio.ensure_future(self._log_message("user", annotated, turn_index=self._turn_index))
 
-            # Issue #196 Phase 2: drain any async judge verdicts produced after
-            # the previous turn ended. Inject as separate <system-reminder>
-            # entries so the agent sees them alongside the new user input on
-            # this turn's first LLM call.
-            if self._pending_verdicts:
-                for body in self._pending_verdicts:
-                    self.messages.append({
-                        "role": "user",
-                        "content": f"<system-reminder>\n{body}\n</system-reminder>",
-                    })
-                self._pending_verdicts.clear()
-
-            # Issue #281 P3 — drain MemoryPulse hooks (G/A) the same way.
-            if self._pending_pulses:
-                for body in self._pending_pulses:
-                    self.messages.append({
-                        "role": "user",
-                        "content": f"<system-reminder>\n{body}\n</system-reminder>",
-                    })
-                self._pending_pulses.clear()
+            # Issue #196 Phase 2 + #281 P3 — drain async-produced reminders
+            # (judge verdicts and MemoryPulse hooks) before the agent's next
+            # LLM call. Order is incidental: both render as identical
+            # <system-reminder> blocks, indistinguishable to the model.
+            for body in (*self._pending_verdicts, *self._pending_pulses):
+                self.messages.append({
+                    "role": "user",
+                    "content": f"<system-reminder>\n{body}\n</system-reminder>",
+                })
+            self._pending_verdicts.clear()
+            self._pending_pulses.clear()
 
             await self._memory.episodic.write(
                 EpisodicEntry(


### PR DESCRIPTION
## Summary
Second slice of Memory v2 Phase 3. Adds two proactive hooks (G + A from ontology §5). Both reuse the Issue #196 Phase 2 pattern — append text to a session-scoped buffer, drained at the top of next \`stream_turn\` as \`<system-reminder>\` blocks.

### Hook G — Session preheat
Once per \`LoomSession.start()\`, query the previous active session's \`domain=project AND temporal=milestone\` facts, top-3 by confidence. Surfaces continuity across session boundaries without polluting context. Silent no-op when no prior session or no recently-touched milestone facts.

### Hook A — Contradiction notice
Every \`governed_upsert\` that detects a contradiction emits an old-vs-new diff. Once-per-(key × session) gate via \`memory_meta\` (key \`pulse.contradiction.<key>\`) so a hot key being rewritten repeatedly doesn't spam the agent. Gate clears at session start — next session sees the contradiction once again if the issue is still live.

The remaining four hooks from #280 (E water-mark / H skill hint / B decay warn / D dream inject) stay deferred until G+A have run two weeks and noise is measurable.

## Integration

| File | Change |
|------|--------|
| **NEW** \`loom/core/memory/pulse.py\` | \`MemoryPulse\` class — both hooks |
| \`loom/core/session.py\` | \`_pending_pulses\` buffer + drain block beside \`_pending_verdicts\`; pulse instantiated at end of \`start()\` and wired into governor |
| \`loom/core/memory/governance.py\` | Optional \`self._pulse\`, fires after \`detector.resolve()\` (regardless of resolution — even KEEP benefits the agent knowing it happened) |

## Test plan
- [x] 369 existing tests pass (memory + autonomy + governance + session)
- [x] Manual Hook G smoke: domain filter (knowledge excluded), top-3 confidence ordering, returns silent on empty prior
- [x] Manual Hook A smoke: 1st fires, 2nd same-key skips, 3rd different-key fires, new session re-fires
- [x] \`gitnexus_detect_changes\`: LOW risk, 0 affected processes — pure additive

## Follow-ups
- **PR-3**: Dream 2.0 themed sampling (\`WHERE domain=X\`)
- After two weeks of G+A runtime: re-evaluate whether E/H/B/D add value or noise

Refs ontology draft \`outputs/doc/memory_ontology_draft_2026-05-03.md\` §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)