### PR TITLE
fix(#290): Discord footer reflects active tier model + tier badge

### DIFF
--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -57,7 +57,7 @@ import json
 import os
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 try:
     import discord
@@ -198,6 +198,32 @@ def _format_envelope_status(view: ExecutionEnvelopeView) -> str:
         lines.append(f"-# {prefix}{'  '.join(level_parts)}")
 
     return "\n".join(lines)
+
+
+def _resolve_active_model_and_tier(session: Any) -> tuple[str, str]:
+    """Return (active_model, tier_badge_suffix) for footer rendering.
+
+    Issue #290: Discord footer used to read ``session.model`` directly,
+    which returns the registered default and silently ignores sticky tier
+    overrides. This mirrors the CLI footer wiring (loom/platform/cli/main.py
+    + loom/platform/cli/app.py): when the tier system is configured, prefer
+    ``_active_model()`` and surface a tier badge only when the active tier
+    differs from the default (matches CLI #276 gating).
+
+    Returns ``("model", "")`` when the tier system isn't configured or the
+    session is on its default tier, so the call site can append the tier
+    suffix unconditionally.
+    """
+    if getattr(session, "_tier_models", None):
+        active_model = session._active_model()
+        active_tier = session._active_tier()
+        tier_badge = (
+            f"  ·  ⇪ Tier {active_tier}"
+            if active_tier != session._default_tier
+            else ""
+        )
+        return active_model, tier_badge
+    return session.model, ""
 
 
 class LoomDiscordBot:
@@ -1186,6 +1212,12 @@ class LoomDiscordBot:
         cache_hit_pct = (_cache_read_tokens / cache_total * 100) if cache_total > 0 else 0.0
         cache_tag = f"  ·  cache {cache_hit_pct:.0f}%" if cache_hit_pct > 0 else ""
 
+        # Issue #290: footer must reflect the *active* model + tier so
+        # users see what actually answered the turn. session.model returns
+        # the registered default and ignores sticky tier overrides — the
+        # helper mirrors CLI footer wiring (#276 gating).
+        active_model, tier_badge = _resolve_active_model_and_tier(session)
+
         # ── Turn summary (if enabled) ─────────────────────────────────────
         if self._summary_mode != "off" and _envelope_count > 0:
             # Grants info
@@ -1210,7 +1242,7 @@ class LoomDiscordBot:
                 if _had_rollback:
                     embed.add_field(name="Rollbacks", value="Yes", inline=True)
                 embed.add_field(name="Grants", value=grants_str, inline=True)
-                embed.set_footer(text=f"{session.current_personality or 'default'}  ·  context {session.budget.usage_fraction * 100:.1f}%  ·  {session.model}{cache_tag}")
+                embed.set_footer(text=f"{session.current_personality or 'default'}  ·  context {session.budget.usage_fraction * 100:.1f}%  ·  {active_model}{cache_tag}{tier_badge}")
                 await message.channel.send(embed=embed)
             else:
                 # Compact one-liner
@@ -1224,11 +1256,10 @@ class LoomDiscordBot:
         # ── Footer: persona / context / model ────────────────────────────
         persona = session.current_personality or "default"
         pct = session.budget.usage_fraction * 100
-        model = session.model
         # Skip footer if detail summary already includes it
         if not (self._summary_mode == "detail" and _envelope_count > 0):
-            await _safe_send(message.channel, 
-                f"-# {persona}  ·  context {pct:.1f}%{cache_tag}  ·  {model}"
+            await _safe_send(message.channel,
+                f"-# {persona}  ·  context {pct:.1f}%{cache_tag}  ·  {active_model}{tier_badge}"
             )
 
         # ── Mark done (#188 lifecycle reaction) ──────────────────────────

--- a/tests/test_discord_footer_active_tier.py
+++ b/tests/test_discord_footer_active_tier.py
@@ -1,0 +1,72 @@
+"""Issue #290 — Discord footer must reflect active tier model + tier badge,
+not the registered default. Mirrors CLI footer #276 gating: badge only
+when sticky tier ≠ default tier.
+"""
+
+from types import SimpleNamespace
+
+from loom.platform.discord.bot import _resolve_active_model_and_tier
+
+
+def _stub_session(
+    *,
+    model: str = "minimax-m2.7",
+    tier_models: dict[int, str] | None = None,
+    default_tier: int = 1,
+    sticky_tier: int | None = None,
+) -> SimpleNamespace:
+    """Minimal stub mirroring the LoomSession fields the helper reads."""
+    active_tier = sticky_tier if sticky_tier is not None else default_tier
+    return SimpleNamespace(
+        model=model,
+        _tier_models=tier_models or {},
+        _default_tier=default_tier,
+        _active_tier=lambda: active_tier,
+        _active_model=lambda: (tier_models or {}).get(active_tier, model),
+    )
+
+
+def test_no_tier_system_uses_session_model_no_badge():
+    s = _stub_session(model="minimax-m2.7")
+    model, badge = _resolve_active_model_and_tier(s)
+    assert model == "minimax-m2.7"
+    assert badge == ""
+
+
+def test_tier_system_on_default_tier_no_badge():
+    s = _stub_session(
+        model="minimax-m2.7",
+        tier_models={1: "minimax-m2.7", 2: "deepseek-v4-pro"},
+        default_tier=1,
+        sticky_tier=None,
+    )
+    model, badge = _resolve_active_model_and_tier(s)
+    assert model == "minimax-m2.7"
+    assert badge == ""
+
+
+def test_tier_system_sticky_override_shows_active_model_and_badge():
+    """The exact scenario from issue #290: session escalated to Tier 2,
+    Discord footer used to keep showing the Tier 1 default."""
+    s = _stub_session(
+        model="minimax-m2.7",
+        tier_models={1: "minimax-m2.7", 2: "deepseek-v4-pro"},
+        default_tier=1,
+        sticky_tier=2,
+    )
+    model, badge = _resolve_active_model_and_tier(s)
+    assert model == "deepseek-v4-pro"
+    assert "Tier 2" in badge
+    assert "⇪" in badge
+
+
+def test_badge_suffix_is_appendable_format():
+    """Badge starts with the `  ·  ` separator so the call site can
+    concatenate unconditionally without conditional spacing."""
+    s = _stub_session(
+        tier_models={1: "a", 2: "b"},
+        default_tier=1,
+        sticky_tier=2,
+    )
+    _, badge = _resolve_active_model_and_tier(s)
+    assert badge.startswith("  ·  ")


### PR DESCRIPTION
Closes #290

## 根因

Discord 端 turn-end footer 兩個渲染路徑（`embed.set_footer` 與 compact one-liner）都直接讀 `session.model`，但這個 property 回傳的是 constructor / `set_model` 設定的 registered default — **sticky tier 升降（#276）完全不會反映**。

User 觀察到的具體案例：session 已升至 Tier 2 跑 `deepseek-v4-pro`，但 Discord footer 仍顯示 `minimax-m2.7`。

CLI footer 早就走 `session._active_model()` + `_active_tier()`（loom/platform/cli/main.py:591；tier badge gating 在 loom/platform/cli/app.py:575）。Discord 沒對齊。

## 修法

抽出 `_resolve_active_model_and_tier(session)` helper：

| 情境 | active_model | tier_badge |
|------|--------------|-----------|
| 沒設 `tier_models` | `session.model` | `""`（保持向後相容） |
| 有 `tier_models`，跑在 default tier | `_active_model()`（== default model） | `""` |
| 有 `tier_models`，sticky 升到非 default tier | `_active_model()` | `\"  ·  ⇪ Tier N\"` |

兩個 footer 路徑都用 helper。badge 字串自帶分隔符 `  ·  `，call site 可以無條件 concat，不用條件式空格。

## 測試

新增 `tests/test_discord_footer_active_tier.py`（4 個 unit test）覆蓋 helper 的四種行為——其中 `test_tier_system_sticky_override_shows_active_model_and_badge` 直接重現 issue 描述的場景（Tier 1 → Tier 2 升級下 footer 顯示）。

全套 1442 tests pass。

## Impact

- gitnexus_detect_changes: 7 changed symbols（多數是行號漂移），LOW risk，0 affected processes
- 沒有 tier_models 的 session 行為完全不變（fallback path）
- 修改僅在渲染層，不影響 tier 切換、model 路由、cache 計算等任何邏輯

## Test plan

- [x] Unit test 覆蓋 4 種情境
- [x] 全套 pytest pass
- [ ] 手動驗證：Discord 觸發 tier 升級（or 用 `/sticky` 命令切到非 default tier），下一個 turn 結束時 footer 應顯示新 model + `⇪ Tier N` badge
- [ ] 手動驗證：tier 系統未啟用的 session footer 行為不變

🤖 Generated with [Claude Code](https://claude.com/claude-code)