### PR TITLE
feat(ledger): #334 — emit deferred event types (thought / model_event / judge_verdict / artifact_emit)

### DIFF
--- a/doc/53-AgentLedger-設計.md
+++ b/doc/53-AgentLedger-設計.md
@@ -879,7 +879,7 @@ Step 6. 測試全綠 → merge → 切換 Loom Agent 啟新版開新 session
 | Event type | Step 2 狀態 | 備註 |
 |---|---|---|
 | `turn_start` | ✅ emit | PromptStack snapshot 含 persona + tool_catalog_size；`memory_layers` / `context_token_count` 未追蹤所以省略（不放 placeholder 誤導 reader） |
-| `turn_end` | ✅ emit | `outcome` 從 `sys.exc_info()` 推導；`token_usage={}` 直到 model_event 落地 |
+| `turn_end` | ✅ emit | `outcome` 從 `sys.exc_info()` 推導；`token_usage` 由 `_emit_ledger_model_event` 累計（#334） |
 | `tool_lifecycle` BEGIN/END | ✅ emit | STATE_CHANGE / ROLLBACK 簡化見 §3.1 註記 |
 | `permission_decision` | ✅ emit | grant / deny；scope 子類型未 emit（需 reason 字串解析，違反 `feedback_avoid_regex_on_llm_output`） |
 | `memory_op` read / write | ✅ emit | search / get_fact / query_relations / memorize / relate 五路徑 |
@@ -888,17 +888,17 @@ Step 6. 測試全綠 → merge → 切換 Loom Agent 啟新版開新 session
 | `task_mutation` | ✅ emit | operation 簡化見 §3.1 註記 |
 | `env_observation` timer / external / anomaly | ✅ emit | TriggerEvaluator 三類 trigger |
 | `env_observation` notification / contradiction | ⚠️ schema ready, no emitter | MemoryPulse / ContradictionDetector 自己的 commit |
-| `thought` | ❌ deferred | §3.3 buffered full_text capture 需要 stream_turn 內 reasoning loop 整合 |
-| `model_event` | ❌ deferred | 需要 token_usage 在 router.chat / stream_chat 各 call site threading |
-| `judge_verdict` | ❌ deferred | emit 點在 _maybe_run_judge 旁邊 |
-| `artifact_emit` | ❌ deferred | emit 在 code / image / audio 產出位置 |
+| `thought` | ✅ emit（#334） | §3.3 signal accumulator：judge fail/uncertain、outcome abandoned/error、artifact >10KB 任一觸發 commit；inline ≤50KB / blob > 50KB |
+| `model_event` | ✅ emit（#334） | stream_turn 主 loop、`run_judge`（sync + async）、subagent 三條 router 路徑都 emit；`_turn_token_usage` 餵 turn_end |
+| `judge_verdict` | ✅ emit（#334） | `_maybe_run_judge` / `_run_judge_async` 兩條路徑；判定 pass/fail/uncertain → PASS/FAIL/CONCERN，`error` 設值 → ERROR |
+| `artifact_emit` | ✅ emit（#334） | LifecycleMiddleware END 後檢查 `_ARTIFACT_PRODUCERS={write_file, openai__text_to_image}`；rolled_back 或 failed 不 emit |
 
 `三類 exception 自開新 correlation_id`（§4.2）：
 - `env_observation` ✅ 實作（PR #330 commit 4）
 - `memory_op.compact` ⚠️ deferred（無 emitter）
 - `turn_end.outcome=error` ⚠️ schema 就緒；目前 turn_end 用 stream_turn 主 correlation 不另開新 corr — 待 follow-up issue 評估是否要切
 
-Deferred 事件類型不阻擋 Step 5 cutover：它們是 additive event types，不是替換既有 observability 信號。Follow-up issue 在 Step 2 merge 後另開。
+Deferred 事件類型不阻擋 Step 5 cutover：它們是 additive event types，不是替換既有 observability 信號。Follow-up issue 在 Step 2 merge 後另開。**#334（feat/ledger-deferred-events）落地後，原本 ❌ 的四個 event types 全部轉 ✅；後續仍 deferred 的是 `memory_op` compact / batch_read 與 `env_observation` notification / contradiction，等對應 caller 出現再 emit。**
 
 **Step 3-5 進度補記**（PR #331 / #332 / Step 5 PR）：
 

--- a/loom/core/agent/subagent.py
+++ b/loom/core/agent/subagent.py
@@ -80,7 +80,14 @@ async def run_subagent(
     workspace: Any,              # pathlib.Path
     parent_grants: "list[Any] | None" = None,
     scratchpad: Any = None,
-    ledger_emitter: Any = None,  # parent session's LedgerEmitter (#334)
+    # parent session's LedgerEmitter (#334). The subagent inherits the
+    # parent's ``turn_id`` via contextvar, so its ``model_event`` events
+    # file under the parent turn during replay. Caveat (#334 review S2):
+    # contextvar propagation only holds within the same async task tree
+    # (asyncio.create_task / gather / await chains). If a future iteration
+    # spawns the subagent in a separate process or thread pool, the caller
+    # must explicitly thread ``turn_id`` instead of relying on this kwarg.
+    ledger_emitter: Any = None,
 ) -> SubAgentResult:
     """
     Run a sub-agent to completion and return a SubAgentResult.

--- a/loom/core/agent/subagent.py
+++ b/loom/core/agent/subagent.py
@@ -80,6 +80,7 @@ async def run_subagent(
     workspace: Any,              # pathlib.Path
     parent_grants: "list[Any] | None" = None,
     scratchpad: Any = None,
+    ledger_emitter: Any = None,  # parent session's LedgerEmitter (#334)
 ) -> SubAgentResult:
     """
     Run a sub-agent to completion and return a SubAgentResult.
@@ -301,6 +302,25 @@ async def run_subagent(
 
         if response is None:
             break
+
+        # #334 — emit model_event for the subagent's LLM call. Subagent
+        # inherits the parent turn_id via contextvar, so the call shows
+        # up under the parent's turn during replay.
+        if ledger_emitter is not None:
+            try:
+                from loom.core.ledger import ModelEventPayload
+                _usage = {
+                    "input_tokens": int(getattr(response, "input_tokens", 0) or 0),
+                    "output_tokens": int(getattr(response, "output_tokens", 0) or 0),
+                }
+                await ledger_emitter.emit_model_event(
+                    payload=ModelEventPayload(
+                        model=config.model, tier=0, token_usage=_usage,
+                    ),
+                )
+            except Exception:
+                # Best-effort — never break the subagent loop on ledger emit.
+                pass
 
         messages.append(response.raw_message)
 

--- a/loom/core/cognition/judge.py
+++ b/loom/core/cognition/judge.py
@@ -316,9 +316,13 @@ async def run_judge(
     router: "LLMRouter",
     model: str,
     digest: str,
-) -> JudgeVerdict:
+) -> tuple[JudgeVerdict, Any]:
     """Single-shot LLM call. Never raises — failures become uncertain
-    verdicts with the error preserved on the result."""
+    verdicts with the error preserved on the result.
+
+    Returns ``(verdict, response)`` where ``response`` is the raw
+    ``ChatResponse`` (``None`` when the call raised). Callers use the
+    response to emit ``model_event`` ledger entries (doc/53 §3.1)."""
     try:
         response = await router.chat(
             model=model,
@@ -328,13 +332,16 @@ async def run_judge(
             ],
             max_tokens=400,
         )
-        return parse_verdict(response.text or "")
+        return parse_verdict(response.text or ""), response
     except Exception as exc:
         logger.warning("Judge call failed: %s", exc, exc_info=True)
-        return JudgeVerdict(
-            verdict=VERDICT_UNCERTAIN,
-            reason="judge call failed; treat as no-signal",
-            error=f"{type(exc).__name__}: {exc}",
+        return (
+            JudgeVerdict(
+                verdict=VERDICT_UNCERTAIN,
+                reason="judge call failed; treat as no-signal",
+                error=f"{type(exc).__name__}: {exc}",
+            ),
+            None,
         )
 
 

--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -1735,6 +1735,56 @@ class LifecycleMiddleware(Middleware):
         body = (result.output or "") + "|" + (result.error or "")
         return "sha256:" + hashlib.sha256(body.encode("utf-8")).hexdigest()
 
+    # Producer tools whose successful results materialise external artifacts
+    # (#334 / doc/53 §3.1). Inspection happens in lifecycle END so neither the
+    # tool factory nor the registry needs to know about ledger emit.
+    _ARTIFACT_PRODUCERS: tuple[str, ...] = (
+        "write_file", "openai__text_to_image",
+    )
+
+    async def _maybe_emit_artifact(
+        self, call: "ToolCall", result: "ToolResult", rec: "ActionRecord"
+    ) -> None:
+        if call.tool_name not in self._ARTIFACT_PRODUCERS:
+            return
+        import hashlib
+        import json as _json
+        artifact_type = "unknown"
+        size_bytes = 0
+        location: str | None = None
+        digest_input = b""
+        if call.tool_name == "write_file":
+            artifact_type = "text_file"
+            content = call.args.get("content", "") or ""
+            size_bytes = len(content.encode("utf-8"))
+            digest_input = content.encode("utf-8")
+            meta = result.metadata or {}
+            location = meta.get("_resolved_path") or call.args.get("path")
+        elif call.tool_name == "openai__text_to_image":
+            artifact_type = "image"
+            try:
+                payload = _json.loads(result.output or "{}")
+            except Exception:
+                payload = {}
+            size_bytes = int(payload.get("bytes", 0) or 0)
+            location = payload.get("path")
+            # Image bytes aren't kept on the result; digest the metadata
+            # tuple so replays at least see a stable artifact identity.
+            digest_input = (
+                f"{payload.get('path','')}|{size_bytes}|{payload.get('model','')}"
+            ).encode("utf-8")
+        digest = "sha256:" + hashlib.sha256(digest_input).hexdigest()
+        from loom.core.ledger import ArtifactEmitPayload
+        await self._ledger_emitter.emit_artifact_emit(
+            payload=ArtifactEmitPayload(
+                artifact_type=artifact_type,
+                size_bytes=size_bytes,
+                digest=digest,
+                location=location,
+            ),
+            parent_event_id=f"evt_tool_end_{rec.id[:12]}",
+        )
+
     async def _emit_lifecycle_begin(
         self, call: "ToolCall", record: "ActionRecord"
     ) -> None:
@@ -1797,6 +1847,13 @@ class LifecycleMiddleware(Middleware):
                 )
             except Exception:
                 _log.exception("ledger tool_lifecycle END emit failed; continuing")
+
+            # #334 — emit artifact_emit for known producer tools.
+            if result is not None and result.success and not rolled_back:
+                try:
+                    await self._maybe_emit_artifact(call, result, rec)
+                except Exception:
+                    _log.exception("ledger artifact_emit failed; continuing")
 
             if original is not None:
                 await original(rec)

--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -119,6 +119,75 @@ def _trace_middleware(
     trace.append({"middleware": name, "decision": decision, **extra})
 
 # ---------------------------------------------------------------------------
+# Artifact extraction (#334 / doc/53 §3.1)
+# ---------------------------------------------------------------------------
+#
+# Producer tools whose successful results materialise external artifacts
+# are inspected at lifecycle END so neither the tool factory nor the
+# registry needs to know about ledger emit. The same extractor is used
+# by ``LoomSession._on_trace`` to feed ``_turn_artifact_max_size`` so the
+# §3.3 thought-capture signal (artifact > 10 KB) actually fires.
+#
+# To register a new producer: add an extractor returning the four-tuple
+# below (or ``None`` if the result didn't actually produce an artifact)
+# and drop it into ``_ARTIFACT_EXTRACTORS``. One place, no duplication.
+
+
+def _extract_write_file_artifact(call: "ToolCall", result: "ToolResult") -> dict | None:
+    import hashlib
+    content = call.args.get("content", "") or ""
+    encoded = content.encode("utf-8")
+    meta = result.metadata or {}
+    return {
+        "artifact_type": "text_file",
+        "size_bytes": len(encoded),
+        "digest": "sha256:" + hashlib.sha256(encoded).hexdigest(),
+        "location": meta.get("_resolved_path") or call.args.get("path"),
+    }
+
+
+def _extract_openai_image_artifact(
+    call: "ToolCall", result: "ToolResult"
+) -> dict | None:
+    import hashlib
+    import json as _json
+    try:
+        payload = _json.loads(result.output or "{}")
+    except Exception:
+        payload = {}
+    size_bytes = int(payload.get("bytes", 0) or 0)
+    # Image bytes aren't kept on the result; digest the metadata tuple
+    # so replays at least see a stable artifact identity.
+    digest_input = (
+        f"{payload.get('path','')}|{size_bytes}|{payload.get('model','')}"
+    ).encode("utf-8")
+    return {
+        "artifact_type": "image",
+        "size_bytes": size_bytes,
+        "digest": "sha256:" + hashlib.sha256(digest_input).hexdigest(),
+        "location": payload.get("path"),
+    }
+
+
+_ARTIFACT_EXTRACTORS: dict[str, Callable[["ToolCall", "ToolResult"], dict | None]] = {
+    "write_file": _extract_write_file_artifact,
+    "openai__text_to_image": _extract_openai_image_artifact,
+}
+
+
+def extract_artifact_info(call: "ToolCall", result: "ToolResult") -> dict | None:
+    """Return ``{artifact_type, size_bytes, digest, location}`` for known
+    producers, or ``None`` if ``call.tool_name`` doesn't produce artifacts
+    or the result wasn't successful."""
+    if result is None or not result.success:
+        return None
+    fn = _ARTIFACT_EXTRACTORS.get(call.tool_name)
+    if fn is None:
+        return None
+    return fn(call, result)
+
+
+# ---------------------------------------------------------------------------
 # Middleware base
 # ---------------------------------------------------------------------------
 
@@ -1735,52 +1804,19 @@ class LifecycleMiddleware(Middleware):
         body = (result.output or "") + "|" + (result.error or "")
         return "sha256:" + hashlib.sha256(body.encode("utf-8")).hexdigest()
 
-    # Producer tools whose successful results materialise external artifacts
-    # (#334 / doc/53 §3.1). Inspection happens in lifecycle END so neither the
-    # tool factory nor the registry needs to know about ledger emit.
-    _ARTIFACT_PRODUCERS: tuple[str, ...] = (
-        "write_file", "openai__text_to_image",
-    )
-
     async def _maybe_emit_artifact(
         self, call: "ToolCall", result: "ToolResult", rec: "ActionRecord"
     ) -> None:
-        if call.tool_name not in self._ARTIFACT_PRODUCERS:
+        info = extract_artifact_info(call, result)
+        if info is None:
             return
-        import hashlib
-        import json as _json
-        artifact_type = "unknown"
-        size_bytes = 0
-        location: str | None = None
-        digest_input = b""
-        if call.tool_name == "write_file":
-            artifact_type = "text_file"
-            content = call.args.get("content", "") or ""
-            size_bytes = len(content.encode("utf-8"))
-            digest_input = content.encode("utf-8")
-            meta = result.metadata or {}
-            location = meta.get("_resolved_path") or call.args.get("path")
-        elif call.tool_name == "openai__text_to_image":
-            artifact_type = "image"
-            try:
-                payload = _json.loads(result.output or "{}")
-            except Exception:
-                payload = {}
-            size_bytes = int(payload.get("bytes", 0) or 0)
-            location = payload.get("path")
-            # Image bytes aren't kept on the result; digest the metadata
-            # tuple so replays at least see a stable artifact identity.
-            digest_input = (
-                f"{payload.get('path','')}|{size_bytes}|{payload.get('model','')}"
-            ).encode("utf-8")
-        digest = "sha256:" + hashlib.sha256(digest_input).hexdigest()
         from loom.core.ledger import ArtifactEmitPayload
         await self._ledger_emitter.emit_artifact_emit(
             payload=ArtifactEmitPayload(
-                artifact_type=artifact_type,
-                size_bytes=size_bytes,
-                digest=digest,
-                location=location,
+                artifact_type=info["artifact_type"],
+                size_bytes=info["size_bytes"],
+                digest=info["digest"],
+                location=info["location"],
             ),
             parent_event_id=f"evt_tool_end_{rec.id[:12]}",
         )

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -3643,6 +3643,17 @@ class LoomSession:
             logger.exception("ledger thought emit failed; continuing")
 
     async def _on_trace(self, call: ToolCall, result: ToolResult) -> None:
+        # #334 / doc/53 §3.3 — feed the per-turn artifact size accumulator
+        # so the "artifact > 10 KB" thought capture signal actually fires.
+        # The middleware-side ``extract_artifact_info`` is the single source
+        # of truth for which tools produce artifacts; we reuse it here.
+        from loom.core.harness.middleware import extract_artifact_info
+        info = extract_artifact_info(call, result)
+        if info is not None:
+            size = int(info.get("size_bytes", 0) or 0)
+            if size > self._turn_artifact_max_size:
+                self._turn_artifact_max_size = size
+
         summary = (
             f"Tool '{call.tool_name}' "
             f"({'ok' if result.success else 'failed'}, "

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -42,9 +42,12 @@ from rich.rule import Rule
 from loom.core.diagnostic import DiagnosticReport, StartupDiagnostic
 from loom.core.ledger import (
     CallMeta,
+    JudgeVerdictPayload,
     LedgerEmitter,
     LedgerEnvelopeProjector,
     LedgerStore,
+    ModelEventPayload,
+    ThoughtPayload,
     TurnEndPayload,
     TurnStartPayload,
     new_correlation_id,
@@ -704,6 +707,17 @@ class LoomSession:
         self._envelope_projector: LedgerEnvelopeProjector | None = None
         self._call_metadata: dict[str, CallMeta] = {}
         self._envelope_call_ids: list[str] = []
+        # Per-turn ledger aggregators (#334). Reset at every turn_start.
+        # _turn_token_usage feeds turn_end.token_usage so the placeholder
+        # `{}` from Step 2 finally goes away. _thought_buffer holds the
+        # raw reasoning text accumulated during the turn; commit-or-discard
+        # at turn_end follows doc/53 §3.3 signal accumulator rules.
+        self._turn_token_usage: dict[str, int] = {}
+        self._turn_thought_text: str = ""
+        self._turn_thought_started: float | None = None
+        self._turn_tool_calls_in_turn: int = 0
+        self._turn_judge_capture_signal: bool = False
+        self._turn_artifact_max_size: int = 0
 
         # Build prompt stack from loom.toml [identity] config
         config = _load_loom_config()
@@ -1788,6 +1802,13 @@ class LoomSession:
         _ledger_turn_token: Any = None
         _ledger_corr_token: Any = None
         _turn_start_monotonic = time.monotonic()
+        # #334 — per-turn ledger aggregator reset.
+        self._turn_token_usage = {}
+        self._turn_thought_text = ""
+        self._turn_thought_started = _turn_start_monotonic
+        self._turn_tool_calls_in_turn = 0
+        self._turn_judge_capture_signal = False
+        self._turn_artifact_max_size = 0
         if self._ledger_emitter is not None:
             _ledger_turn_token = set_turn_id(_turn_id_v2)
             _ledger_corr_token = set_correlation(_turn_corr_id)
@@ -2063,6 +2084,8 @@ class LoomSession:
 
                 # Replace (not accumulate) — input_tokens is the total context this call.
                 self.budget.record_response(response.input_tokens, response.output_tokens)
+                # #334 — emit model_event + accumulate token_usage for turn_end.
+                await self._emit_ledger_model_event(_active_model, response)
                 # Issue #142: feed the authoritative total into the context_layout
                 # dimension so layer attribution reflects real usage, not estimates.
                 if self._telemetry is not None:
@@ -2556,6 +2579,18 @@ class LoomSession:
                     _duration_ms = int(
                         (time.monotonic() - _turn_start_monotonic) * 1000
                     )
+                    # #334 — mirror local accumulators into session state so
+                    # commit-or-discard can run after the try/except scope.
+                    try:
+                        self._turn_thought_text = "".join(_think_parts)
+                    except NameError:
+                        # Exception before _think_parts was declared (rare).
+                        self._turn_thought_text = ""
+                    try:
+                        self._turn_tool_calls_in_turn = tool_count
+                    except NameError:
+                        self._turn_tool_calls_in_turn = 0
+                    await self._commit_or_discard_thought(_turn_id_v2, _outcome)
                     await self._emit_ledger_turn_end(
                         _turn_id_v2, _outcome, _duration_ms
                     )
@@ -2680,8 +2715,11 @@ class LoomSession:
         digest = build_trace_digest(envelopes, final_text)
 
         if is_high_stakes(envelopes):
-            verdict = await run_judge(self.router, self.model, digest)
+            verdict, response = await run_judge(self.router, self.model, digest)
             self._record_verdict_telemetry(verdict, sync=True)
+            if response is not None:
+                await self._emit_ledger_model_event(self.model, response)
+            await self._emit_ledger_judge_verdict(verdict, "turn_final_text")
             if should_inject_reminder(verdict):
                 return format_verdict_reminder(verdict)
             return None
@@ -2696,8 +2734,11 @@ class LoomSession:
         return None
 
     async def _run_judge_async(self, digest: str) -> None:
-        verdict = await run_judge(self.router, self.model, digest)
+        verdict, response = await run_judge(self.router, self.model, digest)
         self._record_verdict_telemetry(verdict, sync=False)
+        if response is not None:
+            await self._emit_ledger_model_event(self.model, response)
+        await self._emit_ledger_judge_verdict(verdict, "turn_final_text")
         if should_inject_reminder(verdict):
             self._pending_verdicts.append(format_verdict_reminder(verdict))
 
@@ -3483,20 +3524,6 @@ class LoomSession:
     async def _emit_ledger_turn_end(
         self, turn_id: str, outcome: str, duration_ms: int
     ) -> None:
-        # NOTE: deferred event types from doc/53 §3.1 — these will land
-        # as a Step 2 follow-up issue. They were kept out of the initial
-        # Step 2 PR (#330) to bound scope; none of them block the Step 5
-        # cutover because they are additive event types, not
-        # replacements for existing observability signals.
-        #
-        #   thought         — §3.3 buffered full_text capture (signal
-        #                     accumulator + turn_end commit-or-discard);
-        #                     emit at each reasoning block in stream_turn
-        #   model_event     — token_usage threading at every router.chat
-        #                     / stream_chat call site; until then,
-        #                     turn_end.token_usage stays {} (placeholder)
-        #   judge_verdict   — emit alongside _maybe_run_judge() result
-        #   artifact_emit   — emit at code/image/audio emission sites
         if self._ledger_emitter is None:
             return
         await self._ledger_emitter.emit_turn_end(
@@ -3504,11 +3531,116 @@ class LoomSession:
             payload=TurnEndPayload(
                 outcome=outcome,
                 duration_ms=duration_ms,
-                token_usage={},  # populated when model_event emit lands (deferred)
+                token_usage=dict(self._turn_token_usage),
             ),
             event_id=f"evt_turn_end_{turn_id[5:]}",
             parent_event_id=f"evt_turn_start_{turn_id[5:]}",
         )
+
+    async def _emit_ledger_model_event(
+        self, model: str, response: Any
+    ) -> None:
+        """Emit ``model_event`` for one router call and aggregate the
+        token usage into ``self._turn_token_usage`` so ``turn_end``
+        carries the per-turn rollup (doc/53 §3.1 / §11.2.1)."""
+        if self._ledger_emitter is None:
+            return
+        usage = {
+            "input_tokens": int(getattr(response, "input_tokens", 0) or 0),
+            "output_tokens": int(getattr(response, "output_tokens", 0) or 0),
+        }
+        cache_read = int(getattr(response, "cache_read_input_tokens", 0) or 0)
+        cache_creation = int(
+            getattr(response, "cache_creation_input_tokens", 0) or 0
+        )
+        if cache_read:
+            usage["cache_read_input_tokens"] = cache_read
+        if cache_creation:
+            usage["cache_creation_input_tokens"] = cache_creation
+        for k, v in usage.items():
+            self._turn_token_usage[k] = self._turn_token_usage.get(k, 0) + v
+        try:
+            await self._ledger_emitter.emit_model_event(
+                payload=ModelEventPayload(
+                    model=model,
+                    tier=self._active_tier(),
+                    token_usage=usage,
+                ),
+            )
+        except Exception:
+            logger.exception("ledger model_event emit failed; continuing")
+
+    async def _emit_ledger_judge_verdict(
+        self, verdict: "JudgeVerdict", judged_subject: str
+    ) -> None:
+        """Emit ``judge_verdict`` (doc/53 §3.1) after ``run_judge`` returns.
+        Verdict-driven thought capture: FAIL/UNCERTAIN flips the per-turn
+        signal so the reasoning trail gets persisted at turn_end."""
+        if verdict.verdict in ("fail", "uncertain"):
+            self._turn_judge_capture_signal = True
+        if self._ledger_emitter is None:
+            return
+        # Map judge verdict → schema literal. Judge produces lowercase
+        # pass/fail/uncertain; ledger uses uppercase plus an explicit
+        # ERROR for transport failures.
+        if verdict.error:
+            mapped = "ERROR"
+        else:
+            mapped = {
+                "pass": "PASS",
+                "fail": "FAIL",
+                "uncertain": "CONCERN",
+            }.get(verdict.verdict, "CONCERN")
+        try:
+            await self._ledger_emitter.emit_judge_verdict(
+                payload=JudgeVerdictPayload(
+                    verdict=mapped,
+                    confidence=0.0,  # judge prompt has no confidence axis today
+                    reason=(verdict.reason or "")[:500],
+                    judged_subject=judged_subject,
+                ),
+            )
+        except Exception:
+            logger.exception("ledger judge_verdict emit failed; continuing")
+
+    async def _commit_or_discard_thought(
+        self, turn_id: str, outcome: str
+    ) -> None:
+        """doc/53 §3.3 — commit accumulated reasoning text iff the turn
+        produced a capture signal (judge fail/uncertain, abandoned/error
+        outcome, or a >10KB artifact). Drop otherwise to keep the ledger
+        slim. Inline up to 50KB; spill to blob storage above that."""
+        if self._ledger_emitter is None or not self._turn_thought_text:
+            return
+        signal = (
+            self._turn_judge_capture_signal
+            or outcome in ("abandoned", "error")
+            or self._turn_artifact_max_size > 10_000
+        )
+        if not signal:
+            return
+        store = self._ledger_store
+        if store is None:
+            return
+        eid = f"evt_thought_{turn_id[5:]}"
+        duration_ms = (
+            int((time.monotonic() - self._turn_thought_started) * 1000)
+            if self._turn_thought_started is not None
+            else 0
+        )
+        try:
+            payload = await store.build_thought_payload(
+                self._turn_thought_text,
+                turn_id=turn_id,
+                event_id=eid,
+                duration_ms=duration_ms,
+                produced_tool_calls=self._turn_tool_calls_in_turn,
+            )
+            await self._ledger_emitter.emit_thought(
+                turn_id=turn_id, payload=payload, event_id=eid,
+            )
+        except Exception:
+            logger.exception("ledger thought emit failed; continuing")
 
     async def _on_trace(self, call: ToolCall, result: ToolResult) -> None:
         summary = (

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -3020,6 +3020,7 @@ def make_spawn_agent_tool(parent_session: Any) -> "ToolDefinition":
                 workspace=parent_session.workspace,
                 parent_grants=parent_session.perm.grants,
                 scratchpad=getattr(parent_session, "_scratchpad", None),
+                ledger_emitter=getattr(parent_session, "_ledger_emitter", None),
             )
         except Exception as exc:
             return ToolResult(call_id=call.id, tool_name=call.tool_name,

--- a/tests/test_ledger_deferred_events.py
+++ b/tests/test_ledger_deferred_events.py
@@ -1,0 +1,397 @@
+"""#334 — emit deferred event types.
+
+Covers ``thought`` / ``model_event`` / ``judge_verdict`` / ``artifact_emit``
+landing in the ledger. Session-level helpers are exercised against a stub
+session that owns just enough state (emitter, store, _turn_* aggregators)
+to drive the helper without booting the full LoomSession machinery.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest_asyncio
+
+from loom.core.harness.middleware import (
+    LifecycleMiddleware,
+    MiddlewarePipeline,
+    ToolCall,
+    ToolResult,
+)
+from loom.core.harness.permissions import TrustLevel
+from loom.core.harness.registry import ToolDefinition, ToolRegistry
+from loom.core.ledger import (
+    LedgerEmitter,
+    LedgerStore,
+    async_correlation_scope,
+    async_turn_scope,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def ledger(tmp_path: Path) -> LedgerStore:
+    s = LedgerStore(
+        db_path=tmp_path / "ledger.db",
+        blob_dir=tmp_path / "blobs",
+    )
+    await s.open()
+    try:
+        yield s
+    finally:
+        await s.close()
+
+
+@pytest_asyncio.fixture
+def emitter(ledger: LedgerStore) -> LedgerEmitter:
+    return LedgerEmitter(ledger, session_id="sess_def")
+
+
+def _make_call(
+    name: str = "write_file", args: dict | None = None
+) -> ToolCall:
+    return ToolCall(
+        tool_name=name,
+        args=args or {},
+        trust_level=TrustLevel.SAFE,
+        session_id="sess_def",
+    )
+
+
+def _make_session_stub(emitter: LedgerEmitter, store: LedgerStore):
+    """Bind the four session helpers from #334 onto an Any-shaped stub.
+
+    Avoids spinning up a full LoomSession (which requires Discord, memory,
+    Anthropic credentials etc.). The helpers only touch ``_ledger_emitter``,
+    ``_ledger_store`` and the ``_turn_*`` aggregators.
+    """
+    from loom.core.session import LoomSession
+
+    class _Stub:
+        pass
+
+    s = _Stub()
+    s._ledger_emitter = emitter
+    s._ledger_store = store
+    s._turn_token_usage = {}
+    s._turn_thought_text = ""
+    s._turn_thought_started = 0.0
+    s._turn_tool_calls_in_turn = 0
+    s._turn_judge_capture_signal = False
+    s._turn_artifact_max_size = 0
+
+    # Tier helper used by _emit_ledger_model_event.
+    s._active_tier = lambda: 1  # type: ignore[attr-defined]
+
+    s._emit_ledger_model_event = LoomSession._emit_ledger_model_event.__get__(s)
+    s._emit_ledger_judge_verdict = LoomSession._emit_ledger_judge_verdict.__get__(s)
+    s._commit_or_discard_thought = LoomSession._commit_or_discard_thought.__get__(s)
+    s._emit_ledger_turn_end = LoomSession._emit_ledger_turn_end.__get__(s)
+    return s
+
+
+class _FakeResp:
+    def __init__(
+        self, *, input_tokens: int, output_tokens: int,
+        cache_read: int = 0, cache_creation: int = 0,
+    ) -> None:
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+        self.cache_read_input_tokens = cache_read
+        self.cache_creation_input_tokens = cache_creation
+
+
+# ---------------------------------------------------------------------------
+# model_event
+# ---------------------------------------------------------------------------
+
+
+async def test_model_event_emits_and_aggregates(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    s = _make_session_stub(emitter, ledger)
+    async with async_turn_scope("turn_me"), async_correlation_scope("c1"):
+        await s._emit_ledger_model_event("claude-x", _FakeResp(
+            input_tokens=100, output_tokens=20, cache_read=8,
+        ))
+        await s._emit_ledger_model_event("claude-x", _FakeResp(
+            input_tokens=110, output_tokens=30,
+        ))
+    rows = [r for r in await ledger.fetch_by_turn("turn_me")
+            if r.event_type == "model_event"]
+    assert len(rows) == 2
+    assert rows[0].payload["model"] == "claude-x"
+    assert rows[0].payload["tier"] == 1
+    # Second call's usage is independent on the event but accumulator sums.
+    assert s._turn_token_usage["input_tokens"] == 210
+    assert s._turn_token_usage["output_tokens"] == 50
+    assert s._turn_token_usage["cache_read_input_tokens"] == 8
+
+
+async def test_turn_end_carries_aggregated_token_usage(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    s = _make_session_stub(emitter, ledger)
+    async with async_turn_scope("turn_te"), async_correlation_scope("c1"):
+        await s._emit_ledger_model_event("m", _FakeResp(
+            input_tokens=42, output_tokens=7,
+        ))
+        await s._emit_ledger_turn_end("turn_te", "clean", 1234)
+    rows = [r for r in await ledger.fetch_by_turn("turn_te")
+            if r.event_type == "turn_end"]
+    assert len(rows) == 1
+    assert rows[0].payload["token_usage"]["input_tokens"] == 42
+    assert rows[0].payload["token_usage"]["output_tokens"] == 7
+    assert rows[0].payload["outcome"] == "clean"
+
+
+# ---------------------------------------------------------------------------
+# judge_verdict
+# ---------------------------------------------------------------------------
+
+
+async def test_judge_verdict_pass_emits_and_no_capture_signal(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    from loom.core.cognition.judge import JudgeVerdict
+    s = _make_session_stub(emitter, ledger)
+    async with async_turn_scope("turn_j"), async_correlation_scope("c1"):
+        await s._emit_ledger_judge_verdict(
+            JudgeVerdict(verdict="pass", reason="ok"), "turn_final_text"
+        )
+    rows = [r for r in await ledger.fetch_by_turn("turn_j")
+            if r.event_type == "judge_verdict"]
+    assert len(rows) == 1
+    assert rows[0].payload["verdict"] == "PASS"
+    assert s._turn_judge_capture_signal is False
+
+
+async def test_judge_verdict_fail_sets_capture_signal(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    from loom.core.cognition.judge import JudgeVerdict
+    s = _make_session_stub(emitter, ledger)
+    async with async_turn_scope("turn_jf"), async_correlation_scope("c1"):
+        await s._emit_ledger_judge_verdict(
+            JudgeVerdict(verdict="fail", reason="bad"), "turn_final_text"
+        )
+    rows = [r for r in await ledger.fetch_by_turn("turn_jf")
+            if r.event_type == "judge_verdict"]
+    assert rows[0].payload["verdict"] == "FAIL"
+    assert s._turn_judge_capture_signal is True
+
+
+async def test_judge_verdict_error_maps_to_error_literal(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    from loom.core.cognition.judge import JudgeVerdict
+    s = _make_session_stub(emitter, ledger)
+    async with async_turn_scope("turn_je"), async_correlation_scope("c1"):
+        await s._emit_ledger_judge_verdict(
+            JudgeVerdict(
+                verdict="uncertain",
+                reason="judge call failed",
+                error="TimeoutError",
+            ),
+            "turn_final_text",
+        )
+    rows = [r for r in await ledger.fetch_by_turn("turn_je")
+            if r.event_type == "judge_verdict"]
+    assert rows[0].payload["verdict"] == "ERROR"
+
+
+# ---------------------------------------------------------------------------
+# thought (commit-or-discard)
+# ---------------------------------------------------------------------------
+
+
+async def test_thought_discarded_on_clean_turn_no_signal(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    s = _make_session_stub(emitter, ledger)
+    s._turn_thought_text = "some reasoning that nobody needs to keep"
+    async with async_turn_scope("turn_th_drop"), async_correlation_scope("c1"):
+        await s._commit_or_discard_thought("turn_th_drop", "clean")
+    rows = [r for r in await ledger.fetch_by_turn("turn_th_drop")
+            if r.event_type == "thought"]
+    assert rows == []
+
+
+async def test_thought_committed_when_judge_fail_signal(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    s = _make_session_stub(emitter, ledger)
+    s._turn_thought_text = "wrestled with prompt; eventually misfired"
+    s._turn_judge_capture_signal = True
+    s._turn_tool_calls_in_turn = 3
+    async with async_turn_scope("turn_th_keep"), async_correlation_scope("c1"):
+        await s._commit_or_discard_thought("turn_th_keep", "clean")
+    rows = [r for r in await ledger.fetch_by_turn("turn_th_keep")
+            if r.event_type == "thought"]
+    assert len(rows) == 1
+    p = rows[0].payload
+    assert p["full_text"].startswith("wrestled")
+    assert p["external_ref"] is None  # well under 50 KB
+    assert p["produced_tool_calls"] == 3
+    assert p["digest"].startswith("sha256:")
+
+
+async def test_thought_committed_on_abandoned_outcome(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    s = _make_session_stub(emitter, ledger)
+    s._turn_thought_text = "user pressed cancel mid-thought"
+    async with async_turn_scope("turn_th_abandon"), async_correlation_scope("c1"):
+        await s._commit_or_discard_thought("turn_th_abandon", "abandoned")
+    rows = [r for r in await ledger.fetch_by_turn("turn_th_abandon")
+            if r.event_type == "thought"]
+    assert len(rows) == 1
+
+
+async def test_thought_blob_spillover_above_threshold(
+    ledger: LedgerStore, emitter: LedgerEmitter, tmp_path: Path
+) -> None:
+    s = _make_session_stub(emitter, ledger)
+    s._turn_thought_text = "x" * 60_000  # > 50 KB threshold
+    s._turn_judge_capture_signal = True
+    async with async_turn_scope("turn_th_blob"), async_correlation_scope("c1"):
+        await s._commit_or_discard_thought("turn_th_blob", "clean")
+    rows = [r for r in await ledger.fetch_by_turn("turn_th_blob")
+            if r.event_type == "thought"]
+    assert len(rows) == 1
+    p = rows[0].payload
+    assert p["full_text"] is None
+    assert p["external_ref"] and p["external_ref"].startswith("turn_th_blob/")
+    assert (ledger.blob_dir / p["external_ref"]).exists()
+
+
+# ---------------------------------------------------------------------------
+# artifact_emit (driven through LifecycleMiddleware on real producer names)
+# ---------------------------------------------------------------------------
+
+
+def _producer_registry(name: str, output: str, metadata: dict | None = None):
+    reg = ToolRegistry()
+
+    async def handler(call: ToolCall) -> ToolResult:
+        return ToolResult(
+            call_id=call.id,
+            tool_name=call.tool_name,
+            success=True,
+            output=output,
+            metadata=metadata or {},
+        )
+
+    reg.register(
+        ToolDefinition(
+            name=name,
+            description="artifact producer",
+            trust_level=TrustLevel.SAFE,
+            input_schema={"type": "object"},
+            executor=handler,
+        )
+    )
+    return reg
+
+
+async def test_artifact_emit_for_write_file(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    reg = _producer_registry(
+        "write_file", "Written 11 chars to /tmp/out.txt",
+        metadata={"_resolved_path": "/tmp/out.txt"},
+    )
+    pipeline = MiddlewarePipeline(
+        [LifecycleMiddleware(registry=reg, ledger_emitter=emitter)]
+    )
+    call = _make_call("write_file", {"path": "/tmp/out.txt", "content": "hello world"})
+    async with async_turn_scope("turn_aw"), async_correlation_scope("c1"):
+        await pipeline.execute(call, reg.get("write_file").executor)
+
+    rows = [r for r in await ledger.fetch_by_turn("turn_aw")
+            if r.event_type == "artifact_emit"]
+    assert len(rows) == 1
+    p = rows[0].payload
+    assert p["artifact_type"] == "text_file"
+    assert p["size_bytes"] == len("hello world".encode("utf-8"))
+    assert p["location"] == "/tmp/out.txt"
+    assert p["digest"].startswith("sha256:")
+
+
+async def test_artifact_emit_for_openai_text_to_image(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    import json
+    reg = _producer_registry(
+        "openai__text_to_image",
+        json.dumps({
+            "path": "img/out.png", "model": "gpt-image-2",
+            "credential_source": "env", "bytes": 4096,
+        }),
+    )
+    pipeline = MiddlewarePipeline(
+        [LifecycleMiddleware(registry=reg, ledger_emitter=emitter)]
+    )
+    call = _make_call(
+        "openai__text_to_image", {"prompt": "a cat", "output_path": "img/out.png"},
+    )
+    async with async_turn_scope("turn_ai"), async_correlation_scope("c1"):
+        await pipeline.execute(call, reg.get("openai__text_to_image").executor)
+
+    rows = [r for r in await ledger.fetch_by_turn("turn_ai")
+            if r.event_type == "artifact_emit"]
+    assert len(rows) == 1
+    p = rows[0].payload
+    assert p["artifact_type"] == "image"
+    assert p["size_bytes"] == 4096
+    assert p["location"] == "img/out.png"
+
+
+async def test_artifact_emit_skipped_on_failed_tool(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    reg = ToolRegistry()
+
+    async def handler(call: ToolCall) -> ToolResult:
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=False, error="boom",
+        )
+
+    reg.register(
+        ToolDefinition(
+            name="write_file", description="x", trust_level=TrustLevel.SAFE,
+            input_schema={"type": "object"}, executor=handler,
+        )
+    )
+    pipeline = MiddlewarePipeline(
+        [LifecycleMiddleware(registry=reg, ledger_emitter=emitter)]
+    )
+    call = _make_call("write_file", {"path": "x", "content": "y"})
+    async with async_turn_scope("turn_afail"), async_correlation_scope("c1"):
+        await pipeline.execute(call, reg.get("write_file").executor)
+
+    rows = [r for r in await ledger.fetch_by_turn("turn_afail")
+            if r.event_type == "artifact_emit"]
+    assert rows == []
+
+
+async def test_artifact_emit_skipped_for_non_producer_tool(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    reg = _producer_registry("read_file", "file contents")
+    pipeline = MiddlewarePipeline(
+        [LifecycleMiddleware(registry=reg, ledger_emitter=emitter)]
+    )
+    call = _make_call("read_file", {"path": "x"})
+    async with async_turn_scope("turn_anp"), async_correlation_scope("c1"):
+        await pipeline.execute(call, reg.get("read_file").executor)
+
+    rows = [r for r in await ledger.fetch_by_turn("turn_anp")
+            if r.event_type == "artifact_emit"]
+    assert rows == []

--- a/tests/test_ledger_deferred_events.py
+++ b/tests/test_ledger_deferred_events.py
@@ -241,6 +241,48 @@ async def test_thought_committed_when_judge_fail_signal(
     assert p["digest"].startswith("sha256:")
 
 
+async def test_thought_committed_on_large_artifact_signal(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    """Review B1 regression guard — `artifact > 10 KB` must trigger
+    thought capture (doc/53 §3.3)."""
+    s = _make_session_stub(emitter, ledger)
+    s._turn_thought_text = "produced a sizeable file"
+    s._turn_artifact_max_size = 12_345  # > 10 KB threshold
+    async with async_turn_scope("turn_th_artifact"), async_correlation_scope("c1"):
+        await s._commit_or_discard_thought("turn_th_artifact", "clean")
+    rows = [r for r in await ledger.fetch_by_turn("turn_th_artifact")
+            if r.event_type == "thought"]
+    assert len(rows) == 1
+
+
+async def test_extract_artifact_info_dispatch_known_and_unknown(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    """Review S1 — single dict-dispatch extractor used by both
+    middleware emit and session size accumulator."""
+    from loom.core.harness.middleware import extract_artifact_info
+    ok = ToolResult(
+        call_id="c1", tool_name="write_file", success=True,
+        output="ok", metadata={"_resolved_path": "/x.txt"},
+    )
+    fail = ToolResult(
+        call_id="c2", tool_name="write_file", success=False, error="boom",
+    )
+    info = extract_artifact_info(
+        _make_call("write_file", {"path": "/x.txt", "content": "hi"}), ok,
+    )
+    assert info is not None
+    assert info["artifact_type"] == "text_file"
+    assert info["size_bytes"] == 2
+    assert extract_artifact_info(
+        _make_call("write_file", {"path": "/x.txt", "content": "hi"}), fail,
+    ) is None
+    assert extract_artifact_info(
+        _make_call("read_file", {"path": "/x.txt"}), ok,
+    ) is None
+
+
 async def test_thought_committed_on_abandoned_outcome(
     ledger: LedgerStore, emitter: LedgerEmitter
 ) -> None:


### PR DESCRIPTION
Closes #334. Unblocks #335.

doc/53 §3.1 lists 11 event types; PR #330 wired 5 subsystems but 4 were deferred because they need stream_turn / judge / producer-tool integration. This PR lands all four.

## Summary

- **`model_event`** — emit at every router call site (stream_turn main loop, `run_judge` sync + async, subagent inner loop). Per-turn `_turn_token_usage` aggregator replaces the `{}` placeholder in `turn_end.token_usage`.
- **`judge_verdict`** — emit after `run_judge` returns in `_maybe_run_judge` / `_run_judge_async`. Mapping: pass/fail/uncertain → PASS/FAIL/CONCERN; `verdict.error` set → ERROR. fail/uncertain flips the per-turn capture signal so the reasoning trail gets persisted.
- **`thought`** — signal accumulator per §3.3: capture iff judge fail/uncertain, outcome abandoned/error, or artifact >10KB. Inline ≤50KB, blob spill above (`.loom/ledger_blobs/{turn_id}/{event_id}.txt`).
- **`artifact_emit`** — `LifecycleMiddleware` inspects (call, result) on END for known producers (`write_file`, `openai__text_to_image`). Skipped on failure or rollback. Producer enumeration stays in one place; tools remain unaware of the ledger.

## Notable signature changes

- `run_judge` now returns `(JudgeVerdict, ChatResponse | None)` so callers can emit `model_event` for the judge LLM call. Only two call sites in `session.py`; tests untouched.
- `run_subagent` gains optional `ledger_emitter` kwarg (default `None`, no behaviour change for existing callers / tests). `spawn_agent` factory threads `parent_session._ledger_emitter` through. Subagent inherits the parent `turn_id` via contextvar so its `model_event` files under the parent turn during replay.

## Exit criteria (issue #334)

- [x] 4 event types have emit paths
- [x] thought capture follows §3.3 signal accumulator
- [x] `turn_end.token_usage` no longer `{}`
- [x] doc/53 §11.2.1 status table marked ✅
- [ ] dual-emit comparator extended — **deliberate skip**: dual-emit's purpose is envelope vs ledger sequence agreement; the four new event types have no envelope-side projection to compare against. New `tests/test_ledger_deferred_events.py` (13 tests) directly validates ledger-side correctness instead.

## Test plan

- [x] `pytest tests/` — 1611 passed (+13 new), 1 skipped
- [ ] Manual: `loom chat` a turn that triggers a fail verdict → confirm `thought` event written with `external_ref=None` (small) and `judge_verdict.payload.verdict=FAIL`
- [ ] Manual: write a >50 KB file via `write_file` → confirm `artifact_emit` size_bytes matches and `.loom/ledger_blobs/` not used (artifact is small enough), reasoning trail spills to blob if a fail verdict triggers thought capture
- [ ] Manual: run a subagent task → confirm subagent `model_event` rows file under parent `turn_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)