### PR TITLE
fix(harness): 日常開發摩擦修補 — verifier 保留 output、per-tool spill 閾值、section 0-N (#298, #302)

### DIFF
--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -250,9 +250,21 @@ class JITRetrievalMiddleware(Middleware):
         if tool_def is not None and getattr(tool_def, "inline_only", False):
             return result
 
+        # Per-tool override (Issue #302): tools that benefit from a larger
+        # inline budget — read_file, etc. — declare spill_threshold_chars.
+        # 0 means "never spill" (same as inline_only). None falls back to the
+        # pipeline-wide default.
+        threshold = self._threshold_chars
+        if tool_def is not None:
+            override = getattr(tool_def, "spill_threshold_chars", None)
+            if override is not None:
+                if override <= 0:
+                    return result
+                threshold = override
+
         output_str = "" if result.output is None else str(result.output)
         size = len(output_str)
-        if size <= self._threshold_chars:
+        if size <= threshold:
             return result
 
         # Generate a stable, agent-readable ref. uuid suffix avoids
@@ -1588,17 +1600,31 @@ class LifecycleMiddleware(Middleware):
                     # Previously this branch silently committed a "success"
                     # result — the failure signal was lost. Now we surface
                     # semantic_failure so the model can self-correct.
+                    # Issue #298: keep the original output in `error` too —
+                    # session rendering only shows `error` on failure, so
+                    # dropping output here means the agent can't see what
+                    # actually happened (traceback text, test output, etc.)
+                    # and has no signal to act on beyond the reason string.
+                    original_output = result.output
+                    if original_output:
+                        full_error = (
+                            f"{reason}\n\n"
+                            f"--- captured output ---\n{original_output}"
+                        )
+                    else:
+                        full_error = reason
                     result = ToolResult(
                         call_id=result.call_id,
                         tool_name=result.tool_name,
                         success=False,
-                        error=reason,
+                        error=full_error,
                         failure_type="semantic_failure",
                         duration_ms=result.duration_ms,
                         metadata={
                             **result.metadata,
                             "verifier_signal": verdict.signal,
-                            "original_output": result.output,
+                            "verifier_reason": reason,
+                            "original_output": original_output,
                         },
                     )
                     record.result = result

--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -250,10 +250,7 @@ class JITRetrievalMiddleware(Middleware):
         if tool_def is not None and getattr(tool_def, "inline_only", False):
             return result
 
-        # Per-tool override (Issue #302): tools that benefit from a larger
-        # inline budget — read_file, etc. — declare spill_threshold_chars.
-        # 0 means "never spill" (same as inline_only). None falls back to the
-        # pipeline-wide default.
+        # Per-tool override — see ToolDefinition.spill_threshold_chars (#302).
         threshold = self._threshold_chars
         if tool_def is not None:
             override = getattr(tool_def, "spill_threshold_chars", None)

--- a/loom/core/harness/registry.py
+++ b/loom/core/harness/registry.py
@@ -93,6 +93,20 @@ class ToolDefinition:
     ``task_write`` (structured short responses).
     """
 
+    spill_threshold_chars: int | None = None
+    """
+    Per-tool override for ``JITRetrievalMiddleware`` spill threshold (Issue #302).
+
+    When set, the JIT spill is gated by this value instead of the pipeline-wide
+    default (8000 chars). Use a higher value for tools whose output the agent
+    nearly always wants inline — e.g. ``read_file`` returning a few hundred
+    lines of source: spilling those forces an extra ``scratchpad_read`` round
+    trip with no token savings worth the friction.
+
+    ``None`` (default) means "use the global threshold". ``0`` disables spill
+    entirely (equivalent to ``inline_only=True``).
+    """
+
     # --- Scope-aware permission (Issue #45 Phase A) ---
     scope_descriptions: list[str] = field(default_factory=list)
     """

--- a/loom/core/jobs/scratchpad.py
+++ b/loom/core/jobs/scratchpad.py
@@ -92,7 +92,10 @@ def _apply_section(text: str, section: str) -> str:
     Supported:
       - "head"     → first 50 lines
       - "tail"     → last 50 lines
-      - "N-M"      → lines N..M inclusive (1-indexed)
+      - "N-M"      → lines N..M inclusive (1-indexed). N is clamped to 1
+                     if a caller passes 0 (Issue #302 F2 — previously this
+                     silently fell through to keyword search and returned
+                     an empty string for huge files).
       - any other  → treat as keyword; return lines containing it
     """
     lines = text.splitlines()
@@ -101,12 +104,23 @@ def _apply_section(text: str, section: str) -> str:
     if section == "tail":
         return "\n".join(lines[-50:])
     if "-" in section:
+        lo_s, hi_s = section.split("-", 1)
         try:
-            lo, hi = section.split("-", 1)
-            i, j = int(lo), int(hi)
-            if i >= 1 and j >= i:
-                return "\n".join(lines[i - 1:j])
+            i, j = int(lo_s), int(hi_s)
         except ValueError:
-            pass
+            # Not a numeric range — fall through to keyword search.
+            i = j = None  # type: ignore[assignment]
+        if i is not None and j is not None:
+            # Both halves parsed as ints → treat as a line range. Clamp
+            # i to 1 (caller-friendly: "0-500" reads as "from start"),
+            # require j >= i. Out-of-range j is harmless thanks to
+            # Python slice semantics.
+            if i < 1:
+                i = 1
+            if j >= i:
+                return "\n".join(lines[i - 1:j])
+            # Inverted range (j < i) is almost certainly a typo, not a
+            # keyword — return empty rather than misleading keyword hits.
+            return ""
     matches = [line for line in lines if section in line]
     return "\n".join(matches)

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -428,6 +428,11 @@ def make_filesystem_tools(workspace: Path) -> list["ToolDefinition"]:
             executor=_read_file,
             tags=["filesystem", "read"],
             impact_scope="filesystem",
+            # Issue #302 F1: source files in the 8K–24K char range are
+            # nearly always wanted inline (mid-size Python modules, configs).
+            # Spilling them forces a redundant scratchpad_read round trip.
+            # 24K ≈ ~6K tokens — still safely under typical attention budgets.
+            spill_threshold_chars=24000,
         ),
         ToolDefinition(
             name="write_file",

--- a/tests/test_jit_retrieval.py
+++ b/tests/test_jit_retrieval.py
@@ -36,7 +36,11 @@ def _make_registry(*tools: ToolDefinition) -> ToolRegistry:
     return reg
 
 
-def _make_tool(name: str, *, inline_only: bool = False) -> ToolDefinition:
+def _make_tool(
+    name: str, *,
+    inline_only: bool = False,
+    spill_threshold_chars: int | None = None,
+) -> ToolDefinition:
     async def _executor(call: ToolCall) -> ToolResult:
         return ToolResult(
             call_id=call.id, tool_name=call.tool_name,
@@ -46,6 +50,7 @@ def _make_tool(name: str, *, inline_only: bool = False) -> ToolDefinition:
         name=name, description="", input_schema={},
         executor=_executor, trust_level=TrustLevel.SAFE,
         inline_only=inline_only,
+        spill_threshold_chars=spill_threshold_chars,
     )
 
 
@@ -114,6 +119,65 @@ class TestJITRetrievalThreshold:
 
         assert result.output == big_output
         assert scratchpad.list_refs() == []
+
+
+class TestJITPerToolSpillThreshold:
+    """Issue #302 F1: ToolDefinition.spill_threshold_chars overrides the
+    pipeline-wide threshold for a specific tool. Used by read_file so that
+    mid-size source files (8K–24K chars) stay inline."""
+
+    async def test_per_tool_threshold_raises_inline_budget(self) -> None:
+        scratchpad = Scratchpad()
+        registry = _make_registry(
+            _make_tool("read_file", spill_threshold_chars=24000)
+        )
+        jit = JITRetrievalMiddleware(scratchpad, registry, threshold_chars=100)
+
+        # 17K chars — would spill under default 100, must stay inline at 24000.
+        body = "x" * 17_000
+        result = await _run(jit, _call("read_file"), output=body)
+
+        assert result.output == body
+        assert "jit_spilled" not in result.metadata
+        assert scratchpad.list_refs() == []
+
+    async def test_per_tool_threshold_still_spills_above_override(self) -> None:
+        scratchpad = Scratchpad()
+        registry = _make_registry(
+            _make_tool("read_file", spill_threshold_chars=24000)
+        )
+        jit = JITRetrievalMiddleware(scratchpad, registry, threshold_chars=100)
+
+        # 30K chars exceeds the override → still spills.
+        body = "y" * 30_000
+        result = await _run(jit, _call("read_file"), output=body)
+
+        assert "spilled to scratchpad" in result.output
+        assert result.metadata["jit_spilled"] is True
+
+    async def test_per_tool_threshold_zero_disables_spill(self) -> None:
+        """spill_threshold_chars=0 acts like inline_only — never spills."""
+        scratchpad = Scratchpad()
+        registry = _make_registry(
+            _make_tool("never_spill", spill_threshold_chars=0)
+        )
+        jit = JITRetrievalMiddleware(scratchpad, registry, threshold_chars=100)
+
+        body = "z" * 100_000
+        result = await _run(jit, _call("never_spill"), output=body)
+
+        assert result.output == body
+        assert "jit_spilled" not in result.metadata
+
+    async def test_default_none_falls_back_to_global(self) -> None:
+        """spill_threshold_chars=None → uses pipeline-wide threshold."""
+        scratchpad = Scratchpad()
+        registry = _make_registry(_make_tool("plain"))  # default: None
+        jit = JITRetrievalMiddleware(scratchpad, registry, threshold_chars=100)
+
+        result = await _run(jit, _call("plain"), output="q" * 5000)
+
+        assert result.metadata["jit_spilled"] is True
 
 
 class TestJITInlineOnlyOptOut:

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -108,6 +108,34 @@ class TestScratchpad:
         pad.write("log", "apple\nbanana\napricot\ncarrot")
         assert pad.read("log", section="ap") == "apple\napricot"
 
+    def test_section_range_zero_lower_bound_clamps_to_one(self):
+        """Issue #302 F2: section="0-N" used to fall through to keyword
+        search (matching nothing → empty result) on huge files. Now it
+        clamps to 1 and reads from the start as the caller obviously
+        intended."""
+        pad = Scratchpad()
+        body = "\n".join(f"line-{i}" for i in range(1, 21))  # 20 lines
+        pad.write("log", body)
+        result = pad.read("log", section="0-5")
+        assert result.splitlines() == [f"line-{i}" for i in range(1, 6)]
+
+    def test_section_range_past_end_returns_remaining(self):
+        """Asking for lines past EOF returns what exists — Python slice
+        semantics. No empty-result surprise on big files."""
+        pad = Scratchpad()
+        body = "\n".join(f"line-{i}" for i in range(1, 11))  # 10 lines
+        pad.write("log", body)
+        result = pad.read("log", section="8-9999")
+        assert result.splitlines() == [f"line-{i}" for i in range(8, 11)]
+
+    def test_section_range_inverted_returns_empty_not_keyword(self):
+        """Inverted range like '5-2' is a typo, not a keyword. Don't
+        silently search for the literal '5-2'."""
+        pad = Scratchpad()
+        pad.write("log", "alpha\n5-2 is here\nbeta")
+        # Bug-era behavior would have matched the line containing "5-2".
+        assert pad.read("log", section="5-2") == ""
+
     def test_max_bytes_truncates_with_notice(self):
         pad = Scratchpad()
         pad.write("big", "x" * 1000)

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -819,6 +819,61 @@ class TestSemanticFailureSurfacing:
         assert result.metadata.get("verifier_signal") == "mismatch"
 
     @pytest.mark.asyncio
+    async def test_verifier_failure_preserves_original_output_in_error(self):
+        """Issue #298: when a verifier flags semantic_failure on a tool with
+        no rollback (e.g. run_bash detecting a Python traceback in stdout),
+        the captured output must remain visible to the agent — not just the
+        reason string. Session rendering only shows `error` on failure, so
+        the original output is appended there."""
+
+        captured_output = (
+            "shop ready\n"
+            "Traceback (most recent call last):\n"
+            '  File "pet.py", line 42, in run\n'
+            "    raise ValueError('out of stock')\n"
+            "ValueError: out of stock\n"
+            "(handled at top level)\n"
+        )
+
+        async def handler(call):
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=True, output=captured_output,
+            )
+
+        async def validator(call, result):
+            return VerifierResult(
+                passed=False,
+                reason="Command exit=0 but Python traceback detected",
+                signal="python_traceback",
+            )
+
+        tool = ToolDefinition(
+            name="ran", description="",
+            input_schema={}, executor=handler,
+            trust_level=TrustLevel.SAFE,
+            post_validator=validator,
+        )
+        reg = _make_registry(tool)
+        pipeline = _build_pipeline(reg)
+        call = _make_call("ran")
+
+        result = await pipeline.execute(call, handler)
+        assert result.success is False
+        assert result.failure_type == "semantic_failure"
+        # Reason still surfaces.
+        assert "Python traceback detected" in (result.error or "")
+        # And — the bug fix — original output is recoverable from `error`.
+        assert "ValueError: out of stock" in (result.error or "")
+        assert "out of stock" in (result.error or "")
+        # Structured copy still in metadata for telemetry / programmatic use.
+        assert result.metadata.get("verifier_signal") == "python_traceback"
+        assert result.metadata.get("verifier_reason") == (
+            "Command exit=0 but Python traceback detected"
+        )
+        assert result.metadata.get("original_output") == captured_output
+
+    @pytest.mark.asyncio
     async def test_legacy_bool_true_still_works(self):
         """Backward compat: returning True is coerced to VerifierResult(passed=True)."""
 


### PR DESCRIPTION
## Summary

三個來自日常開發/審查的 friction，整合修補：

### #298 — verifier 命中時保留原始 output
`run_bash` 等 tool 的 `post_validator` 命中（如 Python traceback、pytest fail）時，先前 no-rollback 路徑只把 reason 塞進 `error`，原始 output 被 metadata 收掉、agent 看不到。修法是把 `result.output` 拼進 `error`（`<reason>\n\n--- captured output ---\n<output>`），同時保留 `metadata.verifier_reason` / `original_output` 結構化副本給 telemetry 用。

> 行為改變：semantic_failure 的 `error` 變多行了。下游若有對 `error` 做 single-line 假設要留意 — repo 內無此假設。

### #302 F1 — per-tool spill threshold
`ToolDefinition` 新增 `spill_threshold_chars: int | None`：
- `None`（default）→ 沿用全域 `JITRetrievalMiddleware.threshold_chars`（8000）
- `0` → 永不 spill（語意同 `inline_only=True`）
- 正整數 → 該 tool 專屬閾值

`read_file` 設 **24000 chars**（≈ 6K tokens）。先前 17K 的 Python 檔會被掃進 scratchpad、多跑一輪 `scratchpad_read` 才能讀；24K 涵蓋絕大多數 source file，超出仍照常 spill。

### #302 F2 — section "0-N" 不再回空
`_apply_section`：兩端能 parse 成 int 就視為 line range（不再 fallback 成 keyword 搜尋）。`i<1` clamp 為 1，inverted range（如 `5-2`）回空字串而非當成關鍵字。先前 `section="0-500"` 在超大檔案上看起來像「section filter 壞了」。

## Test plan

- [x] `pytest tests/test_lifecycle.py tests/test_jit_retrieval.py tests/test_jobs.py tests/test_tool_verifiers.py tests/test_jobs_tools.py` — 142 passed
- [x] 新增測試覆蓋三個 case：
  - `test_verifier_failure_preserves_original_output_in_error`（#298）
  - `TestJITPerToolSpillThreshold` 4 cases（F1）
  - `test_section_range_zero_lower_bound_clamps_to_one` / `_past_end_returns_remaining` / `_inverted_returns_empty_not_keyword`（F2）
- [ ] 手動驗證：`python3 some_script_with_handled_traceback.py` 跑出 exit 0 + traceback 時 agent 看得到實際錯誤內容
- [ ] 手動驗證：`read_file` 對 ~500 行 Python 檔不再 spill

## Issues
Closes #298, closes #302（F1+F2；F3 ref 命名 hint 暫緩，後續觀察 friction 再決定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)