### PR TITLE
feat(llm): add OpenAI auth onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ LMSTUDIO_BASE_URL=http://localhost:1234/v1
 loom auth openai                  # Phase 1: Codex CLI login helper + OPENAI_API_KEY setup
 loom chat                          # interactive CLI
 loom chat --tui                    # TUI mode
-loom chat --model gpt-5.2          # OpenAI model
+loom chat --model gpt-5.5          # OpenAI model
 loom chat --model ollama/llama3.2  # local model
 loom discord start --autonomy --channel <id>
 loom autonomy start

--- a/README.md
+++ b/README.md
@@ -379,16 +379,16 @@ LMSTUDIO_BASE_URL=http://localhost:1234/v1
 ```
 
 ```bash
-loom auth openai                  # Codex CLI login helper + OPENAI_API_KEY setup
+loom auth openai                  # Phase 1: Codex CLI login helper + OPENAI_API_KEY setup
 loom chat                          # interactive CLI
 loom chat --tui                    # TUI mode
-loom chat --model gpt-4.1          # OpenAI model
+loom chat --model gpt-5.2          # OpenAI model
 loom chat --model ollama/llama3.2  # local model
 loom discord start --autonomy --channel <id>
 loom autonomy start
 ```
 
-Model routing works by prefix — `gpt-*`, `o3` / `o4-*`, `openai/<model>`, `claude-*`, `ollama/<name>`, `lmstudio/<name>`, `MiniMax-*`. Switch mid-session with `/model`.
+Model routing works by prefix — `gpt-*`, `o3` / `o3-*` / `o4-*`, `openai/<model>`, `claude-*`, `ollama/<name>`, `lmstudio/<name>`, `MiniMax-*`. Switch mid-session with `/model`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ Model routing works by prefix — `gpt-*`, `openai/<model>`, `claude-*`, `ollama
 
 Image generation includes `openai__text_to_image`, which calls `gpt-image-2`
 and writes a PNG/WebP/JPEG under the workspace. It prefers an unexpired Codex
-OAuth token from `codex --login`, then falls back to `OPENAI_API_KEY`.
+OAuth token from `codex login`, then falls back to `OPENAI_API_KEY`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ LMSTUDIO_BASE_URL=http://localhost:1234/v1
 ```
 
 ```bash
-loom auth openai                  # Phase 1: Codex CLI login helper + OPENAI_API_KEY setup
+loom auth openai                  # Codex CLI login helper + OPENAI_API_KEY setup
 loom chat                          # interactive CLI
 loom chat --tui                    # TUI mode
 loom chat --model gpt-5.5          # OpenAI model
@@ -389,6 +389,10 @@ loom autonomy start
 ```
 
 Model routing works by prefix — `gpt-*`, `o3` / `o3-*` / `o4-*`, `openai/<model>`, `claude-*`, `ollama/<name>`, `lmstudio/<name>`, `MiniMax-*`. Switch mid-session with `/model`.
+
+Image generation includes `openai__text_to_image`, which calls `gpt-image-2`
+and writes a PNG/WebP/JPEG under the workspace. It prefers an unexpired Codex
+OAuth token from `codex --login`, then falls back to `OPENAI_API_KEY`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -391,8 +391,8 @@ loom autonomy start
 Model routing works by prefix — `gpt-*`, `openai/<model>`, `claude-*`, `ollama/<name>`, `lmstudio/<name>`, `MiniMax-*`. Switch mid-session with `/model`.
 
 Image generation includes `openai__text_to_image`, which calls `gpt-image-2`
-and writes a PNG/WebP/JPEG under the workspace. It prefers an unexpired Codex
-OAuth token from `codex login`, then falls back to `OPENAI_API_KEY`.
+and writes a PNG/WebP/JPEG under the workspace. With Codex OAuth it uses the
+Codex Responses backend; with `OPENAI_API_KEY` it uses the OpenAI Images API.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ loom discord start --autonomy --channel <id>
 loom autonomy start
 ```
 
-Model routing works by prefix — `gpt-*`, `o3` / `o3-*` / `o4-*`, `openai/<model>`, `claude-*`, `ollama/<name>`, `lmstudio/<name>`, `MiniMax-*`. Switch mid-session with `/model`.
+Model routing works by prefix — `gpt-*`, `openai/<model>`, `claude-*`, `ollama/<name>`, `lmstudio/<name>`, `MiniMax-*`. Switch mid-session with `/model`.
 
 Image generation includes `openai__text_to_image`, which calls `gpt-image-2`
 and writes a PNG/WebP/JPEG under the workspace. It prefers an unexpired Codex

--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ pip install -e ".[dev]"
 Create a `.env` in the project root with at least one provider:
 
 ```env
+OPENAI_API_KEY=your_openai_key_here
 ANTHROPIC_API_KEY=your_key_here
 
 # Local providers (no API key needed)
@@ -378,14 +379,16 @@ LMSTUDIO_BASE_URL=http://localhost:1234/v1
 ```
 
 ```bash
+loom auth openai                  # Codex CLI login helper + OPENAI_API_KEY setup
 loom chat                          # interactive CLI
 loom chat --tui                    # TUI mode
+loom chat --model gpt-4.1          # OpenAI model
 loom chat --model ollama/llama3.2  # local model
 loom discord start --autonomy --channel <id>
 loom autonomy start
 ```
 
-Model routing works by prefix — `claude-*`, `ollama/<name>`, `lmstudio/<name>`, `MiniMax-*`. Switch mid-session with `/model`.
+Model routing works by prefix — `gpt-*`, `o3` / `o4-*`, `openai/<model>`, `claude-*`, `ollama/<name>`, `lmstudio/<name>`, `MiniMax-*`. Switch mid-session with `/model`.
 
 ---
 

--- a/doc/14-LLM-Router.md
+++ b/doc/14-LLM-Router.md
@@ -22,9 +22,10 @@ _ROUTING: list[tuple[str, str]] = [
     ("MiniMax-",   "minimax"),    # MiniMax-M2.7, MiniMax-Sirius 等
     ("minimax-",   "minimax"),    # 小寫前綴
     ("claude-",    "anthropic"),  # Anthropic claude-3.5-sonnet 等
-    ("gpt-",       "openai"),     # GPT-4o 等
-    ("o3",         "openai"),     # OpenAI reasoning models
-    ("o4",         "openai"),     # OpenAI reasoning models
+    ("gpt-",       "openai"),     # GPT-5.2 等
+    ("o3",         "openai"),     # exact OpenAI reasoning model
+    ("o3-",        "openai"),     # o3-pro 等
+    ("o4-",        "openai"),     # o4-mini 等
     ("openai/",    "openai"),     # 明確指定 OpenAI provider
     ("ollama/",    "ollama"),     # 本地 Ollama 模型
     ("lmstudio/",  "lmstudio"),   # 本地 LM Studio 模型
@@ -94,7 +95,7 @@ from loom.core.cognition.providers import (
 router = LLMRouter()
 router.register(MiniMaxProvider(api_key=..., model="MiniMax-M2.7"), default=True)
 router.register(AnthropicProvider(api_key=...))
-router.register(OpenAIProvider(api_key=..., model="gpt-4.1"))
+router.register(OpenAIProvider(api_key=..., model="gpt-5.2"))
 router.register(OllamaProvider(base_url="http://localhost:11434"))
 ```
 

--- a/doc/14-LLM-Router.md
+++ b/doc/14-LLM-Router.md
@@ -22,10 +22,7 @@ _ROUTING: list[tuple[str, str]] = [
     ("MiniMax-",   "minimax"),    # MiniMax-M2.7, MiniMax-Sirius 等
     ("minimax-",   "minimax"),    # 小寫前綴
     ("claude-",    "anthropic"),  # Anthropic claude-3.5-sonnet 等
-    ("gpt-",       "openai"),     # GPT-5.5 等
-    ("o3",         "openai"),     # exact OpenAI reasoning model
-    ("o3-",        "openai"),     # o3-pro 等
-    ("o4-",        "openai"),     # o4-mini 等
+    ("gpt-",       "openai"),     # GPT-5.5、GPT-5.5-pro 等
     ("openai/",    "openai"),     # 明確指定 OpenAI provider
     ("ollama/",    "ollama"),     # 本地 Ollama 模型
     ("lmstudio/",  "lmstudio"),   # 本地 LM Studio 模型

--- a/doc/14-LLM-Router.md
+++ b/doc/14-LLM-Router.md
@@ -22,7 +22,7 @@ _ROUTING: list[tuple[str, str]] = [
     ("MiniMax-",   "minimax"),    # MiniMax-M2.7, MiniMax-Sirius 等
     ("minimax-",   "minimax"),    # 小寫前綴
     ("claude-",    "anthropic"),  # Anthropic claude-3.5-sonnet 等
-    ("gpt-",       "openai"),     # GPT-5.2 等
+    ("gpt-",       "openai"),     # GPT-5.5 等
     ("o3",         "openai"),     # exact OpenAI reasoning model
     ("o3-",        "openai"),     # o3-pro 等
     ("o4-",        "openai"),     # o4-mini 等
@@ -95,7 +95,7 @@ from loom.core.cognition.providers import (
 router = LLMRouter()
 router.register(MiniMaxProvider(api_key=..., model="MiniMax-M2.7"), default=True)
 router.register(AnthropicProvider(api_key=...))
-router.register(OpenAIProvider(api_key=..., model="gpt-5.2"))
+router.register(OpenAIProvider(api_key=..., model="gpt-5.5"))
 router.register(OllamaProvider(base_url="http://localhost:11434"))
 ```
 

--- a/doc/14-LLM-Router.md
+++ b/doc/14-LLM-Router.md
@@ -23,6 +23,9 @@ _ROUTING: list[tuple[str, str]] = [
     ("minimax-",   "minimax"),    # 小寫前綴
     ("claude-",    "anthropic"),  # Anthropic claude-3.5-sonnet 等
     ("gpt-",       "openai"),     # GPT-4o 等
+    ("o3",         "openai"),     # OpenAI reasoning models
+    ("o4",         "openai"),     # OpenAI reasoning models
+    ("openai/",    "openai"),     # 明確指定 OpenAI provider
     ("ollama/",    "ollama"),     # 本地 Ollama 模型
     ("lmstudio/",  "lmstudio"),   # 本地 LM Studio 模型
 ]
@@ -91,6 +94,7 @@ from loom.core.cognition.providers import (
 router = LLMRouter()
 router.register(MiniMaxProvider(api_key=..., model="MiniMax-M2.7"), default=True)
 router.register(AnthropicProvider(api_key=...))
+router.register(OpenAIProvider(api_key=..., model="gpt-4.1"))
 router.register(OllamaProvider(base_url="http://localhost:11434"))
 ```
 

--- a/doc/33-CLI-命令.md
+++ b/doc/33-CLI-命令.md
@@ -62,7 +62,7 @@ loom auth openai --api-key sk-...
 loom auth openai --skip-codex-login
 ```
 
-優先引導官方 Codex CLI OAuth 流程（`codex --login`），再視需要把
+優先引導官方 Codex CLI OAuth 流程（`codex login`），再視需要把
 `OPENAI_API_KEY` 寫入專案 `.env`，供 Loom 的 OpenAI provider 使用。OpenAI 圖像工具會優先使用
 未過期的 Codex OAuth access token，並在自動模式下 fallback 到 `OPENAI_API_KEY`。
 
@@ -79,7 +79,7 @@ Agent 可用工具，透過 OpenAI Images API 生成圖片並寫入 workspace：
 }
 ```
 
-`auth_mode` 可為 `auto`、`codex`、`api_key`。`auto` 會優先使用 `codex --login` 產生的
+`auth_mode` 可為 `auto`、`codex`、`api_key`。`auto` 會優先使用 `codex login` 產生的
 Codex OAuth access token，若 API 拒絕且 `.env` 有 `OPENAI_API_KEY`，則 fallback 到 API key。
 
 ---

--- a/doc/33-CLI-命令.md
+++ b/doc/33-CLI-命令.md
@@ -62,8 +62,9 @@ loom auth openai --api-key sk-...
 loom auth openai --skip-codex-login
 ```
 
-優先引導官方 Codex CLI OAuth 流程（`codex --login`），再視需要把
-`OPENAI_API_KEY` 寫入專案 `.env`，供 Loom 的 OpenAI provider 使用。
+Phase 1 命令：優先引導官方 Codex CLI OAuth 流程（`codex --login`），再視需要把
+`OPENAI_API_KEY` 寫入專案 `.env`，供 Loom 的 OpenAI provider 使用。Loom 不會讀取或搬移
+Codex CLI 的私有 token；真正的 Codex OAuth token 整合會另行設計。
 
 ---
 

--- a/doc/33-CLI-命令.md
+++ b/doc/33-CLI-命令.md
@@ -62,9 +62,25 @@ loom auth openai --api-key sk-...
 loom auth openai --skip-codex-login
 ```
 
-Phase 1 命令：優先引導官方 Codex CLI OAuth 流程（`codex --login`），再視需要把
-`OPENAI_API_KEY` 寫入專案 `.env`，供 Loom 的 OpenAI provider 使用。Loom 不會讀取或搬移
-Codex CLI 的私有 token；真正的 Codex OAuth token 整合會另行設計。
+優先引導官方 Codex CLI OAuth 流程（`codex --login`），再視需要把
+`OPENAI_API_KEY` 寫入專案 `.env`，供 Loom 的 OpenAI provider 使用。OpenAI 圖像工具會優先使用
+未過期的 Codex OAuth access token，並在自動模式下 fallback 到 `OPENAI_API_KEY`。
+
+### `openai__text_to_image`
+
+Agent 可用工具，透過 OpenAI Images API 生成圖片並寫入 workspace：
+
+```json
+{
+  "prompt": "a clean product mockup",
+  "model": "gpt-image-2",
+  "output_path": "outputs/mockup.png",
+  "auth_mode": "auto"
+}
+```
+
+`auth_mode` 可為 `auto`、`codex`、`api_key`。`auto` 會優先使用 `codex --login` 產生的
+Codex OAuth access token，若 API 拒絕且 `.env` 有 `OPENAI_API_KEY`，則 fallback 到 API key。
 
 ---
 

--- a/doc/33-CLI-命令.md
+++ b/doc/33-CLI-命令.md
@@ -68,7 +68,8 @@ loom auth openai --skip-codex-login
 
 ### `openai__text_to_image`
 
-Agent 可用工具，透過 OpenAI Images API 生成圖片並寫入 workspace：
+Agent 可用工具，生成圖片並寫入 workspace。`auth_mode=codex` 走 Codex Responses backend；
+`auth_mode=api_key` 走 OpenAI Images API：
 
 ```json
 {
@@ -80,7 +81,7 @@ Agent 可用工具，透過 OpenAI Images API 生成圖片並寫入 workspace：
 ```
 
 `auth_mode` 可為 `auto`、`codex`、`api_key`。`auto` 會優先使用 `codex login` 產生的
-Codex OAuth access token，若 API 拒絕且 `.env` 有 `OPENAI_API_KEY`，則 fallback 到 API key。
+Codex OAuth access token；若 Codex backend 拒絕且 `.env` 有 `OPENAI_API_KEY`，則 fallback 到 API key。
 
 ---
 

--- a/doc/33-CLI-命令.md
+++ b/doc/33-CLI-命令.md
@@ -52,6 +52,21 @@ loom chat --tui --session abc123       # TUI + 指定 session
 
 ---
 
+## Provider 認證命令
+
+### `loom auth openai`
+
+```bash
+loom auth openai
+loom auth openai --api-key sk-...
+loom auth openai --skip-codex-login
+```
+
+優先引導官方 Codex CLI OAuth 流程（`codex --login`），再視需要把
+`OPENAI_API_KEY` 寫入專案 `.env`，供 Loom 的 OpenAI provider 使用。
+
+---
+
 ## 對話中 HITL 命令
 
 在 `loom chat` 或 TUI 的輸入框中即時輸入：

--- a/doc/38-環境變數.md
+++ b/doc/38-環境變數.md
@@ -46,7 +46,7 @@ DATABASE_URL=sqlite:///~/.loom/data/loom.db
 | 變數 | 說明 | 必要 |
 |------|------|------|
 | `MINIMAX_API_KEY` | MiniMax API Key | 是 |
-| `OPENAI_API_KEY` | OpenAI API Key；可用 `loom auth openai` 互動式設定；OpenAI 圖像工具在 Codex OAuth 不可用時 fallback 使用 | 用於 gpt-* / o3 / o3-* / o4-* / openai/<model> / gpt-image-2 |
+| `OPENAI_API_KEY` | OpenAI API Key；可用 `loom auth openai` 互動式設定；OpenAI 圖像工具在 Codex OAuth 不可用時 fallback 使用 | 用於 gpt-* / openai/<model> / gpt-image-2 |
 | `ANTHROPIC_API_KEY` | Anthropic API Key | 用於 claude-* 模型 |
 | `AZURE_OPENAI_API_KEY` | Azure OpenAI API Key | 否 |
 | `AZURE_OPENAI_ENDPOINT` | Azure OpenAI Endpoint | 否 |

--- a/doc/38-環境變數.md
+++ b/doc/38-環境變數.md
@@ -46,7 +46,7 @@ DATABASE_URL=sqlite:///~/.loom/data/loom.db
 | 變數 | 說明 | 必要 |
 |------|------|------|
 | `MINIMAX_API_KEY` | MiniMax API Key | 是 |
-| `OPENAI_API_KEY` | OpenAI API Key；可用 `loom auth openai` 互動式設定 | 用於 gpt-* / o3 / o4-* / openai/<model> |
+| `OPENAI_API_KEY` | OpenAI API Key；可用 `loom auth openai` 互動式設定 | 用於 gpt-* / o3 / o3-* / o4-* / openai/<model> |
 | `ANTHROPIC_API_KEY` | Anthropic API Key | 用於 claude-* 模型 |
 | `AZURE_OPENAI_API_KEY` | Azure OpenAI API Key | 否 |
 | `AZURE_OPENAI_ENDPOINT` | Azure OpenAI Endpoint | 否 |

--- a/doc/38-環境變數.md
+++ b/doc/38-環境變數.md
@@ -46,7 +46,7 @@ DATABASE_URL=sqlite:///~/.loom/data/loom.db
 | 變數 | 說明 | 必要 |
 |------|------|------|
 | `MINIMAX_API_KEY` | MiniMax API Key | 是 |
-| `OPENAI_API_KEY` | OpenAI API Key | 是 |
+| `OPENAI_API_KEY` | OpenAI API Key；可用 `loom auth openai` 互動式設定 | 用於 gpt-* / o3 / o4-* / openai/<model> |
 | `ANTHROPIC_API_KEY` | Anthropic API Key | 用於 claude-* 模型 |
 | `AZURE_OPENAI_API_KEY` | Azure OpenAI API Key | 否 |
 | `AZURE_OPENAI_ENDPOINT` | Azure OpenAI Endpoint | 否 |

--- a/doc/38-環境變數.md
+++ b/doc/38-環境變數.md
@@ -46,7 +46,7 @@ DATABASE_URL=sqlite:///~/.loom/data/loom.db
 | 變數 | 說明 | 必要 |
 |------|------|------|
 | `MINIMAX_API_KEY` | MiniMax API Key | 是 |
-| `OPENAI_API_KEY` | OpenAI API Key；可用 `loom auth openai` 互動式設定 | 用於 gpt-* / o3 / o3-* / o4-* / openai/<model> |
+| `OPENAI_API_KEY` | OpenAI API Key；可用 `loom auth openai` 互動式設定；OpenAI 圖像工具在 Codex OAuth 不可用時 fallback 使用 | 用於 gpt-* / o3 / o3-* / o4-* / openai/<model> / gpt-image-2 |
 | `ANTHROPIC_API_KEY` | Anthropic API Key | 用於 claude-* 模型 |
 | `AZURE_OPENAI_API_KEY` | Azure OpenAI API Key | 否 |
 | `AZURE_OPENAI_ENDPOINT` | Azure OpenAI Endpoint | 否 |

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -32,7 +32,7 @@ personality = ""
 # Supported prefixes:
 #   MiniMax-*               → MiniMax via Anthropic-compatible endpoint  (MINIMAX_API_KEY in .env)
 #   claude-*                → Anthropic provider                         (ANTHROPIC_API_KEY in .env)
-#   gpt-* / o3 / o4-*       → OpenAI official API                        (OPENAI_API_KEY in .env)
+#   gpt-* / o3 / o3-* / o4-* → OpenAI official API                       (OPENAI_API_KEY in .env)
 #   openai/<model>          → OpenAI official API with explicit prefix    (OPENAI_API_KEY in .env)
 #   deepseek-*              → DeepSeek official via Anthropic-compatible endpoint  (DEEPSEEK_API_KEY in .env)
 #   openrouter/<vendor>/<m> → OpenRouter aggregator (e.g. openrouter/deepseek/deepseek-v4-pro)  (OPENROUTER_API_KEY in .env)
@@ -103,7 +103,7 @@ reminder_after_turns = 10
 
 # [providers.openai]
 # base_url      = "https://api.openai.com/v1"
-# default_model = "gpt-4.1"
+# default_model = "gpt-5.2"
 
 # ─────────────────────────────────────────────
 # Memory

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -106,7 +106,7 @@ reminder_after_turns = 10
 # default_model = "gpt-5.5"
 #
 # OpenAI image generation uses the openai__text_to_image tool.
-# It defaults to gpt-image-2 and prefers Codex OAuth from `codex --login`,
+# It defaults to gpt-image-2 and prefers Codex OAuth from `codex login`,
 # falling back to OPENAI_API_KEY when needed.
 
 # ─────────────────────────────────────────────

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -32,6 +32,8 @@ personality = ""
 # Supported prefixes:
 #   MiniMax-*               → MiniMax via Anthropic-compatible endpoint  (MINIMAX_API_KEY in .env)
 #   claude-*                → Anthropic provider                         (ANTHROPIC_API_KEY in .env)
+#   gpt-* / o3 / o4-*       → OpenAI official API                        (OPENAI_API_KEY in .env)
+#   openai/<model>          → OpenAI official API with explicit prefix    (OPENAI_API_KEY in .env)
 #   deepseek-*              → DeepSeek official via Anthropic-compatible endpoint  (DEEPSEEK_API_KEY in .env)
 #   openrouter/<vendor>/<m> → OpenRouter aggregator (e.g. openrouter/deepseek/deepseek-v4-pro)  (OPENROUTER_API_KEY in .env)
 #   ollama/<name>           → local Ollama server  (enable [providers.ollama] below)
@@ -98,6 +100,10 @@ reminder_after_turns = 10
 # enabled       = true
 # base_url      = "http://localhost:1234/v1"
 # default_model = "phi-4"              # must match the model loaded in LM Studio
+
+# [providers.openai]
+# base_url      = "https://api.openai.com/v1"
+# default_model = "gpt-4.1"
 
 # ─────────────────────────────────────────────
 # Memory

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -32,7 +32,7 @@ personality = ""
 # Supported prefixes:
 #   MiniMax-*               → MiniMax via Anthropic-compatible endpoint  (MINIMAX_API_KEY in .env)
 #   claude-*                → Anthropic provider                         (ANTHROPIC_API_KEY in .env)
-#   gpt-* / o3 / o3-* / o4-* → OpenAI official API                       (OPENAI_API_KEY in .env)
+#   gpt-*                   → OpenAI official API (gpt-5.5, gpt-5.5-pro)  (OPENAI_API_KEY in .env)
 #   openai/<model>          → OpenAI official API with explicit prefix    (OPENAI_API_KEY in .env)
 #   deepseek-*              → DeepSeek official via Anthropic-compatible endpoint  (DEEPSEEK_API_KEY in .env)
 #   openrouter/<vendor>/<m> → OpenRouter aggregator (e.g. openrouter/deepseek/deepseek-v4-pro)  (OPENROUTER_API_KEY in .env)

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -104,6 +104,10 @@ reminder_after_turns = 10
 # [providers.openai]
 # base_url      = "https://api.openai.com/v1"
 # default_model = "gpt-5.5"
+#
+# OpenAI image generation uses the openai__text_to_image tool.
+# It defaults to gpt-image-2 and prefers Codex OAuth from `codex --login`,
+# falling back to OPENAI_API_KEY when needed.
 
 # ─────────────────────────────────────────────
 # Memory

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -106,8 +106,8 @@ reminder_after_turns = 10
 # default_model = "gpt-5.5"
 #
 # OpenAI image generation uses the openai__text_to_image tool.
-# It defaults to gpt-image-2 and prefers Codex OAuth from `codex login`,
-# falling back to OPENAI_API_KEY when needed.
+# It defaults to gpt-image-2. Codex OAuth uses the Codex Responses backend;
+# OPENAI_API_KEY uses the OpenAI Images API.
 
 # ─────────────────────────────────────────────
 # Memory

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -103,7 +103,7 @@ reminder_after_turns = 10
 
 # [providers.openai]
 # base_url      = "https://api.openai.com/v1"
-# default_model = "gpt-5.2"
+# default_model = "gpt-5.5"
 
 # ─────────────────────────────────────────────
 # Memory

--- a/loom/core/cognition/openai_auth.py
+++ b/loom/core/cognition/openai_auth.py
@@ -1,0 +1,103 @@
+"""OpenAI credential helpers.
+
+This module intentionally treats Codex CLI credentials as an experimental
+credential source.  The file format is owned by Codex, so callers must be
+prepared to fall back to a normal ``OPENAI_API_KEY`` when the token is absent,
+expired, or no longer shaped as expected.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class OpenAICredential:
+    """Bearer credential plus non-secret provenance."""
+
+    token: str
+    source: str
+    account_id: str | None = None
+    expires_at: int | None = None
+
+
+def codex_auth_path() -> Path:
+    """Return the default Codex CLI auth file path."""
+
+    home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+    return home / "auth.json"
+
+
+def _jwt_exp(token: str) -> int | None:
+    """Best-effort JWT exp extraction without validating the signature."""
+
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    payload = parts[1] + "=" * ((4 - len(parts[1]) % 4) % 4)
+    try:
+        data = json.loads(base64.urlsafe_b64decode(payload.encode("ascii")))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    exp = data.get("exp")
+    return int(exp) if isinstance(exp, (int, float)) else None
+
+
+def load_codex_oauth_credential(
+    path: Path | None = None,
+    *,
+    now: float | None = None,
+    min_ttl_seconds: int = 60,
+) -> OpenAICredential | None:
+    """Load an unexpired Codex CLI OAuth access token if one is available."""
+
+    auth_path = path or codex_auth_path()
+    try:
+        raw = json.loads(auth_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    tokens = raw.get("tokens")
+    if not isinstance(tokens, dict):
+        return None
+    access_token = tokens.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        return None
+    expires_at = _jwt_exp(access_token)
+    current = time.time() if now is None else now
+    if expires_at is not None and expires_at <= current + min_ttl_seconds:
+        return None
+    account_id = tokens.get("account_id")
+    return OpenAICredential(
+        token=access_token,
+        source="codex_oauth",
+        account_id=account_id if isinstance(account_id, str) else None,
+        expires_at=expires_at,
+    )
+
+
+def resolve_openai_credential(
+    env: dict[str, str] | None = None,
+    *,
+    prefer_codex: bool = True,
+    require_codex: bool = False,
+    codex_auth_file: Path | None = None,
+) -> OpenAICredential | None:
+    """Resolve an OpenAI bearer credential without exposing secret values."""
+
+    env_map: dict[str, Any] = env if env is not None else os.environ
+    if prefer_codex:
+        codex = load_codex_oauth_credential(codex_auth_file)
+        if codex is not None:
+            return codex
+        if require_codex:
+            return None
+    api_key = env_map.get("OPENAI_API_KEY")
+    if isinstance(api_key, str) and api_key:
+        return OpenAICredential(token=api_key, source="api_key")
+    return None

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -855,14 +855,12 @@ class OpenAIProvider(_OpenAICompatibleBase):
     """
     OpenAI — official OpenAI API via the chat completions endpoint.
 
-    Routing prefixes: ``gpt-*``, ``o1`` / ``o1-*``, ``o3`` / ``o3-*``,
-    ``o4-*``, and ``openai/``.
+    Routing prefixes: ``gpt-*`` and ``openai/``.
     Default base URL: ``https://api.openai.com/v1``
 
     Usage::
 
         /model gpt-5.5
-        /model o3
         /model openai/gpt-5.5
 
     Configure in ``.env``::

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -855,15 +855,15 @@ class OpenAIProvider(_OpenAICompatibleBase):
     """
     OpenAI — official OpenAI API via the chat completions endpoint.
 
-    Routing prefixes: ``gpt-*``, ``o1*``, ``o3*``, ``o4*``, and ``openai/``.
+    Routing prefixes: ``gpt-*``, ``o1`` / ``o1-*``, ``o3`` / ``o3-*``,
+    ``o4-*``, and ``openai/``.
     Default base URL: ``https://api.openai.com/v1``
 
     Usage::
 
-        /model gpt-4.1
-        /model gpt-5
+        /model gpt-5.2
         /model o3
-        /model openai/gpt-4.1
+        /model openai/gpt-5.2
 
     Configure in ``.env``::
 
@@ -873,7 +873,7 @@ class OpenAIProvider(_OpenAICompatibleBase):
     name = "openai"
     ROUTING_PREFIX = "openai/"
     DEFAULT_BASE_URL = "https://api.openai.com/v1"
-    DEFAULT_MODEL = "gpt-4.1"
+    DEFAULT_MODEL = "gpt-5.2"
     DEFAULT_TIMEOUT = 180.0
 
 

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -626,6 +626,10 @@ class _OpenAICompatibleBase(LLMProvider):
     DEFAULT_BASE_URL: str = ""
     DEFAULT_MODEL: str = ""
     DEFAULT_TIMEOUT: float = 120.0
+    # OpenAI's GPT-5 era models reject `max_tokens` and require
+    # `max_completion_tokens`. OpenRouter / Ollama / LMStudio still accept
+    # the classic name, so subclasses override only when needed.
+    MAX_TOKENS_PARAM: str = "max_tokens"
 
     def __init__(
         self,
@@ -684,7 +688,7 @@ class _OpenAICompatibleBase(LLMProvider):
         kwargs: dict[str, Any] = {
             "model": self._api_model(),
             "messages": messages,
-            "max_tokens": max_tokens,
+            self.MAX_TOKENS_PARAM: max_tokens,
             "stream": True,
             "stream_options": {"include_usage": True},
         }
@@ -873,6 +877,7 @@ class OpenAIProvider(_OpenAICompatibleBase):
     DEFAULT_BASE_URL = "https://api.openai.com/v1"
     DEFAULT_MODEL = "gpt-5.5"
     DEFAULT_TIMEOUT = 180.0
+    MAX_TOKENS_PARAM = "max_completion_tokens"
 
 
 class LMStudioProvider(_OpenAICompatibleBase):

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -861,9 +861,9 @@ class OpenAIProvider(_OpenAICompatibleBase):
 
     Usage::
 
-        /model gpt-5.2
+        /model gpt-5.5
         /model o3
-        /model openai/gpt-5.2
+        /model openai/gpt-5.5
 
     Configure in ``.env``::
 
@@ -873,7 +873,7 @@ class OpenAIProvider(_OpenAICompatibleBase):
     name = "openai"
     ROUTING_PREFIX = "openai/"
     DEFAULT_BASE_URL = "https://api.openai.com/v1"
-    DEFAULT_MODEL = "gpt-5.2"
+    DEFAULT_MODEL = "gpt-5.5"
     DEFAULT_TIMEOUT = 180.0
 
 

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -7,6 +7,7 @@ a provider SDK directly — it always goes through this interface.
 
 Supported providers
 -------------------
+OpenAIProvider     — api.openai.com/v1 (OpenAI-compatible chat completions)
 AnthropicProvider  — api.anthropic.com  (also MiniMax via base_url="https://api.minimax.io/anthropic")
 OpenRouterProvider — openrouter.ai/api/v1 (OpenAI-compatible aggregator)
 DeepSeek           — official api.deepseek.com via Anthropic-compatible endpoint
@@ -847,6 +848,32 @@ class OpenRouterProvider(_OpenAICompatibleBase):
     ROUTING_PREFIX = "openrouter/"
     DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
     DEFAULT_MODEL = "deepseek/deepseek-v4-pro"
+    DEFAULT_TIMEOUT = 180.0
+
+
+class OpenAIProvider(_OpenAICompatibleBase):
+    """
+    OpenAI — official OpenAI API via the chat completions endpoint.
+
+    Routing prefixes: ``gpt-*``, ``o1*``, ``o3*``, ``o4*``, and ``openai/``.
+    Default base URL: ``https://api.openai.com/v1``
+
+    Usage::
+
+        /model gpt-4.1
+        /model gpt-5
+        /model o3
+        /model openai/gpt-4.1
+
+    Configure in ``.env``::
+
+        OPENAI_API_KEY=sk-...
+    """
+
+    name = "openai"
+    ROUTING_PREFIX = "openai/"
+    DEFAULT_BASE_URL = "https://api.openai.com/v1"
+    DEFAULT_MODEL = "gpt-4.1"
     DEFAULT_TIMEOUT = 180.0
 
 

--- a/loom/core/cognition/router.py
+++ b/loom/core/cognition/router.py
@@ -10,9 +10,9 @@ Model routing rules
 "minimax-*"    → MiniMaxProvider
 "claude-*"     → AnthropicProvider
 "gpt-*"        → OpenAIProvider
-"o1*"          → OpenAIProvider
-"o3*"          → OpenAIProvider
-"o4*"          → OpenAIProvider
+"o1" / "o1-*"  → OpenAIProvider
+"o3" / "o3-*"  → OpenAIProvider
+"o4-*"         → OpenAIProvider
 "openai/*"     → OpenAIProvider
 "ollama/*"     → OllamaProvider    (local Ollama server)
 "lmstudio/*"   → LMStudioProvider  (local LM Studio server)
@@ -76,15 +76,19 @@ class LLMRouter:
         ("minimax-",   "minimax"),
         ("claude-",    "anthropic"),
         ("gpt-",       "openai"),
-        ("o1",         "openai"),
-        ("o3",         "openai"),
-        ("o4",         "openai"),
+        ("o1-",        "openai"),
+        ("o3-",        "openai"),
+        ("o4-",        "openai"),
         ("openai/",    "openai"),
         ("openrouter/", "openrouter"),
         ("deepseek-",  "deepseek"),
         ("ollama/",    "ollama"),
         ("lmstudio/",  "lmstudio"),
     ]
+    _EXACT_ROUTING: dict[str, str] = {
+        "o1": "openai",
+        "o3": "openai",
+    }
 
     def __init__(self) -> None:
         self._providers: dict[str, LLMProvider] = {}
@@ -96,12 +100,21 @@ class LLMRouter:
             self._default = provider.name
         return self
 
-    def get_provider(self, model: str) -> LLMProvider:
+    def _provider_name_for_model(self, model: str) -> str | None:
+        exact = self._EXACT_ROUTING.get(model)
+        if exact:
+            return exact
         for prefix, provider_name in self._ROUTING:
             if model.startswith(prefix):
-                p = self._providers.get(provider_name)
-                if p:
-                    return p
+                return provider_name
+        return None
+
+    def get_provider(self, model: str) -> LLMProvider:
+        provider_name = self._provider_name_for_model(model)
+        if provider_name:
+            p = self._providers.get(provider_name)
+            if p:
+                return p
         if self._default:
             return self._providers[self._default]
         raise RuntimeError(
@@ -169,13 +182,13 @@ class LLMRouter:
         should surface an error rather than silently applying the name to the
         default provider.
         """
-        for prefix, provider_name in self._ROUTING:
-            if model.startswith(prefix):
-                provider = self._providers.get(provider_name)
-                if provider:
-                    provider.model = model
-                    return True
-                # Provider registered in routing table but not in registry
-                # (e.g. key not set) — still a valid prefix, just unavailable.
-                return False
+        provider_name = self._provider_name_for_model(model)
+        if provider_name:
+            provider = self._providers.get(provider_name)
+            if provider:
+                provider.model = model
+                return True
+            # Provider registered in routing table but not in registry
+            # (e.g. key not set) — still a valid prefix, just unavailable.
+            return False
         return False

--- a/loom/core/cognition/router.py
+++ b/loom/core/cognition/router.py
@@ -9,6 +9,11 @@ Model routing rules
 "MiniMax-*"    → MiniMaxProvider
 "minimax-*"    → MiniMaxProvider
 "claude-*"     → AnthropicProvider
+"gpt-*"        → OpenAIProvider
+"o1*"          → OpenAIProvider
+"o3*"          → OpenAIProvider
+"o4*"          → OpenAIProvider
+"openai/*"     → OpenAIProvider
 "ollama/*"     → OllamaProvider    (local Ollama server)
 "lmstudio/*"   → LMStudioProvider  (local LM Studio server)
 (default)      → first registered provider
@@ -71,6 +76,10 @@ class LLMRouter:
         ("minimax-",   "minimax"),
         ("claude-",    "anthropic"),
         ("gpt-",       "openai"),
+        ("o1",         "openai"),
+        ("o3",         "openai"),
+        ("o4",         "openai"),
+        ("openai/",    "openai"),
         ("openrouter/", "openrouter"),
         ("deepseek-",  "deepseek"),
         ("ollama/",    "ollama"),

--- a/loom/core/cognition/router.py
+++ b/loom/core/cognition/router.py
@@ -10,9 +10,6 @@ Model routing rules
 "minimax-*"    → MiniMaxProvider
 "claude-*"     → AnthropicProvider
 "gpt-*"        → OpenAIProvider
-"o1" / "o1-*"  → OpenAIProvider
-"o3" / "o3-*"  → OpenAIProvider
-"o4-*"         → OpenAIProvider
 "openai/*"     → OpenAIProvider
 "ollama/*"     → OllamaProvider    (local Ollama server)
 "lmstudio/*"   → LMStudioProvider  (local LM Studio server)
@@ -76,19 +73,12 @@ class LLMRouter:
         ("minimax-",   "minimax"),
         ("claude-",    "anthropic"),
         ("gpt-",       "openai"),
-        ("o1-",        "openai"),
-        ("o3-",        "openai"),
-        ("o4-",        "openai"),
         ("openai/",    "openai"),
         ("openrouter/", "openrouter"),
         ("deepseek-",  "deepseek"),
         ("ollama/",    "ollama"),
         ("lmstudio/",  "lmstudio"),
     ]
-    _EXACT_ROUTING: dict[str, str] = {
-        "o1": "openai",
-        "o3": "openai",
-    }
 
     def __init__(self) -> None:
         self._providers: dict[str, LLMProvider] = {}
@@ -101,9 +91,6 @@ class LLMRouter:
         return self
 
     def _provider_name_for_model(self, model: str) -> str | None:
-        exact = self._EXACT_ROUTING.get(model)
-        if exact:
-            return exact
         for prefix, provider_name in self._ROUTING:
             if model.startswith(prefix):
                 return provider_name

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -451,6 +451,7 @@ def build_router() -> LLMRouter:
     Cloud providers (require API keys in .env):
       MiniMax    — MINIMAX_API_KEY  (uses Anthropic-compatible endpoint, name="minimax")
       Anthropic  — ANTHROPIC_API_KEY
+      OpenAI     — OPENAI_API_KEY
       OpenRouter — OPENROUTER_API_KEY (OpenAI-compatible multi-vendor aggregator)
       DeepSeek   — DEEPSEEK_API_KEY   (official DeepSeek API, OpenAI-compatible)
 
@@ -462,6 +463,7 @@ def build_router() -> LLMRouter:
     from loom.core.cognition.providers import (
         OllamaProvider,
         LMStudioProvider,
+        OpenAIProvider,
         OpenRouterProvider,
     )
 
@@ -503,6 +505,27 @@ def build_router() -> LLMRouter:
     if anthropic_key:
         ant_model = default if default.startswith("claude") else "claude-sonnet-4-6"
         router.register(AnthropicProvider(api_key=anthropic_key, model=ant_model))
+
+    # OpenAI — official OpenAI API. Supports bare OpenAI model names and the
+    # optional "openai/" Loom routing prefix for users who prefer explicitness.
+    openai_key = (
+        env.get("OPENAI_API_KEY")
+        or os.environ.get("OPENAI_API_KEY", "")
+    )
+    if openai_key:
+        openai_cfg = cfg.get("providers", {}).get("openai", {})
+        base_url = openai_cfg.get("base_url", "") or OpenAIProvider.DEFAULT_BASE_URL
+        raw_model = openai_cfg.get("default_model", OpenAIProvider.DEFAULT_MODEL)
+        default_is_openai = default.startswith(("gpt-", "o1", "o3", "o4", "openai/"))
+        openai_model = default if default_is_openai else raw_model
+        router.register(
+            OpenAIProvider(
+                base_url=base_url,
+                model=openai_model,
+                api_key=openai_key,
+            ),
+            default=default_is_openai,
+        )
 
     # OpenRouter — OpenAI-compatible aggregator. Single key fronts many vendors.
     openrouter_key = (
@@ -596,7 +619,7 @@ def build_router() -> LLMRouter:
     if not router.providers:
         raise RuntimeError(
             "No LLM provider configured. "
-            "Add MINIMAX_API_KEY, ANTHROPIC_API_KEY, OPENROUTER_API_KEY, or DEEPSEEK_API_KEY to .env, "
+            "Add MINIMAX_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY, or DEEPSEEK_API_KEY to .env, "
             "or enable a local provider in loom.toml ([providers.ollama] / [providers.lmstudio])."
         )
     return router

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1113,6 +1113,7 @@ class LoomSession:
             make_probe_file_tool,
             make_exec_escape_fn,
             make_fetch_url_tool,
+            make_openai_image_generation_tool,
             make_load_skill_tool,
             make_memorize_tool,
             make_memory_health_tool,
@@ -1323,6 +1324,7 @@ class LoomSession:
         brave_key = env.get("brave_search_key") or env.get("BRAVE_SEARCH_KEY", "")
         if brave_key:
             self.registry.register(make_web_search_tool(brave_key))
+        self.registry.register(make_openai_image_generation_tool(self.workspace))
 
         # Register sub-agent tool (Phase 5E)
         self.registry.register(make_spawn_agent_tool(self))

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -516,10 +516,7 @@ def build_router() -> LLMRouter:
         openai_cfg = cfg.get("providers", {}).get("openai", {})
         base_url = openai_cfg.get("base_url", "") or OpenAIProvider.DEFAULT_BASE_URL
         raw_model = openai_cfg.get("default_model", OpenAIProvider.DEFAULT_MODEL)
-        default_is_openai = (
-            default in {"o1", "o3"}
-            or default.startswith(("gpt-", "o1-", "o3-", "o4-", "openai/"))
-        )
+        default_is_openai = default.startswith(("gpt-", "openai/"))
         openai_model = default if default_is_openai else raw_model
         router.register(
             OpenAIProvider(

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -516,7 +516,10 @@ def build_router() -> LLMRouter:
         openai_cfg = cfg.get("providers", {}).get("openai", {})
         base_url = openai_cfg.get("base_url", "") or OpenAIProvider.DEFAULT_BASE_URL
         raw_model = openai_cfg.get("default_model", OpenAIProvider.DEFAULT_MODEL)
-        default_is_openai = default.startswith(("gpt-", "o1", "o3", "o4", "openai/"))
+        default_is_openai = (
+            default in {"o1", "o3"}
+            or default.startswith(("gpt-", "o1-", "o3-", "o4-", "openai/"))
+        )
         openai_model = default if default_is_openai else raw_model
         router.register(
             OpenAIProvider(

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -815,7 +815,7 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
                 "[loom.muted]  MiniMax-*           requires MINIMAX_API_KEY in .env (Anthropic-compatible endpoint)[/loom.muted]\n"
                 "[loom.muted]  claude-*            requires ANTHROPIC_API_KEY in .env[/loom.muted]\n"
                 "[loom.muted]  gpt-* / o3 / o3-* / o4-* requires OPENAI_API_KEY in .env (try `loom auth openai`)[/loom.muted]\n"
-                "[loom.muted]  openai/<model>      explicit OpenAI prefix (e.g. openai/gpt-5.2)[/loom.muted]\n"
+                "[loom.muted]  openai/<model>      explicit OpenAI prefix (e.g. openai/gpt-5.5)[/loom.muted]\n"
                 "[loom.muted]  openrouter/<v>/<m>  requires OPENROUTER_API_KEY in .env (e.g. openrouter/deepseek/deepseek-v4-pro)[/loom.muted]\n"
                 "[loom.muted]  deepseek-*          requires DEEPSEEK_API_KEY in .env  (e.g. deepseek-v4-pro)[/loom.muted]\n"
                 "[loom.muted]  ollama/<name>       enable [providers.ollama] in loom.toml[/loom.muted]\n"
@@ -1100,7 +1100,7 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
                 "  [loom.warning]/model[/loom.warning] [loom.muted]<name>[/loom.muted]              Switch model at runtime\n"
                 "    [loom.muted]MiniMax-M2.7            → MiniMax via Anthropic SDK (MINIMAX_API_KEY)[/loom.muted]\n"
                 "    [loom.muted]claude-sonnet-4-6       → Anthropic (ANTHROPIC_API_KEY)[/loom.muted]\n"
-                "    [loom.muted]gpt-5.2 / o3 / o4-mini → OpenAI (OPENAI_API_KEY; run `loom auth openai`)[/loom.muted]\n"
+                "    [loom.muted]gpt-5.5 / o3 / o4-mini → OpenAI (OPENAI_API_KEY; run `loom auth openai`)[/loom.muted]\n"
                 "    [loom.muted]ollama/<model>          → local Ollama  (enable in loom.toml)[/loom.muted]\n"
                 "    [loom.muted]lmstudio/<model>        → local LM Studio  (enable in loom.toml)[/loom.muted]\n"
                 "  [loom.warning]/personality[/loom.warning] [loom.muted]<name>[/loom.muted]      Switch cognitive persona\n"
@@ -2538,7 +2538,7 @@ def auth_openai(api_key: str | None, skip_codex_login: bool, env_file: Path | No
     if api_key:
         _set_env_value(target, "OPENAI_API_KEY", api_key.strip())
         console.print(f"[loom.muted]Saved OPENAI_API_KEY to {target}.[/loom.muted]")
-        console.print("[loom.muted]Try: loom chat --model gpt-5.2[/loom.muted]")
+        console.print("[loom.muted]Try: loom chat --model gpt-5.5[/loom.muted]")
     else:
         console.print(
             "[loom.muted]No API key saved. Codex CLI login is still useful for "

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -18,6 +18,7 @@ import asyncio
 import json
 import logging
 import os
+import subprocess
 import time
 import tomllib
 from pathlib import Path
@@ -85,6 +86,32 @@ console = Console(highlight=False, theme=LOOM_THEME)
 # handlers) can emit without threading a parameter through every call.
 harness = HarnessChannel(console)
 logger = logging.getLogger(__name__)
+
+
+def _project_env_path() -> Path:
+    """Return the .env path Loom should update for CLI onboarding."""
+    return Path.cwd() / ".env"
+
+
+def _set_env_value(path: Path, key: str, value: str) -> None:
+    """Set KEY=value in a dotenv file while preserving unrelated lines."""
+    encoded = f"{key}={value}"
+    lines = path.read_text(encoding="utf-8").splitlines() if path.exists() else []
+    out: list[str] = []
+    replaced = False
+    prefix = f"{key}="
+    for line in lines:
+        if line.startswith(prefix):
+            if not replaced:
+                out.append(encoded)
+                replaced = True
+            continue
+        out.append(line)
+    if not replaced:
+        if out and out[-1].strip():
+            out.append("")
+        out.append(encoded)
+    path.write_text("\n".join(out) + "\n", encoding="utf-8")
 
 # ---------------------------------------------------------------------------
 # CLI commands
@@ -787,6 +814,8 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
                 f"providers: {providers}[/loom.muted]\n"
                 "[loom.muted]  MiniMax-*           requires MINIMAX_API_KEY in .env (Anthropic-compatible endpoint)[/loom.muted]\n"
                 "[loom.muted]  claude-*            requires ANTHROPIC_API_KEY in .env[/loom.muted]\n"
+                "[loom.muted]  gpt-* / o3 / o4-*   requires OPENAI_API_KEY in .env (try `loom auth openai`)[/loom.muted]\n"
+                "[loom.muted]  openai/<model>      explicit OpenAI prefix (e.g. openai/gpt-4.1)[/loom.muted]\n"
                 "[loom.muted]  openrouter/<v>/<m>  requires OPENROUTER_API_KEY in .env (e.g. openrouter/deepseek/deepseek-v4-pro)[/loom.muted]\n"
                 "[loom.muted]  deepseek-*          requires DEEPSEEK_API_KEY in .env  (e.g. deepseek-v4-pro)[/loom.muted]\n"
                 "[loom.muted]  ollama/<name>       enable [providers.ollama] in loom.toml[/loom.muted]\n"
@@ -1071,6 +1100,7 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
                 "  [loom.warning]/model[/loom.warning] [loom.muted]<name>[/loom.muted]              Switch model at runtime\n"
                 "    [loom.muted]MiniMax-M2.7            → MiniMax via Anthropic SDK (MINIMAX_API_KEY)[/loom.muted]\n"
                 "    [loom.muted]claude-sonnet-4-6       → Anthropic (ANTHROPIC_API_KEY)[/loom.muted]\n"
+                "    [loom.muted]gpt-4.1 / gpt-5 / o3    → OpenAI (OPENAI_API_KEY; run `loom auth openai`)[/loom.muted]\n"
                 "    [loom.muted]ollama/<model>          → local Ollama  (enable in loom.toml)[/loom.muted]\n"
                 "    [loom.muted]lmstudio/<model>        → local LM Studio  (enable in loom.toml)[/loom.muted]\n"
                 "  [loom.warning]/personality[/loom.warning] [loom.muted]<name>[/loom.muted]      Switch cognitive persona\n"
@@ -1479,7 +1509,7 @@ async def _handle_slash_tui(cmd: str, session: "LoomSession", app: Any) -> None:
             providers = ", ".join(session.router.providers)
             app.notify(
                 f"Model: {session.model}  |  providers: {providers}\n"
-                "Prefixes: MiniMax-*  claude-*  deepseek-*  openrouter/<vendor>/<model>  ollama/<name>  lmstudio/<name>"
+                "Prefixes: MiniMax-*  claude-*  gpt-*  o3/o4-*  openai/<model>  deepseek-*  openrouter/<vendor>/<model>  ollama/<name>  lmstudio/<name>"
             )
         else:
             ok = session.set_model(arg)
@@ -2453,6 +2483,66 @@ async def _sessions_rm(session_id: str, db: str) -> None:
             return
         await sl.delete_session(session_id)
     console.print(f"[loom.muted]Session [loom.accent]{session_id}[/loom.accent] deleted.[/loom.muted]")
+
+
+# ---------------------------------------------------------------------------
+
+
+@cli.group()
+def auth() -> None:
+    """Configure provider authentication."""
+
+
+@auth.command("openai")
+@click.option("--api-key", default=None, help="OpenAI API key to write to .env.")
+@click.option("--skip-codex-login", is_flag=True, default=False,
+              help="Do not offer to run the official Codex CLI login flow.")
+@click.option("--env-file", type=click.Path(dir_okay=False, path_type=Path),
+              default=None, help="Dotenv file to update (defaults to ./.env).")
+def auth_openai(api_key: str | None, skip_codex_login: bool, env_file: Path | None) -> None:
+    """Sign in with Codex CLI and/or store OPENAI_API_KEY for Loom."""
+    target = env_file or _project_env_path()
+    console.print("[loom.muted]OpenAI setup for Loom[/loom.muted]")
+    console.print(
+        "[loom.muted]Recommended first step: run the official Codex CLI "
+        "OAuth flow (`codex --login`). Loom does not read Codex private "
+        "credentials; OPENAI_API_KEY remains the portable fallback.[/loom.muted]"
+    )
+
+    if api_key is None and not skip_codex_login and click.confirm("Run `codex --login` now?", default=True):
+        try:
+            result = subprocess.run(["codex", "--login"], check=False)
+        except FileNotFoundError:
+            console.print(
+                "[loom.warning]Codex CLI was not found on PATH. Install it or "
+                "continue with an API key.[/loom.warning]"
+            )
+        else:
+            if result.returncode == 0:
+                console.print("[loom.muted]Codex CLI login completed.[/loom.muted]")
+            else:
+                console.print(
+                    f"[loom.warning]`codex --login` exited with code "
+                    f"{result.returncode}; continuing with API-key setup.[/loom.warning]"
+                )
+
+    existing = _load_env().get("OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    if api_key is None:
+        if existing and not click.confirm("OPENAI_API_KEY already exists. Replace it?", default=False):
+            console.print("[loom.muted]Keeping existing OPENAI_API_KEY.[/loom.muted]")
+            return
+        if click.confirm("Store an OPENAI_API_KEY for Loom now?", default=not bool(existing)):
+            api_key = click.prompt("OPENAI_API_KEY", hide_input=True).strip()
+
+    if api_key:
+        _set_env_value(target, "OPENAI_API_KEY", api_key.strip())
+        console.print(f"[loom.muted]Saved OPENAI_API_KEY to {target}.[/loom.muted]")
+        console.print("[loom.muted]Try: loom chat --model gpt-4.1[/loom.muted]")
+    else:
+        console.print(
+            "[loom.muted]No API key saved. Codex CLI login is still useful for "
+            "`codex`, but Loom needs OPENAI_API_KEY for OpenAI provider calls.[/loom.muted]"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -814,7 +814,7 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
                 f"providers: {providers}[/loom.muted]\n"
                 "[loom.muted]  MiniMax-*           requires MINIMAX_API_KEY in .env (Anthropic-compatible endpoint)[/loom.muted]\n"
                 "[loom.muted]  claude-*            requires ANTHROPIC_API_KEY in .env[/loom.muted]\n"
-                "[loom.muted]  gpt-* / o3 / o3-* / o4-* requires OPENAI_API_KEY in .env (try `loom auth openai`)[/loom.muted]\n"
+                "[loom.muted]  gpt-*               requires OPENAI_API_KEY in .env (try `loom auth openai`)[/loom.muted]\n"
                 "[loom.muted]  openai/<model>      explicit OpenAI prefix (e.g. openai/gpt-5.5)[/loom.muted]\n"
                 "[loom.muted]  openrouter/<v>/<m>  requires OPENROUTER_API_KEY in .env (e.g. openrouter/deepseek/deepseek-v4-pro)[/loom.muted]\n"
                 "[loom.muted]  deepseek-*          requires DEEPSEEK_API_KEY in .env  (e.g. deepseek-v4-pro)[/loom.muted]\n"
@@ -1100,7 +1100,7 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
                 "  [loom.warning]/model[/loom.warning] [loom.muted]<name>[/loom.muted]              Switch model at runtime\n"
                 "    [loom.muted]MiniMax-M2.7            → MiniMax via Anthropic SDK (MINIMAX_API_KEY)[/loom.muted]\n"
                 "    [loom.muted]claude-sonnet-4-6       → Anthropic (ANTHROPIC_API_KEY)[/loom.muted]\n"
-                "    [loom.muted]gpt-5.5 / o3 / o4-mini → OpenAI (OPENAI_API_KEY; run `loom auth openai`)[/loom.muted]\n"
+                "    [loom.muted]gpt-5.5 / gpt-5.5-pro   → OpenAI (OPENAI_API_KEY; run `loom auth openai`)[/loom.muted]\n"
                 "    [loom.muted]ollama/<model>          → local Ollama  (enable in loom.toml)[/loom.muted]\n"
                 "    [loom.muted]lmstudio/<model>        → local LM Studio  (enable in loom.toml)[/loom.muted]\n"
                 "  [loom.warning]/personality[/loom.warning] [loom.muted]<name>[/loom.muted]      Switch cognitive persona\n"
@@ -1509,7 +1509,7 @@ async def _handle_slash_tui(cmd: str, session: "LoomSession", app: Any) -> None:
             providers = ", ".join(session.router.providers)
             app.notify(
                 f"Model: {session.model}  |  providers: {providers}\n"
-                "Prefixes: MiniMax-*  claude-*  gpt-*  o3/o3-*/o4-*  openai/<model>  deepseek-*  openrouter/<vendor>/<model>  ollama/<name>  lmstudio/<name>"
+                "Prefixes: MiniMax-*  claude-*  gpt-*  openai/<model>  deepseek-*  openrouter/<vendor>/<model>  ollama/<name>  lmstudio/<name>"
             )
         else:
             ok = session.set_model(arg)

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -814,8 +814,8 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
                 f"providers: {providers}[/loom.muted]\n"
                 "[loom.muted]  MiniMax-*           requires MINIMAX_API_KEY in .env (Anthropic-compatible endpoint)[/loom.muted]\n"
                 "[loom.muted]  claude-*            requires ANTHROPIC_API_KEY in .env[/loom.muted]\n"
-                "[loom.muted]  gpt-* / o3 / o4-*   requires OPENAI_API_KEY in .env (try `loom auth openai`)[/loom.muted]\n"
-                "[loom.muted]  openai/<model>      explicit OpenAI prefix (e.g. openai/gpt-4.1)[/loom.muted]\n"
+                "[loom.muted]  gpt-* / o3 / o3-* / o4-* requires OPENAI_API_KEY in .env (try `loom auth openai`)[/loom.muted]\n"
+                "[loom.muted]  openai/<model>      explicit OpenAI prefix (e.g. openai/gpt-5.2)[/loom.muted]\n"
                 "[loom.muted]  openrouter/<v>/<m>  requires OPENROUTER_API_KEY in .env (e.g. openrouter/deepseek/deepseek-v4-pro)[/loom.muted]\n"
                 "[loom.muted]  deepseek-*          requires DEEPSEEK_API_KEY in .env  (e.g. deepseek-v4-pro)[/loom.muted]\n"
                 "[loom.muted]  ollama/<name>       enable [providers.ollama] in loom.toml[/loom.muted]\n"
@@ -1100,7 +1100,7 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
                 "  [loom.warning]/model[/loom.warning] [loom.muted]<name>[/loom.muted]              Switch model at runtime\n"
                 "    [loom.muted]MiniMax-M2.7            → MiniMax via Anthropic SDK (MINIMAX_API_KEY)[/loom.muted]\n"
                 "    [loom.muted]claude-sonnet-4-6       → Anthropic (ANTHROPIC_API_KEY)[/loom.muted]\n"
-                "    [loom.muted]gpt-4.1 / gpt-5 / o3    → OpenAI (OPENAI_API_KEY; run `loom auth openai`)[/loom.muted]\n"
+                "    [loom.muted]gpt-5.2 / o3 / o4-mini → OpenAI (OPENAI_API_KEY; run `loom auth openai`)[/loom.muted]\n"
                 "    [loom.muted]ollama/<model>          → local Ollama  (enable in loom.toml)[/loom.muted]\n"
                 "    [loom.muted]lmstudio/<model>        → local LM Studio  (enable in loom.toml)[/loom.muted]\n"
                 "  [loom.warning]/personality[/loom.warning] [loom.muted]<name>[/loom.muted]      Switch cognitive persona\n"
@@ -1509,7 +1509,7 @@ async def _handle_slash_tui(cmd: str, session: "LoomSession", app: Any) -> None:
             providers = ", ".join(session.router.providers)
             app.notify(
                 f"Model: {session.model}  |  providers: {providers}\n"
-                "Prefixes: MiniMax-*  claude-*  gpt-*  o3/o4-*  openai/<model>  deepseek-*  openrouter/<vendor>/<model>  ollama/<name>  lmstudio/<name>"
+                "Prefixes: MiniMax-*  claude-*  gpt-*  o3/o3-*/o4-*  openai/<model>  deepseek-*  openrouter/<vendor>/<model>  ollama/<name>  lmstudio/<name>"
             )
         else:
             ok = session.set_model(arg)
@@ -2500,13 +2500,14 @@ def auth() -> None:
 @click.option("--env-file", type=click.Path(dir_okay=False, path_type=Path),
               default=None, help="Dotenv file to update (defaults to ./.env).")
 def auth_openai(api_key: str | None, skip_codex_login: bool, env_file: Path | None) -> None:
-    """Sign in with Codex CLI and/or store OPENAI_API_KEY for Loom."""
+    """Run Codex CLI login helper and/or store OPENAI_API_KEY for Loom."""
     target = env_file or _project_env_path()
     console.print("[loom.muted]OpenAI setup for Loom[/loom.muted]")
     console.print(
-        "[loom.muted]Recommended first step: run the official Codex CLI "
-        "OAuth flow (`codex --login`). Loom does not read Codex private "
-        "credentials; OPENAI_API_KEY remains the portable fallback.[/loom.muted]"
+        "[loom.muted]Phase 1 setup: run the official Codex CLI OAuth flow "
+        "(`codex --login`) as a user-friendly first step. Loom does not read "
+        "Codex private credentials; OPENAI_API_KEY remains the portable "
+        "provider credential.[/loom.muted]"
     )
 
     if api_key is None and not skip_codex_login and click.confirm("Run `codex --login` now?", default=True):
@@ -2537,7 +2538,7 @@ def auth_openai(api_key: str | None, skip_codex_login: bool, env_file: Path | No
     if api_key:
         _set_env_value(target, "OPENAI_API_KEY", api_key.strip())
         console.print(f"[loom.muted]Saved OPENAI_API_KEY to {target}.[/loom.muted]")
-        console.print("[loom.muted]Try: loom chat --model gpt-4.1[/loom.muted]")
+        console.print("[loom.muted]Try: loom chat --model gpt-5.2[/loom.muted]")
     else:
         console.print(
             "[loom.muted]No API key saved. Codex CLI login is still useful for "

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -2501,13 +2501,15 @@ def auth() -> None:
               default=None, help="Dotenv file to update (defaults to ./.env).")
 def auth_openai(api_key: str | None, skip_codex_login: bool, env_file: Path | None) -> None:
     """Run Codex CLI login helper and/or store OPENAI_API_KEY for Loom."""
+    from loom.core.cognition.openai_auth import load_codex_oauth_credential
+
     target = env_file or _project_env_path()
     console.print("[loom.muted]OpenAI setup for Loom[/loom.muted]")
     console.print(
-        "[loom.muted]Phase 1 setup: run the official Codex CLI OAuth flow "
-        "(`codex --login`) as a user-friendly first step. Loom does not read "
-        "Codex private credentials; OPENAI_API_KEY remains the portable "
-        "provider credential.[/loom.muted]"
+        "[loom.muted]Run the official Codex CLI OAuth flow (`codex --login`) "
+        "as a user-friendly first step. Loom can use an unexpired Codex "
+        "access token for OpenAI image generation, while OPENAI_API_KEY "
+        "remains the portable fallback credential.[/loom.muted]"
     )
 
     if api_key is None and not skip_codex_login and click.confirm("Run `codex --login` now?", default=True):
@@ -2521,6 +2523,12 @@ def auth_openai(api_key: str | None, skip_codex_login: bool, env_file: Path | No
         else:
             if result.returncode == 0:
                 console.print("[loom.muted]Codex CLI login completed.[/loom.muted]")
+                codex_credential = load_codex_oauth_credential()
+                if codex_credential is not None:
+                    console.print(
+                        "[loom.muted]Found an unexpired Codex OAuth access token "
+                        "for Loom's experimental Codex credential path.[/loom.muted]"
+                    )
             else:
                 console.print(
                     f"[loom.warning]`codex --login` exited with code "

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -2506,15 +2506,15 @@ def auth_openai(api_key: str | None, skip_codex_login: bool, env_file: Path | No
     target = env_file or _project_env_path()
     console.print("[loom.muted]OpenAI setup for Loom[/loom.muted]")
     console.print(
-        "[loom.muted]Run the official Codex CLI OAuth flow (`codex --login`) "
+        "[loom.muted]Run the official Codex CLI OAuth flow (`codex login`) "
         "as a user-friendly first step. Loom can use an unexpired Codex "
         "access token for OpenAI image generation, while OPENAI_API_KEY "
         "remains the portable fallback credential.[/loom.muted]"
     )
 
-    if api_key is None and not skip_codex_login and click.confirm("Run `codex --login` now?", default=True):
+    if api_key is None and not skip_codex_login and click.confirm("Run `codex login` now?", default=True):
         try:
-            result = subprocess.run(["codex", "--login"], check=False)
+            result = subprocess.run(["codex", "login"], check=False)
         except FileNotFoundError:
             console.print(
                 "[loom.warning]Codex CLI was not found on PATH. Install it or "
@@ -2531,7 +2531,7 @@ def auth_openai(api_key: str | None, skip_codex_login: bool, env_file: Path | No
                     )
             else:
                 console.print(
-                    f"[loom.warning]`codex --login` exited with code "
+                    f"[loom.warning]`codex login` exited with code "
                     f"{result.returncode}; continuing with API-key setup.[/loom.warning]"
                 )
 

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -161,7 +161,7 @@ def _resolve_workspace_path(raw: str, workspace: Path) -> Path:
 
 
 def _make_openai_image_scope_resolver(workspace: Path):
-    """Scope resolver for the OpenAI image tool: write one path + connect to api.openai.com."""
+    """Scope resolver for the OpenAI image tool."""
     import os.path
 
     _workspace_resolved = workspace.resolve()
@@ -189,6 +189,13 @@ def _make_openai_image_scope_resolver(workspace: Path):
                     resource="network",
                     action="connect",
                     selector="api.openai.com",
+                    tool_name=call.tool_name,
+                    capabilities=call.capabilities,
+                ),
+                ScopeRequirement(
+                    resource="network",
+                    action="connect",
+                    selector="chatgpt.com",
                     tool_name=call.tool_name,
                     capabilities=call.capabilities,
                 ),
@@ -2647,6 +2654,47 @@ def make_web_search_tool(brave_api_key: str) -> ToolDefinition:
     )
 
 
+def _extract_image_b64(data: Any) -> str:
+    """Find the newest base64 image field in a Responses payload."""
+
+    found = ""
+
+    def _walk(value: Any) -> None:
+        nonlocal found
+        if isinstance(value, dict):
+            for key, child in value.items():
+                if (
+                    key in {"partial_image_b64", "image_b64", "b64_json"}
+                    and isinstance(child, str)
+                    and child
+                ):
+                    found = child
+                else:
+                    _walk(child)
+        elif isinstance(value, list):
+            for child in value:
+                _walk(child)
+
+    _walk(data)
+    return found
+
+
+async def _decode_openai_image_response(
+    client: httpx.AsyncClient,
+    data: dict[str, Any],
+) -> bytes:
+    """Decode an OpenAI Images API response into image bytes."""
+
+    first = (data.get("data") or [{}])[0]
+    if first.get("b64_json"):
+        return base64.b64decode(first["b64_json"])
+    if first.get("url"):
+        img = await client.get(first["url"])
+        img.raise_for_status()
+        return img.content
+    raise RuntimeError("OpenAI image response did not include b64_json or url.")
+
+
 def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
     """Build an OpenAI GPT Image generation tool."""
 
@@ -2703,17 +2751,18 @@ def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
             output_path = output_path.with_suffix(".png")
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        payload: dict[str, Any] = {
-            "model": str(call.args.get("model", "gpt-image-2")).strip() or "gpt-image-2",
-            "prompt": prompt,
+        image_model = str(call.args.get("model", "gpt-image-2")).strip() or "gpt-image-2"
+        image_options: dict[str, Any] = {
+            "model": image_model,
             "n": int(call.args.get("n", 1) or 1),
         }
         for key in ("size", "quality", "background", "moderation"):
             value = call.args.get(key)
             if isinstance(value, str) and value.strip():
-                payload[key] = value.strip()
+                image_options[key] = value.strip()
 
-        async def _request_image(client: httpx.AsyncClient, bearer: str):
+        async def _request_openai_images(client: httpx.AsyncClient, bearer: str):
+            payload = {"prompt": prompt, **image_options}
             resp = await client.post(
                 "https://api.openai.com/v1/images/generations",
                 headers={"Authorization": f"Bearer {bearer}"},
@@ -2722,41 +2771,96 @@ def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
             resp.raise_for_status()
             return resp.json()
 
+        async def _request_codex_responses(client: httpx.AsyncClient, bearer: str) -> str:
+            output_format = output_path.suffix.lower().lstrip(".") or "png"
+            if output_format == "jpg":
+                output_format = "jpeg"
+            tool_spec = {
+                "type": "image_generation",
+                "model": image_model,
+                "size": image_options.get("size", "auto"),
+                "quality": image_options.get("quality", "auto"),
+                "output_format": output_format,
+            }
+            for key in ("background", "moderation"):
+                value = image_options.get(key)
+                if isinstance(value, str) and value.strip():
+                    tool_spec[key] = value.strip()
+
+            payload = {
+                "model": str(call.args.get("codex_model", "gpt-5.5")).strip() or "gpt-5.5",
+                "instructions": (
+                    "Use image generation to create the requested image. "
+                    "Return no extra text unless needed."
+                ),
+                "input": [{
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": prompt}],
+                }],
+                "tools": [tool_spec],
+                "stream": True,
+                "store": False,
+            }
+            latest_b64 = ""
+            async with client.stream(
+                "POST",
+                "https://chatgpt.com/backend-api/codex/responses",
+                headers={
+                    "Authorization": f"Bearer {bearer}",
+                    "Content-Type": "application/json",
+                    "Accept": "text/event-stream",
+                },
+                json=payload,
+            ) as resp:
+                resp.raise_for_status()
+                event: str | None = None
+                data_lines: list[str] = []
+                async for line in resp.aiter_lines():
+                    if line.startswith("event: "):
+                        event = line[7:]
+                    elif line.startswith("data: "):
+                        data_lines.append(line[6:])
+                    elif line == "" and event:
+                        raw = "\n".join(data_lines)
+                        try:
+                            data = json.loads(raw)
+                        except json.JSONDecodeError:
+                            data = {}
+                        found = _extract_image_b64(data)
+                        if found:
+                            latest_b64 = found
+                        if event in {"response.completed", "response.failed"}:
+                            break
+                        event = None
+                        data_lines = []
+            if not latest_b64:
+                raise RuntimeError("Codex Responses backend did not return an image payload.")
+            return latest_b64
+
         try:
             async with httpx.AsyncClient(timeout=_IMAGE_TIMEOUT) as client:
-                try:
-                    data = await _request_image(client, credential.token)
-                    credential_source = credential.source
-                except httpx.HTTPStatusError as exc:
-                    fallback = resolve_openai_credential(
-                        env,
-                        prefer_codex=False,
-                    )
-                    can_fallback = (
-                        auth_mode == "auto"
-                        and credential.source == "codex_oauth"
-                        and fallback is not None
-                        and fallback.source == "api_key"
-                        and exc.response.status_code in {401, 403}
-                    )
-                    if not can_fallback:
-                        raise
-                    data = await _request_image(client, fallback.token)
-                    credential_source = fallback.source
-                first = (data.get("data") or [{}])[0]
-                if first.get("b64_json"):
-                    image_bytes = base64.b64decode(first["b64_json"])
-                elif first.get("url"):
-                    img = await client.get(first["url"])
-                    img.raise_for_status()
-                    image_bytes = img.content
+                if credential.source == "codex_oauth":
+                    try:
+                        b64_image = await _request_codex_responses(client, credential.token)
+                        image_bytes = base64.b64decode(b64_image)
+                        credential_source = credential.source
+                    except httpx.HTTPStatusError as exc:
+                        fallback = resolve_openai_credential(env, prefer_codex=False)
+                        can_fallback = (
+                            auth_mode == "auto"
+                            and fallback is not None
+                            and fallback.source == "api_key"
+                            and exc.response.status_code in {401, 403}
+                        )
+                        if not can_fallback:
+                            raise
+                        data = await _request_openai_images(client, fallback.token)
+                        image_bytes = await _decode_openai_image_response(client, data)
+                        credential_source = fallback.source
                 else:
-                    return ToolResult(
-                        call_id=call.id,
-                        tool_name=call.tool_name,
-                        success=False,
-                        error="OpenAI image response did not include b64_json or url.",
-                    )
+                    data = await _request_openai_images(client, credential.token)
+                    image_bytes = await _decode_openai_image_response(client, data)
+                    credential_source = credential.source
         except httpx.HTTPStatusError as exc:
             body = exc.response.text[:500] if exc.response is not None else ""
             return ToolResult(
@@ -2784,7 +2888,7 @@ def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
             success=True,
             output=json.dumps({
                 "path": display_path,
-                "model": payload["model"],
+                "model": image_model,
                 "credential_source": credential_source,
                 "bytes": len(image_bytes),
             }, ensure_ascii=False),
@@ -2836,7 +2940,8 @@ def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
         tags=["image", "openai"],
         impact_scope="network",
         scope_descriptions=[
-            "connects to api.openai.com",
+            "connects to api.openai.com for API-key image generation",
+            "connects to chatgpt.com for Codex OAuth image generation",
             "writes one generated image file under the workspace",
         ],
         scope_resolver=_make_openai_image_scope_resolver(workspace),

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -160,8 +160,8 @@ def _resolve_workspace_path(raw: str, workspace: Path) -> Path:
         return (workspace / Path(*parts)).resolve()
 
 
-def _make_write_path_resolver(workspace: Path):
-    """Return a scope_resolver for tools that write one output path."""
+def _make_openai_image_scope_resolver(workspace: Path):
+    """Scope resolver for the OpenAI image tool: write one path + connect to api.openai.com."""
     import os.path
 
     _workspace_resolved = workspace.resolve()
@@ -2839,7 +2839,7 @@ def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
             "connects to api.openai.com",
             "writes one generated image file under the workspace",
         ],
-        scope_resolver=_make_write_path_resolver(workspace),
+        scope_resolver=_make_openai_image_scope_resolver(workspace),
     )
 
 

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -2680,9 +2680,9 @@ def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
         )
         if credential is None:
             detail = (
-                "Run `codex --login` for Codex OAuth or set OPENAI_API_KEY."
+                "Run `codex login` for Codex OAuth or set OPENAI_API_KEY."
                 if auth_mode == "auto"
-                else "Run `codex --login`; no unexpired Codex OAuth token was found."
+                else "Run `codex login`; no unexpired Codex OAuth token was found."
                 if auth_mode == "codex"
                 else "Set OPENAI_API_KEY in .env or the environment."
             )

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -3097,6 +3097,7 @@ def make_spawn_agent_tool(parent_session: Any) -> "ToolDefinition":
                 },
                 "tools": {
                     "type": ["array", "string", "null"],
+                    "items": {"type": "string"},
                     "description": (
                         "Tool whitelist for the sub-agent. "
                         "List of tool names (e.g. ['read_file', 'web_search']) or comma-separated string. "

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -17,6 +17,7 @@ The actual registration happens in main.py via ToolRegistry.
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import os
 import re
@@ -88,6 +89,7 @@ if TYPE_CHECKING:
 _WEB_TIMEOUT = 10.0       # seconds for all HTTP calls
 _CONTENT_LIMIT = 2000     # max chars returned to agent
 _SEARCH_RESULTS = 5       # default Brave results
+_IMAGE_TIMEOUT = 180.0
 
 
 async def _race_abort(coro, abort_signal):
@@ -156,6 +158,43 @@ def _resolve_workspace_path(raw: str, workspace: Path) -> Path:
         # e.g. /etc/passwd → workspace/etc/passwd, C:\Windows → workspace\Windows
         parts = resolved.parts[1:]
         return (workspace / Path(*parts)).resolve()
+
+
+def _make_write_path_resolver(workspace: Path):
+    """Return a scope_resolver for tools that write one output path."""
+    import os.path
+
+    _workspace_resolved = workspace.resolve()
+
+    def _resolve(call: ToolCall) -> ScopeRequest:
+        raw = call.args.get("output_path") or call.args.get("path") or "outputs"
+        p = Path(str(raw))
+        resolved = (workspace / p).resolve() if not p.is_absolute() else p.resolve()
+        try:
+            selector = str(resolved.parent.relative_to(_workspace_resolved))
+        except ValueError:
+            selector = os.path.normpath(str(resolved.parent))
+        return ScopeRequest(
+            tool_name=call.tool_name,
+            capabilities=call.capabilities,
+            requirements=[
+                ScopeRequirement(
+                    resource="path",
+                    action="write",
+                    selector=selector,
+                    tool_name=call.tool_name,
+                    capabilities=call.capabilities,
+                ),
+                ScopeRequirement(
+                    resource="network",
+                    action="connect",
+                    selector="api.openai.com",
+                    tool_name=call.tool_name,
+                    capabilities=call.capabilities,
+                ),
+            ],
+        )
+    return _resolve
 
 
 # ------------------------------------------------------------------
@@ -2605,6 +2644,202 @@ def make_web_search_tool(brave_api_key: str) -> ToolDefinition:
         impact_scope="network",
         scope_descriptions=["connects to Brave Search API"],
         scope_resolver=_web_search_resolver,
+    )
+
+
+def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
+    """Build an OpenAI GPT Image generation tool."""
+
+    from loom.core.session import _load_env
+    from loom.core.cognition.openai_auth import resolve_openai_credential
+
+    async def _openai_image(call: ToolCall) -> ToolResult:
+        prompt = str(call.args.get("prompt", "")).strip()
+        if not prompt:
+            return ToolResult(
+                call_id=call.id,
+                tool_name=call.tool_name,
+                success=False,
+                error="Missing required argument: prompt",
+            )
+
+        auth_mode = str(call.args.get("auth_mode", "auto")).strip().lower()
+        if auth_mode not in {"auto", "codex", "api_key"}:
+            return ToolResult(
+                call_id=call.id,
+                tool_name=call.tool_name,
+                success=False,
+                error="auth_mode must be one of: auto, codex, api_key",
+            )
+
+        env = _load_env()
+        credential = resolve_openai_credential(
+            env,
+            prefer_codex=auth_mode != "api_key",
+            require_codex=auth_mode == "codex",
+        )
+        if credential is None:
+            detail = (
+                "Run `codex --login` for Codex OAuth or set OPENAI_API_KEY."
+                if auth_mode == "auto"
+                else "Run `codex --login`; no unexpired Codex OAuth token was found."
+                if auth_mode == "codex"
+                else "Set OPENAI_API_KEY in .env or the environment."
+            )
+            return ToolResult(
+                call_id=call.id,
+                tool_name=call.tool_name,
+                success=False,
+                error=f"No usable OpenAI credential. {detail}",
+            )
+
+        raw_output = str(call.args.get("output_path", "")).strip()
+        output_path = (
+            _resolve_workspace_path(raw_output, workspace)
+            if raw_output else
+            workspace / "outputs" / f"openai-image-{uuid.uuid4().hex[:8]}.png"
+        )
+        if output_path.suffix.lower() not in {".png", ".webp", ".jpg", ".jpeg"}:
+            output_path = output_path.with_suffix(".png")
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        payload: dict[str, Any] = {
+            "model": str(call.args.get("model", "gpt-image-2")).strip() or "gpt-image-2",
+            "prompt": prompt,
+            "n": int(call.args.get("n", 1) or 1),
+        }
+        for key in ("size", "quality", "background", "moderation"):
+            value = call.args.get(key)
+            if isinstance(value, str) and value.strip():
+                payload[key] = value.strip()
+
+        async def _request_image(client: httpx.AsyncClient, bearer: str):
+            resp = await client.post(
+                "https://api.openai.com/v1/images/generations",
+                headers={"Authorization": f"Bearer {bearer}"},
+                json=payload,
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+        try:
+            async with httpx.AsyncClient(timeout=_IMAGE_TIMEOUT) as client:
+                try:
+                    data = await _request_image(client, credential.token)
+                    credential_source = credential.source
+                except httpx.HTTPStatusError as exc:
+                    fallback = resolve_openai_credential(
+                        env,
+                        prefer_codex=False,
+                    )
+                    can_fallback = (
+                        auth_mode == "auto"
+                        and credential.source == "codex_oauth"
+                        and fallback is not None
+                        and fallback.source == "api_key"
+                        and exc.response.status_code in {401, 403}
+                    )
+                    if not can_fallback:
+                        raise
+                    data = await _request_image(client, fallback.token)
+                    credential_source = fallback.source
+                first = (data.get("data") or [{}])[0]
+                if first.get("b64_json"):
+                    image_bytes = base64.b64decode(first["b64_json"])
+                elif first.get("url"):
+                    img = await client.get(first["url"])
+                    img.raise_for_status()
+                    image_bytes = img.content
+                else:
+                    return ToolResult(
+                        call_id=call.id,
+                        tool_name=call.tool_name,
+                        success=False,
+                        error="OpenAI image response did not include b64_json or url.",
+                    )
+        except httpx.HTTPStatusError as exc:
+            body = exc.response.text[:500] if exc.response is not None else ""
+            return ToolResult(
+                call_id=call.id,
+                tool_name=call.tool_name,
+                success=False,
+                error=f"OpenAI image request failed with HTTP {exc.response.status_code}: {body}",
+            )
+        except Exception as exc:
+            return ToolResult(
+                call_id=call.id,
+                tool_name=call.tool_name,
+                success=False,
+                error=f"OpenAI image request failed: {type(exc).__name__}: {exc}",
+            )
+
+        output_path.write_bytes(image_bytes)
+        try:
+            display_path = str(output_path.relative_to(workspace))
+        except ValueError:
+            display_path = str(output_path)
+        return ToolResult(
+            call_id=call.id,
+            tool_name=call.tool_name,
+            success=True,
+            output=json.dumps({
+                "path": display_path,
+                "model": payload["model"],
+                "credential_source": credential_source,
+                "bytes": len(image_bytes),
+            }, ensure_ascii=False),
+        )
+
+    return ToolDefinition(
+        name="openai__text_to_image",
+        description=(
+            "Generate an image with OpenAI GPT Image and save it to a workspace file. "
+            "Uses Codex OAuth first when available, with OPENAI_API_KEY fallback."
+        ),
+        trust_level=TrustLevel.GUARDED,
+        capabilities=ToolCapability.NETWORK | ToolCapability.MUTATES,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "prompt": {"type": "string", "description": "Image prompt."},
+                "output_path": {
+                    "type": "string",
+                    "description": "Workspace-relative output path. Defaults to outputs/openai-image-<id>.png.",
+                },
+                "model": {
+                    "type": "string",
+                    "description": "OpenAI image model.",
+                    "default": "gpt-image-2",
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Image size supported by the selected model, e.g. auto or 1024x1024.",
+                    "default": "auto",
+                },
+                "quality": {
+                    "type": "string",
+                    "description": "Quality supported by the selected model, e.g. auto, low, medium, high.",
+                    "default": "auto",
+                },
+                "auth_mode": {
+                    "type": "string",
+                    "enum": ["auto", "codex", "api_key"],
+                    "default": "auto",
+                    "description": "auto prefers Codex OAuth and falls back to OPENAI_API_KEY.",
+                },
+                "n": {"type": "integer", "minimum": 1, "maximum": 1, "default": 1},
+            },
+            "required": ["prompt"],
+            "additionalProperties": False,
+        },
+        executor=_openai_image,
+        tags=["image", "openai"],
+        impact_scope="network",
+        scope_descriptions=[
+            "connects to api.openai.com",
+            "writes one generated image file under the workspace",
+        ],
+        scope_resolver=_make_write_path_resolver(workspace),
     )
 
 

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -1,0 +1,45 @@
+from click.testing import CliRunner
+
+from loom.platform.cli.main import _set_env_value, cli
+
+
+def test_set_env_value_adds_key(tmp_path):
+    env_path = tmp_path / ".env"
+
+    _set_env_value(env_path, "OPENAI_API_KEY", "sk-test")
+
+    assert env_path.read_text(encoding="utf-8") == "OPENAI_API_KEY=sk-test\n"
+
+
+def test_set_env_value_replaces_key_and_preserves_other_lines(tmp_path):
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "# comment\nOPENAI_API_KEY=old\nANTHROPIC_API_KEY=ant\n",
+        encoding="utf-8",
+    )
+
+    _set_env_value(env_path, "OPENAI_API_KEY", "new")
+
+    assert env_path.read_text(encoding="utf-8") == (
+        "# comment\nOPENAI_API_KEY=new\nANTHROPIC_API_KEY=ant\n"
+    )
+
+
+def test_auth_openai_api_key_is_non_interactive(tmp_path):
+    env_path = tmp_path / ".env"
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        [
+            "auth",
+            "openai",
+            "--api-key",
+            "sk-test",
+            "--env-file",
+            str(env_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert env_path.read_text(encoding="utf-8") == "OPENAI_API_KEY=sk-test\n"

--- a/tests/test_cognition.py
+++ b/tests/test_cognition.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock
 from loom.core.cognition.context import ContextBudget, estimate_tokens
 from loom.core.cognition.providers import (
     LLMResponse,
+    OpenAIProvider,
     _to_anthropic_messages,
 )
 from loom.core.cognition.router import LLMRouter
@@ -260,6 +261,19 @@ class TestLLMRouter:
         router.register(p_mm)
         router.register(p_ant)
         assert router.get_provider("claude-sonnet-4-6") is p_ant
+
+    def test_routing_by_prefix_openai(self):
+        router = LLMRouter()
+        p_openai = self._make_mock_provider("openai")
+        router.register(p_openai)
+        assert router.get_provider("gpt-4.1") is p_openai
+        assert router.get_provider("o3") is p_openai
+        assert router.get_provider("o4-mini") is p_openai
+        assert router.get_provider("openai/gpt-4.1") is p_openai
+
+    def test_openai_provider_strips_optional_prefix(self):
+        provider = OpenAIProvider(api_key="test", model="openai/gpt-4.1")
+        assert provider._api_model() == "gpt-4.1"
 
     def test_fallback_to_default(self):
         router = LLMRouter()

--- a/tests/test_cognition.py
+++ b/tests/test_cognition.py
@@ -267,19 +267,8 @@ class TestLLMRouter:
         p_openai = self._make_mock_provider("openai")
         router.register(p_openai)
         assert router.get_provider("gpt-5.5") is p_openai
-        assert router.get_provider("o3") is p_openai
-        assert router.get_provider("o3-pro") is p_openai
-        assert router.get_provider("o4-mini") is p_openai
+        assert router.get_provider("gpt-5.5-pro") is p_openai
         assert router.get_provider("openai/gpt-5.5") is p_openai
-
-    def test_openai_o_prefix_requires_exact_or_dash(self):
-        router = LLMRouter()
-        p_default = self._make_mock_provider("minimax")
-        p_openai = self._make_mock_provider("openai")
-        router.register(p_default, default=True)
-        router.register(p_openai)
-
-        assert router.get_provider("o3anything") is p_default
 
     def test_openai_provider_strips_optional_prefix(self):
         provider = OpenAIProvider(api_key="test", model="openai/gpt-5.5")

--- a/tests/test_cognition.py
+++ b/tests/test_cognition.py
@@ -266,14 +266,24 @@ class TestLLMRouter:
         router = LLMRouter()
         p_openai = self._make_mock_provider("openai")
         router.register(p_openai)
-        assert router.get_provider("gpt-4.1") is p_openai
+        assert router.get_provider("gpt-5.2") is p_openai
         assert router.get_provider("o3") is p_openai
+        assert router.get_provider("o3-pro") is p_openai
         assert router.get_provider("o4-mini") is p_openai
-        assert router.get_provider("openai/gpt-4.1") is p_openai
+        assert router.get_provider("openai/gpt-5.2") is p_openai
+
+    def test_openai_o_prefix_requires_exact_or_dash(self):
+        router = LLMRouter()
+        p_default = self._make_mock_provider("minimax")
+        p_openai = self._make_mock_provider("openai")
+        router.register(p_default, default=True)
+        router.register(p_openai)
+
+        assert router.get_provider("o3anything") is p_default
 
     def test_openai_provider_strips_optional_prefix(self):
-        provider = OpenAIProvider(api_key="test", model="openai/gpt-4.1")
-        assert provider._api_model() == "gpt-4.1"
+        provider = OpenAIProvider(api_key="test", model="openai/gpt-5.2")
+        assert provider._api_model() == "gpt-5.2"
 
     def test_fallback_to_default(self):
         router = LLMRouter()

--- a/tests/test_cognition.py
+++ b/tests/test_cognition.py
@@ -266,11 +266,11 @@ class TestLLMRouter:
         router = LLMRouter()
         p_openai = self._make_mock_provider("openai")
         router.register(p_openai)
-        assert router.get_provider("gpt-5.2") is p_openai
+        assert router.get_provider("gpt-5.5") is p_openai
         assert router.get_provider("o3") is p_openai
         assert router.get_provider("o3-pro") is p_openai
         assert router.get_provider("o4-mini") is p_openai
-        assert router.get_provider("openai/gpt-5.2") is p_openai
+        assert router.get_provider("openai/gpt-5.5") is p_openai
 
     def test_openai_o_prefix_requires_exact_or_dash(self):
         router = LLMRouter()
@@ -282,8 +282,8 @@ class TestLLMRouter:
         assert router.get_provider("o3anything") is p_default
 
     def test_openai_provider_strips_optional_prefix(self):
-        provider = OpenAIProvider(api_key="test", model="openai/gpt-5.2")
-        assert provider._api_model() == "gpt-5.2"
+        provider = OpenAIProvider(api_key="test", model="openai/gpt-5.5")
+        assert provider._api_model() == "gpt-5.5"
 
     def test_fallback_to_default(self):
         router = LLMRouter()

--- a/tests/test_openai_auth.py
+++ b/tests/test_openai_auth.py
@@ -1,0 +1,59 @@
+import base64
+import json
+import time
+
+from loom.core.cognition.openai_auth import (
+    load_codex_oauth_credential,
+    resolve_openai_credential,
+)
+
+
+def _jwt(exp: int) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"exp": exp}).encode()
+    ).rstrip(b"=").decode()
+    return f"{header}.{payload}."
+
+
+def test_load_codex_oauth_credential_reads_unexpired_token(tmp_path):
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text(
+        json.dumps({
+            "tokens": {
+                "access_token": _jwt(int(time.time()) + 3600),
+                "refresh_token": "refresh-secret",
+                "account_id": "acct",
+            }
+        }),
+        encoding="utf-8",
+    )
+
+    credential = load_codex_oauth_credential(auth_file)
+
+    assert credential is not None
+    assert credential.source == "codex_oauth"
+    assert credential.account_id == "acct"
+
+
+def test_load_codex_oauth_credential_ignores_expired_token(tmp_path):
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text(
+        json.dumps({"tokens": {"access_token": _jwt(int(time.time()) - 10)}}),
+        encoding="utf-8",
+    )
+
+    assert load_codex_oauth_credential(auth_file) is None
+
+
+def test_resolve_openai_credential_falls_back_to_api_key(tmp_path):
+    missing_codex = tmp_path / "missing.json"
+
+    credential = resolve_openai_credential(
+        {"OPENAI_API_KEY": "sk-test"},
+        codex_auth_file=missing_codex,
+    )
+
+    assert credential is not None
+    assert credential.source == "api_key"
+    assert credential.token == "sk-test"

--- a/tests/test_openai_image_tool.py
+++ b/tests/test_openai_image_tool.py
@@ -47,12 +47,62 @@ class _FakeAsyncClient:
 
 
 class _FallbackAsyncClient(_FakeAsyncClient):
+    def stream(self, method, url, headers=None, json=None):
+        self.requests.append({"url": url, "headers": headers, "json": json})
+
+        class _Stream:
+            async def __aenter__(self_inner):
+                request = httpx.Request(method, url)
+                response = httpx.Response(401, request=request, text="bad token")
+                raise httpx.HTTPStatusError("bad token", request=request, response=response)
+
+            async def __aexit__(self_inner, *exc):
+                return False
+
+        return _Stream()
+
     async def post(self, url, headers=None, json=None):
         self.requests.append({"url": url, "headers": headers, "json": json})
-        if headers and headers.get("Authorization") == "Bearer codex-token":
-            return _FakeResponse({"error": "bad token"}, status_code=401)
         encoded = base64.b64encode(b"fallback-png").decode()
         return _FakeResponse({"data": [{"b64_json": encoded}]})
+
+
+class _CodexStreamAsyncClient(_FakeAsyncClient):
+    def stream(self, method, url, headers=None, json=None):
+        self.requests.append({"url": url, "headers": headers, "json": json})
+        encoded = base64.b64encode(b"codex-png").decode()
+
+        class _Stream:
+            status_code = 200
+
+            async def __aenter__(self_inner):
+                return self_inner
+
+            async def __aexit__(self_inner, *exc):
+                return False
+
+            def raise_for_status(self_inner):
+                return None
+
+            async def aiter_lines(self_inner):
+                payload = json_module.dumps({
+                    "type": "response.image_generation_call.partial_image",
+                    "partial_image_b64": encoded,
+                })
+                for line in [
+                    "event: response.image_generation_call.partial_image",
+                    f"data: {payload}",
+                    "",
+                    "event: response.completed",
+                    "data: {\"type\":\"response.completed\"}",
+                    "",
+                ]:
+                    yield line
+
+        return _Stream()
+
+
+json_module = json
 
 
 @pytest.mark.asyncio
@@ -84,6 +134,40 @@ async def test_openai_image_tool_writes_generated_image(tmp_path, monkeypatch):
     assert output["credential_source"] == "api_key"
     assert output["model"] == "gpt-image-2"
     assert _FakeAsyncClient.requests[0]["headers"]["Authorization"] == "Bearer sk-test"
+
+
+@pytest.mark.asyncio
+async def test_openai_image_tool_uses_codex_responses_backend(tmp_path, monkeypatch):
+    from loom.core import session as session_module
+
+    codex_home = tmp_path / "codex"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text(
+        json.dumps({"tokens": {"access_token": "codex-token"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {})
+    monkeypatch.setattr(cli_tools.httpx, "AsyncClient", _CodexStreamAsyncClient)
+    _CodexStreamAsyncClient.requests = []
+    tool = make_openai_image_generation_tool(tmp_path)
+    call = ToolCall(
+        tool_name=tool.name,
+        args={"prompt": "x", "output_path": "renders/codex.png", "auth_mode": "codex"},
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    result = await tool.executor(call)
+
+    assert result.success
+    assert (tmp_path / "renders" / "codex.png").read_bytes() == b"codex-png"
+    output = json.loads(result.output)
+    assert output["credential_source"] == "codex_oauth"
+    request = _CodexStreamAsyncClient.requests[0]
+    assert request["url"] == "https://chatgpt.com/backend-api/codex/responses"
+    assert request["json"]["model"] == "gpt-5.5"
+    assert request["json"]["tools"][0]["model"] == "gpt-image-2"
 
 
 @pytest.mark.asyncio

--- a/tests/test_openai_image_tool.py
+++ b/tests/test_openai_image_tool.py
@@ -1,0 +1,145 @@
+import base64
+import json
+
+import httpx
+import pytest
+
+from loom.core.harness.middleware import ToolCall
+from loom.core.harness.permissions import TrustLevel
+from loom.platform.cli import tools as cli_tools
+from loom.platform.cli.tools import make_openai_image_generation_tool
+
+
+class _FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload)
+        self.content = b""
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            request = httpx.Request("POST", "https://api.openai.com/v1/images/generations")
+            response = httpx.Response(self.status_code, request=request, text=self.text)
+            raise httpx.HTTPStatusError("boom", request=request, response=response)
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _FakeAsyncClient:
+    requests = []
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, url, headers=None, json=None):
+        self.requests.append({"url": url, "headers": headers, "json": json})
+        encoded = base64.b64encode(b"png-bytes").decode()
+        return _FakeResponse({"data": [{"b64_json": encoded}]})
+
+
+class _FallbackAsyncClient(_FakeAsyncClient):
+    async def post(self, url, headers=None, json=None):
+        self.requests.append({"url": url, "headers": headers, "json": json})
+        if headers and headers.get("Authorization") == "Bearer codex-token":
+            return _FakeResponse({"error": "bad token"}, status_code=401)
+        encoded = base64.b64encode(b"fallback-png").decode()
+        return _FakeResponse({"data": [{"b64_json": encoded}]})
+
+
+@pytest.mark.asyncio
+async def test_openai_image_tool_writes_generated_image(tmp_path, monkeypatch):
+    from loom.core import session as session_module
+
+    monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {
+        "OPENAI_API_KEY": "sk-test",
+    })
+    monkeypatch.setattr(cli_tools.httpx, "AsyncClient", _FakeAsyncClient)
+    _FakeAsyncClient.requests = []
+    tool = make_openai_image_generation_tool(tmp_path)
+    call = ToolCall(
+        tool_name=tool.name,
+        args={
+            "prompt": "a tiny loom logo",
+            "output_path": "renders/logo.png",
+            "auth_mode": "api_key",
+        },
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    result = await tool.executor(call)
+
+    assert result.success
+    assert (tmp_path / "renders" / "logo.png").read_bytes() == b"png-bytes"
+    output = json.loads(result.output)
+    assert output["credential_source"] == "api_key"
+    assert output["model"] == "gpt-image-2"
+    assert _FakeAsyncClient.requests[0]["headers"]["Authorization"] == "Bearer sk-test"
+
+
+@pytest.mark.asyncio
+async def test_openai_image_tool_auto_falls_back_when_codex_token_rejected(
+    tmp_path,
+    monkeypatch,
+):
+    from loom.core import session as session_module
+
+    codex_home = tmp_path / "codex"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text(
+        json.dumps({"tokens": {"access_token": "codex-token"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {
+        "OPENAI_API_KEY": "sk-fallback",
+    })
+    monkeypatch.setattr(cli_tools.httpx, "AsyncClient", _FallbackAsyncClient)
+    _FallbackAsyncClient.requests = []
+    tool = make_openai_image_generation_tool(tmp_path)
+    call = ToolCall(
+        tool_name=tool.name,
+        args={"prompt": "x", "output_path": "renders/fallback.png"},
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    result = await tool.executor(call)
+
+    assert result.success
+    assert (tmp_path / "renders" / "fallback.png").read_bytes() == b"fallback-png"
+    output = json.loads(result.output)
+    assert output["credential_source"] == "api_key"
+    assert [r["headers"]["Authorization"] for r in _FallbackAsyncClient.requests] == [
+        "Bearer codex-token",
+        "Bearer sk-fallback",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_openai_image_tool_requires_codex_when_requested(tmp_path, monkeypatch):
+    from loom.core import session as session_module
+
+    monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {})
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-home"))
+    tool = make_openai_image_generation_tool(tmp_path)
+    call = ToolCall(
+        tool_name=tool.name,
+        args={"prompt": "x", "auth_mode": "codex"},
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    result = await tool.executor(call)
+
+    assert not result.success
+    assert "Codex OAuth token" in result.error

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -39,13 +39,13 @@ class TestBuildRouter:
             "OPENAI_API_KEY": "sk-test",
         })
         monkeypatch.setattr(session_module, "_load_loom_config", lambda: {
-            "cognition": {"default_model": "gpt-5.2"},
+            "cognition": {"default_model": "gpt-5.5"},
         })
 
         router = session_module.build_router()
 
         assert "openai" in router.providers
-        assert router.get_provider("gpt-5.2").name == "openai"
+        assert router.get_provider("gpt-5.5").name == "openai"
 
 
 class TestLoomSessionStartup:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -31,6 +31,23 @@ class TestCoreSessionImport:
         assert CoreSession is CliSession
 
 
+class TestBuildRouter:
+    def test_registers_openai_provider_from_env(self, monkeypatch: pytest.MonkeyPatch):
+        from loom.core import session as session_module
+
+        monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {
+            "OPENAI_API_KEY": "sk-test",
+        })
+        monkeypatch.setattr(session_module, "_load_loom_config", lambda: {
+            "cognition": {"default_model": "gpt-4.1"},
+        })
+
+        router = session_module.build_router()
+
+        assert "openai" in router.providers
+        assert router.get_provider("gpt-4.1").name == "openai"
+
+
 class TestLoomSessionStartup:
     @pytest_asyncio.fixture
     async def session_module(self):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -106,6 +106,7 @@ async def session_plugin_tool(call):
         assert session._pipeline is not None
         assert session._mcp_clients == []
         assert session.registry.get("session_plugin_tool") is not None
+        assert session.registry.get("openai__text_to_image") is not None
 
         await session.stop()
         assert session._db is None

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -39,13 +39,13 @@ class TestBuildRouter:
             "OPENAI_API_KEY": "sk-test",
         })
         monkeypatch.setattr(session_module, "_load_loom_config", lambda: {
-            "cognition": {"default_model": "gpt-4.1"},
+            "cognition": {"default_model": "gpt-5.2"},
         })
 
         router = session_module.build_router()
 
         assert "openai" in router.providers
-        assert router.get_provider("gpt-4.1").name == "openai"
+        assert router.get_provider("gpt-5.2").name == "openai"
 
 
 class TestLoomSessionStartup:


### PR DESCRIPTION
## Summary
- add an official OpenAI provider registration path for OPENAI_API_KEY with gpt/o/openai model routing
- add `loom auth openai` to guide users through `codex --login` first, then optionally persist OPENAI_API_KEY for Loom
- update CLI/model docs and add routing/onboarding tests

## GitNexus
- impact build_router: LOW, 0 direct callers/processes
- impact _OpenAICompatibleBase: LOW, 3 direct provider subclasses
- impact LLMRouter: MEDIUM, direct import dependents only; routing change is additive
- staged detect-changes: LOW, 0 affected processes

## Tests
- `./venv/bin/python -m pytest -q tests/test_cognition.py tests/test_session.py tests/test_cli_auth.py tests/test_output_max_tokens_resolver.py`