### PR TITLE
feat(ledger): Step 1 — LedgerStore schema + emit API + indexes

### DIFF
--- a/loom/core/ledger/__init__.py
+++ b/loom/core/ledger/__init__.py
@@ -1,0 +1,46 @@
+"""AgentLedger — unified append-only event store (Quest B).
+
+See doc/53-AgentLedger-設計.md for design.
+
+Phase 2 Step 1: storage layer only — schema, dataclasses, emit API,
+blob helper, resolve_memory_id helper, maintenance hook.
+Layered emit (Step 2) and projection contract (Step 3-4) come later.
+"""
+
+from loom.core.ledger.schema import (
+    DEFAULT_BRANCH,
+    LEDGER_BLOB_SUBDIR,
+    THOUGHT_EXTERNAL_THRESHOLD,
+    ArtifactEmitPayload,
+    EnvObservationPayload,
+    JudgeVerdictPayload,
+    LedgerEvent,
+    MemoryOpPayload,
+    ModelEventPayload,
+    PermissionDecisionPayload,
+    TaskMutationPayload,
+    ThoughtPayload,
+    ToolLifecyclePayload,
+    TurnEndPayload,
+    TurnStartPayload,
+)
+from loom.core.ledger.store import LedgerStore
+
+__all__ = [
+    "DEFAULT_BRANCH",
+    "LEDGER_BLOB_SUBDIR",
+    "THOUGHT_EXTERNAL_THRESHOLD",
+    "ArtifactEmitPayload",
+    "EnvObservationPayload",
+    "JudgeVerdictPayload",
+    "LedgerEvent",
+    "LedgerStore",
+    "MemoryOpPayload",
+    "ModelEventPayload",
+    "PermissionDecisionPayload",
+    "TaskMutationPayload",
+    "ThoughtPayload",
+    "ToolLifecyclePayload",
+    "TurnEndPayload",
+    "TurnStartPayload",
+]

--- a/loom/core/ledger/schema.py
+++ b/loom/core/ledger/schema.py
@@ -1,0 +1,193 @@
+"""LedgerEvent + per-event-type payload dataclasses + SQL DDL.
+
+Reference: doc/53-AgentLedger-設計.md §5 (storage), §7 (dataclasses).
+
+Field shapes are the contract. Adding fields is fine; renaming or
+re-typing existing fields is a breaking change subject to §9.4.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+THOUGHT_EXTERNAL_THRESHOLD = 50_000
+"""Bytes. thought.full_text above this goes to blob storage (§3.3)."""
+
+LEDGER_BLOB_SUBDIR = "ledger_blobs"
+"""Sub-directory under the ledger root for thought blobs."""
+
+DEFAULT_BRANCH = "main"
+"""v1 branch_id is always 'main'. v2 fork primitive will assign others (§4.4)."""
+
+CURRENT_SCHEMA_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# Base event (§7.1)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(kw_only=True)
+class LedgerEvent:
+    """Base envelope for every ledger event.
+
+    `payload` carries event-type-specific fields (see *Payload classes below)
+    and must include "schema_version" (§9.1).
+    """
+
+    event_id: str
+    session_id: str
+    turn_id: str
+    correlation_id: str
+    event_type: str
+    timestamp: float  # UTC Unix epoch (REAL) — §9.5
+    payload: dict[str, Any]
+    parent_event_id: str | None = None
+    branch_id: str = DEFAULT_BRANCH
+
+
+# ---------------------------------------------------------------------------
+# Per-event-type payloads (§7.2). schema_version defaults to 1.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(kw_only=True)
+class TurnStartPayload:
+    prompt_stack_hash: str
+    prompt_stack_components: dict[str, Any]
+    full_text: str | None = None
+    schema_version: int = CURRENT_SCHEMA_VERSION
+
+
+@dataclass(kw_only=True)
+class TurnEndPayload:
+    outcome: str  # "clean" / "retry" / "abandoned" / "error"
+    duration_ms: int
+    token_usage: dict[str, int]
+    schema_version: int = CURRENT_SCHEMA_VERSION
+
+
+@dataclass(kw_only=True)
+class ThoughtPayload:
+    digest: str
+    duration_ms: int
+    produced_tool_calls: int
+    full_text: str | None = None
+    external_ref: str | None = None
+    schema_version: int = CURRENT_SCHEMA_VERSION
+
+
+@dataclass(kw_only=True)
+class ModelEventPayload:
+    model: str
+    tier: int
+    token_usage: dict[str, int]
+    schema_version: int = CURRENT_SCHEMA_VERSION
+
+
+@dataclass(kw_only=True)
+class ToolLifecyclePayload:
+    phase: str  # "BEGIN" / "STATE_CHANGE" / "END" / "ROLLBACK"
+    tool_name: str
+    tool_call_id: str
+    args_digest: str
+    args: dict[str, Any] | None = None
+    result_digest: str | None = None
+    result_summary: str | None = None
+    state_history: list[dict] = field(default_factory=list)
+    rolled_back: bool = False
+    error: str | None = None
+    schema_version: int = CURRENT_SCHEMA_VERSION
+
+
+@dataclass(kw_only=True)
+class PermissionDecisionPayload:
+    decision: str  # "grant" / "deny" / "scope"
+    tool_call_id: str
+    trust_level: str
+    scope_grant: dict | None = None
+    reason: str | None = None
+    schema_version: int = CURRENT_SCHEMA_VERSION
+
+
+@dataclass(kw_only=True)
+class MemoryOpPayload:
+    operation: str  # "read" / "write" / "compact" / "batch_read"
+    memory_id: str | None = None
+    memory_ids: list[str] | None = None
+    predecessor_memory_id: str | None = None
+    successor_memory_id: str | None = None
+    type_summary: str | None = None
+    trust_tier: str | None = None
+    content_digest: str | None = None
+    trigger: str | None = None
+    schema_version: int = CURRENT_SCHEMA_VERSION
+
+
+@dataclass(kw_only=True)
+class TaskMutationPayload:
+    operation: str  # "write" / "done" / "modify" / "abandon"
+    task_id: str
+    task_state: dict[str, Any] | None = None
+    schema_version: int = CURRENT_SCHEMA_VERSION
+
+
+@dataclass(kw_only=True)
+class JudgeVerdictPayload:
+    verdict: str  # "PASS" / "FAIL" / "ERROR" / "CONCERN"
+    confidence: float
+    reason: str
+    judged_subject: str
+    schema_version: int = CURRENT_SCHEMA_VERSION
+
+
+@dataclass(kw_only=True)
+class ArtifactEmitPayload:
+    artifact_type: str
+    size_bytes: int
+    digest: str
+    location: str | None = None
+    schema_version: int = CURRENT_SCHEMA_VERSION
+
+
+@dataclass(kw_only=True)
+class EnvObservationPayload:
+    observation_type: str
+    source: str
+    detail: dict[str, Any]
+    schema_version: int = CURRENT_SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# SQL DDL — §5.2 / §5.3
+# ---------------------------------------------------------------------------
+
+CREATE_EVENTS_TABLE = """
+CREATE TABLE IF NOT EXISTS events (
+    event_id        TEXT PRIMARY KEY,
+    session_id      TEXT NOT NULL,
+    turn_id         TEXT NOT NULL,
+    parent_event_id TEXT,
+    correlation_id  TEXT NOT NULL,
+    branch_id       TEXT NOT NULL DEFAULT 'main',
+    event_type      TEXT NOT NULL,
+    timestamp       REAL NOT NULL,
+    payload         TEXT NOT NULL,
+
+    tool_name              TEXT GENERATED ALWAYS AS (json_extract(payload, '$.tool_name')) VIRTUAL,
+    verdict                TEXT GENERATED ALWAYS AS (json_extract(payload, '$.verdict')) VIRTUAL,
+    skill_id               TEXT GENERATED ALWAYS AS (json_extract(payload, '$.skill_id')) VIRTUAL,
+    predecessor_memory_id  TEXT GENERATED ALWAYS AS (json_extract(payload, '$.predecessor_memory_id')) VIRTUAL
+)
+"""
+
+CREATE_INDEXES = [
+    "CREATE INDEX IF NOT EXISTS idx_turn           ON events (branch_id, turn_id, timestamp)",
+    "CREATE INDEX IF NOT EXISTS idx_correlation    ON events (branch_id, correlation_id, timestamp)",
+    "CREATE INDEX IF NOT EXISTS idx_session_recent ON events (branch_id, session_id, timestamp DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_tool           ON events (branch_id, tool_name, timestamp)",
+    "CREATE INDEX IF NOT EXISTS idx_verdict        ON events (branch_id, verdict, timestamp)",
+    "CREATE INDEX IF NOT EXISTS idx_parent         ON events (parent_event_id)",
+    "CREATE INDEX IF NOT EXISTS idx_predecessor    ON events (predecessor_memory_id)",
+]

--- a/loom/core/ledger/store.py
+++ b/loom/core/ledger/store.py
@@ -9,6 +9,7 @@ chain walker), §11.2 (six-step roadmap).
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 from dataclasses import asdict, is_dataclass
@@ -138,7 +139,7 @@ class LedgerStore:
         if row is None:
             raise KeyError(f"unknown event_id: {event_id}")
         payload = json.loads(row[0])
-        full_text, external_ref, digest = self.store_thought_text(
+        full_text, external_ref, digest = await self.store_thought_text(
             full_text, turn_id=turn_id, event_id=event_id
         )
         payload["full_text"] = full_text
@@ -152,7 +153,7 @@ class LedgerStore:
 
     # -- thought blob helper (§3.3) ---------------------------------------
 
-    def store_thought_text(
+    async def store_thought_text(
         self, raw_text: str, *, turn_id: str, event_id: str
     ) -> tuple[str | None, str | None, str]:
         """Return (inline_full_text, external_ref, digest).
@@ -160,6 +161,10 @@ class LedgerStore:
         ≤ THOUGHT_EXTERNAL_THRESHOLD bytes → inline.
         > threshold → write to .loom/ledger_blobs/{turn_id}/{event_id}.txt
                       and return relative path as external_ref.
+
+        Blob writes are dispatched via ``asyncio.to_thread`` so the event
+        loop is not blocked. Today's threshold (50 KB) is small, but this
+        helper may also serve future artifact paths where blobs grow.
         """
         encoded = raw_text.encode("utf-8")
         digest = hashlib.sha256(encoded).hexdigest()
@@ -167,11 +172,15 @@ class LedgerStore:
             return raw_text, None, digest
         rel_path = f"{turn_id}/{event_id}.txt"
         abs_path = self.blob_dir / rel_path
-        abs_path.parent.mkdir(parents=True, exist_ok=True)
-        abs_path.write_text(raw_text, encoding="utf-8")
+
+        def _write() -> None:
+            abs_path.parent.mkdir(parents=True, exist_ok=True)
+            abs_path.write_text(raw_text, encoding="utf-8")
+
+        await asyncio.to_thread(_write)
         return None, rel_path, digest
 
-    def build_thought_payload(
+    async def build_thought_payload(
         self,
         raw_text: str,
         *,
@@ -180,7 +189,7 @@ class LedgerStore:
         duration_ms: int,
         produced_tool_calls: int,
     ) -> ThoughtPayload:
-        full_text, external_ref, digest = self.store_thought_text(
+        full_text, external_ref, digest = await self.store_thought_text(
             raw_text, turn_id=turn_id, event_id=event_id
         )
         return ThoughtPayload(
@@ -200,6 +209,12 @@ class LedgerStore:
 
         Each compact event stores a single (predecessor → successor) edge.
         We walk forward until no further edge exists.
+
+        Note:
+            Assumes linear write order — when two compact events share a
+            predecessor, the earlier ``timestamp`` wins. Safe under doc/53
+            §2 principle 6 (solo operator, single-writer). If concurrent
+            emit is ever introduced, ordering must be revisited.
         """
         conn = self._require_conn()
         current = mem_id
@@ -300,8 +315,12 @@ class LedgerStore:
     async def explain_query_plan(self, sql: str, params: tuple = ()) -> list[str]:
         """Return the EXPLAIN QUERY PLAN detail strings for `sql`.
 
-        Used by tests to assert that high-frequency queries hit the
-        intended covering index.
+        .. warning::
+            Test-only helper. Accepts raw SQL — do **not** call from
+            production paths. Step 3-4 of doc/53 §11.2 introduces the
+            proper Pull / Replay APIs; this method exists solely to let
+            unit tests assert that high-frequency queries hit the
+            intended covering index.
         """
         conn = self._require_conn()
         async with conn.execute(

--- a/loom/core/ledger/store.py
+++ b/loom/core/ledger/store.py
@@ -1,0 +1,318 @@
+"""LedgerStore — append-only event sink backed by SQLite WAL.
+
+Pure storage layer (Phase 2 Step 1 of doc/53). Zero coupling to emitters:
+this module knows nothing about middleware / session / memory / scheduler.
+
+See doc/53 §5 (storage), §3.3 (thought blob storage), §5.7 (compaction
+chain walker), §11.2 (six-step roadmap).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+
+from loom.core.ledger.schema import (
+    CREATE_EVENTS_TABLE,
+    CREATE_INDEXES,
+    DEFAULT_BRANCH,
+    LEDGER_BLOB_SUBDIR,
+    THOUGHT_EXTERNAL_THRESHOLD,
+    LedgerEvent,
+    ThoughtPayload,
+)
+
+DEFAULT_DB_PATH = Path.home() / ".loom" / "ledger.db"
+
+
+def _payload_to_dict(payload: Any) -> dict[str, Any]:
+    """Accept dataclass payload or dict; always return dict."""
+    if is_dataclass(payload):
+        return asdict(payload)
+    if isinstance(payload, dict):
+        return payload
+    raise TypeError(f"payload must be dataclass or dict, got {type(payload).__name__}")
+
+
+class LedgerStore:
+    """Async, append-only ledger backed by SQLite WAL.
+
+    Lifecycle:
+        store = LedgerStore(db_path=...)
+        await store.open()
+        await store.emit(event)
+        await store.close()
+
+    Or as async context manager:
+        async with LedgerStore() as store:
+            await store.emit(event)
+    """
+
+    def __init__(
+        self,
+        db_path: Path | str | None = None,
+        blob_dir: Path | str | None = None,
+    ) -> None:
+        self.db_path = Path(db_path) if db_path else DEFAULT_DB_PATH
+        # Default blob_dir sits next to ledger.db: ~/.loom/ledger_blobs/
+        self.blob_dir = (
+            Path(blob_dir)
+            if blob_dir
+            else self.db_path.parent / LEDGER_BLOB_SUBDIR
+        )
+        self._conn: aiosqlite.Connection | None = None
+
+    # -- lifecycle ---------------------------------------------------------
+
+    async def open(self) -> None:
+        if self._conn is not None:
+            return
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.blob_dir.mkdir(parents=True, exist_ok=True)
+        self._conn = await aiosqlite.connect(self.db_path)
+        await self._conn.execute("PRAGMA journal_mode=WAL")
+        await self._conn.execute("PRAGMA synchronous=NORMAL")
+        await self._conn.execute("PRAGMA foreign_keys=ON")
+        await self._conn.execute(CREATE_EVENTS_TABLE)
+        for stmt in CREATE_INDEXES:
+            await self._conn.execute(stmt)
+        await self._conn.commit()
+
+    async def close(self) -> None:
+        if self._conn is not None:
+            await self._conn.close()
+            self._conn = None
+
+    async def __aenter__(self) -> "LedgerStore":
+        await self.open()
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        await self.close()
+
+    # -- emit --------------------------------------------------------------
+
+    async def emit(self, event: LedgerEvent) -> None:
+        """Append a single event. Caller owns event_id uniqueness."""
+        conn = self._require_conn()
+        payload = _payload_to_dict(event.payload)
+        await conn.execute(
+            """
+            INSERT INTO events (
+                event_id, session_id, turn_id, parent_event_id,
+                correlation_id, branch_id, event_type, timestamp, payload
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event.event_id,
+                event.session_id,
+                event.turn_id,
+                event.parent_event_id,
+                event.correlation_id,
+                event.branch_id,
+                event.event_type,
+                event.timestamp,
+                json.dumps(payload, ensure_ascii=False, sort_keys=True),
+            ),
+        )
+        await conn.commit()
+
+    async def update_thought_full_text(
+        self, event_id: str, full_text: str, *, turn_id: str
+    ) -> None:
+        """Late-arrival commit of thought.full_text (§3.3 buffered capture).
+
+        This is the only mutating operation allowed on a written event,
+        endorsed by §2 principle 1 as an explicit exception.
+        """
+        conn = self._require_conn()
+        async with conn.execute(
+            "SELECT payload FROM events WHERE event_id=?", (event_id,)
+        ) as cur:
+            row = await cur.fetchone()
+        if row is None:
+            raise KeyError(f"unknown event_id: {event_id}")
+        payload = json.loads(row[0])
+        full_text, external_ref, digest = self.store_thought_text(
+            full_text, turn_id=turn_id, event_id=event_id
+        )
+        payload["full_text"] = full_text
+        payload["external_ref"] = external_ref
+        payload["digest"] = digest
+        await conn.execute(
+            "UPDATE events SET payload=? WHERE event_id=?",
+            (json.dumps(payload, ensure_ascii=False, sort_keys=True), event_id),
+        )
+        await conn.commit()
+
+    # -- thought blob helper (§3.3) ---------------------------------------
+
+    def store_thought_text(
+        self, raw_text: str, *, turn_id: str, event_id: str
+    ) -> tuple[str | None, str | None, str]:
+        """Return (inline_full_text, external_ref, digest).
+
+        ≤ THOUGHT_EXTERNAL_THRESHOLD bytes → inline.
+        > threshold → write to .loom/ledger_blobs/{turn_id}/{event_id}.txt
+                      and return relative path as external_ref.
+        """
+        encoded = raw_text.encode("utf-8")
+        digest = hashlib.sha256(encoded).hexdigest()
+        if len(encoded) <= THOUGHT_EXTERNAL_THRESHOLD:
+            return raw_text, None, digest
+        rel_path = f"{turn_id}/{event_id}.txt"
+        abs_path = self.blob_dir / rel_path
+        abs_path.parent.mkdir(parents=True, exist_ok=True)
+        abs_path.write_text(raw_text, encoding="utf-8")
+        return None, rel_path, digest
+
+    def build_thought_payload(
+        self,
+        raw_text: str,
+        *,
+        turn_id: str,
+        event_id: str,
+        duration_ms: int,
+        produced_tool_calls: int,
+    ) -> ThoughtPayload:
+        full_text, external_ref, digest = self.store_thought_text(
+            raw_text, turn_id=turn_id, event_id=event_id
+        )
+        return ThoughtPayload(
+            digest=digest,
+            duration_ms=duration_ms,
+            produced_tool_calls=produced_tool_calls,
+            full_text=full_text,
+            external_ref=external_ref,
+        )
+
+    # -- compaction chain walker (§5.7) -----------------------------------
+
+    async def resolve_memory_id(
+        self, mem_id: str, *, branch_id: str = DEFAULT_BRANCH
+    ) -> str:
+        """Walk compaction chain forward to current live memory_id.
+
+        Each compact event stores a single (predecessor → successor) edge.
+        We walk forward until no further edge exists.
+        """
+        conn = self._require_conn()
+        current = mem_id
+        seen: set[str] = set()
+        while True:
+            if current in seen:
+                # Cycle defence — should never happen with append-only
+                # writes, but bail rather than loop forever.
+                return current
+            seen.add(current)
+            async with conn.execute(
+                """
+                SELECT json_extract(payload, '$.successor_memory_id')
+                FROM events
+                WHERE event_type='memory_op'
+                  AND branch_id=?
+                  AND predecessor_memory_id=?
+                  AND json_extract(payload, '$.operation')='compact'
+                ORDER BY timestamp ASC
+                LIMIT 1
+                """,
+                (branch_id, current),
+            ) as cur:
+                row = await cur.fetchone()
+            if row is None or row[0] is None:
+                return current
+            current = row[0]
+
+    # -- maintenance (§5.4) ------------------------------------------------
+
+    async def maintenance(self) -> None:
+        """v1: PRAGMA optimize + VACUUM. Called on demand, not on a timer."""
+        conn = self._require_conn()
+        await conn.execute("PRAGMA optimize")
+        await conn.commit()
+        # VACUUM cannot run inside a transaction; aiosqlite autocommits the
+        # implicit one when we call commit() above.
+        await conn.execute("VACUUM")
+
+    # -- minimal query helpers (storage-layer self-tests / Step 3 will
+    #    replace these with the proper Pull / Replay APIs) --------------
+
+    async def fetch_event(self, event_id: str) -> LedgerEvent | None:
+        conn = self._require_conn()
+        async with conn.execute(
+            """
+            SELECT event_id, session_id, turn_id, parent_event_id,
+                   correlation_id, branch_id, event_type, timestamp, payload
+            FROM events WHERE event_id=?
+            """,
+            (event_id,),
+        ) as cur:
+            row = await cur.fetchone()
+        if row is None:
+            return None
+        return LedgerEvent(
+            event_id=row[0],
+            session_id=row[1],
+            turn_id=row[2],
+            parent_event_id=row[3],
+            correlation_id=row[4],
+            branch_id=row[5],
+            event_type=row[6],
+            timestamp=row[7],
+            payload=json.loads(row[8]),
+        )
+
+    async def fetch_by_turn(
+        self, turn_id: str, *, branch_id: str = DEFAULT_BRANCH
+    ) -> list[LedgerEvent]:
+        conn = self._require_conn()
+        async with conn.execute(
+            """
+            SELECT event_id, session_id, turn_id, parent_event_id,
+                   correlation_id, branch_id, event_type, timestamp, payload
+            FROM events
+            WHERE branch_id=? AND turn_id=?
+            ORDER BY timestamp ASC
+            """,
+            (branch_id, turn_id),
+        ) as cur:
+            rows = await cur.fetchall()
+        return [
+            LedgerEvent(
+                event_id=r[0],
+                session_id=r[1],
+                turn_id=r[2],
+                parent_event_id=r[3],
+                correlation_id=r[4],
+                branch_id=r[5],
+                event_type=r[6],
+                timestamp=r[7],
+                payload=json.loads(r[8]),
+            )
+            for r in rows
+        ]
+
+    async def explain_query_plan(self, sql: str, params: tuple = ()) -> list[str]:
+        """Return the EXPLAIN QUERY PLAN detail strings for `sql`.
+
+        Used by tests to assert that high-frequency queries hit the
+        intended covering index.
+        """
+        conn = self._require_conn()
+        async with conn.execute(
+            f"EXPLAIN QUERY PLAN {sql}", params
+        ) as cur:
+            rows = await cur.fetchall()
+        return [r[-1] for r in rows]
+
+    # -- internal ----------------------------------------------------------
+
+    def _require_conn(self) -> aiosqlite.Connection:
+        if self._conn is None:
+            raise RuntimeError("LedgerStore is not open(); call await store.open() first")
+        return self._conn

--- a/tests/test_ledger_store.py
+++ b/tests/test_ledger_store.py
@@ -1,0 +1,351 @@
+"""Tests for loom.core.ledger storage layer (#321 / doc/53 §5).
+
+Pure-storage tests — no emitter coupling. asyncio_mode=auto in pyproject.toml
+means no @pytest.mark.asyncio decorator needed.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from loom.core.ledger import (
+    DEFAULT_BRANCH,
+    LedgerEvent,
+    LedgerStore,
+    MemoryOpPayload,
+    THOUGHT_EXTERNAL_THRESHOLD,
+    ToolLifecyclePayload,
+)
+
+
+@pytest.fixture
+async def store(tmp_path: Path) -> LedgerStore:
+    s = LedgerStore(
+        db_path=tmp_path / "ledger.db",
+        blob_dir=tmp_path / "ledger_blobs",
+    )
+    await s.open()
+    try:
+        yield s
+    finally:
+        await s.close()
+
+
+def _evt(
+    *,
+    event_id: str,
+    turn_id: str = "turn_1",
+    correlation_id: str = "corr_1",
+    event_type: str = "tool_lifecycle",
+    payload: dict | object | None = None,
+    parent_event_id: str | None = None,
+    branch_id: str = DEFAULT_BRANCH,
+    session_id: str = "sess_1",
+    timestamp: float | None = None,
+) -> LedgerEvent:
+    return LedgerEvent(
+        event_id=event_id,
+        session_id=session_id,
+        turn_id=turn_id,
+        parent_event_id=parent_event_id,
+        correlation_id=correlation_id,
+        branch_id=branch_id,
+        event_type=event_type,
+        timestamp=timestamp if timestamp is not None else time.time(),
+        payload=payload if payload is not None else {"schema_version": 1},
+    )
+
+
+# ---------------------------------------------------------------------------
+# emit / query roundtrip
+# ---------------------------------------------------------------------------
+
+
+async def test_emit_and_fetch_roundtrip(store: LedgerStore) -> None:
+    payload = ToolLifecyclePayload(
+        phase="BEGIN",
+        tool_name="run_bash",
+        tool_call_id="call_1",
+        args_digest="sha256:abc",
+        args={"cmd": "ls"},
+    )
+    evt = _evt(event_id="e1", event_type="tool_lifecycle", payload=payload)
+    await store.emit(evt)
+
+    fetched = await store.fetch_event("e1")
+    assert fetched is not None
+    assert fetched.event_id == "e1"
+    assert fetched.event_type == "tool_lifecycle"
+    assert fetched.branch_id == "main"
+    assert fetched.payload["tool_name"] == "run_bash"
+    assert fetched.payload["schema_version"] == 1
+
+
+async def test_fetch_by_turn_orders_by_timestamp(store: LedgerStore) -> None:
+    base = time.time()
+    await store.emit(_evt(event_id="b", timestamp=base + 1.0))
+    await store.emit(_evt(event_id="a", timestamp=base + 0.0))
+    await store.emit(_evt(event_id="c", timestamp=base + 2.0))
+
+    events = await store.fetch_by_turn("turn_1")
+    assert [e.event_id for e in events] == ["a", "b", "c"]
+
+
+async def test_emit_rejects_duplicate_event_id(store: LedgerStore) -> None:
+    await store.emit(_evt(event_id="dup"))
+    with pytest.raises(Exception):
+        # sqlite3.IntegrityError surfaces through aiosqlite
+        await store.emit(_evt(event_id="dup"))
+
+
+async def test_emit_accepts_dict_payload(store: LedgerStore) -> None:
+    """Caller may pass a plain dict instead of a dataclass."""
+    await store.emit(
+        _evt(
+            event_id="raw",
+            event_type="env_observation",
+            payload={
+                "schema_version": 1,
+                "observation_type": "anomaly",
+                "source": "memory_pulse",
+                "detail": {"note": "ok"},
+            },
+        )
+    )
+    got = await store.fetch_event("raw")
+    assert got.payload["observation_type"] == "anomaly"
+
+
+# ---------------------------------------------------------------------------
+# Index hit (EXPLAIN QUERY PLAN)
+# ---------------------------------------------------------------------------
+
+
+async def test_turn_index_used(store: LedgerStore) -> None:
+    plan = await store.explain_query_plan(
+        "SELECT * FROM events WHERE branch_id=? AND turn_id=? ORDER BY timestamp",
+        ("main", "turn_1"),
+    )
+    plan_text = " ".join(plan)
+    assert "idx_turn" in plan_text, plan_text
+
+
+async def test_correlation_index_used(store: LedgerStore) -> None:
+    plan = await store.explain_query_plan(
+        "SELECT * FROM events WHERE branch_id=? AND correlation_id=? ORDER BY timestamp",
+        ("main", "corr_1"),
+    )
+    assert "idx_correlation" in " ".join(plan)
+
+
+async def test_session_recent_index_used(store: LedgerStore) -> None:
+    plan = await store.explain_query_plan(
+        "SELECT * FROM events WHERE branch_id=? AND session_id=? ORDER BY timestamp DESC",
+        ("main", "sess_1"),
+    )
+    assert "idx_session_recent" in " ".join(plan)
+
+
+async def test_tool_index_used(store: LedgerStore) -> None:
+    plan = await store.explain_query_plan(
+        "SELECT * FROM events WHERE branch_id=? AND tool_name=? ORDER BY timestamp",
+        ("main", "run_bash"),
+    )
+    assert "idx_tool" in " ".join(plan)
+
+
+async def test_predecessor_index_used(store: LedgerStore) -> None:
+    plan = await store.explain_query_plan(
+        "SELECT * FROM events WHERE predecessor_memory_id=?",
+        ("mem_abc",),
+    )
+    assert "idx_predecessor" in " ".join(plan)
+
+
+# ---------------------------------------------------------------------------
+# schema_version preserved
+# ---------------------------------------------------------------------------
+
+
+async def test_schema_version_preserved_through_roundtrip(
+    store: LedgerStore,
+) -> None:
+    payload = {
+        "schema_version": 7,  # imagine some future version
+        "tool_name": "future_tool",
+    }
+    await store.emit(_evt(event_id="v7", payload=payload))
+    fetched = await store.fetch_event("v7")
+    assert fetched.payload["schema_version"] == 7
+
+
+# ---------------------------------------------------------------------------
+# Thought blob threshold (§3.3)
+# ---------------------------------------------------------------------------
+
+
+async def test_thought_inline_when_under_threshold(store: LedgerStore) -> None:
+    text = "small thought"
+    full_text, ext, digest = store.store_thought_text(
+        text, turn_id="turn_x", event_id="evt_y"
+    )
+    assert full_text == text
+    assert ext is None
+    assert len(digest) == 64  # sha256 hex
+
+
+async def test_thought_external_when_over_threshold(
+    store: LedgerStore, tmp_path: Path
+) -> None:
+    text = "x" * (THOUGHT_EXTERNAL_THRESHOLD + 1)
+    full_text, ext, digest = store.store_thought_text(
+        text, turn_id="turn_x", event_id="evt_y"
+    )
+    assert full_text is None
+    assert ext == "turn_x/evt_y.txt"
+    blob = store.blob_dir / ext
+    assert blob.exists()
+    assert blob.read_text(encoding="utf-8") == text
+    assert len(digest) == 64
+
+
+async def test_thought_payload_helper_round_trip(store: LedgerStore) -> None:
+    payload = store.build_thought_payload(
+        "hello",
+        turn_id="t1",
+        event_id="e1",
+        duration_ms=12,
+        produced_tool_calls=0,
+    )
+    assert payload.full_text == "hello"
+    assert payload.external_ref is None
+    assert payload.duration_ms == 12
+
+
+async def test_update_thought_full_text_late_arrival(store: LedgerStore) -> None:
+    # Initial emit with full_text=None (buffered capture path).
+    await store.emit(
+        _evt(
+            event_id="th1",
+            event_type="thought",
+            payload={
+                "schema_version": 1,
+                "digest": "sha256:placeholder",
+                "duration_ms": 5,
+                "produced_tool_calls": 0,
+                "full_text": None,
+                "external_ref": None,
+            },
+        )
+    )
+    await store.update_thought_full_text("th1", "the actual text", turn_id="turn_1")
+
+    fetched = await store.fetch_event("th1")
+    assert fetched.payload["full_text"] == "the actual text"
+    assert fetched.payload["external_ref"] is None
+    assert fetched.payload["digest"].startswith(("sha256:",)) or len(
+        fetched.payload["digest"]
+    ) == 64
+
+
+async def test_update_thought_unknown_event_raises(store: LedgerStore) -> None:
+    with pytest.raises(KeyError):
+        await store.update_thought_full_text("nope", "x", turn_id="t")
+
+
+# ---------------------------------------------------------------------------
+# resolve_memory_id walks compaction chain (§5.7)
+# ---------------------------------------------------------------------------
+
+
+async def _emit_compact(
+    store: LedgerStore,
+    *,
+    event_id: str,
+    predecessor: str,
+    successor: str,
+    timestamp: float,
+) -> None:
+    payload = MemoryOpPayload(
+        operation="compact",
+        memory_id=successor,
+        predecessor_memory_id=predecessor,
+        successor_memory_id=successor,
+        type_summary="semantic_triple",
+        trust_tier="user_explicit",
+        content_digest="sha256:" + successor,
+    )
+    await store.emit(
+        _evt(
+            event_id=event_id,
+            event_type="memory_op",
+            payload=payload,
+            timestamp=timestamp,
+        )
+    )
+
+
+async def test_resolve_memory_id_walks_chain(store: LedgerStore) -> None:
+    base = time.time()
+    await _emit_compact(
+        store, event_id="c1", predecessor="m_a", successor="m_b", timestamp=base
+    )
+    await _emit_compact(
+        store, event_id="c2", predecessor="m_b", successor="m_c", timestamp=base + 1
+    )
+    await _emit_compact(
+        store, event_id="c3", predecessor="m_c", successor="m_d", timestamp=base + 2
+    )
+
+    assert await store.resolve_memory_id("m_a") == "m_d"
+    assert await store.resolve_memory_id("m_b") == "m_d"
+    assert await store.resolve_memory_id("m_d") == "m_d"
+    assert await store.resolve_memory_id("m_unknown") == "m_unknown"
+
+
+async def test_resolve_memory_id_ignores_non_compact(store: LedgerStore) -> None:
+    payload = MemoryOpPayload(
+        operation="write",
+        memory_id="m_x",
+        predecessor_memory_id="m_a",  # write events never set this in practice,
+        successor_memory_id="m_x",  # but we defend against accidental injection
+        content_digest="sha256:x",
+    )
+    await store.emit(_evt(event_id="w1", event_type="memory_op", payload=payload))
+    # Because operation != "compact", resolve should not follow it.
+    assert await store.resolve_memory_id("m_a") == "m_a"
+
+
+# ---------------------------------------------------------------------------
+# Maintenance hook smoke
+# ---------------------------------------------------------------------------
+
+
+async def test_maintenance_runs_clean(store: LedgerStore) -> None:
+    await store.emit(_evt(event_id="m1"))
+    await store.maintenance()  # must not raise
+    assert (await store.fetch_event("m1")) is not None
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_emit_before_open_raises(tmp_path: Path) -> None:
+    s = LedgerStore(db_path=tmp_path / "x.db", blob_dir=tmp_path / "blobs")
+    with pytest.raises(RuntimeError):
+        await s.emit(_evt(event_id="e"))
+
+
+async def test_async_context_manager_creates_files(tmp_path: Path) -> None:
+    db = tmp_path / "ledger.db"
+    blobs = tmp_path / "ledger_blobs"
+    async with LedgerStore(db_path=db, blob_dir=blobs):
+        pass
+    assert db.exists()
+    assert blobs.exists()

--- a/tests/test_ledger_store.py
+++ b/tests/test_ledger_store.py
@@ -190,7 +190,7 @@ async def test_schema_version_preserved_through_roundtrip(
 
 async def test_thought_inline_when_under_threshold(store: LedgerStore) -> None:
     text = "small thought"
-    full_text, ext, digest = store.store_thought_text(
+    full_text, ext, digest = await store.store_thought_text(
         text, turn_id="turn_x", event_id="evt_y"
     )
     assert full_text == text
@@ -202,7 +202,7 @@ async def test_thought_external_when_over_threshold(
     store: LedgerStore, tmp_path: Path
 ) -> None:
     text = "x" * (THOUGHT_EXTERNAL_THRESHOLD + 1)
-    full_text, ext, digest = store.store_thought_text(
+    full_text, ext, digest = await store.store_thought_text(
         text, turn_id="turn_x", event_id="evt_y"
     )
     assert full_text is None
@@ -214,7 +214,7 @@ async def test_thought_external_when_over_threshold(
 
 
 async def test_thought_payload_helper_round_trip(store: LedgerStore) -> None:
-    payload = store.build_thought_payload(
+    payload = await store.build_thought_payload(
         "hello",
         turn_id="t1",
         event_id="e1",


### PR DESCRIPTION
Closes #321 · sub-issue of #320 · doc/53 §5 / §7 / §3.3 / §5.7 / §5.4

## Summary

Phase 2 Step 1 of Quest B — pure storage layer for AgentLedger. Zero emitter coupling: this PR ships the sink, layered emit comes in #322.

- `loom/core/ledger/schema.py` — `LedgerEvent` + 11 `*Payload` dataclasses (kw_only) + SQL DDL constants
- `loom/core/ledger/store.py` — `LedgerStore` class (async, aiosqlite, WAL)
- `tests/test_ledger_store.py` — 20 unit tests

## Deliverables ↔ doc/53

| #321 deliverable | doc/53 ref | Implementation |
|---|---|---|
| `LedgerStore` class (init / open / emit / close) | §5.1 | `store.py` |
| events 表 + 4 generated columns | §5.2 | `schema.CREATE_EVENTS_TABLE` |
| 6+1 indexes（branch_id-prefixed covering） | §5.3 | `schema.CREATE_INDEXES` |
| `LedgerEvent` + per-event-type `*Payload` dataclasses | §7 | 11 dataclasses, `kw_only=True` |
| thought blob storage helper | §3.3 | `LedgerStore.store_thought_text` / `build_thought_payload` / `update_thought_full_text` (late-arrival) |
| `resolve_memory_id()` chain walker | §5.7 | `LedgerStore.resolve_memory_id` |
| `LedgerStore.maintenance()` | §5.4 | `PRAGMA optimize` + `VACUUM` |

## Test plan

- [x] `pytest tests/test_ledger_store.py` — 20/20 green
- [x] `pytest tests/` full suite — 1486 passed, 1 skipped (pre-existing), no regressions
- [x] Index plan asserted via `EXPLAIN QUERY PLAN` for the 5 high-frequency query shapes (turn / correlation / session_recent / tool / predecessor)
- [x] Blob threshold flip verified at exactly `THOUGHT_EXTERNAL_THRESHOLD + 1` byte
- [x] Compaction chain walker handles 3-hop chain, unknown ids, and non-compact memory_ops
- [x] `grep` confirmed no imports from middleware / session / memory / scheduler / autonomy → zero coupling invariant holds

## Exit criteria (from #321)

- [x] 純儲存層測試全綠
- [x] 不依賴任何 emitter（zero coupling 進入點）
- [x] doc/53 §7 dataclass 形狀完整實作

## Notes for review

- Async API matches project convention (aiosqlite, asyncio_mode=auto). Sync emit was considered but rejected — subscribe API in §6.1 is async, and emit call sites are all async (middleware / session).
- `kw_only=True` on every dataclass to sidestep the non-default-after-default ordering trap with §7.1's mixed required/optional fields.
- `branch_id` defaults to `"main"`; v2 fork primitive (§4.4) will produce other values without schema migration.
- Thought blob path is **relative** in payload (`{turn_id}/{event_id}.txt`) per §3.3 — leaves room to swap blob_dir to S3/object store without touching ledger rows.
- `fetch_event` / `fetch_by_turn` / `explain_query_plan` are **storage self-test helpers**, not the public Pull API. Step 3-4 will replace them with the proper fluent / replay primitives (§6.2 / §6.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)