### PR TITLE
fix(#312): kill process group on cancel + real task cancel for CLI abort-on-submit

### DIFF
--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -454,9 +454,17 @@ async def _chat(
 
         # Abort-on-submit: if a turn is in flight, cancel and queue
         # the new message with the interrupt prefix.
+        #
+        # Issue #312: we used to call only `session.cancel()`, which
+        # sets a soft `_abort` flag checked at LLM-call boundaries —
+        # an in-flight `run_bash` (or any long await) would still run
+        # to completion. Mirror /stop and Escape (action_interrupt) by
+        # also cancelling the worker task, so awaits inside the turn
+        # receive CancelledError immediately.
         in_flight = current_turn_task is not None and not current_turn_task.done()
         if in_flight:
             session.cancel()
+            current_turn_task.cancel()
             harness.inline("⏸ 上一輪已中斷，接收新訊息…", level="info")
             try:
                 await asyncio.wait_for(current_turn_task, timeout=3.0)

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -46,8 +46,28 @@ def _killpg_quiet(pid: int, sig: int) -> None:
     PermissionError so cancellation/timeout cleanup never raises."""
     try:
         os.killpg(os.getpgid(pid), sig)
-    except (ProcessLookupError, PermissionError, OSError):
+    except (ProcessLookupError, PermissionError):
         pass
+
+
+async def _terminate_proc_group(proc: asyncio.subprocess.Process) -> None:
+    """Reap a subprocess that was launched with start_new_session=True.
+
+    SIGTERM the whole process group, give it 2s, then SIGKILL. Bounded
+    waits ensure cancellation/timeout cleanup never hangs even if a
+    pipe child is wedged on a write to a closed fd.
+    """
+    if proc.returncode is not None:
+        return
+    _killpg_quiet(proc.pid, signal.SIGTERM)
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=2)
+    except (asyncio.TimeoutError, BaseException):
+        _killpg_quiet(proc.pid, signal.SIGKILL)
+        try:
+            await proc.wait()
+        except BaseException:
+            pass
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -749,31 +769,16 @@ def make_run_bash_tool(
                 try:
                     stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
                 except asyncio.TimeoutError:
-                    _killpg_quiet(proc.pid, signal.SIGTERM)
-                    try:
-                        await asyncio.wait_for(proc.wait(), timeout=2)
-                    except asyncio.TimeoutError:
-                        _killpg_quiet(proc.pid, signal.SIGKILL)
-                        await proc.wait()
+                    await _terminate_proc_group(proc)
                     return ToolResult(call_id=call.id, tool_name=call.tool_name,
                                       success=False, error=f"Command timed out after {timeout}s",
                                       failure_type="timeout")
             finally:
                 # Issue #222 / #312: cancellation (Discord cancel-and-relaunch,
                 # _abort.abort(), CLI /stop) bypasses the TimeoutError branch
-                # — kill the whole process group so pipe children don't keep
-                # the pipe open and stall communicate(). returncode is None
-                # iff still running.
-                if proc.returncode is None:
-                    _killpg_quiet(proc.pid, signal.SIGTERM)
-                    try:
-                        await asyncio.wait_for(proc.wait(), timeout=2)
-                    except (asyncio.TimeoutError, BaseException):
-                        _killpg_quiet(proc.pid, signal.SIGKILL)
-                        try:
-                            await proc.wait()
-                        except BaseException:
-                            pass
+                # — reap the whole process group so pipe children don't keep
+                # the pipe open and stall communicate().
+                await _terminate_proc_group(proc)
 
             output = stdout.decode("utf-8", errors="replace")
             success = proc.returncode == 0
@@ -863,26 +868,12 @@ async def _run_bash_job(
             try:
                 stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
             except asyncio.TimeoutError:
-                _killpg_quiet(proc.pid, signal.SIGTERM)
-                try:
-                    await asyncio.wait_for(proc.wait(), timeout=2)
-                except asyncio.TimeoutError:
-                    _killpg_quiet(proc.pid, signal.SIGKILL)
-                    await proc.wait()
+                await _terminate_proc_group(proc)
                 return None, None, f"Command timed out after {timeout}s"
         finally:
-            # Issue #222 / #312: kill the whole process group on cancellation
+            # Issue #222 / #312: reap the whole process group on cancellation
             # so async jobs don't orphan pipe children.
-            if proc.returncode is None:
-                _killpg_quiet(proc.pid, signal.SIGTERM)
-                try:
-                    await asyncio.wait_for(proc.wait(), timeout=2)
-                except (asyncio.TimeoutError, BaseException):
-                    _killpg_quiet(proc.pid, signal.SIGKILL)
-                    try:
-                        await proc.wait()
-                    except BaseException:
-                        pass
+            await _terminate_proc_group(proc)
         output = stdout.decode("utf-8", errors="replace")
         ref = f"bash_{uuid.uuid4().hex[:8]}"
         scratchpad.write(ref, output)

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import re
+import signal
 import subprocess
 import uuid
 from pathlib import Path
@@ -37,6 +39,15 @@ import logging
 _log = logging.getLogger(__name__)
 _self_term_guard = SelfTerminationGuard()
 _cmd_scanner = CommandScanner()
+
+
+def _killpg_quiet(pid: int, sig: int) -> None:
+    """Best-effort process-group signal. Swallows ProcessLookupError and
+    PermissionError so cancellation/timeout cleanup never raises."""
+    try:
+        os.killpg(os.getpgid(pid), sig)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -722,32 +733,47 @@ def make_run_bash_tool(
             )
 
         try:
+            # Issue #312: start_new_session=True puts the shell in its own
+            # process group so killpg can reap pipe children (e.g.
+            # `git log | head`) — proc.kill() alone only signals the shell
+            # PID, leaving children holding stdout fds and communicate()
+            # blocked indefinitely past cancel/timeout.
             proc = await asyncio.create_subprocess_shell(
                 command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 cwd=cwd,
+                start_new_session=True,
             )
             try:
                 try:
                     stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
                 except asyncio.TimeoutError:
-                    proc.kill()
-                    await proc.wait()
+                    _killpg_quiet(proc.pid, signal.SIGTERM)
+                    try:
+                        await asyncio.wait_for(proc.wait(), timeout=2)
+                    except asyncio.TimeoutError:
+                        _killpg_quiet(proc.pid, signal.SIGKILL)
+                        await proc.wait()
                     return ToolResult(call_id=call.id, tool_name=call.tool_name,
                                       success=False, error=f"Command timed out after {timeout}s",
                                       failure_type="timeout")
             finally:
-                # Issue #222: cancellation (Discord cancel-and-relaunch,
-                # _abort.abort()) bypasses the TimeoutError branch — kill
-                # the subprocess so we don't orphan Playwright / shell
-                # children. returncode is None iff still running.
+                # Issue #222 / #312: cancellation (Discord cancel-and-relaunch,
+                # _abort.abort(), CLI /stop) bypasses the TimeoutError branch
+                # — kill the whole process group so pipe children don't keep
+                # the pipe open and stall communicate(). returncode is None
+                # iff still running.
                 if proc.returncode is None:
-                    proc.kill()
+                    _killpg_quiet(proc.pid, signal.SIGTERM)
                     try:
-                        await proc.wait()
-                    except BaseException:
-                        pass
+                        await asyncio.wait_for(proc.wait(), timeout=2)
+                    except (asyncio.TimeoutError, BaseException):
+                        _killpg_quiet(proc.pid, signal.SIGKILL)
+                        try:
+                            await proc.wait()
+                        except BaseException:
+                            pass
 
             output = stdout.decode("utf-8", errors="replace")
             success = proc.returncode == 0
@@ -831,22 +857,32 @@ async def _run_bash_job(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
             cwd=cwd,
+            start_new_session=True,  # Issue #312: see _run_bash for rationale
         )
         try:
             try:
                 stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
             except asyncio.TimeoutError:
-                proc.kill()
-                await proc.wait()
+                _killpg_quiet(proc.pid, signal.SIGTERM)
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=2)
+                except asyncio.TimeoutError:
+                    _killpg_quiet(proc.pid, signal.SIGKILL)
+                    await proc.wait()
                 return None, None, f"Command timed out after {timeout}s"
         finally:
-            # Issue #222: kill on cancellation so async jobs don't orphan.
+            # Issue #222 / #312: kill the whole process group on cancellation
+            # so async jobs don't orphan pipe children.
             if proc.returncode is None:
-                proc.kill()
+                _killpg_quiet(proc.pid, signal.SIGTERM)
                 try:
-                    await proc.wait()
-                except BaseException:
-                    pass
+                    await asyncio.wait_for(proc.wait(), timeout=2)
+                except (asyncio.TimeoutError, BaseException):
+                    _killpg_quiet(proc.pid, signal.SIGKILL)
+                    try:
+                        await proc.wait()
+                    except BaseException:
+                        pass
         output = stdout.decode("utf-8", errors="replace")
         ref = f"bash_{uuid.uuid4().hex[:8]}"
         scratchpad.write(ref, output)

--- a/tests/test_jobs_tools.py
+++ b/tests/test_jobs_tools.py
@@ -454,3 +454,55 @@ class TestJobsInjectMessage:
         assert "kaboom" in msg
         assert "cancelled" in msg
         assert "unneeded" in msg
+
+
+# --- Issue #312: process-group kill on cancel/timeout ----------------
+
+
+class TestRunBashCancelKillsPipeChildren:
+    """Regression tests for #312.
+
+    `proc.kill()` only signals the shell PID; pipe children keep stdout
+    open and `communicate()` hangs past cancel/timeout. Using
+    `start_new_session=True` + `os.killpg` reaps the whole group.
+
+    The canonical repro is `sleep 30 | cat` — the shell exits quickly but
+    `cat` survives, holding stdout open until `sleep` finishes.
+    """
+
+    async def test_timeout_kills_pipe_child(self, tmp_path: Path):
+        import time
+        tool = make_run_bash_tool(tmp_path)
+        t0 = time.monotonic()
+        result = await tool.executor(_call("run_bash", {
+            "command": "sleep 30 | cat",
+            "justification": "test",
+            "timeout": 1,
+        }))
+        elapsed = time.monotonic() - t0
+        assert result.success is False
+        assert result.failure_type == "timeout"
+        # Pre-fix: the cat child kept stdout open and we hung ~30s. Now
+        # the whole group is reaped, so we return shortly after the
+        # 1s timeout (allow generous margin for CI noise).
+        assert elapsed < 5.0, f"timeout cleanup took {elapsed:.1f}s — pipe child not reaped"
+
+    async def test_cancel_kills_pipe_child(self, tmp_path: Path):
+        import time
+        tool = make_run_bash_tool(tmp_path)
+        task = asyncio.create_task(tool.executor(_call("run_bash", {
+            "command": "sleep 30 | cat",
+            "justification": "test",
+            "timeout": 60,
+        })))
+        # Let the subprocess actually start.
+        await asyncio.sleep(0.3)
+        t0 = time.monotonic()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        elapsed = time.monotonic() - t0
+        # Pre-fix: cancel propagated but `cat` kept stdout open and the
+        # finally-block proc.wait() hung. Now killpg + bounded wait
+        # ensures fast cleanup.
+        assert elapsed < 5.0, f"cancel cleanup took {elapsed:.1f}s — pipe child not reaped"


### PR DESCRIPTION
Closes #312

## 根因（與 issue 描述不同）

Issue 原描述把 root cause 指向「`subprocess.Popen.wait()` 是 C-level blocking」，但實際上 `run_bash` 用的是 `asyncio.create_subprocess_shell` + `await proc.communicate()`，**是可以被 cancel 的**。真正卡住的點有兩個，分別影響不同平台：

### Bug 1 — `proc.kill()` 只殺 shell PID，不殺 pipe children

`sleep 30 | cat` 這類 pipeline，`kill()` 信號只送給 shell，但 shell 死了之後 `cat` 還在跑、還握著 stdout pipe 的寫端 — `proc.communicate()` 等不到 EOF，整個 cleanup 路徑（timeout、Discord cancel、`/stop`）全部卡住直到 `sleep` 自然結束。

這就是為什麼使用者觀察到「特定進程下 `/stop` 也殺不掉」。

**修法**：`start_new_session=True` 把 shell 放進獨立 process group，cleanup 改用 `os.killpg(SIGTERM)`，2 秒 grace 後升 `SIGKILL`。同套修補在 `_run_bash`（sync 路徑）與 `_run_bash_job`（async_mode 路徑）。

### Bug 2 — CLI abort-on-submit 是 soft cancel，對 in-flight tool 無效

Issue 原本聲稱「CLI / TUI 不受影響」，實際上 CLI 的 abort-on-submit（`main.py:_on_submit`，使用者打字打斷上一輪）只呼叫 `session.cancel()` — 這只是設定 `_abort` flag，僅在 LLM call 邊界檢查，**對正在 await 的 `run_bash` 完全沒有作用**。`/stop` 和 Escape 走的是 `workers.cancel_all()`（真 task cancel），所以那兩條路徑相對 OK。

**修法**：在 `session.cancel()` 之外多呼叫 `current_turn_task.cancel()`，跟 `/stop` / Escape 對齊。

## 測試

新增 `tests/test_jobs_tools.py::TestRunBashCancelKillsPipeChildren`：

- `test_timeout_kills_pipe_child` — `sleep 30 | cat` + timeout=1s，要求 5 秒內收尾（修前約 30 秒）
- `test_cancel_kills_pipe_child` — 啟動後外部 `task.cancel()`，要求 5 秒內收尾

全套 1438 tests pass。

## Impact

- gitnexus_impact: `_run_bash` / `LoomSession.cancel` 都是 LOW risk，0 affected processes
- gitnexus_detect_changes: 14 changed symbols（含因行號漂移而被標記的區域變數），0 affected processes
- 行為變更僅在 cancel/timeout 的清理路徑：原本 hang 改為快速結束。正常路徑（成功完成的 bash）邏輯未變

## Test plan

- [x] 新增 2 個迴歸測試，pipe-child reap 在 cancel/timeout 下都 <5s
- [x] 全套 pytest pass（1438 passed, 1 skipped）
- [ ] 手動驗證：Discord 中執行 `sleep 30 | cat` 然後傳新訊息，舊 turn 應該秒停
- [ ] 手動驗證：CLI `loom chat` 中執行 long bash，打字打斷應該秒停

🤖 Generated with [Claude Code](https://claude.com/claude-code)