### PR TITLE
feat(memory): P3-C Dream 2.0 themed sampling — round-robin domain (#281)

### DIFF
--- a/loom/core/cognition/dreaming.py
+++ b/loom/core/cognition/dreaming.py
@@ -95,6 +95,10 @@ async def next_themed_domain(db: "aiosqlite.Connection") -> str:
         "updated_at = excluded.updated_at",
         (_META_KEY_LAST_THEME, next_theme, now),
     )
+    # Same boundary effect note as pulse._mark_notified (#307 B1):
+    # this commits whatever else is pending on the connection. Caller
+    # (dream_cycle) holds no other un-committed writes at this point —
+    # do not introduce any before next_themed_domain() returns.
     await db.commit()
     return next_theme
 

--- a/loom/core/cognition/dreaming.py
+++ b/loom/core/cognition/dreaming.py
@@ -35,9 +35,68 @@ import logging
 import re
 import uuid
 from datetime import datetime, UTC
-from typing import Callable, Awaitable
+from typing import Callable, Awaitable, TYPE_CHECKING
+
+from loom.core.memory.ontology import (
+    DOMAIN_KNOWLEDGE,
+    DOMAIN_PROJECT,
+    DOMAIN_SELF,
+    DOMAIN_USER,
+)
+
+if TYPE_CHECKING:
+    import aiosqlite
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Round-robin theme selector (Issue #281 P3-D)
+# ---------------------------------------------------------------------------
+#
+# When themed sampling is requested without an explicit domain, the daemon
+# cycles through the four ontology domains in order, persisting "what I
+# dreamed last" in ``memory_meta`` so restarts don't reset the rotation.
+#
+# Design rationale (ontology §5): we explicitly chose round-robin over
+# auto-heuristics ("most-written domain", "least-recently-dreamed", etc.)
+# — simpler, no thinking required, no metric drift, and predictable enough
+# for the agent to develop intuition over time. Re-evaluate after two weeks.
+
+_THEME_ROTATION = (DOMAIN_SELF, DOMAIN_USER, DOMAIN_PROJECT, DOMAIN_KNOWLEDGE)
+_META_KEY_LAST_THEME = "dream.last_theme"
+
+
+async def next_themed_domain(db: "aiosqlite.Connection") -> str:
+    """Return the next domain in the round-robin and persist it.
+
+    Idempotent within a single call: reads the previous theme from
+    ``memory_meta``, advances by one step in ``_THEME_ROTATION``, writes
+    the new theme back, and returns it. First call ever returns the first
+    domain in the cycle.
+    """
+    cursor = await db.execute(
+        "SELECT value FROM memory_meta WHERE key = ?",
+        (_META_KEY_LAST_THEME,),
+    )
+    row = await cursor.fetchone()
+    last = row[0] if row else None
+
+    if last in _THEME_ROTATION:
+        idx = (_THEME_ROTATION.index(last) + 1) % len(_THEME_ROTATION)
+    else:
+        idx = 0  # first call, or stored value drifted out of the enum
+    next_theme = _THEME_ROTATION[idx]
+
+    now = datetime.now(UTC).isoformat()
+    await db.execute(
+        "INSERT INTO memory_meta(key, value, updated_at) VALUES (?, ?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value, "
+        "updated_at = excluded.updated_at",
+        (_META_KEY_LAST_THEME, next_theme, now),
+    )
+    await db.commit()
+    return next_theme
 
 
 # ---------------------------------------------------------------------------
@@ -112,6 +171,9 @@ async def dream_cycle(
     llm_fn: Callable[..., Awaitable[str]],         # async fn(messages) -> str
     sample_size: int = 15,
     dry_run: bool = False,
+    domain: str | None = None,
+    themed: bool = False,
+    db: "aiosqlite.Connection | None" = None,
 ) -> dict:
     """
     Execute one dreaming cycle.
@@ -125,6 +187,14 @@ async def dream_cycle(
                   ``LoomSession._router.route()`` or a provider ``complete()``.
     sample_size:  Number of random semantic facts to sample (default 15).
     dry_run:      When True, run the prompt and parse but skip writing to DB.
+    domain:       Constrain sampling to a single ontology domain
+                  (self/user/project/knowledge). ``None`` keeps the original
+                  cross-domain free-dream behaviour.
+    themed:       When True and ``domain`` is None, round-robin the next
+                  domain via ``next_themed_domain(db)`` (requires ``db``).
+                  Issue #281 P3-D — themed dreams stay focused, free
+                  dreams find cross-domain bridges; both modes coexist.
+    db:           Required only when ``themed=True``; ignored otherwise.
 
     Returns
     -------
@@ -132,15 +202,29 @@ async def dream_cycle(
       - ``facts_sampled``   int
       - ``triples_found``   int
       - ``triples_written`` int
+      - ``domain``          str | None  (resolved domain, or None for free)
       - ``errors``          list[str]  (non-fatal parse issues)
     """
     errors: list[str] = []
 
+    # ── 0. Resolve domain (themed → round-robin) ───────────────────────
+    if themed and domain is None:
+        if db is None:
+            errors.append("themed=True requires db connection — falling back to free dream")
+        else:
+            domain = await next_themed_domain(db)
+
     # ── 1. Sample random facts ──────────────────────────────────────────
-    facts = await semantic.get_random(limit=sample_size)
+    facts = await semantic.get_random(limit=sample_size, domain=domain)
     if not facts:
-        logger.info("[dreaming] No semantic facts found — skipping cycle.")
-        return {"facts_sampled": 0, "triples_found": 0, "triples_written": 0, "errors": []}
+        logger.info(
+            "[dreaming] No semantic facts found (domain=%s) — skipping cycle.",
+            domain or "any",
+        )
+        return {
+            "facts_sampled": 0, "triples_found": 0, "triples_written": 0,
+            "domain": domain, "errors": errors,
+        }
 
     # ── 1b. Enrich facts with topic + timestamp ────────────────────────
     fact_lines: list[str] = []
@@ -174,7 +258,8 @@ async def dream_cycle(
             "facts_sampled": len(facts),
             "triples_found": 0,
             "triples_written": 0,
-            "errors": [f"LLM error: {exc}"],
+            "domain": domain,
+            "errors": [*errors, f"LLM error: {exc}"],
         }
 
     # ── 3. Parse JSON triples ──────────────────────────────────────────
@@ -208,6 +293,7 @@ async def dream_cycle(
         "facts_sampled": len(facts),
         "triples_found": len(triples),
         "triples_written": written,
+        "domain": domain,
         "errors": errors,
     }
     logger.info("[dreaming] Cycle complete: %s", result)

--- a/loom/core/memory/maintenance.py
+++ b/loom/core/memory/maintenance.py
@@ -22,6 +22,7 @@ from loom.core.harness.permissions import TrustLevel
 from loom.core.harness.registry import ToolDefinition
 
 if TYPE_CHECKING:
+    import aiosqlite
     from loom.core.memory.relational import RelationalMemory
     from loom.core.memory.semantic import SemanticMemory
 
@@ -33,6 +34,7 @@ def make_dream_cycle_tool(
     semantic: "SemanticMemory",
     relational: "RelationalMemory",
     llm_fn: LLMFn,
+    db: "aiosqlite.Connection | None" = None,
 ) -> ToolDefinition:
     """Build the ``dream_cycle`` ToolDefinition.
 
@@ -45,12 +47,32 @@ def make_dream_cycle_tool(
         Async callable that takes an OpenAI-style messages list and returns
         the assistant's text. ``LoomSession.start()`` wires this to its
         configured router + model.
+    db:
+        Optional aiosqlite connection — required only when the agent
+        invokes the tool with ``themed=true`` (round-robin theme picker
+        reads/writes ``memory_meta``). Falls back to free dream when
+        absent. Issue #281 P3-D.
     """
     from loom.core.cognition.dreaming import dream_cycle
+    from loom.core.memory.ontology import (
+        DOMAIN_KNOWLEDGE, DOMAIN_PROJECT, DOMAIN_SELF, DOMAIN_USER,
+    )
+
+    _ALLOWED_DOMAINS = {DOMAIN_SELF, DOMAIN_USER, DOMAIN_PROJECT, DOMAIN_KNOWLEDGE}
 
     async def _executor(call) -> ToolResult:
         sample = int(call.args.get("sample_size", 15))
         dry_run = bool(call.args.get("dry_run", False))
+        themed = bool(call.args.get("themed", False))
+        domain = call.args.get("domain")
+        if domain is not None and domain not in _ALLOWED_DOMAINS:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name, success=False,
+                output=(
+                    f"Invalid domain={domain!r}. Allowed: "
+                    f"{sorted(_ALLOWED_DOMAINS)} or omit for free dream."
+                ),
+            )
 
         result = await dream_cycle(
             semantic=semantic,
@@ -58,10 +80,15 @@ def make_dream_cycle_tool(
             llm_fn=llm_fn,
             sample_size=sample,
             dry_run=dry_run,
+            domain=domain,
+            themed=themed,
+            db=db,
         )
 
         lines = [
             "Dream cycle complete",
+            f"  Mode         : {'themed' if result.get('domain') else 'free'}"
+            + (f" (domain={result['domain']})" if result.get("domain") else ""),
             f"  Facts sampled: {result['facts_sampled']}",
             f"  Triples found: {result['triples_found']}",
             f"  Triples written: {result['triples_written']}",
@@ -82,8 +109,10 @@ def make_dream_cycle_tool(
             "Run an offline dreaming cycle: sample random semantic facts, "
             "discover non-obvious connections via the LLM, and store the "
             "resulting insights as Relational triples (source='dreaming'). "
-            "Use this when the autonomy scheduler triggers a background "
-            "synthesis task."
+            "Default is a free cross-domain dream. Pass themed=true to "
+            "round-robin through ontology domains (self → user → project "
+            "→ knowledge), or domain='<name>' to pin one. Use this when "
+            "the autonomy scheduler triggers a background synthesis task."
         ),
         input_schema={
             "type": "object",
@@ -96,6 +125,23 @@ def make_dream_cycle_tool(
                 "dry_run": {
                     "type": "boolean",
                     "description": "If true, run the full cycle but skip writing to the DB.",
+                    "default": False,
+                },
+                "domain": {
+                    "type": "string",
+                    "enum": ["self", "user", "project", "knowledge"],
+                    "description": (
+                        "Pin the sample to one ontology domain. Mutually "
+                        "exclusive with themed (themed wins)."
+                    ),
+                },
+                "themed": {
+                    "type": "boolean",
+                    "description": (
+                        "Round-robin the next domain (cycles self → user → "
+                        "project → knowledge). Ignores domain when both are "
+                        "set; falls back to free dream if no DB is wired."
+                    ),
                     "default": False,
                 },
             },

--- a/loom/core/memory/maintenance.py
+++ b/loom/core/memory/maintenance.py
@@ -131,16 +131,17 @@ def make_dream_cycle_tool(
                     "type": "string",
                     "enum": ["self", "user", "project", "knowledge"],
                     "description": (
-                        "Pin the sample to one ontology domain. Mutually "
-                        "exclusive with themed (themed wins)."
+                        "Pin the sample to one ontology domain. When set "
+                        "alongside themed=true, domain wins (explicit name "
+                        "is stronger than rotation)."
                     ),
                 },
                 "themed": {
                     "type": "boolean",
                     "description": (
                         "Round-robin the next domain (cycles self → user → "
-                        "project → knowledge). Ignores domain when both are "
-                        "set; falls back to free dream if no DB is wired."
+                        "project → knowledge). Skipped when domain is also "
+                        "set, or falls back to free dream if no DB is wired."
                     ),
                     "default": False,
                 },

--- a/loom/core/memory/semantic.py
+++ b/loom/core/memory/semantic.py
@@ -290,18 +290,36 @@ class SemanticMemory:
         rows = await cursor.fetchall()
         return [_row_to_entry(r) for r in rows]
 
-    async def get_random(self, limit: int = 15) -> list[SemanticEntry]:
+    async def get_random(
+        self,
+        limit: int = 15,
+        domain: str | None = None,
+    ) -> list[SemanticEntry]:
         """
-        Return up to *limit* entries chosen at random from all semantic facts.
+        Return up to *limit* entries chosen at random from semantic facts.
 
         Used by the dreaming cycle so each dream surfaces a varied, non-recency-
         biased sample of the knowledge base.  SQLite's ORDER BY RANDOM() is fine
         for typical Loom memory sizes (< 50k rows).
+
+        Issue #281 P3-D — when ``domain`` is set, sampling is constrained to
+        that ontology axis (themed dream); ``None`` keeps original
+        cross-domain behaviour (free dream). Empty result for an unknown
+        domain is returned silently — caller should not validate the enum
+        here, the closed enum is enforced at write time.
         """
-        cursor = await self._db.execute(
-            f"SELECT {_SELECT_COLS} FROM semantic_entries ORDER BY RANDOM() LIMIT ?",
-            (limit,),
-        )
+        if domain is None:
+            cursor = await self._db.execute(
+                f"SELECT {_SELECT_COLS} FROM semantic_entries "
+                "ORDER BY RANDOM() LIMIT ?",
+                (limit,),
+            )
+        else:
+            cursor = await self._db.execute(
+                f"SELECT {_SELECT_COLS} FROM semantic_entries "
+                "WHERE domain = ? ORDER BY RANDOM() LIMIT ?",
+                (domain, limit),
+            )
         rows = await cursor.fetchall()
         return [_row_to_entry(r) for r in rows]
 

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1124,6 +1124,7 @@ class LoomSession:
         self.registry.register(
             make_dream_cycle_tool(
                 self._memory.semantic, self._memory.relational, _dream_llm_fn,
+                db=self._db,
             )
         )
         self.registry.register(make_memory_prune_tool(self._memory.semantic))

--- a/tests/test_memory_maintenance.py
+++ b/tests/test_memory_maintenance.py
@@ -33,20 +33,25 @@ def test_dream_cycle_definition_shape():
     assert tool.name == "dream_cycle"
     assert tool.trust_level == TrustLevel.SAFE
     props = tool.input_schema["properties"]
-    assert set(props) == {"sample_size", "dry_run"}
+    assert set(props) == {"sample_size", "dry_run", "domain", "themed"}
     assert props["sample_size"]["default"] == 15
     assert props["dry_run"]["default"] is False
+    assert props["themed"]["default"] is False
+    assert set(props["domain"]["enum"]) == {"self", "user", "project", "knowledge"}
 
 
 async def test_dream_cycle_executor_passes_args_through(monkeypatch):
     captured = {}
 
-    async def fake_dream_cycle(*, semantic, relational, llm_fn, sample_size, dry_run):
+    async def fake_dream_cycle(*, semantic, relational, llm_fn, sample_size, dry_run, **kwargs):
         captured["sample_size"] = sample_size
         captured["dry_run"] = dry_run
+        captured.update({k: kwargs[k] for k in ("domain", "themed") if k in kwargs})
         return {
             "facts_sampled": 7, "triples_found": 3,
-            "triples_written": 0 if dry_run else 3, "errors": [],
+            "triples_written": 0 if dry_run else 3,
+            "domain": kwargs.get("domain"),
+            "errors": [],
         }
 
     monkeypatch.setattr(
@@ -57,7 +62,9 @@ async def test_dream_cycle_executor_passes_args_through(monkeypatch):
     res = await tool.executor(_call("dream_cycle", {"sample_size": 7, "dry_run": True}))
 
     assert res.success
-    assert captured == {"sample_size": 7, "dry_run": True}
+    assert captured == {
+        "sample_size": 7, "dry_run": True, "domain": None, "themed": False,
+    }
     assert "Facts sampled: 7" in res.output
     assert "dry-run" in res.output  # dry_run banner appears
 


### PR DESCRIPTION
## Summary
Third (and final) slice of Memory v2 Phase 3. Adds an optional theme axis to \`dream_cycle\`. Default behaviour unchanged — free cross-domain dream. Two new opt-in modes:

- \`domain="<name>"\` — pin sampling to one ontology domain (\`self\` / \`user\` / \`project\` / \`knowledge\`)
- \`themed=true\` — round-robin in cycle order, state persisted in \`memory_meta.dream.last_theme\`

## Why round-robin (not auto-heuristic)

Per ontology §5 lock: explicitly chose round-robin over auto-heuristics ("most-written domain", "least-recently-dreamed", etc.) — simpler, no thinking required, predictable enough for the agent to develop intuition over time. Re-evaluate after two weeks of runtime data.

The user explicitly picked option B over A (caller-specified) and C (auto-heuristic) for "簡單不用思考" reasons.

## Changes

| File | Change |
|------|--------|
| \`loom/core/memory/semantic.py\` | \`get_random\` gains optional \`domain=\` filter |
| \`loom/core/cognition/dreaming.py\` | \`dream_cycle\` accepts \`domain\` / \`themed\` / \`db\`; new \`next_themed_domain(db)\` round-robin selector; result dict gains \`"domain"\` key |
| \`loom/core/memory/maintenance.py\` | Tool schema exposes both modes with \`enum\` validation on \`domain\` |
| \`loom/core/session.py\` | Pass \`self._db\` to tool factory so themed mode has its rotation state |

## Test plan
- [x] 269 existing tests pass (memory + governance + session + autonomy + maintenance + search + lifecycle)
- [x] Updated \`test_memory_maintenance.py\` for new schema fields + executor signature
- [x] Manual smoke: rotation order \`[self, user, project, knowledge]\` × 2, domain filter isolates 1 row each, free returns all 4, \`themed=True\` picks next in cycle
- [x] \`gitnexus_detect_changes\`: medium risk, 1 affected process — \`dream_cycle\` itself, expected

## Explicitly NOT in scope (per ontology §5)
- Approval queue (Dream 2.0 P3 — killed)
- Auto-heuristic theme picker (E.g. "most-written domain")
- New cron triggers (free vs themed remains caller's choice)

## P3 milestone status
- ✅ PR-1 #305 — daemon-cron MaintenanceLoop + run() throttle
- ✅ PR-2 #307 — MemoryPulse Hooks G + A
- 🟢 PR-3 (this) — Dream 2.0 themed sampling

After this lands, Phase 3 of #281 is feature-complete. Phase 4 (#295 skill 共現 + health dashboard) opens next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)