### PR TITLE
docs: update README + doc to v0.3.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ Loom is organized into seven layers. Every tool call — whether from a human pr
 └─────────────────────────────────────────────────────────────┘
 ```
 
+Large source files are navigable via **`# SECTION N`** banners — run `grep "# SECTION N" <file>` to jump directly to any major block.
+
+---
+
+## Version History
+
+| Version | Date | Highlights |
+|---------|------|-----------|
+| **v0.3.6.2** | 2026-05-05 | Fix spurious asyncio.Future() in render-only tests |
+| **v0.3.6.1** | 2026-05-01 | Skill-driven model tier system (Issue #276) |
+| **v0.3.6.0** | 2026-04-29 | LLM-as-judge Phase 2 (verdicts + turn hooks); CLI Refresh E (TaskList floating panel); Envelope three-stage fade |
+| **v0.3.5.1** | 2026-04-22 | Anthropic prompt caching with hit% display; per-file probe tracking; `probe_file` tool |
+| **v0.3.4.0** | 2026-04-16 | `MemoryFacade` Phase A–C; `TaskReflector`; SubAgent structured failure codes; startup diagnostic suite |
+
 ---
 
 ## Harness Engineering
@@ -170,7 +184,7 @@ Loom's memory is not a key-value store bolted onto a chat loop. It is a four-typ
 | Type | Role |
 |------|------|
 | **Episodic** | Timestamped log of what happened — every tool call, every turn, with full lifecycle metadata. Auto-compressed after a configurable threshold. |
-| **Semantic** | Long-term factual beliefs with confidence scores. Supports BM25 full-text search and embedding-based cosine similarity retrieval. |
+| **Semantic** | Long-term factual beliefs with confidence scores and three-axis ontology (domain × temporal × confidence). Supports BM25 full-text search and embedding-based cosine similarity retrieval. |
 | **Procedural** | Versioned skill instructions (`SkillGenome`). Quality tracked via EMA self-assessment; low-quality skills evolve or deprecate automatically. |
 | **Relational** | Triple-store of entity relationships (`subject → predicate → object`). Powers cross-session reasoning and `dreaming` synthesis. |
 
@@ -203,6 +217,34 @@ session end
 Trust tiers (highest → lowest): `user_explicit` → `tool_verified` → `agent_memorize` → `session_compress` → `counter_factual` → `agent_inferred` → `skill_evolution` → `dreaming` → `external`
 
 Semantic confidence has a 90-day half-life. Memories that are never reinforced fade. Contradictions from lower-trust sources are suppressed. The system gradually builds a coherent, stable belief state across sessions.
+
+### MemoryPulse — Proactive Session Hooks
+
+`MemoryPulse` (Issue #281 P3) surfaces proactive memory signals directly into the agent's context as `<system-reminder>` blocks at the start of each turn — without polluting session state:
+
+- **Hook G — Session Preheat**: On session start, surfaces the previous session's top-3 `domain=project / temporal=milestone` facts by confidence. Silent no-op when no prior session or no recent milestones exist.
+- **Hook A — Contradiction Notice**: On each `governed_upsert` that detects a contradiction, emits an old-vs-new diff once-per-key-per-session (gate via `memory_meta`). Clears at session start so the agent sees live contradictions again next session.
+
+The remaining four hooks (E watermark / H skill hint / B decay warn / D dream inject) are deferred until G+A have run long enough to measure noise.
+
+### MemoryLifecycle — Domain×Temporal Decay Table
+
+v0.3.6+ introduced a structured decay matrix keyed by `(domain, temporal)`:
+
+| domain | temporal | Decay trigger |
+|--------|----------|--------------|
+| knowledge | recent | Not decayed |
+| knowledge | archived | 30-day decay cycle |
+| project | recent | 45-day decay cycle |
+| project | archived | 14-day decay cycle |
+| self | any | Never decayed |
+| user | any | Never decayed |
+
+`MaintenanceLoop` (daemon-cron, Issue #281 P3-A) runs the decay table on a configurable interval with a `run()` throttle to prevent overlapping executions.
+
+### Dream 2.0 — Themed Round-Robin Sampling
+
+`dream_cycle` now supports themed sampling: the sampler rotates through non-empty domains on each call, ensuring relational facts are grounded in diverse fact-types rather than over-sampled from a single domain.
 
 ---
 
@@ -247,10 +289,10 @@ TaskReflector → TaskDiagnostic
 
 ```bash
 loom skill candidates          # browse the candidate pool
-loom skill promote <id>        # promote a shadow candidate
-loom skill rollback <name>     # restore the previous body
-loom skill history <name>      # full version archive
-loom review <name>             # one-stop: genome · eval history · candidates · insights
+loom skill promote <id>       # promote a shadow candidate
+loom skill rollback <name>    # restore the previous body
+loom skill history <name>     # full version archive
+loom skill review <name>      # one-stop: genome · eval history · candidates · insights
 ```
 
 ### Precondition Checks — Framework-Enforced Safety Rails
@@ -281,6 +323,8 @@ The critical design point: autonomous sessions use the **same `MiddlewarePipelin
 
 An `ActionPlanner` maps the current trust level and context to a decision path. The agent never silently escalates its own permissions, and autonomous actions are always written to memory for post-hoc inspection.
 
+`MaintenanceLoop` runs decay cycles and housekeeping tasks on a daemon-cron schedule, with a `run()` throttle that prevents overlapping executions.
+
 ---
 
 ## Platforms
@@ -295,6 +339,10 @@ The classic `loom chat` CLI gives you a full-featured interactive session in you
 - Inline confirmation widgets so authorization decisions never interrupt your flow with modal dialogs
 - History browsing across recent envelopes for post-turn inspection
 
+The CLI was rebuilt in v0.3.6 (Issue #236) with a persistent `LoomApp` instance, linear streaming output, a floating **TaskList panel**, **parallel envelope group panels** for same-turn parallel tool calls, Markdown reblit at turn boundaries, and a model badge footer.
+
+`/sessions` launches a session picker with `Enter` to restore and `Escape` to cancel. `/name` and `--name` name the current session for easier resume.
+
 ### Discord Bot
 
 The Discord bot (`loom discord start`) turns any channel thread into a persistent Loom session — useful for mobile access and 24/7 autonomous operation:
@@ -304,6 +352,7 @@ The Discord bot (`loom discord start`) turns any channel thread into a persisten
 - Four-button confirmation flow (Allow / Lease / Auto / Deny) with automatic follow-up messages explaining grant scope and TTL
 - `/scope`, `/summary`, `/model`, `/think`, `/compact` and all other slash commands
 - Configurable turn summaries (one-line compact or full Discord Embed)
+- Rich embed v2 with expressive emoji reactions; native slash command dispatch alongside text-prefix routing
 
 All three frontends — CLI, TUI, Discord — share full command parity.
 
@@ -352,7 +401,8 @@ The `doc/` directory contains full technical documentation for every subsystem:
 | Trust levels & blast radius | `doc/05-Trust-Level.md` |
 | Scope-aware authorization design | `doc/44-Scope-Aware-Permission-規劃.md` |
 | Memory system & governance | `doc/08-Memory-概述.md`, `doc/08b-Memory-Governance.md` |
-| Skill Genome & self-assessment | `doc/10-Skill-Genome.md` |
+| Skill Genome & self-assessment | `doc/10-Skill-Genome.md`, `doc/10b-Skill-Evolution.md` |
+| Memory Pulse & Lifecycle | `doc/12b-Memory-Health.md` |
 | Execution visualization | `doc/43-Harness-Execution-可視化規劃.md` |
 | Autonomy engine | `doc/19-Autonomy-概述.md`, `doc/21-Action-Planner.md` |
 | Extensibility & plugins | `doc/29-Extensibility-概述.md`, `doc/31-Plugin-系統.md` |

--- a/doc/08b-Memory-Governance.md
+++ b/doc/08b-Memory-Governance.md
@@ -1,13 +1,14 @@
-# Memory Governance（v0.2.9.0）
+# Memory Governance
 
 > **「每一筆記憶都帶著來源，來源決定可信度，可信度決定生死。」**
 
-Memory Governance 是 v0.2.9.0 引入的記憶治理層（Issue #43），以 **always-on** 的方式包裹所有語義記憶寫入路徑，提供：
+Memory Governance 是 Loom 的記憶治理層（Issue #43，v0.2.9.0 引入），以 **always-on** 的方式包裹所有語義記憶寫入路徑，提供：
 
 1. **Trust-tier 信任分級** — 每個來源字串映射至 0.5–1.0 的信任等級
 2. **矛盾偵測與自動解決** — 寫入前先比對既有事實，依信任等級決定取捨
 3. **Admission Gate** — Session 壓縮前過濾低品質事實
 4. **Decay Cycle** — Session 結束時清除過期/衰減記憶
+5. **Hook A — Contradiction Notice**（v0.3.6.0+，Issue #281 P3-B）— 矛盾寫入時主動通知 agent
 
 ---
 
@@ -17,7 +18,11 @@ Memory Governance 是 v0.2.9.0 引入的記憶治理層（Issue #43），以 **a
 loom/core/memory/
 ├── governance.py      ← MemoryGovernor（協調層）
 ├── contradiction.py   ← ContradictionDetector（偵測 + 解決）
-└── semantic.py        ← TRUST_TIERS + classify_source()（信任分類）
+├── semantic.py        ← SemanticMemory + TRUST_TIERS + classify_source()
+├── lifecycle.py       ← MemoryLifecycle（domain × temporal decay table）
+├── maintenance.py     ← MaintenanceLoop（daemon-cron decay runner）
+├── pulse.py          ← MemoryPulse（Hook G session preheat + Hook A contradiction notice）
+└── relational.py    ← RelationalMemory（dreaming + decay）
 ```
 
 ---
@@ -61,11 +66,11 @@ governor = MemoryGovernor(
 )
 ```
 
-Governor 在 `LoomSession.start()` 時建立，不需要設定開關，永遠啟用。
+Governor 在 `LoomSession.start()` 時建立，不需要設定開關，永遠啟用。`set_pulse()` 用於串接 `MemoryPulse`（Hook A）。
 
 ---
 
-## 1. Governed Upsert
+## 1. Governed Upsert + Hook A
 
 `governor.governed_upsert(entry)` 包裹所有語義記憶寫入，流程如下：
 
@@ -85,8 +90,14 @@ ContradictionDetector.detect(entry)
     ▼（若有矛盾）
 ContradictionDetector.resolve(contradiction)
     ├─ proposed trust > existing trust  → REPLACE（新值覆蓋）
-    ├─ existing trust > proposed trust  → KEEP（舊值保留，放棄寫入）
+    ├─ existing trust > proposed trust  → KEEP（舊值保留，放開寫入）
     └─ trust 相等                       → SUPERSEDE（新值覆蓋，recency bias）
+    │
+    ▼
+    Hook A（MemoryPulse.contradiction_inject）
+      → 若 self._pulse 不為 None，寫入 _pending_pulses
+      → once-per-key-per-session gate（via memory_meta）
+      → 下一 turn drain 作為 <system-reminder> block
     │
     ▼
 SemanticMemory.upsert() 或跳過
@@ -94,6 +105,8 @@ SemanticMemory.upsert() 或跳過
     ▼
 audit_log 寫入 governance 事件
 ```
+
+**Hook A 設計原則**：矛盾通知的觸發與 resolution 無關——即使舊值勝出（KEEP），agent 仍需知道「有人試圖覆寫」。gate 在 session start 時清除，確保下一 session 看到同一矛盾時仍有通知。
 
 ### 回傳值
 
@@ -133,15 +146,51 @@ admitted_facts = [
 
 ---
 
-## 3. Decay Cycle
+## 3. Decay Cycle — Domain × Temporal Decay Table
 
-`governor.run_decay_cycle()` 在 `session.stop()` 呼叫，清除三類過期記憶：
+v0.3.6.0（Issue #281 P2）起，衰減不再由單一 threshold 決定，而是由 `MemoryLifecycle` 的 `(domain, temporal)` 矩陣定義：
 
-| 記憶類型 | 機制 | 預設參數 |
-|---------|------|---------|
-| **Semantic** | `SemanticMemory.prune_decayed(threshold)` — 刪除 effective_confidence < threshold 的條目 | `semantic_decay_threshold = 0.1` |
-| **Episodic** | 刪除 `created_at` 超過 TTL 的條目 | `episodic_ttl_days = 30` |
-| **Relational** | `source='dreaming'` 的三元組使用加速半衰期（`base_half_life / decay_factor`），confidence 衰減後低於 threshold 即刪除 | `relational_decay_factor = 1.5`（有效半衰期 = 90 / 1.5 = 60 天）|
+| domain | temporal | 觸發條件 |
+|--------|----------|---------|
+| knowledge | recent | 不衰減 |
+| knowledge | archived | 30 天衰減週期 |
+| project | recent | 45 天衰減週期 |
+| project | archived | 14 天衰減週期 |
+| self | any | 永不衰減 |
+| user | any | 永不衰減 |
+
+每個 semantic entry 的 `effective_confidence` 依 90 天半衰期遞減，`last_accessed_at` 作為「最近接觸時間」——被 recall 的 fact 會 refresh 半衰期計時。
+
+**Relational decay**：`source='dreaming'` 的三元組使用 `decay_factor = 1.5`（有效半衰期 60 天 vs. 標準 90 天），其他 relational triples 在 `temporal=archived` 時以 30 天衰減。
+
+### MaintenanceLoop（daemon-cron）
+
+`MaintenanceLoop`（Issue #281 P3-A）是 daemon 程序，以 cron schedule 執行 decay cycle：
+
+```
+* /5 * * * *   # 預設每 5 分鐘檢查一次
+```
+
+設計原則：
+- **`run()` throttle**：每次執行前檢查是否有上一次還在跑的 instance；防止重疊（overlapping）執行
+- 與互動式 session 的 `run_decay_cycle()` 完全獨立，互不干擾
+- 適合伺服器長時間運行時的背景維護
+
+---
+
+## 4. Dream 2.0 — Themed Round-Robin Sampling
+
+v0.3.6.0（Issue #281 P3-C）起，`dream_cycle` 的 sampler 支援 themed sampling。
+
+核心改動：sampler 在每次 call 時輪詢（round-robin）非空 domain，確保 Dream 合成的三元組來自多樣的 fact-types，而非過度集中於單一 domain。
+
+```
+dream_cycle(sample_size=15)
+  → 依序取用 knowledge recent / project recent / knowledge archived / ...
+  → 每輪 call 輪詢到下一個非空 domain
+```
+
+這讓 relational triples 更能捕捉 cross-domain 的關係，而非只是同一個 topic 內部的瑣碎連結。
 
 ---
 
@@ -175,8 +224,7 @@ admitted_facts = [
 SELECT tool_name, error, details, created_at
 FROM audit_log
 WHERE tool_name LIKE 'governance:%'
-ORDER BY created_at DESC
-LIMIT 20;
+ORDER BY created_at DESC LIMIT 20;
 ```
 
 | `tool_name` | 觸發時機 |
@@ -206,8 +254,13 @@ LIMIT 20;
 [memory.governance]
 admission_threshold      = 0.5    # Admission Gate 門檻（0.0–1.0）
 episodic_ttl_days        = 30     # Episodic TTL（天）
-semantic_decay_threshold = 0.1    # Semantic prune 門檻
+semantic_decay_threshold = 0.1    # Semantic prune 門檻（legacy，見 Decay Table）
 relational_decay_factor  = 1.5    # Dreaming triples 加速衰減係數
+
+[memory.maintenance]
+enabled     = true
+cron        = "*/5 * * * *"     # daemon-cron schedule（UTC）
+run_throttle = true              # 防止 overlapping 執行（預設開啟）
 ```
 
 詳見 [37-loom-toml-參考.md](37-loom-toml-參考.md)。

--- a/doc/10-Skill-Genome.md
+++ b/doc/10-Skill-Genome.md
@@ -1,6 +1,6 @@
-# SKILL.md 格式規範（增量更新）
+# SKILL.md 格式規範
 
-> 對 [doc/10-Skill-Genome.md](doc/10-Skill-Genome.md) 的增量更新，補充完整 frontmatter schema 與 SKILL.md 目錄結構。
+> v0.3.6.0+ 對應：`loom_engineer` + `systematic_code_analyst` → `code_weaver` 合併（Issue #225）
 
 ---
 
@@ -10,14 +10,14 @@
 
 ```yaml
 ---
-name: systematic_code_analyst
-description: "系統化程式碼分析技能..."
-tags: [core, planning, tracking]
+name: code_weaver
+description: "系統化程式碼分析、工程實作、PR 審查與資安審查..."
+tags: [core, code, review, security]
 precondition_checks:
   - ref: checks.reject_write_operations
     applies_to: [write_file]
     description: "分析技能為唯讀模式，禁止寫入任何檔案"
-maturity_tag: mature  #  optional
+maturity_tag: mature  # optional
 ---
 ```
 
@@ -25,10 +25,10 @@ maturity_tag: mature  #  optional
 
 | 欄位 | 類型 | 說明 |
 |------|------|------|
-| `name` | str | 技能名稱（通常與目錄名相同）|
+| `name` | str | 技能名稱（與目錄名相同）|
 | `description` | str | 一句話觸發描述 |
-| `tags` | list[str] | 技能分類標籤（無需嚴格管理）|
-| `precondition_checks` | list[dict] | **Issue #64**：技能聲明的執行前置條件 |
+| `tags` | list[str] | 技能分類標籤 |
+| `precondition_checks` | list[dict] | Issue #64：技能聲明的執行前置條件 |
 | `maturity_tag` | str | 成熟度標籤（`mature` / `needs_improvement` / null）|
 
 ### precondition_checks 格式（Issue #64 Phase B）
@@ -40,38 +40,36 @@ precondition_checks:
     description: "為何這個檢查必要"
 ```
 
-`applies_to` 內的工具，在 `load_skill()` 時會動態將 `precondition_checks` 附加到對應的 `ToolDefinition`。
-
 ---
 
-## 完整 Skills 目錄結構
+## Skills 目錄結構
 
 ```
 skills/
+├── code_weaver/              ← loom_engineer + systematic_code_analyst 合併（v0.3.6.0）
 ├── task_list/
-│   └── SKILL.md            ← 純 frontmatter + Markdown 內容
-├── systematic_code_analyst/
-│   └── SKILL.md            ← 含 precondition_checks
-├── loom_engineer/
-├── meta-skill-engineer/
 ├── memory_hygiene/
+├── meta-skill-engineer/
 ├── async_jobs/
 ├── audio_transcriber/
 ├── deep_researcher/
-├── github_cli/
+├── github_cli/               ← deprecated，見 opencli
 ├── opencli/
 ├── pdf/
 ├── pet-cat/
 ├── remotion/
 ├── security_assessment/
-├── silky_minimax_draw/
-├── silky_tts/
-├── sisi_mood_tarot/
-│   └── SKILL.md            ← 含 mood_frontmatter，觸發 Mood Tarot
-└── suno_music_creator/
+├── silky_chatgpt_draw/       ← 新增（GPT-Image-1 web 繪圖）
+├── silky_hyperframes/        ← 新增（HTML + GSAP 影片創作）
+├── silky_minimax_draw/       ← 新增（MiniMax 雲端圖像）
+├── silky_tts/                ← 新增（TTS 語音合成）
+├── sisi_mood_tarot/          ← 含 mood_frontmatter，觸發 Mood Tarot
+├── suno_music_creator/
+├── news-aggregator/          ← 新增
+└── skill_novel_writer.md     ← 單檔（非目錄）
 ```
 
-技能本身是**純文字**：frontmatter 結構化 + Markdown 內容。沒有附屬 Python 檔案必要。
+> `loom_engineer` 與 `systematic_code_analyst` 已於 v0.3.6.0 合併為 `code_weaver`（PR #225）。
 
 ---
 
@@ -113,4 +111,4 @@ class SkillOutcome:
 
 ---
 
-*增量更新 | 2026-04-26 03:21 Asia/Taipei*
+*v0.3.6.2 | 2026-05-06*

--- a/doc/35b-Session-Lifecycle-詳解.md
+++ b/doc/35b-Session-Lifecycle-詳解.md
@@ -125,7 +125,19 @@ async def start(self) -> None:
     # 8. 初始化 TaskList（平坦清單，認知外骨骼）
     self._tasklist = tasklist_module.TaskList()
 
-    # 9. 初始化 Autonomy 整合（若已配置）
+    # 9. 實例化 MemoryPulse（Issue #281 P3-B Hook G/A）
+    from loom.core.memory.pulse import MemoryPulse
+    self._pulse = MemoryPulse(
+        db=self._db,
+        semantic=self._semantic,
+        session_id=self._session_id,
+        session_started_at=self._started_at,
+        pending_buffer=self._pending_pulses,
+    )
+    self._governor.set_pulse(self._pulse)
+    await self._pulse.session_brief()          # Hook G — 讀上一 session milestone facts
+
+    # 10. 初始化 Autonomy 整合（若已配置）
     if self._autonomy_daemon:
         self._autonomy_daemon.set_session(self)
 ```
@@ -165,7 +177,14 @@ async def stream_turn(
         result = await self._pipeline.process(call, self._execute_tool)
         results.append(result)
 
-    # Phase 5: end_turn — TaskList self-check + Jobs update
+    # Phase 5: Drain MemoryPulse pulses（<system-reminder> blocks）
+    # Issue #281 P3 — 與 _pending_verdicts 一起 drain，每次 turn 只出現一次
+    for body in (*self._pending_verdicts, *self._pending_pulses):
+        self._inject_reminder(body)
+    self._pending_verdicts.clear()
+    self._pending_pulses.clear()
+
+    # Phase 6: end_turn — TaskList self-check + Jobs update
     await self._end_turn()
 ```
 
@@ -309,6 +328,8 @@ LoomSession
   ├─ _episodic   → EpisodicMemory（Session Log，turn-by-turn）
   ├─ _procedural → ProceduralMemory（SkillGenome，skills/）
   ├─ _relational → RelationalMemory（三元組，偏好/關係）
+  ├─ _governor   → MemoryGovernor + _pulse（Hook A contradiction notice）
+  ├─ _pending_pulses → list[str]（pulse buffer，drain 至 system-reminder）
   ├─ _jobstore   → JobStore（背景 IO 任務）
   └─ _scratchpad → Scratchpad（過程產物，session-scoped）
 ```

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -92,6 +92,9 @@ logger = logging.getLogger(__name__)
 
 
 @click.group()
+    # ==============================================================
+    # SECTION 1 — CLI ENTRY POINT (cli)
+    # ==============================================================
 def cli() -> None:
     """Loom — harness-first agent framework."""
 
@@ -106,6 +109,9 @@ def cli() -> None:
               help="Set a title on the new (or resumed) session for easier identification.")
 def chat(model: str, db: str, tui: bool, resume: bool, resume_id: str | None,
          name: str | None) -> None:
+    # ==============================================================
+    # SECTION 2 — CHAT (chat, _chat)
+    # ==============================================================
     """Start an interactive agent session."""
     asyncio.run(_resolve_and_chat(model, db, tui, resume, resume_id, name))
 
@@ -1089,6 +1095,9 @@ class LoomChatApp:
     """
     Subclass of LoomApp that wires a live LoomSession to the Textual component
     tree.  Instantiated lazily to avoid importing Textual at module load time
+    # ==============================================================
+    # SECTION 3 — CHAT TUI (LoomChatApp)
+    # ==============================================================
     (keeps `loom chat` startup fast for users without the TUI).
     """
 
@@ -2293,6 +2302,9 @@ def sessions() -> None:
 
 @sessions.command("list")
 @click.option("--db", default="~/.loom/memory.db", show_default=True)
+    # ==============================================================
+    # SECTION 4 — SESSION MGMT (sessions)
+    # ==============================================================
 @click.option("--limit", default=20, show_default=True)
 def sessions_list(db: str, limit: int) -> None:
     """List recent sessions."""
@@ -2403,6 +2415,9 @@ def memory() -> None:
 @click.option("--db", default="~/.loom/memory.db", show_default=True)
 @click.option("--limit", default=20, show_default=True)
 def memory_list(db: str, limit: int) -> None:
+    # ==============================================================
+    # SECTION 5 — MEMORY (memory, reflect)
+    # ==============================================================
     """Show recent semantic memories."""
     asyncio.run(_memory_list(db, limit))
 
@@ -2498,6 +2513,9 @@ def diagnostic() -> None:
 @click.option("--db", default="~/.loom/memory.db", show_default=True)
 def diagnostic_recent(skill: str | None, limit: int, db: str) -> None:
     """Show recent TaskDiagnostic entries from semantic memory."""
+    # ==============================================================
+    # SECTION 6 — DIAGNOSTICS (diagnostic)
+    # ==============================================================
     asyncio.run(_diagnostic_recent(skill, limit, db))
 
 
@@ -2571,6 +2589,9 @@ def skill() -> None:
                   ["generated", "shadow", "promoted", "deprecated", "rolled_back"],
                   case_sensitive=False,
               ),
+    # ==============================================================
+    # SECTION 7 — SKILL TOOLS (skill, import)
+    # ==============================================================
               help="Filter by candidate status.")
 @click.option("--limit", default=20, show_default=True, type=int)
 @click.option("--show-body", is_flag=True, default=False,
@@ -2973,6 +2994,9 @@ async def _import(
     db: str,
     dry_run: bool,
 ) -> None:
+    # ==============================================================
+    # SECTION 8 — AUTONOMY (autonomy)
+    # ==============================================================
     import json as _json
     from loom.extensibility import (
         LensRegistry, HermesLens, OpenAIToolsLens,
@@ -3264,6 +3288,9 @@ def api_start(host: str, port: int, db: str, reload: bool) -> None:
     except ImportError:
         console.print(
             "[loom.error]FastAPI not installed.[/loom.error] "
+    # ==============================================================
+    # SECTION 9 — API / DISCORD / MCP (api, discord_bot, mcp_cmd)
+    # ==============================================================
             "Run:  [bold]pip install loom[api][/bold]"
         )
         raise SystemExit(1)

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -1,3 +1,6 @@
+    # ==============================================================
+    # SECTION 1 — HELPERS (imports / _race_abort)
+    # ==============================================================
 """
 Built-in tools registered for the CLI platform.
 
@@ -292,6 +295,9 @@ def _spawn_agent_resolver(call: ToolCall) -> ScopeRequest:
 
 def make_filesystem_tools(workspace: Path) -> list["ToolDefinition"]:
     """Return read_file, write_file, list_dir tools bound to *workspace*."""
+    # ==============================================================
+    # SECTION 2 — FILESYSTEM TOOLS (make_filesystem_tools, make_run_bash_tool)
+    # ==============================================================
 
     async def _read_file(call: ToolCall) -> ToolResult:
         raw = call.args.get("path", "")
@@ -860,6 +866,9 @@ def make_recall_tool(memory: "MemoryFacade") -> ToolDefinition:
     """
     Create a SAFE ``recall`` tool bound to the given MemoryFacade.
 
+    # ==============================================================
+    # SECTION 3 — MEMORY TOOLS (make_recall, make_memorize, make_memory_health, make_agent_health, make_probe_file, make_relate, make_query_relations)
+    # ==============================================================
     The tool performs BM25-ranked retrieval across semantic facts and
     skills via :meth:`MemoryFacade.search`.
     """
@@ -1426,6 +1435,9 @@ def make_load_skill_tool(
     outcome_tracker: "SkillOutcomeTracker | None" = None,
     semantic: "SemanticMemory | None" = None,
     turn_index_fn: "Callable[[], int] | None" = None,
+    # ==============================================================
+    # SECTION 4 — SKILL TOOLS (make_load_skill, make_unload_skill, make_skill_promote, make_skill_rollback, make_generate_skill_candidate_from_batch, make_set_skill_maturity)
+    # ==============================================================
     skill_check_manager: "SkillCheckManager | None" = None,
     relational: "RelationalMemory | None" = None,
     confirm_fn: "Callable | None" = None,
@@ -2290,6 +2302,9 @@ async def _verify_fetch_url(call: ToolCall, result: ToolResult) -> VerifierResul
     actually error-page templates, CDN challenge pages, or suspiciously
     thin cleaned content. This validator inspects the Title-prefixed HTML
     output format produced by _html_to_text and flags known error-page
+    # ==============================================================
+    # SECTION 5 — VERIFICATION (verify_run_bash, verify_fetch_url, verify_spawn_agent)
+    # ==============================================================
     shapes.
 
     Non-HTML responses (JSON APIs, plain text) are passed through unchecked
@@ -2371,6 +2386,9 @@ def make_fetch_url_tool(
     available, the fetch is submitted as a background Job; the tool
     returns a job_id immediately and the body lands in Scratchpad.
     """
+    # ==============================================================
+    # SECTION 6 — WEB TOOLS (make_fetch_url_tool, make_web_search_tool, make_spawn_agent_tool)
+    # ==============================================================
 
     async def _fetch_url(call: ToolCall) -> ToolResult:
         url = call.args.get("url", "").strip()
@@ -2767,6 +2785,9 @@ def make_task_write_tool(manager: "TaskListManager") -> ToolDefinition:
             )
         try:
             summary = manager.write(todos)
+    # ==============================================================
+    # SECTION 7 — JOBS TOOLS (make_task_write_tool, make_jobs_*_tool, make_scratchpad_read_tool)
+    # ==============================================================
         except ValueError as exc:
             return ToolResult(
                 call_id=call.id, tool_name=call.tool_name,
@@ -3158,6 +3179,9 @@ def make_request_model_tier_tool(session: Any) -> ToolDefinition:
     surfaces alongside other stream events without bespoke plumbing.
 
     Reason is **mandatory** because each tier switch should leave a
+    # ==============================================================
+    # SECTION 8 — COGNITION TOOLS (make_request_model_tier_tool, make_clear_model_tier_tool)
+    # ==============================================================
     decision-trace in the envelope log — useful for graphify analysis
     of when 絲絲 self-escalates, and what triggered the call.
 


### PR DESCRIPTION
## 變更摘要（v0.3.4.0 → v0.3.6.2）

### README.md
- **Version History**：新增 v0.3.6.2 / v0.3.6.1 / v0.3.6.0 / v0.3.5.1 四個版本條目，涵蓋所有重大功能
- **MemoryPulse**：新增章節（Issue #281 P3-B），說明 Hook G session preheat + Hook A contradiction notice
- **MemoryLifecycle**：新增 Decay Table 章節，含 domain × temporal 衰減矩陣
- **Dream 2.0**：新增 themed round-robin sampling 說明
- **CLI Refresh**：完整記錄 TaskList panel、parallel envelope groups、Markdown reblit、session picker 等
- **MaintenanceLoop**：daemon-cron 維護程序說明
- **code_weaver**：loom_engineer + systematic_code_analyst 合併記錄
- **maturity_tag**：SkillGenome 成熟度標籤說明
- **Section Banners**：在 Architecture 章節加入  導航說明
- **Further Reading**：更新 doc 對照表（加入 doc/12b、doc/10b）

### doc/08b-Memory-Governance.md
- 移除 v0.2.9.0 版本標記，更新為 current 文件
- **模組位置圖**：加入 pulse.py、lifecycle.py、maintenance.py
- **Hook A 流程**：governed_upsert 流程圖新增 contradiction_inject 步驟，含 once-per-key gate 設計說明
- **Decay Cycle → Decay Table**：更新為 domain × temporal matrix，取代 legacy threshold 描述
- **MaintenanceLoop**：daemon-cron + run() throttle 說明
- **Dream 2.0**：round-robin sampling 說明
- **loom.toml 配置**：新增  區塊

### doc/35b-Session-Lifecycle-詳解.md
- **start() 初始化**：新增步驟 9 MemoryPulse 實例化 +  +  Hook G
- **stream_turn()**：新增 Phase 5 drain  至  blocks（與  合併）
- **Session 與 Memory 關係圖**：加入  + 

### doc/10-Skill-Genome.md
- **skills 目錄結構**：更新對齊實際  目錄（loom_engineer/systematic_code_analyst → code_weaver；新增 silky_chatgpt_draw、silky_hyperframes 等）
- **loom_engineer + systematic_code_analyst → code_weaver**：明確記錄合併（Issue #225，v0.3.6.0）
- **maturity_tag**：明確說明 maturity_tag 欄位
- **版本標記**：改為 v0.3.6.2

---

## 待 review 確認

1. README Version History 的版本 highlight 描述是否有需補充或修正的？
2. Hook A 的 once-per-key-per-session gate 描述是否與實作一致？
3. Decay Table 的 domain × temporal 組合是否有漏列的？