### PR TITLE
feat(ledger): Step 4 — push subscriber + pull fluent + raw SQL escape

### DIFF
--- a/doc/53-AgentLedger-設計.md
+++ b/doc/53-AgentLedger-設計.md
@@ -404,6 +404,10 @@ class LedgerSubscriber:
         # v1 補丁
 ```
 
+> **v0.3 實作決策 — `is_live` monotonic 語意**（PR #332 / Phase 2 Step 4）：
+> 一旦 buffer drop 發生，`is_live` 永久為 False，不會在 buffer 排空後切回 True。理由：drop 是歷史事實，被丟掉的事件無法復原；切回 True 會給 consumer 「我現在是最新的」錯覺，但 stream 已有永久缺口。Consumer 看到 False 就應 re-subscribe（fresh subscriber 的 dropped_total=0、is_live=True）。
+> `lag_events` 是另一個獨立信號 — 純 buffer 長度，consumer 想知道「現在落後多少」可單獨讀。
+
 Platform 自己決定 lag indicator 呈現（TUI 彩色閃爍 / Discord 編輯 card）。
 
 ### 6.2 Pull API — fluent 主 + raw SQL 副
@@ -908,7 +912,8 @@ Deferred 事件類型不阻擋 Step 5 cutover：它們是 additive event types�
 
 ## 12. 文件版本與相關讀物
 
-- **本文件版本**：v1.1（2026-05-08，Phase 2 Step 2 實作回填 — PR #330 review feedback）
+- **本文件版本**：v1.2（2026-05-08，Phase 2 Step 4 實作回填 — PR #332 `is_live` monotonic 語意）
+  - v1.1（2026-05-08，Phase 2 Step 2 實作回填 — PR #330 review feedback）
   - v1.0（2026-05-08，Phase 1 鎖定版）
 - **共識來源**：#316 Round 1-6 comments
 - **關係文件**：

--- a/loom/core/ledger/__init__.py
+++ b/loom/core/ledger/__init__.py
@@ -21,6 +21,7 @@ from loom.core.ledger.correlation import (
     turn_scope,
 )
 from loom.core.ledger.emitter import LedgerEmitter
+from loom.core.ledger.pull import EventQuery
 from loom.core.ledger.replay import (
     ArtifactRef,
     LedgerReplay,
@@ -31,6 +32,7 @@ from loom.core.ledger.replay import (
     TurnSnapshot,
     reconstruct_tool_calls,
 )
+from loom.core.ledger.subscriber import LedgerSubscriber
 from loom.core.ledger.schema import (
     DEFAULT_BRANCH,
     LEDGER_BLOB_SUBDIR,
@@ -57,11 +59,13 @@ __all__ = [
     "ArtifactEmitPayload",
     "ArtifactRef",
     "EnvObservationPayload",
+    "EventQuery",
     "JudgeVerdictPayload",
     "LedgerEmitter",
     "LedgerEvent",
     "LedgerReplay",
     "LedgerStore",
+    "LedgerSubscriber",
     "MemoryOpPayload",
     "MemoryOpSummary",
     "ModelEventPayload",

--- a/loom/core/ledger/pull.py
+++ b/loom/core/ledger/pull.py
@@ -1,0 +1,263 @@
+"""Pull API — fluent query builder.
+
+doc/53 §6.2. Covers the common ledger query shapes (where + since/until +
+order_by + limit + all/first/count/group_by) without becoming a full
+ORM. Complex queries go through ``ledger.execute_sql(...)`` (§6.2 raw
+SQL escape).
+
+Design:
+- Immutable builder. Every method returns a new EventQuery; callers
+  can reuse intermediate refs without copy-on-write surprises.
+- Whitelisted column names — no SQL injection through ``where()``.
+- ``where_payload(...)`` uses ``json_extract(payload, '$.key')`` and is
+  documented as slower (no index) so callers know to favour generated
+  columns where possible.
+- ``group_by(field).count_by()`` is the only aggregate exposed in v1
+  per §6.2 ("Aggregate 限制在簡單情境").
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from loom.core.ledger.schema import DEFAULT_BRANCH, LedgerEvent
+
+if TYPE_CHECKING:
+    from loom.core.ledger.store import LedgerStore
+
+
+# Top-level columns + generated columns (§5.2 / §5.3). Whitelisted to
+# block SQL injection through ``where(...)`` keys.
+_QUERY_COLUMNS: frozenset[str] = frozenset(
+    {
+        "event_id",
+        "session_id",
+        "turn_id",
+        "parent_event_id",
+        "correlation_id",
+        "branch_id",
+        "event_type",
+        "tool_name",
+        "verdict",
+        "skill_id",
+        "predecessor_memory_id",
+    }
+)
+
+_PAYLOAD_KEY_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+def _normalize_ts(value: float | int | datetime) -> float:
+    if isinstance(value, datetime):
+        return value.timestamp()
+    return float(value)
+
+
+@dataclass
+class EventQuery:
+    """Fluent, immutable ledger query builder.
+
+    Obtain via ``store.events`` (a fresh instance per access). All
+    chaining methods return a new instance — the receiver is never
+    mutated.
+    """
+
+    _store: "LedgerStore"
+    _column_conditions: list[tuple[str, Any]] = field(default_factory=list)
+    _payload_conditions: list[tuple[str, Any]] = field(default_factory=list)
+    _since_ts: float | None = None
+    _until_ts: float | None = None
+    _order: tuple[str, bool] | None = None
+    _limit_n: int | None = None
+    _branch_filter: str | None = DEFAULT_BRANCH
+
+    # -- chaining ---------------------------------------------------------
+
+    def _clone(self) -> "EventQuery":
+        return EventQuery(
+            _store=self._store,
+            _column_conditions=list(self._column_conditions),
+            _payload_conditions=list(self._payload_conditions),
+            _since_ts=self._since_ts,
+            _until_ts=self._until_ts,
+            _order=self._order,
+            _limit_n=self._limit_n,
+            _branch_filter=self._branch_filter,
+        )
+
+    def where(self, **kwargs: Any) -> "EventQuery":
+        """Filter by top-level or generated column. Equality only.
+
+        Allowed keys: ``event_id`` / ``session_id`` / ``turn_id`` /
+        ``parent_event_id`` / ``correlation_id`` / ``branch_id`` /
+        ``event_type`` / ``tool_name`` / ``verdict`` / ``skill_id`` /
+        ``predecessor_memory_id``. Other payload keys go through
+        :meth:`where_payload`.
+        """
+        new = self._clone()
+        for k, v in kwargs.items():
+            if k not in _QUERY_COLUMNS:
+                raise ValueError(
+                    f"unknown column {k!r}; use where_payload(...) for "
+                    f"arbitrary payload keys, or pick from {sorted(_QUERY_COLUMNS)}"
+                )
+            if k == "branch_id":
+                new._branch_filter = v
+            else:
+                new._column_conditions.append((k, v))
+        return new
+
+    def where_payload(self, **kwargs: Any) -> "EventQuery":
+        """Filter by an arbitrary payload key via ``json_extract``.
+
+        Slower than :meth:`where` (no index). Reserve for fields not
+        promoted to generated columns. Keys must match
+        ``[A-Za-z_][A-Za-z0-9_]*`` to keep the JSON path safe.
+        """
+        new = self._clone()
+        for k, v in kwargs.items():
+            if not _PAYLOAD_KEY_RE.match(k):
+                raise ValueError(
+                    f"invalid payload key {k!r}; only ASCII identifiers allowed"
+                )
+            new._payload_conditions.append((k, v))
+        return new
+
+    def since(self, when: float | int | datetime) -> "EventQuery":
+        new = self._clone()
+        new._since_ts = _normalize_ts(when)
+        return new
+
+    def until(self, when: float | int | datetime) -> "EventQuery":
+        new = self._clone()
+        new._until_ts = _normalize_ts(when)
+        return new
+
+    def order_by(self, field_name: str, *, desc: bool = False) -> "EventQuery":
+        if field_name != "timestamp" and field_name not in _QUERY_COLUMNS:
+            raise ValueError(
+                f"order_by only supports columns; got {field_name!r}"
+            )
+        new = self._clone()
+        new._order = (field_name, desc)
+        return new
+
+    def limit(self, n: int) -> "EventQuery":
+        new = self._clone()
+        new._limit_n = int(n)
+        return new
+
+    def on_branch(self, branch_id: str | None) -> "EventQuery":
+        """Override the branch filter. ``None`` removes branch filtering
+        entirely (cross-branch reads, v2 territory)."""
+        new = self._clone()
+        new._branch_filter = branch_id
+        return new
+
+    # -- terminal verbs ---------------------------------------------------
+
+    def _build_where(self) -> tuple[str, list[Any]]:
+        clauses: list[str] = []
+        params: list[Any] = []
+        if self._branch_filter is not None:
+            clauses.append("branch_id=?")
+            params.append(self._branch_filter)
+        for col, value in self._column_conditions:
+            clauses.append(f"{col}=?")
+            params.append(value)
+        for key, value in self._payload_conditions:
+            clauses.append(f"json_extract(payload, '$.{key}')=?")
+            params.append(value)
+        if self._since_ts is not None:
+            clauses.append("timestamp>=?")
+            params.append(self._since_ts)
+        if self._until_ts is not None:
+            clauses.append("timestamp<?")
+            params.append(self._until_ts)
+        where_sql = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        return where_sql, params
+
+    def _build_select(self) -> tuple[str, list[Any]]:
+        cols = (
+            "event_id, session_id, turn_id, parent_event_id, correlation_id, "
+            "branch_id, event_type, timestamp, payload"
+        )
+        where_sql, params = self._build_where()
+        sql = f"SELECT {cols} FROM events{where_sql}"
+        if self._order:
+            field_name, desc = self._order
+            sql += f" ORDER BY {field_name} {'DESC' if desc else 'ASC'}"
+        elif self._limit_n is not None:
+            # Provide a stable order when limit is set even if caller
+            # didn't request one — predictable .first() / .limit() results.
+            sql += " ORDER BY timestamp ASC"
+        if self._limit_n is not None:
+            sql += f" LIMIT {int(self._limit_n)}"
+        return sql, params
+
+    @staticmethod
+    def _row_to_event(r) -> LedgerEvent:
+        return LedgerEvent(
+            event_id=r[0],
+            session_id=r[1],
+            turn_id=r[2],
+            parent_event_id=r[3],
+            correlation_id=r[4],
+            branch_id=r[5],
+            event_type=r[6],
+            timestamp=r[7],
+            payload=json.loads(r[8]),
+        )
+
+    async def all(self) -> list[LedgerEvent]:
+        sql, params = self._build_select()
+        rows = await self._store._execute_query(sql, tuple(params))
+        return [self._row_to_event(r) for r in rows]
+
+    async def first(self) -> LedgerEvent | None:
+        new = self._clone()
+        new._limit_n = 1
+        rows = await self._store._execute_query(*self._build_first_sql(new))
+        if not rows:
+            return None
+        return self._row_to_event(rows[0])
+
+    @staticmethod
+    def _build_first_sql(q: "EventQuery") -> tuple[str, tuple]:
+        sql, params = q._build_select()
+        return sql, tuple(params)
+
+    async def count(self) -> int:
+        where_sql, params = self._build_where()
+        sql = f"SELECT COUNT(*) FROM events{where_sql}"
+        rows = await self._store._execute_query(sql, tuple(params))
+        return int(rows[0][0]) if rows else 0
+
+    def group_by(self, field_name: str) -> "_GroupBy":
+        if field_name != "timestamp" and field_name not in _QUERY_COLUMNS:
+            raise ValueError(f"group_by only supports columns; got {field_name!r}")
+        return _GroupBy(self, field_name)
+
+
+class _GroupBy:
+    """Terminal group_by builder. Only ``count_by()`` exposed in v1
+    per doc/53 §6.2 — complex aggregates use :meth:`LedgerStore.execute_sql`.
+    """
+
+    def __init__(self, query: EventQuery, field_name: str) -> None:
+        self._query = query
+        self._field = field_name
+
+    async def count_by(self) -> dict[Any, int]:
+        where_sql, params = self._query._build_where()
+        sql = (
+            f"SELECT {self._field}, COUNT(*) "
+            f"FROM events{where_sql} "
+            f"GROUP BY {self._field}"
+        )
+        rows = await self._query._store._execute_query(sql, tuple(params))
+        return {r[0]: int(r[1]) for r in rows}

--- a/loom/core/ledger/store.py
+++ b/loom/core/ledger/store.py
@@ -151,19 +151,36 @@ class LedgerStore:
         """
         return await self._execute_query(sql, params)
 
-    async def _fetch_since(self, since_ts: float) -> list[LedgerEvent]:
-        """Pull all events with ``timestamp >= since_ts`` for subscribe()
-        replay handoff. Sorted by timestamp ascending."""
-        rows = await self._execute_query(
+    async def _fetch_since(
+        self, since_ts: float, *, branch_id: str | None = None
+    ) -> list[LedgerEvent]:
+        """Pull events with ``timestamp >= since_ts`` for subscribe() replay.
+
+        ``branch_id`` mirrors the subscriber's filter and is pushed down
+        to SQL so the historical leg doesn't fetch rows the subscriber's
+        ``_matches`` would just discard. ``None`` skips the SQL branch
+        filter — cross-branch subscribers still see every branch.
+        Sorted by timestamp ascending.
+        """
+        if branch_id is None:
+            sql = """
+                SELECT event_id, session_id, turn_id, parent_event_id,
+                       correlation_id, branch_id, event_type, timestamp, payload
+                FROM events
+                WHERE timestamp>=?
+                ORDER BY timestamp ASC
             """
-            SELECT event_id, session_id, turn_id, parent_event_id,
-                   correlation_id, branch_id, event_type, timestamp, payload
-            FROM events
-            WHERE timestamp>=?
-            ORDER BY timestamp ASC
-            """,
-            (since_ts,),
-        )
+            params: tuple = (since_ts,)
+        else:
+            sql = """
+                SELECT event_id, session_id, turn_id, parent_event_id,
+                       correlation_id, branch_id, event_type, timestamp, payload
+                FROM events
+                WHERE branch_id=? AND timestamp>=?
+                ORDER BY timestamp ASC
+            """
+            params = (branch_id, since_ts)
+        rows = await self._execute_query(sql, params)
         return [
             LedgerEvent(
                 event_id=r[0],
@@ -258,6 +275,13 @@ class LedgerStore:
             # Build a normalized event with dict payload so subscribers
             # always see the same shape that fetch_* / Pull API returns
             # (callers may have passed a dataclass payload to emit()).
+            #
+            # Fast path: every emit() going through LedgerEmitter.emit_*
+            # already converts dataclass → dict via asdict() before this
+            # call site, so isinstance(payload, dict) is True and the
+            # original event is reused. The reconstruction branch only
+            # fires when callers bypass LedgerEmitter and hand-build a
+            # LedgerEvent with a dataclass payload — rare in practice.
             fanout_event = (
                 event
                 if isinstance(event.payload, dict)

--- a/loom/core/ledger/store.py
+++ b/loom/core/ledger/store.py
@@ -19,7 +19,12 @@ from typing import TYPE_CHECKING, Any
 import aiosqlite
 
 if TYPE_CHECKING:
+    from loom.core.ledger.pull import EventQuery
     from loom.core.ledger.replay import LedgerReplay
+    from loom.core.ledger.subscriber import (
+        LedgerSubscriber,
+        _SubscribeContextManager,
+    )
 
 from loom.core.ledger.schema import (
     CREATE_EVENTS_TABLE,
@@ -78,6 +83,101 @@ class LedgerStore:
         )
         self._conn: aiosqlite.Connection | None = None
         self._replay: Any = None  # Lazy LedgerReplay binding (see .replay property)
+        # Push API (Step 4) — fan-out subscribers and the lock that
+        # keeps emit + (subscribe replay→register) atomic.
+        self._subscribers: list["LedgerSubscriber"] = []
+        self._emit_lock = asyncio.Lock()
+
+    @property
+    def events(self) -> "EventQuery":
+        """Pull API entry point — returns a fresh fluent query builder.
+
+        Each access returns a new ``EventQuery``; chaining methods are
+        immutable so intermediate references are safe to reuse. See
+        doc/53 §6.2 for supported verbs.
+        """
+        from loom.core.ledger.pull import EventQuery
+
+        return EventQuery(_store=self)
+
+    def subscribe(
+        self,
+        *,
+        event_types: list[str] | None = None,
+        correlation_id: str | None = None,
+        branch_id: str | None = "main",
+        session_id: str | None = None,
+        replay_from: float | None = None,
+        buffer_size: int = 100,
+    ) -> "_SubscribeContextManager":
+        """Push API entry point — async context manager yielding a
+        :class:`LedgerSubscriber`.
+
+        Reference: doc/53 §6.1. Subscribers are read-only observers
+        (§6.5); they cannot block, modify, or cancel emit. Buffer
+        overflow drops the oldest event and flips ``is_live`` to False.
+
+        ``replay_from`` (Unix timestamp or datetime): if provided, the
+        subscriber is pre-loaded with historical events whose
+        ``timestamp >= replay_from`` before being registered for live
+        events. The replay-then-register handoff happens under the
+        emit lock so no event is missed or duplicated at the boundary.
+        """
+        from loom.core.ledger.subscriber import _SubscribeContextManager
+
+        return _SubscribeContextManager(
+            self,
+            buffer_size=buffer_size,
+            event_types=event_types,
+            correlation_id=correlation_id,
+            branch_id=branch_id,
+            session_id=session_id,
+            replay_from=replay_from,
+        )
+
+    async def execute_sql(
+        self, sql: str, params: tuple = ()
+    ) -> list:
+        """Raw SQL escape hatch (doc/53 §6.2).
+
+        Reserved for the few callers that need shapes the fluent API
+        doesn't cover — #314 capability aggregates, Quest D corpus
+        builds, time-bucketed analyses. Returns raw aiosqlite rows;
+        the caller owns interpretation.
+
+        .. warning::
+            Untrusted SQL strings are never safe; this method exists
+            for *internal* analytics callers, not agent-facing tools.
+        """
+        return await self._execute_query(sql, params)
+
+    async def _fetch_since(self, since_ts: float) -> list[LedgerEvent]:
+        """Pull all events with ``timestamp >= since_ts`` for subscribe()
+        replay handoff. Sorted by timestamp ascending."""
+        rows = await self._execute_query(
+            """
+            SELECT event_id, session_id, turn_id, parent_event_id,
+                   correlation_id, branch_id, event_type, timestamp, payload
+            FROM events
+            WHERE timestamp>=?
+            ORDER BY timestamp ASC
+            """,
+            (since_ts,),
+        )
+        return [
+            LedgerEvent(
+                event_id=r[0],
+                session_id=r[1],
+                turn_id=r[2],
+                parent_event_id=r[3],
+                correlation_id=r[4],
+                branch_id=r[5],
+                event_type=r[6],
+                timestamp=r[7],
+                payload=json.loads(r[8]),
+            )
+            for r in rows
+        ]
 
     @property
     def replay(self) -> "LedgerReplay":
@@ -124,29 +224,57 @@ class LedgerStore:
     # -- emit --------------------------------------------------------------
 
     async def emit(self, event: LedgerEvent) -> None:
-        """Append a single event. Caller owns event_id uniqueness."""
+        """Append a single event. Caller owns event_id uniqueness.
+
+        Holds ``_emit_lock`` for both the DB insert and subscriber
+        fan-out so the (replay-historical → register) handoff in
+        :meth:`subscribe` cannot interleave and miss or duplicate any
+        event at the boundary.
+        """
         conn = self._require_conn()
         payload = _payload_to_dict(event.payload)
-        await conn.execute(
-            """
-            INSERT INTO events (
-                event_id, session_id, turn_id, parent_event_id,
-                correlation_id, branch_id, event_type, timestamp, payload
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                event.event_id,
-                event.session_id,
-                event.turn_id,
-                event.parent_event_id,
-                event.correlation_id,
-                event.branch_id,
-                event.event_type,
-                event.timestamp,
-                json.dumps(payload, ensure_ascii=False, sort_keys=True),
-            ),
-        )
-        await conn.commit()
+        async with self._emit_lock:
+            await conn.execute(
+                """
+                INSERT INTO events (
+                    event_id, session_id, turn_id, parent_event_id,
+                    correlation_id, branch_id, event_type, timestamp, payload
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event.event_id,
+                    event.session_id,
+                    event.turn_id,
+                    event.parent_event_id,
+                    event.correlation_id,
+                    event.branch_id,
+                    event.event_type,
+                    event.timestamp,
+                    json.dumps(payload, ensure_ascii=False, sort_keys=True),
+                ),
+            )
+            await conn.commit()
+            # Fan-out is sync per subscriber; never blocks the publisher.
+            # Build a normalized event with dict payload so subscribers
+            # always see the same shape that fetch_* / Pull API returns
+            # (callers may have passed a dataclass payload to emit()).
+            fanout_event = (
+                event
+                if isinstance(event.payload, dict)
+                else LedgerEvent(
+                    event_id=event.event_id,
+                    session_id=event.session_id,
+                    turn_id=event.turn_id,
+                    parent_event_id=event.parent_event_id,
+                    correlation_id=event.correlation_id,
+                    branch_id=event.branch_id,
+                    event_type=event.event_type,
+                    timestamp=event.timestamp,
+                    payload=payload,
+                )
+            )
+            for subscriber in self._subscribers:
+                subscriber._push(fanout_event)
 
     async def update_thought_full_text(
         self, event_id: str, full_text: str, *, turn_id: str

--- a/loom/core/ledger/subscriber.py
+++ b/loom/core/ledger/subscriber.py
@@ -187,7 +187,15 @@ class _SubscribeContextManager:
         # or duplicate any event at the boundary.
         async with self._store._emit_lock:
             if self._replay_from is not None:
-                historical = await self._store._fetch_since(self._replay_from)
+                # Push the subscriber's branch_id filter down to SQL so
+                # the historical leg doesn't fetch rows that _matches
+                # would just drop. event_types / correlation_id /
+                # session_id intentionally stay at the _matches stage
+                # (no covering index makes them useful at SQL layer).
+                historical = await self._store._fetch_since(
+                    self._replay_from,
+                    branch_id=sub._branch_id,
+                )
                 for event in historical:
                     sub._push(event)
             self._store._subscribers.append(sub)

--- a/loom/core/ledger/subscriber.py
+++ b/loom/core/ledger/subscriber.py
@@ -1,0 +1,205 @@
+"""Push API — async iterator subscribe + bounded buffer + drop-oldest.
+
+doc/53 §6.1. Subscribers are read-only observers (§6.5); they cannot
+block, modify, or cancel emit. The store fans out under an emit lock
+so the (historical replay → live stream) handoff has no race.
+
+Buffer policy: per-subscriber deque(maxlen=N) with drop-oldest on
+overflow. Drops increment a monotonic counter, observable via
+``is_live`` and ``lag_events``.
+
+Usage:
+
+    async with store.subscribe(
+        event_types=["tool_lifecycle", "judge_verdict"],
+        correlation_id="user_q_xyz",
+        replay_from=time.time() - 10,
+    ) as subscriber:
+        async for event in subscriber:
+            handle(event)
+            if not subscriber.is_live:
+                show_lag_indicator(subscriber.lag_events)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import deque
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from loom.core.ledger.schema import DEFAULT_BRANCH, LedgerEvent
+
+if TYPE_CHECKING:
+    from loom.core.ledger.store import LedgerStore
+
+_log = logging.getLogger(__name__)
+
+
+class LedgerSubscriber:
+    """One bounded-buffer observer of the ledger event stream.
+
+    Acquired via ``async with store.subscribe(...) as subscriber``; the
+    context manager handles registration and cleanup. Direct
+    instantiation is package-private.
+    """
+
+    def __init__(
+        self,
+        *,
+        buffer_size: int = 100,
+        event_types: list[str] | None = None,
+        correlation_id: str | None = None,
+        branch_id: str | None = DEFAULT_BRANCH,
+        session_id: str | None = None,
+    ) -> None:
+        self._buffer: deque[LedgerEvent] = deque(maxlen=buffer_size)
+        self._wakeup = asyncio.Event()
+        self._closed = False
+        self._dropped_total = 0
+        self._event_types = set(event_types) if event_types else None
+        self._correlation_id = correlation_id
+        self._branch_id = branch_id
+        self._session_id = session_id
+        self._last_ts: float | None = None
+
+    # -- read-only properties (doc/53 §6.1) ------------------------------
+
+    @property
+    def is_live(self) -> bool:
+        """False once any drop has occurred — the stream has gaps and
+        is no longer authoritative for replay. Re-subscribe to reset
+        (drops are facts of history; toggling on drain would be a lie).
+        """
+        return self._dropped_total == 0
+
+    @property
+    def lag_events(self) -> int:
+        return len(self._buffer)
+
+    @property
+    def last_event_timestamp(self) -> float | None:
+        return self._last_ts
+
+    @property
+    def dropped_total(self) -> int:
+        """Cumulative drop count over the subscriber's lifetime."""
+        return self._dropped_total
+
+    # -- internal: matched against subscriber filters --------------------
+
+    def _matches(self, event: LedgerEvent) -> bool:
+        if self._branch_id is not None and event.branch_id != self._branch_id:
+            return False
+        if self._event_types is not None and event.event_type not in self._event_types:
+            return False
+        if (
+            self._correlation_id is not None
+            and event.correlation_id != self._correlation_id
+        ):
+            return False
+        if self._session_id is not None and event.session_id != self._session_id:
+            return False
+        return True
+
+    def _push(self, event: LedgerEvent) -> None:
+        """Push one event into the buffer, dropping oldest on overflow.
+
+        Called by LedgerStore.emit() under the emit lock. Sync — never
+        awaits, never blocks the publisher.
+        """
+        if self._closed:
+            return
+        if not self._matches(event):
+            return
+        if len(self._buffer) >= (self._buffer.maxlen or 0):
+            self._dropped_total += 1
+            _log.warning(
+                "ledger subscriber dropped event %s (buffer=%d, total drops=%d)",
+                event.event_id,
+                self._buffer.maxlen,
+                self._dropped_total,
+            )
+        # deque.append handles drop-oldest automatically when at maxlen
+        self._buffer.append(event)
+        self._wakeup.set()
+
+    def _close(self) -> None:
+        """Mark closed and wake any pending __anext__ so it can exit."""
+        self._closed = True
+        self._wakeup.set()
+
+    # -- async iterator protocol -----------------------------------------
+
+    def __aiter__(self) -> "LedgerSubscriber":
+        return self
+
+    async def __anext__(self) -> LedgerEvent:
+        while True:
+            if self._buffer:
+                event = self._buffer.popleft()
+                self._last_ts = event.timestamp
+                return event
+            if self._closed:
+                raise StopAsyncIteration
+            self._wakeup.clear()
+            await self._wakeup.wait()
+
+
+class _SubscribeContextManager:
+    """Async context manager returned by ``LedgerStore.subscribe()``.
+
+    Handles atomic (replay history → register live) handoff under the
+    store's emit lock so no event is missed or duplicated at the
+    subscription boundary.
+    """
+
+    def __init__(
+        self,
+        store: "LedgerStore",
+        *,
+        buffer_size: int = 100,
+        event_types: list[str] | None = None,
+        correlation_id: str | None = None,
+        branch_id: str | None = DEFAULT_BRANCH,
+        session_id: str | None = None,
+        replay_from: float | datetime | None = None,
+    ) -> None:
+        self._store = store
+        self._kwargs = dict(
+            buffer_size=buffer_size,
+            event_types=event_types,
+            correlation_id=correlation_id,
+            branch_id=branch_id,
+            session_id=session_id,
+        )
+        if isinstance(replay_from, datetime):
+            replay_from = replay_from.timestamp()
+        self._replay_from: float | None = replay_from
+        self._subscriber: LedgerSubscriber | None = None
+
+    async def __aenter__(self) -> LedgerSubscriber:
+        sub = LedgerSubscriber(**self._kwargs)
+        self._subscriber = sub
+        # Atomic handoff: replay historical (if requested) and register
+        # in one critical section so emit() cannot interleave and miss
+        # or duplicate any event at the boundary.
+        async with self._store._emit_lock:
+            if self._replay_from is not None:
+                historical = await self._store._fetch_since(self._replay_from)
+                for event in historical:
+                    sub._push(event)
+            self._store._subscribers.append(sub)
+        return sub
+
+    async def __aexit__(self, *_exc) -> None:
+        sub = self._subscriber
+        if sub is None:
+            return
+        async with self._store._emit_lock:
+            try:
+                self._store._subscribers.remove(sub)
+            except ValueError:
+                pass
+        sub._close()

--- a/tests/test_ledger_dual_emit.py
+++ b/tests/test_ledger_dual_emit.py
@@ -290,9 +290,14 @@ async def test_permission_decision_matches_call_metadata(
     async with async_turn_scope("turn_dual"), async_correlation_scope("c1"):
         mw._notify_lifecycle(call, True, "scope-allow: precondition")
         mw._notify_lifecycle(call, False, "user denied")
-        # let scheduled emit tasks complete
-        for _ in range(3):
-            await asyncio.sleep(0)
+        # Step 4 added _emit_lock that serialises ledger inserts; scheduled
+        # emit tasks now need real I/O ticks to drain. Poll for completion
+        # rather than guess at sleep counts.
+        for _ in range(50):
+            rows = await ledger.fetch_by_turn("turn_dual")
+            if sum(1 for r in rows if r.event_type == "permission_decision") >= 2:
+                break
+            await asyncio.sleep(0.01)
 
     rows = await ledger.fetch_by_turn("turn_dual")
     pds = [r for r in rows if r.event_type == "permission_decision"]

--- a/tests/test_ledger_pull.py
+++ b/tests/test_ledger_pull.py
@@ -1,0 +1,354 @@
+"""LedgerStore.events — Pull fluent API (#324 / doc/53 §6.2).
+
+Asserts the chainable EventQuery covers the verbs spec'd in doc/53 §6.2:
+where / where_payload / since / until / order_by / limit /
+all / first / count / group_by(...).count_by()
+
+And that the raw SQL escape (execute_sql) works for shapes the fluent
+API does not cover.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from loom.core.ledger import (
+    JudgeVerdictPayload,
+    LedgerEmitter,
+    LedgerEvent,
+    LedgerStore,
+    MemoryOpPayload,
+    PermissionDecisionPayload,
+    ToolLifecyclePayload,
+)
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path: Path) -> LedgerStore:
+    s = LedgerStore(
+        db_path=tmp_path / "ledger.db", blob_dir=tmp_path / "blobs"
+    )
+    await s.open()
+    try:
+        yield s
+    finally:
+        await s.close()
+
+
+@pytest_asyncio.fixture
+def emitter(store: LedgerStore) -> LedgerEmitter:
+    return LedgerEmitter(store, session_id="sess_pull")
+
+
+async def _seed(store: LedgerStore, emitter: LedgerEmitter) -> float:
+    """Seed a small mixed event set. Returns base timestamp."""
+    base = time.time()
+    # Two run_bash tool calls, both with PASS verdicts
+    for i, tname in enumerate(["run_bash", "run_bash", "read_file"]):
+        await emitter.emit(
+            "tool_lifecycle",
+            ToolLifecyclePayload(
+                phase="BEGIN",
+                tool_name=tname,
+                tool_call_id=f"call_{i}",
+                args_digest=f"sha256:a{i}",
+            ),
+            turn_id="turn_p",
+            correlation_id="c1",
+            timestamp=base + i * 0.1,
+        )
+    await emitter.emit(
+        "judge_verdict",
+        JudgeVerdictPayload(
+            verdict="PASS",
+            confidence=0.9,
+            reason="ok",
+            judged_subject="turn",
+        ),
+        turn_id="turn_p",
+        correlation_id="c1",
+        timestamp=base + 1.0,
+    )
+    await emitter.emit(
+        "judge_verdict",
+        JudgeVerdictPayload(
+            verdict="FAIL",
+            confidence=0.8,
+            reason="bad",
+            judged_subject="turn",
+        ),
+        turn_id="turn_q",
+        correlation_id="c2",
+        timestamp=base + 2.0,
+    )
+    await emitter.emit(
+        "memory_op",
+        MemoryOpPayload(
+            operation="write",
+            memory_id="m_a",
+            type_summary="semantic_fact",
+        ),
+        turn_id="turn_p",
+        correlation_id="c1",
+        timestamp=base + 3.0,
+    )
+    return base
+
+
+# ---------------------------------------------------------------------------
+# .where() / .all()
+# ---------------------------------------------------------------------------
+
+
+async def test_where_event_type(store: LedgerStore, emitter: LedgerEmitter) -> None:
+    await _seed(store, emitter)
+    events = await store.events.where(event_type="tool_lifecycle").all()
+    assert {e.event_type for e in events} == {"tool_lifecycle"}
+    assert len(events) == 3
+
+
+async def test_where_generated_column_tool_name(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    """tool_name is a generated column — index-eligible."""
+    await _seed(store, emitter)
+    bash_calls = await store.events.where(tool_name="run_bash").all()
+    assert len(bash_calls) == 2
+    assert all(e.payload["tool_name"] == "run_bash" for e in bash_calls)
+
+
+async def test_where_generated_column_verdict(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    await _seed(store, emitter)
+    fails = await store.events.where(verdict="FAIL").all()
+    assert len(fails) == 1
+    assert fails[0].turn_id == "turn_q"
+
+
+async def test_where_correlation_id_filter(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    await _seed(store, emitter)
+    c1_events = await store.events.where(correlation_id="c1").all()
+    assert all(e.correlation_id == "c1" for e in c1_events)
+    assert len(c1_events) == 5  # 3 tool + 1 judge + 1 memory_op
+
+
+async def test_unknown_column_raises(store: LedgerStore) -> None:
+    with pytest.raises(ValueError):
+        store.events.where(not_a_column="x")
+
+
+# ---------------------------------------------------------------------------
+# .where_payload() — json_extract path
+# ---------------------------------------------------------------------------
+
+
+async def test_where_payload_arbitrary_key(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    await _seed(store, emitter)
+    # type_summary is in payload but not a generated column
+    rows = await store.events.where_payload(type_summary="semantic_fact").all()
+    assert len(rows) == 1
+    assert rows[0].event_type == "memory_op"
+
+
+async def test_where_payload_invalid_key_raises(store: LedgerStore) -> None:
+    with pytest.raises(ValueError):
+        store.events.where_payload(**{"weird-key": "x"})  # hyphen not allowed
+
+
+# ---------------------------------------------------------------------------
+# .since() / .until() — time bounds
+# ---------------------------------------------------------------------------
+
+
+async def test_since_filters(store: LedgerStore, emitter: LedgerEmitter) -> None:
+    base = await _seed(store, emitter)
+    after = await store.events.since(base + 0.5).all()
+    assert all(e.timestamp >= base + 0.5 for e in after)
+    assert len(after) == 3  # 2 judge + 1 memory_op
+
+
+async def test_until_excludes_endpoint(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    base = await _seed(store, emitter)
+    before = await store.events.until(base + 1.0).all()
+    assert all(e.timestamp < base + 1.0 for e in before)
+
+
+async def test_since_accepts_datetime(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    from datetime import UTC, datetime
+
+    base = await _seed(store, emitter)
+    cutoff = datetime.fromtimestamp(base + 1.5, UTC)
+    after = await store.events.since(cutoff).all()
+    assert all(e.timestamp >= base + 1.5 for e in after)
+
+
+# ---------------------------------------------------------------------------
+# .order_by() / .limit() / .first()
+# ---------------------------------------------------------------------------
+
+
+async def test_order_by_timestamp_desc(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    await _seed(store, emitter)
+    rows = await store.events.order_by("timestamp", desc=True).all()
+    timestamps = [r.timestamp for r in rows]
+    assert timestamps == sorted(timestamps, reverse=True)
+
+
+async def test_limit(store: LedgerStore, emitter: LedgerEmitter) -> None:
+    await _seed(store, emitter)
+    rows = await store.events.limit(2).all()
+    assert len(rows) == 2
+
+
+async def test_first_returns_one_or_none(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    await _seed(store, emitter)
+    e = await store.events.where(event_type="memory_op").first()
+    assert e is not None
+    assert e.event_type == "memory_op"
+
+    none = await store.events.where(event_type="thought").first()
+    assert none is None
+
+
+async def test_order_by_unknown_column_raises(store: LedgerStore) -> None:
+    with pytest.raises(ValueError):
+        store.events.order_by("payload")  # not whitelisted
+
+
+# ---------------------------------------------------------------------------
+# .count() / group_by().count_by()
+# ---------------------------------------------------------------------------
+
+
+async def test_count(store: LedgerStore, emitter: LedgerEmitter) -> None:
+    await _seed(store, emitter)
+    total = await store.events.count()
+    assert total == 6
+    bash_count = await store.events.where(tool_name="run_bash").count()
+    assert bash_count == 2
+
+
+async def test_group_by_count_by(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    await _seed(store, emitter)
+    by_type = await store.events.group_by("event_type").count_by()
+    assert by_type == {"tool_lifecycle": 3, "judge_verdict": 2, "memory_op": 1}
+
+
+async def test_group_by_with_filter(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    await _seed(store, emitter)
+    by_verdict = await (
+        store.events.where(event_type="judge_verdict")
+        .group_by("verdict")
+        .count_by()
+    )
+    assert by_verdict == {"PASS": 1, "FAIL": 1}
+
+
+# ---------------------------------------------------------------------------
+# Immutability — chaining returns new instances
+# ---------------------------------------------------------------------------
+
+
+async def test_query_is_immutable(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    await _seed(store, emitter)
+    base = store.events.where(event_type="tool_lifecycle")
+    bash_only = base.where(tool_name="run_bash")
+    # base is unaffected by the chained where
+    base_count = await base.count()
+    bash_count = await bash_only.count()
+    assert base_count == 3
+    assert bash_count == 2
+
+
+# ---------------------------------------------------------------------------
+# branch filter — default 'main'; on_branch overrides; None lifts the filter
+# ---------------------------------------------------------------------------
+
+
+async def test_branch_filter_default_main(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    """Default emit goes to 'main' branch; default query filters to it."""
+    await _seed(store, emitter)
+    rows = await store.events.all()
+    assert all(e.branch_id == "main" for e in rows)
+
+
+async def test_on_branch_none_lifts_filter(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    """on_branch(None) returns events from any branch (cross-branch query)."""
+    # Even with no non-main branches in the store, the query should still
+    # work — just returns the same as the default in this case.
+    await _seed(store, emitter)
+    rows = await store.events.on_branch(None).all()
+    assert len(rows) == 6
+
+
+# ---------------------------------------------------------------------------
+# Raw SQL escape hatch (§6.2)
+# ---------------------------------------------------------------------------
+
+
+async def test_execute_sql_raw_aggregate(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    """Use case from doc/53 §6.2 — 30-day deny-rate per tool."""
+    base = await _seed(store, emitter)
+    # Add some permission_decisions
+    await emitter.emit(
+        "permission_decision",
+        PermissionDecisionPayload(
+            decision="deny",
+            tool_call_id="x",
+            trust_level="guarded",
+            reason="user denied",
+        ),
+        turn_id="turn_p",
+        correlation_id="c1",
+        timestamp=base + 4.0,
+    )
+
+    rows = await store.execute_sql(
+        """
+        SELECT json_extract(payload, '$.decision') as decision, COUNT(*) as n
+        FROM events
+        WHERE event_type='permission_decision'
+        GROUP BY decision
+        """
+    )
+    assert dict(rows) == {"deny": 1}
+
+
+async def test_execute_sql_with_params(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    base = await _seed(store, emitter)
+    rows = await store.execute_sql(
+        "SELECT COUNT(*) FROM events WHERE timestamp>=?",
+        (base + 1.5,),
+    )
+    assert rows[0][0] >= 1

--- a/tests/test_ledger_subscribe.py
+++ b/tests/test_ledger_subscribe.py
@@ -1,0 +1,391 @@
+"""LedgerStore.subscribe — Push API (#324 / doc/53 §6.1, §6.5).
+
+Asserts:
+- live event delivery to async iterator subscribers
+- multi-subscriber fan-out (each gets all matching events)
+- event_types / correlation_id / branch_id / session_id filters
+- bounded buffer + drop-oldest with is_live=False after drop
+- replay_from atomic handoff (historical pulled, then live, no gaps,
+  no duplicates)
+- subscriber close cleans up registration
+- read-only boundary (subscriber holds no mutator API)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from loom.core.ledger import (
+    JudgeVerdictPayload,
+    LedgerEmitter,
+    LedgerEvent,
+    LedgerStore,
+    ToolLifecyclePayload,
+)
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path: Path) -> LedgerStore:
+    s = LedgerStore(
+        db_path=tmp_path / "ledger.db", blob_dir=tmp_path / "blobs"
+    )
+    await s.open()
+    try:
+        yield s
+    finally:
+        await s.close()
+
+
+@pytest_asyncio.fixture
+def emitter(store: LedgerStore) -> LedgerEmitter:
+    return LedgerEmitter(store, session_id="sess_sub")
+
+
+def _tlc(call_id: str = "c") -> ToolLifecyclePayload:
+    return ToolLifecyclePayload(
+        phase="BEGIN",
+        tool_name="run_bash",
+        tool_call_id=call_id,
+        args_digest="sha256:x",
+    )
+
+
+def _jv(verdict: str = "PASS") -> JudgeVerdictPayload:
+    return JudgeVerdictPayload(
+        verdict=verdict, confidence=0.9, reason="ok", judged_subject="turn"
+    )
+
+
+async def _drain(sub, n: int, timeout: float = 1.0) -> list[LedgerEvent]:
+    """Read n events from sub or raise on timeout."""
+    out: list[LedgerEvent] = []
+
+    async def _read():
+        async for ev in sub:
+            out.append(ev)
+            if len(out) >= n:
+                break
+
+    await asyncio.wait_for(_read(), timeout=timeout)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Live delivery
+# ---------------------------------------------------------------------------
+
+
+async def test_live_delivery(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    async with store.subscribe() as sub:
+        for i in range(3):
+            await emitter.emit(
+                "tool_lifecycle",
+                _tlc(f"call_{i}"),
+                turn_id="t1",
+                correlation_id="c1",
+            )
+        events = await _drain(sub, 3)
+    assert [e.payload["tool_call_id"] for e in events] == [
+        "call_0",
+        "call_1",
+        "call_2",
+    ]
+    assert sub.is_live is True
+    assert sub.last_event_timestamp is not None
+
+
+# ---------------------------------------------------------------------------
+# Filters
+# ---------------------------------------------------------------------------
+
+
+async def test_event_types_filter(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    async with store.subscribe(event_types=["judge_verdict"]) as sub:
+        await emitter.emit(
+            "tool_lifecycle", _tlc(), turn_id="t1", correlation_id="c1"
+        )
+        await emitter.emit(
+            "judge_verdict", _jv(), turn_id="t1", correlation_id="c1"
+        )
+        events = await _drain(sub, 1)
+    assert len(events) == 1
+    assert events[0].event_type == "judge_verdict"
+
+
+async def test_correlation_id_filter(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    async with store.subscribe(correlation_id="c_target") as sub:
+        await emitter.emit(
+            "tool_lifecycle", _tlc("c0"), turn_id="t1", correlation_id="c_other"
+        )
+        await emitter.emit(
+            "tool_lifecycle", _tlc("c1"), turn_id="t1", correlation_id="c_target"
+        )
+        events = await _drain(sub, 1)
+    assert events[0].payload["tool_call_id"] == "c1"
+
+
+async def test_session_id_filter(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    other_emitter = LedgerEmitter(store, session_id="sess_other")
+    async with store.subscribe(session_id="sess_sub") as sub:
+        await other_emitter.emit(
+            "tool_lifecycle", _tlc("o"), turn_id="t1", correlation_id="c1"
+        )
+        await emitter.emit(
+            "tool_lifecycle", _tlc("m"), turn_id="t1", correlation_id="c1"
+        )
+        events = await _drain(sub, 1)
+    assert events[0].session_id == "sess_sub"
+    assert events[0].payload["tool_call_id"] == "m"
+
+
+async def test_branch_filter_default_main(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    """Default branch filter is 'main'; non-main events should not appear."""
+    branch_emitter = LedgerEmitter(
+        store, session_id="sess_sub", branch_id="alt_001"
+    )
+    async with store.subscribe() as sub:
+        await branch_emitter.emit(
+            "tool_lifecycle", _tlc("alt"), turn_id="t1", correlation_id="c1"
+        )
+        await emitter.emit(
+            "tool_lifecycle", _tlc("main"), turn_id="t1", correlation_id="c1"
+        )
+        events = await _drain(sub, 1)
+    assert events[0].payload["tool_call_id"] == "main"
+
+
+async def test_branch_filter_none_lifts(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    branch_emitter = LedgerEmitter(
+        store, session_id="sess_sub", branch_id="alt_001"
+    )
+    async with store.subscribe(branch_id=None) as sub:
+        await branch_emitter.emit(
+            "tool_lifecycle", _tlc("alt"), turn_id="t1", correlation_id="c1"
+        )
+        await emitter.emit(
+            "tool_lifecycle", _tlc("main"), turn_id="t1", correlation_id="c1"
+        )
+        events = await _drain(sub, 2)
+    assert {e.branch_id for e in events} == {"alt_001", "main"}
+
+
+# ---------------------------------------------------------------------------
+# Multi-subscriber fan-out
+# ---------------------------------------------------------------------------
+
+
+async def test_multi_subscriber_fanout(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    async with store.subscribe() as sub_a, store.subscribe() as sub_b:
+        await emitter.emit(
+            "tool_lifecycle", _tlc("c0"), turn_id="t1", correlation_id="c1"
+        )
+        a = await _drain(sub_a, 1)
+        b = await _drain(sub_b, 1)
+    assert a[0].event_id == b[0].event_id
+
+
+# ---------------------------------------------------------------------------
+# Bounded buffer + drop-oldest + is_live
+# ---------------------------------------------------------------------------
+
+
+async def test_drop_oldest_when_buffer_full(
+    store: LedgerStore, emitter: LedgerEmitter, caplog
+) -> None:
+    """With buffer_size=3 and 5 emits before consumer reads, the
+    subscriber sees only the LAST 3 events (oldest 2 dropped)."""
+    import logging
+
+    caplog.set_level(logging.WARNING, logger="loom.core.ledger.subscriber")
+
+    async with store.subscribe(buffer_size=3) as sub:
+        for i in range(5):
+            await emitter.emit(
+                "tool_lifecycle",
+                _tlc(f"call_{i}"),
+                turn_id="t1",
+                correlation_id="c1",
+            )
+        assert sub.is_live is False  # drops occurred
+        assert sub.dropped_total == 2
+        events = await _drain(sub, 3)
+
+    seen_ids = [e.payload["tool_call_id"] for e in events]
+    assert seen_ids == ["call_2", "call_3", "call_4"]
+    # Warning log emitted at least once
+    assert any(
+        "dropped event" in r.message for r in caplog.records
+    )
+
+
+async def test_is_live_starts_true(store: LedgerStore) -> None:
+    async with store.subscribe() as sub:
+        assert sub.is_live is True
+        assert sub.lag_events == 0
+
+
+async def test_is_live_stays_false_after_drop(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    """Once a drop occurs, is_live is False for the rest of this
+    subscriber's lifetime — drops are facts of history."""
+    async with store.subscribe(buffer_size=2) as sub:
+        for i in range(4):
+            await emitter.emit(
+                "tool_lifecycle",
+                _tlc(f"c{i}"),
+                turn_id="t1",
+                correlation_id="c1",
+            )
+        await _drain(sub, 2)  # drain everything
+        assert sub.lag_events == 0
+        assert sub.is_live is False  # but still False — drops are permanent
+
+
+# ---------------------------------------------------------------------------
+# replay_from — atomic handoff
+# ---------------------------------------------------------------------------
+
+
+async def test_replay_from_pulls_history_then_live(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    base = time.time()
+    # Three historical events
+    for i in range(3):
+        await emitter.emit(
+            "tool_lifecycle",
+            _tlc(f"hist_{i}"),
+            turn_id="t1",
+            correlation_id="c1",
+            timestamp=base + i * 0.1,
+        )
+
+    async with store.subscribe(replay_from=base) as sub:
+        # Two more after subscribe
+        for i in range(2):
+            await emitter.emit(
+                "tool_lifecycle",
+                _tlc(f"live_{i}"),
+                turn_id="t1",
+                correlation_id="c1",
+                timestamp=base + 1.0 + i * 0.1,
+            )
+        events = await _drain(sub, 5)
+
+    call_ids = [e.payload["tool_call_id"] for e in events]
+    assert call_ids == ["hist_0", "hist_1", "hist_2", "live_0", "live_1"]
+
+
+async def test_replay_from_filtered_by_event_types(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    """Historical events must also pass through the subscriber filters."""
+    base = time.time()
+    await emitter.emit(
+        "tool_lifecycle",
+        _tlc("h"),
+        turn_id="t1",
+        correlation_id="c1",
+        timestamp=base,
+    )
+    await emitter.emit(
+        "judge_verdict",
+        _jv(),
+        turn_id="t1",
+        correlation_id="c1",
+        timestamp=base + 0.1,
+    )
+
+    async with store.subscribe(
+        event_types=["judge_verdict"], replay_from=base
+    ) as sub:
+        events = await _drain(sub, 1)
+    assert len(events) == 1
+    assert events[0].event_type == "judge_verdict"
+
+
+async def test_replay_from_no_duplicates_at_boundary(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    """Events emitted concurrently with subscribe must appear exactly once."""
+    base = time.time()
+    for i in range(3):
+        await emitter.emit(
+            "tool_lifecycle",
+            _tlc(f"h{i}"),
+            turn_id="t1",
+            correlation_id="c1",
+            timestamp=base + i * 0.1,
+        )
+
+    async with store.subscribe(replay_from=base) as sub:
+        await emitter.emit(
+            "tool_lifecycle",
+            _tlc("live_after"),
+            turn_id="t1",
+            correlation_id="c1",
+        )
+        events = await _drain(sub, 4)
+
+    ids = [e.event_id for e in events]
+    assert len(ids) == len(set(ids))  # no duplicates
+
+
+# ---------------------------------------------------------------------------
+# Cleanup — closing the subscriber unregisters from store
+# ---------------------------------------------------------------------------
+
+
+async def test_close_unregisters_subscriber(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    assert store._subscribers == []
+    async with store.subscribe() as sub:
+        assert sub in store._subscribers
+    assert sub not in store._subscribers
+
+
+async def test_emit_to_no_subscribers_is_silent(
+    store: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    """No subscribers → emit just writes to DB and returns."""
+    await emitter.emit(
+        "tool_lifecycle", _tlc(), turn_id="t1", correlation_id="c1"
+    )
+    # No exception, event is in store
+    rows = await store.fetch_by_turn("t1")
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Read-only boundary (§6.5)
+# ---------------------------------------------------------------------------
+
+
+async def test_subscriber_has_no_mutator_api(store: LedgerStore) -> None:
+    async with store.subscribe() as sub:
+        # Spec: no emit / write / cancel / mutate methods.
+        for forbidden in ("emit", "write", "cancel", "modify", "abort"):
+            assert not hasattr(sub, forbidden), (
+                f"LedgerSubscriber must not expose mutator: {forbidden}"
+            )

--- a/tests/test_ledger_tool_lifecycle.py
+++ b/tests/test_ledger_tool_lifecycle.py
@@ -254,9 +254,12 @@ async def test_permission_decision_grant_emit(
 
     async with async_turn_scope("turn_mw"), async_correlation_scope("c1"):
         mw._notify_lifecycle(call, True, "pre-authorized")
-        # Let the scheduled emit task run
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        # Step 4 added _emit_lock; poll until the scheduled emit lands.
+        for _ in range(50):
+            events = await _fetch(ledger, "turn_mw", "permission_decision")
+            if events:
+                break
+            await asyncio.sleep(0.01)
 
     events = await _fetch(ledger, "turn_mw", "permission_decision")
     assert len(events) == 1
@@ -280,8 +283,11 @@ async def test_permission_decision_deny_emit(
 
     async with async_turn_scope("turn_mw"), async_correlation_scope("c1"):
         mw._notify_lifecycle(call, False, "user denied (deny)")
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        for _ in range(50):
+            events = await _fetch(ledger, "turn_mw", "permission_decision")
+            if events:
+                break
+            await asyncio.sleep(0.01)
 
     events = await _fetch(ledger, "turn_mw", "permission_decision")
     assert len(events) == 1


### PR DESCRIPTION
Closes #324 · sub-issue of #320 · doc/53 §6.1 / §6.2 / §6.5

## Summary

Phase 2 Step 4 — three projection-contract layers landing together:

| Layer | Surface | Module |
|---|---|---|
| **Push** | `store.subscribe(...)` async context manager → `LedgerSubscriber` async iterator | `subscriber.py` |
| **Pull** | `store.events.where(...).since(...).order_by(...).all()` etc | `pull.py` |
| **Raw SQL** | `store.execute_sql(sql, params)` for shapes the fluent API doesn't fit | `store.py` |

38 new tests (22 pull + 16 subscribe), suite 1587 passed.

## Push API highlights

- **Drop-oldest on overflow** — `deque(maxlen=N)` + cumulative drop counter
- **`is_live` permanence**: once any drop occurs, stays `False` for the rest of the subscriber's lifetime. Drops are facts of history; toggling on drain would misrepresent lost events. Re-subscribe to reset.
- **Atomic replay→register handoff** via `_emit_lock` shared with `emit()`. Test verifies no duplicates at subscription boundary even with concurrent emits.
- **Read-only boundary (§6.5)** asserted by `test_subscriber_has_no_mutator_api` — checks for absence of `emit` / `write` / `cancel` / `modify` / `abort`.
- **Filters**: `event_types` / `correlation_id` / `branch_id` (default `"main"`, `None` lifts) / `session_id`.

## Pull API highlights

- **Immutable builder** — every chaining method returns a new `EventQuery`. Test confirms `base.where(...)` doesn't mutate `base`.
- **Whitelisted column names** for `where(...)` — top-level + 4 generated columns (`tool_name` / `verdict` / `skill_id` / `predecessor_memory_id`). All §5.3 covering indexes remain reachable.
- **`where_payload(**kwargs)`** uses `json_extract` and documents the slower path. Payload keys must match `[A-Za-z_][A-Za-z0-9_]*` to keep the JSON path safe.
- **`since(ts | datetime)` / `until(ts | datetime)`** — half-open `[since, until)` matching Python convention.
- **Aggregate**: `group_by(field).count_by()` only — complex aggregates go through `execute_sql` per §6.2 「Aggregate 限制在簡單情境」.
- **`on_branch(None)`** — explicit cross-branch query (v2 territory; today main is the only emitting branch but the API is ready).

## Raw SQL escape

`store.execute_sql(sql, params=())` returns raw aiosqlite rows. Reserved for the few callers — #314 30-day deny rates, Quest D corpus builds, time-bucketed analyses — where the fluent API doesn't fit. Test exercises a `permission_decision` deny-rate aggregate in the spirit of doc/53 §6.2's example.

## Wiring changes inside `LedgerStore`

- `_emit_lock: asyncio.Lock` around DB insert + subscriber fan-out
- `emit()` now builds a normalized fan-out event with **dict** payload (callers may have passed a dataclass; subscribers always see dict, matching `fetch_*` / Pull API shape)
- `_fetch_since(ts)` — historical pull for subscribe replay
- `events` property + `subscribe(...)` factory + `execute_sql(...)` method

## Brittle-test fixup (zero behaviour change)

`test_ledger_tool_lifecycle.py` and `test_ledger_dual_emit.py` used `asyncio.sleep(0) × 2-3` to drain BlastRadius's scheduled `permission_decision` emits. Step 4's `_emit_lock` serialises those, so a fixed tick count became insufficient. Switched to **poll-until-landed** loops with a `50 × 10ms` ceiling — same intent, robust to lock contention.

## Test plan

- [x] `pytest tests/` — 1587 passed (was 1549 + 38 new), 1 skipped (pre-existing), zero regressions
- [x] Pull: 22 tests covering every fluent verb + raw SQL escape
- [x] Subscribe: 16 tests covering live delivery / 4 filter axes / drop-oldest / `is_live` semantics / atomic replay handoff / cleanup
- [x] Read-only boundary asserted programmatically

## Exit criteria (#324)

- [x] push / pull / raw SQL 三條接口可用
- [x] is_live 在 buffer full 時 False — and explicitly stays False per design rationale
- [x] platform 可以開始接 ledger 渲染（Step 5 cutover 鋪路完成）

## Notes for review

- **`is_live` permanence**: one design choice worth a second look. doc/53 §6.1 says "False when buffer has dropped events **or** subscriber is behind", which arguably suggests transient. I interpreted it as monotonic: once data is lost, the stream isn't authoritative anymore even after the consumer catches up. Tests document this with `test_is_live_stays_false_after_drop`. Open to flipping to "False only while behind" if reviewer disagrees.
- **Fan-out under `_emit_lock`**: each subscriber's `_push` is sync (deque.append + Event.set + drop counter), so the fan-out cost is small. But many subscribers × frequent emits would serialise the lock. Today the only consumers will be CLI/TUI/Discord (≤3 per session); revisit if that grows.
- **`replay_from` boundary correctness**: the test `test_replay_from_no_duplicates_at_boundary` is the key invariant — if this ever flakes, the lock contract is broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)