### PR TITLE
feat(ledger): Step 5 — ExecutionEnvelope cutover (projection from ledger)

### DIFF
--- a/doc/53-AgentLedger-設計.md
+++ b/doc/53-AgentLedger-設計.md
@@ -874,7 +874,7 @@ Step 6. 測試全綠 → merge → 切換 Loom Agent 啟新版開新 session
 
 性質：Step 1-4 不影響運行系統；Step 5-6 是切版時刻。
 
-### 11.2.1 Step 2 實作狀態（PR #330 截止）
+### 11.2.1 Phase 2 實作狀態
 
 | Event type | Step 2 狀態 | 備註 |
 |---|---|---|
@@ -900,6 +900,16 @@ Step 6. 測試全綠 → merge → 切換 Loom Agent 啟新版開新 session
 
 Deferred 事件類型不阻擋 Step 5 cutover：它們是 additive event types，不是替換既有 observability 信號。Follow-up issue 在 Step 2 merge 後另開。
 
+**Step 3-5 進度補記**（PR #331 / #332 / Step 5 PR）：
+
+| 工作 | 狀態 | 備註 |
+|---|---|---|
+| Step 3 — Replay primitive (events_for_* + TurnSnapshot) | ✅ 完成（#331） | `LedgerStore.replay` lazy property，§8.2 trivial+medium 欄位 reconstruct 全綠 |
+| Step 4 — Push subscriber + Pull fluent + raw SQL | ✅ 完成（#332） | `subscribe(...)` async ctx、`events.where().since().all()` 等、`execute_sql`；`is_live` monotonic 語意（一旦 drop 永久 False，`re-subscribe` 重置） |
+| Step 5 — ExecutionEnvelope 投影切換 | ✅ 完成 | `LedgerEnvelopeProjector` + `_build_envelope_view` async 委派；`envelope.records` 僅作 transitional bridge 給 `_live_record_for`，view 不再讀；`[ledger].enabled=false` 仍走 legacy fallback |
+| Step 5 — SessionLog 投影 | ⚠️ deferred | SessionLog 存 OpenAI-canonical raw 訊息 text，ledger 沒有對應 raw text 事件（thought event 內嵌邏輯仍 deferred）。完整投影需與 thought event capture 一起實作 |
+| Step 5 — Memory compaction subscribe `turn_end` 觸發 | ⚠️ deferred | 目前 inline trigger 在 stream_turn 內、行為正確；移成 background subscriber 為 architectural improvement，timing 細節需評估，獨立 follow-up issue |
+
 ### 11.3 舊資料 — Leave alone
 
 舊 session_log 留 `memory.db`、舊 `ExecutionEnvelope` artifact 留原處；新 session 從 `ledger.db` 開始。
@@ -912,7 +922,8 @@ Deferred 事件類型不阻擋 Step 5 cutover：它們是 additive event types�
 
 ## 12. 文件版本與相關讀物
 
-- **本文件版本**：v1.2（2026-05-08，Phase 2 Step 4 實作回填 — PR #332 `is_live` monotonic 語意）
+- **本文件版本**：v1.3（2026-05-09，Phase 2 Step 5 cutover 完成 — envelope 投影切換；SessionLog / compaction-subscribe 標 deferred follow-up）
+  - v1.2（2026-05-08，Phase 2 Step 4 實作回填 — PR #332 `is_live` monotonic 語意）
   - v1.1（2026-05-08，Phase 2 Step 2 實作回填 — PR #330 review feedback）
   - v1.0（2026-05-08，Phase 1 鎖定版）
 - **共識來源**：#316 Round 1-6 comments

--- a/loom/core/ledger/__init__.py
+++ b/loom/core/ledger/__init__.py
@@ -21,6 +21,7 @@ from loom.core.ledger.correlation import (
     turn_scope,
 )
 from loom.core.ledger.emitter import LedgerEmitter
+from loom.core.ledger.envelope_view import CallMeta, LedgerEnvelopeProjector
 from loom.core.ledger.pull import EventQuery
 from loom.core.ledger.replay import (
     ArtifactRef,
@@ -58,10 +59,12 @@ __all__ = [
     "THOUGHT_EXTERNAL_THRESHOLD",
     "ArtifactEmitPayload",
     "ArtifactRef",
+    "CallMeta",
     "EnvObservationPayload",
     "EventQuery",
     "JudgeVerdictPayload",
     "LedgerEmitter",
+    "LedgerEnvelopeProjector",
     "LedgerEvent",
     "LedgerReplay",
     "LedgerStore",

--- a/loom/core/ledger/envelope_view.py
+++ b/loom/core/ledger/envelope_view.py
@@ -1,0 +1,261 @@
+"""LedgerEnvelopeProjector — build ExecutionEnvelopeView from ledger events.
+
+Phase 2 Step 5 cutover (#325 / doc/53 §11.2). Replaces the envelope's
+``records[]`` mutation path: instead of ``ExecutionEnvelope.records``
+being the source of truth for what happened in a tool batch, the
+projector queries ``tool_lifecycle`` events for the tool_call_ids
+belonging to the batch and reconstructs the view from there.
+
+What the ledger does not track today:
+- full args (Step 2 commit 5 chose args_digest only)
+- auth_decision / auth_selector (live in call.metadata, set by
+  BlastRadiusMiddleware)
+- auth_expires (read live from session.perm at view-build time)
+
+Those bits are supplied by the caller via ``CallMeta`` records and
+the ``live_record_lookup`` / ``auth_expires_lookup`` callables. The
+caller (LoomSession) populates them at tool dispatch / state-change
+time. When the deferred STATE_CHANGE event emits land, the live
+lookup can drop in favour of pure ledger projection.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Callable
+
+from loom.core.events import ExecutionEnvelopeView, ExecutionNodeView
+from loom.core.ledger.replay import reconstruct_tool_calls
+
+if TYPE_CHECKING:
+    from loom.core.harness.lifecycle import ActionRecord
+    from loom.core.harness.registry import ToolRegistry
+    from loom.core.ledger.store import LedgerStore
+
+
+# Mirrors ``ActionState._TERMINAL_STATES`` / ``_FAILURE_STATES`` as
+# strings so the projector does not import the lifecycle module
+# (zero-coupling: ledger reads, lifecycle writes).
+_TERMINAL_STATES: frozenset[str] = frozenset(
+    {"memorialized", "denied", "aborted", "timed_out"}
+)
+_FAILURE_STATES: frozenset[str] = frozenset(
+    {"denied", "aborted", "timed_out", "reverted"}
+)
+
+
+@dataclass
+class CallMeta:
+    """Per-tool-call metadata not represented in the ledger.
+
+    Populated by LoomSession at dispatch / authorization time; queried
+    by the projector when building an ExecutionEnvelopeView. This is
+    the small surface that survives Step 5's elimination of
+    ``ExecutionEnvelope.records[].ActionRecord``.
+    """
+
+    call_id: str
+    tool_name: str
+    full_args: dict[str, Any] = field(default_factory=dict)
+    args_preview: str = ""
+    auth_decision: str = ""
+    auth_selector: str = ""
+
+
+class LedgerEnvelopeProjector:
+    """Builds ExecutionEnvelopeView snapshots from ledger events.
+
+    The projector is stateless across calls — each ``build_view()``
+    invocation queries the ledger fresh. Per-batch identity (which
+    call_ids belong to this envelope) and per-call metadata (args,
+    auth) are passed in by the caller.
+    """
+
+    def __init__(
+        self,
+        store: "LedgerStore",
+        registry: "ToolRegistry | None" = None,
+    ) -> None:
+        self._store = store
+        self._registry = registry
+
+    async def build_view(
+        self,
+        *,
+        envelope_id: str,
+        session_id: str,
+        turn_id: str,
+        turn_index: int,
+        call_ids: list[str],
+        call_meta: dict[str, CallMeta],
+        live_record_lookup: Callable[[str], "ActionRecord | None"] | None = None,
+        auth_expires_lookup: Callable[[str], float] | None = None,
+        batch_t0: float = 0.0,
+    ) -> ExecutionEnvelopeView:
+        """Project the ledger into an ExecutionEnvelopeView.
+
+        ``call_ids`` is the batch's tool_call_id set in dispatch order.
+        ``call_meta`` carries args / auth fields the ledger does not
+        store. ``live_record_lookup`` is a fallback for in-flight calls
+        (BEGIN seen, END not yet) where the ledger does not yet have
+        an authoritative state — this lets cutover preserve mid-batch
+        TUI / CLI behaviour during parallel dispatch. When the deferred
+        STATE_CHANGE event emits land (doc/53 §3.1 v0.3 simplification
+        note), the live lookup becomes redundant.
+        """
+        events = await self._store.replay.events_for_turn(turn_id)
+        # Filter to tool_lifecycle events whose tool_call_id belongs to
+        # this envelope. reconstruct_tool_calls preserves first-seen
+        # ordering — matches dispatch order natively.
+        call_id_set = set(call_ids)
+        batch_events = [
+            e
+            for e in events
+            if e.event_type == "tool_lifecycle"
+            and e.payload.get("tool_call_id") in call_id_set
+        ]
+        summaries = reconstruct_tool_calls(batch_events)
+
+        # If a call was registered but no BEGIN landed yet (rare race),
+        # also surface it as an empty placeholder so the UI sees the
+        # node count caller expects.
+        seen_call_ids = {s.tool_call_id for s in summaries}
+        missing = [cid for cid in call_ids if cid not in seen_call_ids]
+
+        nodes: list[ExecutionNodeView] = []
+        terminal_count = 0
+        failure_count = 0
+
+        for s in summaries:
+            meta = call_meta.get(s.tool_call_id)
+            tdef = self._registry.get(s.tool_name) if self._registry else None
+
+            # Derive current state. Priority:
+            #   1) ledger state_transitions last "to" (authoritative when END seen)
+            #   2) live_record_lookup (covers in-flight parallel dispatch)
+            #   3) "executing" (BEGIN seen, no END yet)
+            state = self._derive_state(s, live_record_lookup)
+            if state in _TERMINAL_STATES:
+                terminal_count += 1
+            if state in _FAILURE_STATES or s.rolled_back:
+                failure_count += 1
+
+            duration_ms = self._batch_duration_ms(batch_events, s.tool_call_id)
+            auth_expires = (
+                auth_expires_lookup(s.tool_call_id) if auth_expires_lookup else 0.0
+            )
+            error_snippet = (s.error or "")[:80] if s.error else ""
+            output_preview = (s.result_summary or "")[:200]
+
+            nodes.append(
+                ExecutionNodeView(
+                    node_id=s.tool_call_id,
+                    call_id=s.tool_call_id,
+                    action_id=s.tool_call_id,
+                    tool_name=s.tool_name,
+                    level=0,
+                    state=state,
+                    trust_level=tdef.trust_level.plain if tdef else "SAFE",
+                    capabilities=[c.name for c in tdef.capabilities] if tdef else [],
+                    args_preview=meta.args_preview if meta else "",
+                    duration_ms=duration_ms,
+                    error_snippet=error_snippet,
+                    full_args=dict(meta.full_args) if meta else {},
+                    state_history=list(s.state_transitions),
+                    auth_decision=meta.auth_decision if meta else "",
+                    auth_expires=auth_expires,
+                    auth_selector=meta.auth_selector if meta else "",
+                    output_preview=output_preview,
+                )
+            )
+
+        # Surface placeholders for registered-but-not-yet-emitted calls.
+        for cid in missing:
+            meta = call_meta.get(cid)
+            tdef = (
+                self._registry.get(meta.tool_name)
+                if (meta and self._registry)
+                else None
+            )
+            nodes.append(
+                ExecutionNodeView(
+                    node_id=cid,
+                    call_id=cid,
+                    action_id=cid,
+                    tool_name=meta.tool_name if meta else "(unknown)",
+                    level=0,
+                    state="declared",
+                    trust_level=tdef.trust_level.plain if tdef else "SAFE",
+                    capabilities=[c.name for c in tdef.capabilities] if tdef else [],
+                    args_preview=meta.args_preview if meta else "",
+                    full_args=dict(meta.full_args) if meta else {},
+                    auth_decision=meta.auth_decision if meta else "",
+                    auth_selector=meta.auth_selector if meta else "",
+                )
+            )
+
+        # Aggregate status — matches the legacy _build_envelope_view
+        # logic (all terminal AND any failure → "failed"; all terminal
+        # AND no failure → "completed"; otherwise "running").
+        node_count = len(nodes)
+        all_terminal = node_count > 0 and terminal_count == node_count
+        if all_terminal and failure_count > 0:
+            status = "failed"
+        elif all_terminal:
+            status = "completed"
+        else:
+            status = "running"
+
+        elapsed_ms = (time.monotonic() - batch_t0) * 1000 if batch_t0 else 0.0
+
+        return ExecutionEnvelopeView(
+            envelope_id=envelope_id,
+            session_id=session_id,
+            turn_index=turn_index,
+            status=status,
+            node_count=node_count,
+            parallel_groups=1,  # all current parallel dispatch = single level
+            elapsed_ms=elapsed_ms,
+            levels=[[n.node_id for n in nodes]] if nodes else [],
+            nodes=nodes,
+        )
+
+    # -- helpers ---------------------------------------------------------
+
+    @staticmethod
+    def _derive_state(
+        summary,
+        live_record_lookup: Callable[[str], "ActionRecord | None"] | None,
+    ) -> str:
+        # 1) ledger has full transition history (BEGIN+END seen)
+        if summary.state_transitions:
+            last = summary.state_transitions[-1]
+            return last.get("to", "executing")
+        # 2) live ActionRecord — bridges the v0.3 STATE_CHANGE-emit gap
+        if live_record_lookup is not None:
+            rec = live_record_lookup(summary.tool_call_id)
+            if rec is not None:
+                return rec.state.value
+        # 3) BEGIN seen, no END yet → assume executing
+        return "executing" if "BEGIN" in summary.state_history else "declared"
+
+    @staticmethod
+    def _batch_duration_ms(events, call_id: str) -> float:
+        """Compute duration_ms from BEGIN/END timestamps for one call."""
+        begin_ts = None
+        end_ts = None
+        for e in events:
+            if e.payload.get("tool_call_id") != call_id:
+                continue
+            phase = e.payload.get("phase")
+            if phase == "BEGIN":
+                begin_ts = e.timestamp
+            elif phase == "END":
+                end_ts = e.timestamp
+        if begin_ts is None:
+            return 0.0
+        # Use END if available; otherwise current wall-clock vs BEGIN
+        # (matches ActionRecord.elapsed_ms behaviour for in-flight calls).
+        anchor = end_ts if end_ts is not None else time.time()
+        return (anchor - begin_ts) * 1000.0

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -41,7 +41,9 @@ from rich.rule import Rule
 
 from loom.core.diagnostic import DiagnosticReport, StartupDiagnostic
 from loom.core.ledger import (
+    CallMeta,
     LedgerEmitter,
+    LedgerEnvelopeProjector,
     LedgerStore,
     TurnEndPayload,
     TurnStartPayload,
@@ -688,6 +690,13 @@ class LoomSession:
         # ledger_emitter wiring is a no-op (existing tests rely on this).
         self._ledger_store: LedgerStore | None = None
         self._ledger_emitter: LedgerEmitter | None = None
+        # Step 5 cutover: envelope view projects from ledger instead of
+        # ExecutionEnvelope.records. _call_metadata caches per-call args /
+        # auth bits not stored in the ledger; _envelope_call_ids preserves
+        # dispatch order for the current envelope.
+        self._envelope_projector: LedgerEnvelopeProjector | None = None
+        self._call_metadata: dict[str, CallMeta] = {}
+        self._envelope_call_ids: list[str] = []
 
         # Build prompt stack from loom.toml [identity] config
         config = _load_loom_config()
@@ -1046,6 +1055,9 @@ class LoomSession:
                 self._ledger_emitter = LedgerEmitter(
                     self._ledger_store, session_id=self.session_id
                 )
+                self._envelope_projector = LedgerEnvelopeProjector(
+                    self._ledger_store, registry=self.registry
+                )
             except Exception:
                 logger.exception(
                     "ledger init failed — proceeding without ledger; "
@@ -1054,6 +1066,7 @@ class LoomSession:
                 )
                 self._ledger_store = None
                 self._ledger_emitter = None
+                self._envelope_projector = None
 
         # Issue #147 Phase C: build the facade up-front so every later step
         # in start() (auto-import, MemoryIndexer, tool registration, etc.)
@@ -1716,6 +1729,7 @@ class LoomSession:
                     logger.debug("ledger close error during shutdown: %s", exc)
                 self._ledger_store = None
                 self._ledger_emitter = None
+                self._envelope_projector = None
 
     # ------------------------------------------------------------------
     # Streaming agent loop
@@ -2213,10 +2227,31 @@ class LoomSession:
                         turn_index=self._turn_index,
                     )
                     self._current_envelope = envelope
+                    # Step 5: reset per-batch call_id ordering (call_metadata
+                    # itself is turn-scoped and stays). Pre-populate with
+                    # the tool_uses about to dispatch so EnvelopeStarted
+                    # has the same node_count as the legacy path.
+                    self._envelope_call_ids = []
+                    for _tu in response.tool_uses:
+                        self._envelope_call_ids.append(_tu.id)
+                        # Best-effort args_preview from first string arg —
+                        # mirrors the legacy view's args extraction.
+                        _first = next(iter(_tu.args.values()), "") if _tu.args else ""
+                        _preview = (
+                            _first.replace("\n", "↵")[:60]
+                            if isinstance(_first, str)
+                            else ""
+                        )
+                        self._call_metadata[_tu.id] = CallMeta(
+                            call_id=_tu.id,
+                            tool_name=_tu.name,
+                            full_args=dict(_tu.args) if _tu.args else {},
+                            args_preview=_preview,
+                        )
                     _batch_t0 = time.monotonic()
 
                     # Yield EnvelopeStarted *before* ToolBegin events
-                    yield EnvelopeStarted(envelope=self._build_envelope_view(_batch_t0))
+                    yield EnvelopeStarted(envelope=await self._build_envelope_view(_batch_t0))
 
                     if parallel:
                         # Announce all tools, then run concurrently
@@ -2240,7 +2275,7 @@ class LoomSession:
                             while not self._lifecycle_events.empty():
                                 yield self._lifecycle_events.get_nowait()
                             # Issue #106: Yield envelope update after each tool completes
-                            yield EnvelopeUpdated(envelope=self._build_envelope_view(_batch_t0))
+                            yield EnvelopeUpdated(envelope=await self._build_envelope_view(_batch_t0))
                             # Issue #197 Phase 2: tag for observation masking.
                             # Underscore-prefixed keys are ignored by provider
                             # conversion (verified for OpenAI native + Anthropic
@@ -2298,7 +2333,7 @@ class LoomSession:
                                 now_mono = time.monotonic()
                                 if drained or (now_mono - _last_envelope_yield) > 1.0:
                                     yield EnvelopeUpdated(
-                                        envelope=self._build_envelope_view(_batch_t0)
+                                        envelope=await self._build_envelope_view(_batch_t0)
                                     )
                                     _last_envelope_yield = now_mono
 
@@ -2331,7 +2366,7 @@ class LoomSession:
                             while not self._lifecycle_events.empty():
                                 yield self._lifecycle_events.get_nowait()
                             # Issue #106: Yield envelope update after each tool completes
-                            yield EnvelopeUpdated(envelope=self._build_envelope_view(_batch_t0))
+                            yield EnvelopeUpdated(envelope=await self._build_envelope_view(_batch_t0))
                             # Issue #197 Phase 2: tag for observation masking.
                             _tool_msg = self.router.format_tool_result(
                                 self.model, tu.id, tool_output, result.success,
@@ -2352,7 +2387,7 @@ class LoomSession:
                     # ── Issue #106: Envelope completed ─────────────────────────
                     if self._current_envelope is not None:
                         self._current_envelope.complete()
-                    _completed_view = self._build_envelope_view(_batch_t0)
+                    _completed_view = await self._build_envelope_view(_batch_t0)
                     yield EnvelopeCompleted(envelope=_completed_view)
                     # Keep last 50 envelopes — covers TUI history display *and*
                     # the Issue #196 turn-boundary judge digest. 10 was enough for
@@ -3374,11 +3409,21 @@ class LoomSession:
         )
         result = await self._pipeline.execute(call, tool_def.executor)
 
-        # Issue #106: link ActionRecord to the envelope (if not already linked
-        # by _on_state_change during execution — see #109 early-add logic).
+        # Step 5 cutover: capture per-call metadata that the ledger does
+        # not store (full args / auth_decision / auth_selector). The
+        # projector joins these with ledger tool_lifecycle events to
+        # build ExecutionEnvelopeView. ``ExecutionEnvelope.records``
+        # mutation is kept as a transitional bridge so
+        # ``_live_record_for`` can surface mid-batch states until
+        # STATE_CHANGE event emits land (doc/53 §3.1 simplification
+        # note). The view itself no longer reads records[] directly.
         ctx = call.metadata.get(LIFECYCLE_CTX_KEY)
-        if ctx is not None and self._current_envelope is not None:
-            if ctx.record not in self._current_envelope.records:
+        if ctx is not None:
+            self._register_call_meta(ctx.record)
+            if (
+                self._current_envelope is not None
+                and ctx.record not in self._current_envelope.records
+            ):
                 self._current_envelope.add(ctx.record)
 
         return result
@@ -3555,10 +3600,18 @@ class LoomSession:
         change so _build_envelope_view() can see ⏳ awaiting_confirm
         while the confirm widget is blocking.
         """
-        # Early-add record to envelope (#109)
-        if self._current_envelope is not None:
-            if record not in self._current_envelope.records:
-                self._current_envelope.add(record)
+        # Step 5: register the call's metadata as soon as we observe it
+        # so the envelope view can render even before the call ends
+        # (#109 early-display while ⏳ awaiting_confirm). envelope.records
+        # mutation is the transitional bridge for _live_record_for
+        # (see _build_envelope_view docstring); the view no longer
+        # reads from records directly.
+        self._register_call_meta(record)
+        if (
+            self._current_envelope is not None
+            and record not in self._current_envelope.records
+        ):
+            self._current_envelope.add(record)
 
         call_id = record.call.id if record.call else ""
         self._lifecycle_events.put_nowait(
@@ -3591,12 +3644,118 @@ class LoomSession:
     # Issue #106: Envelope projection — build read-only view for UI
     # ------------------------------------------------------------------
 
-    def _build_envelope_view(self, batch_t0: float = 0.0) -> ExecutionEnvelopeView:
-        """Build a read-only ``ExecutionEnvelopeView`` from the live envelope.
+    def _register_call_meta(self, record) -> None:
+        """Capture per-call args / auth bits for the envelope projector.
 
-        This is the projection layer described in doc/43 — it only does
-        view shaping, never mutates middleware state.
+        Called from ``_on_state_change`` (early-add path #109) and the
+        post-pipeline link site so the projector sees consistent
+        metadata regardless of which hook fires first. Also appends
+        ``call.id`` to ``_envelope_call_ids`` if not already present —
+        this is how the projector knows which calls belong to the
+        current batch (replaces the pre-Step-5
+        ``ExecutionEnvelope.records[]`` source of truth).
         """
+        call = record.call
+        if call is None:
+            return
+        if call.id not in self._envelope_call_ids:
+            self._envelope_call_ids.append(call.id)
+
+        # Args preview — first string argument truncated to 60 chars,
+        # newlines collapsed for the UI.
+        args_preview = ""
+        if call.args:
+            first_val = next(iter(call.args.values()), "")
+            if isinstance(first_val, str):
+                args_preview = first_val.replace("\n", "↵")[:60]
+
+        # auth_decision / auth_selector come from BlastRadiusMiddleware
+        # writes to call.metadata.
+        auth_decision = call.metadata.get("confirm_decision", "")
+        auth_selector = ""
+        scope_req = call.metadata.get("scope_request")
+        if scope_req is not None:
+            reqs = getattr(scope_req, "requirements", [])
+            if reqs:
+                auth_selector = reqs[0].selector
+
+        self._call_metadata[call.id] = CallMeta(
+            call_id=call.id,
+            tool_name=record.tool_name,
+            full_args=dict(call.args) if call.args else {},
+            args_preview=args_preview,
+            auth_decision=auth_decision,
+            auth_selector=auth_selector,
+        )
+
+    def _live_record_for(self, call_id: str):
+        """Live ActionRecord lookup for the projector.
+
+        Step 5 transitional bridge: until STATE_CHANGE events emit
+        (deferred per doc/53 §3.1 v0.3 simplification note), the
+        ledger only sees BEGIN/END for each call. Mid-batch the
+        projector needs a way to read the current ActionRecord state
+        so parallel-dispatch UIs don't all show "executing" until END.
+        Sourced from ``ExecutionEnvelope.records`` while it remains
+        the live ActionRecord registry; returns None when no record
+        is found for ``call_id`` and the projector falls back to its
+        BEGIN/END heuristic.
+        """
+        env = self._current_envelope
+        if env is None:
+            return None
+        for r in env.records:
+            if r.call and r.call.id == call_id:
+                return r
+        return None
+
+    def _auth_expires_for(self, call_id: str) -> float:
+        """Live lookup of scope-grant expiry for a tool call.
+
+        Reads ``self.perm._effective_grants()`` at view-build time —
+        this is session-level state, not per-call ledger data.
+        """
+        meta = self._call_metadata.get(call_id)
+        if meta is None or meta.auth_decision != "scope":
+            return 0.0
+        for g in self.perm._effective_grants():
+            if hasattr(g, "source") and g.source == "lease" and g.valid_until > 0:
+                return g.valid_until
+        return 0.0
+
+    async def _build_envelope_view(
+        self, batch_t0: float = 0.0
+    ) -> ExecutionEnvelopeView:
+        """Build a read-only ``ExecutionEnvelopeView``.
+
+        Step 5 cutover: when a ledger-backed projector is wired
+        (``self._envelope_projector`` non-None), the view is built by
+        querying ``tool_lifecycle`` events for the call_ids in the
+        current batch. Falls back to the legacy
+        ``ExecutionEnvelope.records[ActionRecord]`` walk when no
+        ledger is wired (tests, ``[ledger].enabled=false`` mode).
+
+        This is the projection layer described in doc/43 — it only
+        does view shaping, never mutates middleware state.
+        """
+        if self._envelope_projector is not None:
+            from loom.core.ledger import current_turn_id
+
+            turn_id = current_turn_id() or "system"
+            return await self._envelope_projector.build_view(
+                envelope_id=f"e{self._envelope_counter}",
+                session_id=self.session_id,
+                turn_id=turn_id,
+                turn_index=self._turn_index,
+                call_ids=list(self._envelope_call_ids),
+                call_meta=self._call_metadata,
+                live_record_lookup=self._live_record_for,
+                auth_expires_lookup=self._auth_expires_for,
+                batch_t0=batch_t0,
+            )
+
+        # Legacy path — kept for no-ledger sessions and the transition
+        # period. Equivalent to pre-Step-5 behaviour.
         env = self._current_envelope
         if env is None:
             return ExecutionEnvelopeView(

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -694,6 +694,13 @@ class LoomSession:
         # ExecutionEnvelope.records. _call_metadata caches per-call args /
         # auth bits not stored in the ledger; _envelope_call_ids preserves
         # dispatch order for the current envelope.
+        #
+        # Lifecycle: _envelope_call_ids resets at each new envelope (per
+        # tool batch). _call_metadata is turn-scoped — entries from
+        # earlier batches in the same turn stay reachable for cross-
+        # batch correlation. Today's per-turn call counts are small
+        # (< 50); if that assumption ever breaks, switch to a per-batch
+        # eviction policy.
         self._envelope_projector: LedgerEnvelopeProjector | None = None
         self._call_metadata: dict[str, CallMeta] = {}
         self._envelope_call_ids: list[str] = []
@@ -3700,6 +3707,13 @@ class LoomSession:
         the live ActionRecord registry; returns None when no record
         is found for ``call_id`` and the projector falls back to its
         BEGIN/END heuristic.
+
+        .. warning::
+            The returned object is the live, mutable ActionRecord —
+            callers (projector code) MUST treat it as read-only.
+            Any mutation will alter the lifecycle state machine's
+            view of the world. The projector reads ``rec.state.value``
+            only.
         """
         env = self._current_envelope
         if env is None:
@@ -3756,6 +3770,9 @@ class LoomSession:
 
         # Legacy path — kept for no-ledger sessions and the transition
         # period. Equivalent to pre-Step-5 behaviour.
+        # TODO(quest-b): remove this entire branch when STATE_CHANGE
+        # events emit and the _live_record_for / envelope.records
+        # bridge can be deleted (doc/53 §11.2.1 deferred follow-ups).
         env = self._current_envelope
         if env is None:
             return ExecutionEnvelopeView(

--- a/tests/test_ledger_envelope_projector.py
+++ b/tests/test_ledger_envelope_projector.py
@@ -1,0 +1,447 @@
+"""LedgerEnvelopeProjector — tool batch view from ledger (#325 commit 1).
+
+Builds synthetic ledger entries and asserts the projector produces an
+ExecutionEnvelopeView equivalent to what the legacy
+``LoomSession._build_envelope_view`` would have produced from
+``ExecutionEnvelope.records``.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+
+from loom.core.ledger import (
+    CallMeta,
+    LedgerEmitter,
+    LedgerEnvelopeProjector,
+    LedgerStore,
+    ToolLifecyclePayload,
+    TurnStartPayload,
+)
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path: Path) -> LedgerStore:
+    s = LedgerStore(
+        db_path=tmp_path / "ledger.db", blob_dir=tmp_path / "blobs"
+    )
+    await s.open()
+    try:
+        yield s
+    finally:
+        await s.close()
+
+
+@pytest_asyncio.fixture
+def emitter(store: LedgerStore) -> LedgerEmitter:
+    return LedgerEmitter(store, session_id="sess_proj")
+
+
+@pytest_asyncio.fixture
+def projector(store: LedgerStore) -> LedgerEnvelopeProjector:
+    # No registry — capabilities/trust_level fall back to defaults.
+    return LedgerEnvelopeProjector(store, registry=None)
+
+
+async def _emit_lifecycle_pair(
+    emitter: LedgerEmitter,
+    *,
+    call_id: str,
+    tool_name: str,
+    turn_id: str,
+    timestamps: tuple[float, float],
+    rolled_back: bool = False,
+    error: str | None = None,
+    result_summary: str | None = "ok",
+) -> None:
+    begin_ts, end_ts = timestamps
+    await emitter.emit(
+        "tool_lifecycle",
+        ToolLifecyclePayload(
+            phase="BEGIN",
+            tool_name=tool_name,
+            tool_call_id=call_id,
+            args_digest=f"sha256:{call_id}",
+        ),
+        turn_id=turn_id,
+        correlation_id="c1",
+        timestamp=begin_ts,
+    )
+    state_transitions = (
+        [
+            {"from": "declared", "to": "authorized", "ts": "x", "reason": None},
+            {"from": "authorized", "to": "executing", "ts": "x", "reason": None},
+            {"from": "executing", "to": "observed", "ts": "x", "reason": None},
+            {"from": "observed", "to": "validated", "ts": "x", "reason": None},
+        ]
+        + (
+            [
+                {"from": "validated", "to": "reverting", "ts": "x", "reason": None},
+                {"from": "reverting", "to": "reverted", "ts": "x", "reason": None},
+                {"from": "reverted", "to": "memorialized", "ts": "x", "reason": None},
+            ]
+            if rolled_back
+            else [
+                {"from": "validated", "to": "committed", "ts": "x", "reason": None},
+                {"from": "committed", "to": "memorialized", "ts": "x", "reason": None},
+            ]
+        )
+    )
+    await emitter.emit(
+        "tool_lifecycle",
+        ToolLifecyclePayload(
+            phase="END",
+            tool_name=tool_name,
+            tool_call_id=call_id,
+            args_digest=f"sha256:{call_id}",
+            result_summary=result_summary,
+            state_history=state_transitions,
+            rolled_back=rolled_back,
+            error=error,
+        ),
+        turn_id=turn_id,
+        correlation_id="c1",
+        timestamp=end_ts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Single-call batch
+# ---------------------------------------------------------------------------
+
+
+async def test_completed_batch_single_call(
+    store: LedgerStore, emitter: LedgerEmitter, projector
+) -> None:
+    base = time.time()
+    await emitter.emit(
+        "turn_start",
+        TurnStartPayload(
+            prompt_stack_hash="sha256:p",
+            prompt_stack_components={"persona": "x", "tool_catalog_size": 1},
+        ),
+        turn_id="turn_p",
+        correlation_id="c1",
+        timestamp=base,
+    )
+    await _emit_lifecycle_pair(
+        emitter,
+        call_id="call_1",
+        tool_name="run_bash",
+        turn_id="turn_p",
+        timestamps=(base + 0.1, base + 0.5),
+    )
+
+    view = await projector.build_view(
+        envelope_id="e1",
+        session_id="sess_proj",
+        turn_id="turn_p",
+        turn_index=0,
+        call_ids=["call_1"],
+        call_meta={
+            "call_1": CallMeta(
+                call_id="call_1",
+                tool_name="run_bash",
+                full_args={"cmd": "ls"},
+                args_preview="ls",
+                auth_decision="auto",
+            )
+        },
+    )
+
+    assert view.envelope_id == "e1"
+    assert view.status == "completed"
+    assert view.node_count == 1
+    n = view.nodes[0]
+    assert n.tool_name == "run_bash"
+    assert n.state == "memorialized"
+    assert n.args_preview == "ls"
+    assert n.full_args == {"cmd": "ls"}
+    assert n.auth_decision == "auto"
+    assert n.duration_ms == pytest.approx(400, abs=5)
+    assert n.output_preview == "ok"
+    # state_history is the bundled lifecycle transitions
+    assert any(t["to"] == "memorialized" for t in n.state_history)
+
+
+# ---------------------------------------------------------------------------
+# Failed call (rolled back) → status="failed"
+# ---------------------------------------------------------------------------
+
+
+async def test_failed_batch_status(
+    store: LedgerStore, emitter: LedgerEmitter, projector
+) -> None:
+    base = time.time()
+    await _emit_lifecycle_pair(
+        emitter,
+        call_id="call_x",
+        tool_name="run_bash",
+        turn_id="turn_p",
+        timestamps=(base, base + 0.3),
+        rolled_back=True,
+        error="rejected by post-validator",
+    )
+
+    view = await projector.build_view(
+        envelope_id="e2",
+        session_id="sess_proj",
+        turn_id="turn_p",
+        turn_index=0,
+        call_ids=["call_x"],
+        call_meta={
+            "call_x": CallMeta(call_id="call_x", tool_name="run_bash"),
+        },
+    )
+
+    assert view.status == "failed"
+    n = view.nodes[0]
+    assert n.state == "memorialized"
+    # error_snippet truncates at 80
+    assert "rejected" in n.error_snippet
+
+
+# ---------------------------------------------------------------------------
+# Parallel batch — mid-execution → status="running"
+# ---------------------------------------------------------------------------
+
+
+async def test_parallel_batch_one_running_one_done(
+    store: LedgerStore, emitter: LedgerEmitter, projector
+) -> None:
+    base = time.time()
+    # Call A finishes
+    await _emit_lifecycle_pair(
+        emitter,
+        call_id="call_a",
+        tool_name="read_file",
+        turn_id="turn_p",
+        timestamps=(base, base + 0.2),
+    )
+    # Call B only has BEGIN
+    await emitter.emit(
+        "tool_lifecycle",
+        ToolLifecyclePayload(
+            phase="BEGIN",
+            tool_name="run_bash",
+            tool_call_id="call_b",
+            args_digest="sha256:b",
+        ),
+        turn_id="turn_p",
+        correlation_id="c1",
+        timestamp=base + 0.1,
+    )
+
+    view = await projector.build_view(
+        envelope_id="e3",
+        session_id="sess_proj",
+        turn_id="turn_p",
+        turn_index=0,
+        call_ids=["call_a", "call_b"],
+        call_meta={
+            "call_a": CallMeta(call_id="call_a", tool_name="read_file"),
+            "call_b": CallMeta(call_id="call_b", tool_name="run_bash"),
+        },
+    )
+
+    assert view.status == "running"
+    states = {n.tool_name: n.state for n in view.nodes}
+    assert states["read_file"] == "memorialized"
+    # Call B has only BEGIN → "executing" derivation
+    assert states["run_bash"] == "executing"
+
+
+# ---------------------------------------------------------------------------
+# Live record fallback for in-flight states
+# ---------------------------------------------------------------------------
+
+
+async def test_live_record_lookup_overrides_in_flight_state(
+    store: LedgerStore, emitter: LedgerEmitter, projector
+) -> None:
+    base = time.time()
+    await emitter.emit(
+        "tool_lifecycle",
+        ToolLifecyclePayload(
+            phase="BEGIN",
+            tool_name="run_bash",
+            tool_call_id="call_live",
+            args_digest="sha256:l",
+        ),
+        turn_id="turn_p",
+        correlation_id="c1",
+        timestamp=base,
+    )
+
+    # Mock ActionRecord with a current state of "awaiting_confirm"
+    fake_record = MagicMock()
+    fake_record.state.value = "awaiting_confirm"
+
+    view = await projector.build_view(
+        envelope_id="e4",
+        session_id="sess_proj",
+        turn_id="turn_p",
+        turn_index=0,
+        call_ids=["call_live"],
+        call_meta={
+            "call_live": CallMeta(call_id="call_live", tool_name="run_bash")
+        },
+        live_record_lookup=lambda cid: fake_record if cid == "call_live" else None,
+    )
+
+    assert view.nodes[0].state == "awaiting_confirm"
+
+
+# ---------------------------------------------------------------------------
+# auth_expires_lookup
+# ---------------------------------------------------------------------------
+
+
+async def test_auth_expires_threaded_through_callable(
+    store: LedgerStore, emitter: LedgerEmitter, projector
+) -> None:
+    base = time.time()
+    await _emit_lifecycle_pair(
+        emitter,
+        call_id="call_e",
+        tool_name="write_file",
+        turn_id="turn_p",
+        timestamps=(base, base + 0.1),
+    )
+
+    expiry = base + 600
+    view = await projector.build_view(
+        envelope_id="e5",
+        session_id="sess_proj",
+        turn_id="turn_p",
+        turn_index=0,
+        call_ids=["call_e"],
+        call_meta={"call_e": CallMeta(call_id="call_e", tool_name="write_file")},
+        auth_expires_lookup=lambda cid: expiry if cid == "call_e" else 0.0,
+    )
+    assert view.nodes[0].auth_expires == expiry
+
+
+# ---------------------------------------------------------------------------
+# Placeholder for registered-but-not-emitted call
+# ---------------------------------------------------------------------------
+
+
+async def test_call_id_with_no_lifecycle_event_yet(
+    store: LedgerStore, emitter: LedgerEmitter, projector
+) -> None:
+    """Caller registers a call_id but no BEGIN has landed (race window)."""
+    view = await projector.build_view(
+        envelope_id="e6",
+        session_id="sess_proj",
+        turn_id="turn_empty",
+        turn_index=0,
+        call_ids=["call_pending"],
+        call_meta={
+            "call_pending": CallMeta(
+                call_id="call_pending",
+                tool_name="run_bash",
+                args_preview="ls",
+            )
+        },
+    )
+    assert view.node_count == 1
+    n = view.nodes[0]
+    assert n.state == "declared"
+    assert n.tool_name == "run_bash"
+    assert n.args_preview == "ls"
+
+
+# ---------------------------------------------------------------------------
+# Ordering — calls appear in dispatch order (first-seen ts)
+# ---------------------------------------------------------------------------
+
+
+async def test_calls_ordered_by_first_seen(
+    store: LedgerStore, emitter: LedgerEmitter, projector
+) -> None:
+    base = time.time()
+    await _emit_lifecycle_pair(
+        emitter,
+        call_id="call_2nd",
+        tool_name="t",
+        turn_id="turn_p",
+        timestamps=(base, base + 0.5),
+    )
+    await _emit_lifecycle_pair(
+        emitter,
+        call_id="call_1st",
+        tool_name="t",
+        turn_id="turn_p",
+        timestamps=(base + 0.1, base + 0.6),
+    )
+
+    view = await projector.build_view(
+        envelope_id="e7",
+        session_id="sess_proj",
+        turn_id="turn_p",
+        turn_index=0,
+        call_ids=["call_2nd", "call_1st"],
+        call_meta={
+            "call_2nd": CallMeta(call_id="call_2nd", tool_name="t"),
+            "call_1st": CallMeta(call_id="call_1st", tool_name="t"),
+        },
+    )
+    assert [n.call_id for n in view.nodes] == ["call_2nd", "call_1st"]
+    assert view.levels == [["call_2nd", "call_1st"]]
+
+
+# ---------------------------------------------------------------------------
+# Empty envelope (no call_ids registered yet)
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_envelope_running_status(
+    store: LedgerStore, projector
+) -> None:
+    view = await projector.build_view(
+        envelope_id="e_empty",
+        session_id="sess_proj",
+        turn_id="turn_unknown",
+        turn_index=0,
+        call_ids=[],
+        call_meta={},
+    )
+    assert view.status == "running"
+    assert view.node_count == 0
+    assert view.nodes == []
+    assert view.levels == []
+
+
+# ---------------------------------------------------------------------------
+# elapsed_ms uses batch_t0 from monotonic clock
+# ---------------------------------------------------------------------------
+
+
+async def test_elapsed_ms_from_batch_t0(
+    store: LedgerStore, emitter: LedgerEmitter, projector
+) -> None:
+    base = time.time()
+    await _emit_lifecycle_pair(
+        emitter,
+        call_id="c",
+        tool_name="t",
+        turn_id="turn_p",
+        timestamps=(base, base + 0.05),
+    )
+    batch_t0 = time.monotonic() - 1.0  # pretend batch started 1s ago
+    view = await projector.build_view(
+        envelope_id="e8",
+        session_id="sess_proj",
+        turn_id="turn_p",
+        turn_index=0,
+        call_ids=["c"],
+        call_meta={"c": CallMeta(call_id="c", tool_name="t")},
+        batch_t0=batch_t0,
+    )
+    assert view.elapsed_ms >= 1000  # at least 1s

--- a/tests/test_ledger_session_wiring.py
+++ b/tests/test_ledger_session_wiring.py
@@ -186,3 +186,121 @@ async def test_emit_turn_end_links_to_turn_start(
         assert ends[0].payload["duration_ms"] == 1234
     finally:
         await session.stop()
+
+
+# ---------------------------------------------------------------------------
+# Step 5 cutover — _build_envelope_view delegates to LedgerEnvelopeProjector
+# ---------------------------------------------------------------------------
+
+
+async def test_envelope_view_built_from_ledger_when_projector_wired(
+    monkeypatch, tmp_path, session_module
+):
+    """When ledger is enabled, the view comes from tool_lifecycle events,
+    not from ExecutionEnvelope.records."""
+    import time
+
+    from loom.core.ledger import (
+        CallMeta,
+        ToolLifecyclePayload,
+        set_turn_id,
+        reset_turn_id,
+    )
+
+    session = await _start_session(monkeypatch, tmp_path, session_module)
+    try:
+        assert session._envelope_projector is not None
+
+        # Set the contextvar so _build_envelope_view's
+        # current_turn_id() picks it up.
+        token = set_turn_id("turn_view_test")
+        try:
+            # Register a call_id and metadata (mimics dispatch).
+            session._envelope_call_ids = ["call_v1"]
+            session._call_metadata["call_v1"] = CallMeta(
+                call_id="call_v1",
+                tool_name="run_bash",
+                full_args={"cmd": "echo hi"},
+                args_preview="echo hi",
+            )
+
+            # Emit lifecycle events directly via the session emitter.
+            base = time.time()
+            await session._ledger_emitter.emit(
+                "tool_lifecycle",
+                ToolLifecyclePayload(
+                    phase="BEGIN",
+                    tool_name="run_bash",
+                    tool_call_id="call_v1",
+                    args_digest="sha256:x",
+                ),
+                turn_id="turn_view_test",
+                correlation_id="c1",
+                timestamp=base,
+            )
+            await session._ledger_emitter.emit(
+                "tool_lifecycle",
+                ToolLifecyclePayload(
+                    phase="END",
+                    tool_name="run_bash",
+                    tool_call_id="call_v1",
+                    args_digest="sha256:x",
+                    result_summary="hi",
+                    state_history=[
+                        {"from": "executing", "to": "memorialized", "ts": "x", "reason": None},
+                    ],
+                ),
+                turn_id="turn_view_test",
+                correlation_id="c1",
+                timestamp=base + 0.1,
+            )
+
+            view = await session._build_envelope_view()
+        finally:
+            reset_turn_id(token)
+
+        assert view.node_count == 1
+        assert view.nodes[0].tool_name == "run_bash"
+        assert view.nodes[0].state == "memorialized"
+        assert view.nodes[0].args_preview == "echo hi"
+        assert view.status == "completed"
+    finally:
+        await session.stop()
+
+
+async def test_envelope_view_falls_back_to_legacy_without_ledger(
+    monkeypatch, tmp_path, session_module
+):
+    """[ledger].enabled=false → projector is None → legacy records walk."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(session_module, "build_router", lambda: MagicMock())
+    monkeypatch.setattr(
+        session_module, "_load_loom_config", lambda: {"ledger": {"enabled": False}}
+    )
+    monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {})
+    monkeypatch.setattr(session_module, "build_embedding_provider", lambda env, cfg: None)
+    from rich.prompt import Confirm
+
+    monkeypatch.setattr(Confirm, "ask", lambda *args, **kwargs: True)
+
+    from loom.core.session import LoomSession
+
+    session = LoomSession(
+        model="gpt-test",
+        db_path=str(tmp_path / "loom.db"),
+        workspace=workspace,
+    )
+    await session.start()
+    try:
+        assert session._envelope_projector is None
+        # Legacy path returns an empty running envelope when no
+        # current_envelope is set — same behaviour as pre-Step-5.
+        view = await session._build_envelope_view()
+        assert view.status == "running"
+        assert view.node_count == 0
+    finally:
+        await session.stop()


### PR DESCRIPTION
Refs #325 · sub-issue of #320 · doc/53 §6.4 / §11.2 Step 5

## Summary

Step 5 envelope cutover. `_build_envelope_view` now builds `ExecutionEnvelopeView` from ledger `tool_lifecycle` events instead of walking `ExecutionEnvelope.records[ActionRecord]`. Platform consumers (CLI / Discord / TUI) see the same `ExecutionEnvelopeView` shape — no consumer-side changes needed.

3 commits, 11 new tests, 1598 passed (1 pre-existing skip), zero regressions.

## Commits

| # | Commit | Surface | New tests |
|---|---|---|---|
| 1 | `a1de57a` | `LedgerEnvelopeProjector` + `CallMeta` | 9 |
| 2 | `3c81d89` | `LoomSession` wires the projector; `_build_envelope_view` async + delegation | 2 |
| 3 | `2b94b62` | doc/53 v1.3 — Phase 2 Step 3-5 status table | — |

## What this cutover changes

| Aspect | Before (Step 2 dual-emit) | After (Step 5) |
|---|---|---|
| View source of truth | `ExecutionEnvelope.records` (mutable list of `ActionRecord`) | `tool_lifecycle` ledger events for the batch's `call_ids` |
| Per-call args / auth | live read from `call.metadata` and `record.call.args` | `CallMeta` cache populated at dispatch / state-change |
| Mid-batch state granularity | live `ActionRecord.state` per transition | END events seen → authoritative; in-flight → `_live_record_for` bridge OR "executing" fallback |
| `ExecutionEnvelope.records[]` | source of truth | transitional bridge for `_live_record_for` (vestigial; cleanup follow-up) |
| `[ledger].enabled = false` | n/a | falls back to legacy records-walk path |

Platform-side view shape is **identical** — `ExecutionEnvelopeView` / `ExecutionNodeView` dataclasses unchanged. CLI / Discord render the same data.

## Honest scope assessment (deferred items)

The issue's deliverables list also asks for **SessionLog** projection and **memory compaction subscribe(turn_end)** trigger move. Both are deferred in this PR with rationale documented in doc/53 §11.2.1:

### SessionLog projection — **deferred**

`SessionLog` stores OpenAI-canonical raw message text (user / assistant / tool result). The ledger has no corresponding raw-text event — `thought` event with §3.3 buffered full_text capture is on Step 2's deferred-event-types list. Full projection needs the thought event to land first; meanwhile SessionLog continues to use its existing implementation (no regression).

### Memory compaction subscribe trigger — **deferred**

Current inline trigger in `stream_turn` (after each turn, if `ep_count >= threshold`, run `compress_session`) is correct and tested. Moving to a background ledger-`turn_end` subscriber is an architectural cleanup with subtle timing consequences — compaction would race the next turn's start instead of completing inline. Warrants its own follow-up issue rather than bundling into Step 5.

Neither defer blocks Quest B's mainline goals: **envelope no longer owns its state for view-building**, **platform rendering identical**, **dual-emit naturally collapsing into single ledger emit + projection**.

## Design decisions

### Why keep `ExecutionEnvelope.records[]` mutated as a transitional bridge

Mid-batch state granularity (parallel dispatch, where some calls have only BEGIN and others have BEGIN+END) needs a fallback. The cleanest pure-ledger path requires `STATE_CHANGE` event emits per state transition — those are explicitly deferred in Step 2 (`tool_lifecycle` simplification, doc/53 §3.1 v0.3 note). Until they land, `_live_record_for(call_id)` queries `envelope.records` to surface the current `ActionRecord.state`.

When STATE_CHANGE event emits land, this bridge can be deleted — `envelope.records` becomes truly vestigial.

### Why `_call_metadata` is turn-scoped, not envelope-scoped

A turn can have multiple envelopes (one per LLM tool batch). `call_id`s are unique within a turn. Keeping `_call_metadata` turn-scoped means the CallMeta entries from envelope #1 are still queryable when envelope #2 builds its view (for cross-batch correlation, future use case). `_envelope_call_ids` is reset per envelope to keep batch identity correct.

## Test plan

- [x] `pytest tests/` — 1598 passed (was 1587 + 11 new), 1 skipped (pre-existing), zero regressions
- [x] Projector correctness — 9 tests covering full success / failed (rolled back) / mixed parallel / live-record fallback / auth_expires / placeholder for not-yet-emitted call / first-seen ordering / empty envelope / elapsed_ms
- [x] Session-level integration — view actually built from ledger when projector wired; legacy fallback when `[ledger].enabled=false`

## Exit criteria for #325

- [x] envelope **view** 不再依賴 `records[]` (cutover complete; records mutation is transitional bridge documented for future cleanup)
- [x] 三平台 rendering 行為與 cutover 前一致 (view shape unchanged; existing tests green)
- [x] dual-emit 自然消失 (view source switched; ledger remains the single emit path)
- [x] 既有測試全綠
- [ ] SessionLog projection — **deferred follow-up** (blocked on thought event)
- [ ] Memory compaction subscribe trigger — **deferred follow-up** (architectural cleanup, no behaviour gain)

## Notes for review

- **Bridge legitimacy**: `_live_record_for` walks `envelope.records` — open to alternatives. The cleanest deletion path is "wait for STATE_CHANGE emits". Today's bridge is documented in code, narrow, and goes away naturally.
- **Async `_build_envelope_view`**: switched from sync to async (5 `await` call sites in `stream_turn`). All call sites are inside `async def stream_turn`, so safe.
- **`current_turn_id()` contextvar**: the projector reads turn_id from the contextvar already set by `stream_turn`'s turn scope (Step 2 commit 6). No new state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)