### PR TITLE
fix(session_log): #335 — read-time secret redaction; declare ledger-projection wontfix

### DIFF
--- a/doc/53-AgentLedger-設計.md
+++ b/doc/53-AgentLedger-設計.md
@@ -936,6 +936,19 @@ ledger 設計初衷是「事件流動的東西」（§2 / §3.2），存的是 t
 
 **#335 實際做的事**：把 SessionLog 的 secret redaction 從寫入時搬到讀取時。raw text 在磁碟上保留原貌、未來 regex 改進仍能即時對舊資料生效；同時實作了 `_redact_in_place(node)`，在 parse JSON 後對 leaf string 做 redaction，避開 regex 吞掉 escape quote 破壞 JSON 結構的舊問題（write-time 路徑剛好沒踩到、但 read-time naive 套用會炸）。
 
+**SECURITY — threat model 變更需明確承認**：這不是 Issue #92 的等價實現。#92 處理的是 **at-rest** 洩漏（DB 備份、lost laptop、file permission 設錯），write-time redaction 確保磁碟上看不到 secret。#335 改成 read-time 後：
+
+| 防護面 | #92 write-time | #335 read-time |
+|---|---|---|
+| `load_messages()` 回傳值 | ✅ redacted | ✅ redacted |
+| TUI / Discord / resume 重播 | ✅ redacted | ✅ redacted |
+| `~/.loom/memory.db` 檔案被竊取 | ✅ redacted | ❌ **plaintext** |
+| 跨備份系統洩漏（iCloud / Dropbox sync） | ✅ redacted | ❌ **plaintext** |
+
+換取的是「regex 可逆、未來改進仍能套用到舊資料」。這個取捨在「私人開發環境、單機使用」假設下成立；若未來 Loom 進入多用戶 / 共用主機 / cloud-synced 場景，需要重新評估。
+
+at-rest 防護現在沒有 first-class 機制，獨立追蹤於 **#342**（候選方案：DB 檔案 chmod 0600 baseline / opt-in retention pruning / SQLCipher）。在 #342 落地前，使用 Loom 應視同把 secret 寫進 `~/.loom/memory.db` plaintext。
+
 未來真需要把 raw text 也納入事件流時（例如 Quest D 想做 corpus 訓練），開新 event types 而不是改 SessionLog 投影方向；那時 ledger 會明確扮演「事件流 + opt-in raw text 副本」雙角色，而不是把 SessionLog 拆掉。
 
 ### 11.3 舊資料 — Leave alone

--- a/doc/53-AgentLedger-設計.md
+++ b/doc/53-AgentLedger-設計.md
@@ -907,8 +907,36 @@ Deferred 事件類型不阻擋 Step 5 cutover：它們是 additive event types�
 | Step 3 — Replay primitive (events_for_* + TurnSnapshot) | ✅ 完成（#331） | `LedgerStore.replay` lazy property，§8.2 trivial+medium 欄位 reconstruct 全綠 |
 | Step 4 — Push subscriber + Pull fluent + raw SQL | ✅ 完成（#332） | `subscribe(...)` async ctx、`events.where().since().all()` 等、`execute_sql`；`is_live` monotonic 語意（一旦 drop 永久 False，`re-subscribe` 重置） |
 | Step 5 — ExecutionEnvelope 投影切換 | ✅ 完成（#333 + #337） | `LedgerEnvelopeProjector` + `_build_envelope_view` async 委派；#337 移除 `_live_record_for` / `envelope.records` transitional bridge — projector 純從 ledger 讀取，`ExecutionEnvelope` 退成 thin marker。`[ledger].enabled=false` 改 graceful empty-view fallback：EnvelopeStarted/Completed 仍 fire（shape 一致），但 nodes 為空 — tool detail 改由 `ToolBegin` / `ToolEnd` stream 提供，不保證 full envelope UI parity。把 ledger disable 視為 safety/diagnostic opt-out，不是支援 tier |
-| Step 5 — SessionLog 投影 | ⚠️ deferred | SessionLog 存 OpenAI-canonical raw 訊息 text，ledger 沒有對應 raw text 事件（thought event 內嵌邏輯仍 deferred）。完整投影需與 thought event capture 一起實作 |
+| Step 5 — SessionLog 投影 | ✗ wontfix（#335） | 重新審視後決定不做純投影。理由見下方 §11.2.2。#335 改去處理可獨立分離的痛點：secret redaction 從寫入時搬到讀取時 |
 | Step 5 — Memory compaction subscribe `turn_end` 觸發 | ⚠️ deferred | 目前 inline trigger 在 stream_turn 內、行為正確；移成 background subscriber 為 architectural improvement，timing 細節需評估，獨立 follow-up issue |
+
+### 11.2.2 SessionLog 與 ledger 的邊界（#335 決策）
+
+#335 原本要把 SessionLog 改寫為 ledger pure projection。survey 完現況後改變決策——**不做投影，劃清邊界**。
+
+**為什麼不做：**
+
+ledger 設計初衷是「事件流動的東西」（§2 / §3.2），存的是 turn / tool / memory / judge / artifact 等 transition 訊號。SessionLog 存的是 OpenAI-canonical raw text（user input、assistant raw_message 含 tool_use blocks、tool result 全文），是**內容性質**，不是事件性質。要讓 ledger 能完整投影 SessionLog，需要：
+
+- 在 `turn_start.payload` 塞 `user_input` 全文 — 違反 §3.4 PromptStack snapshot 的設計（只放 hash，不放原文）
+- 開新 event type `assistant_message`、或讓 `thought` 一律 commit（丟掉 §3.3 capture signal）— 失去 thought 的篩選價值
+- 擴 `tool_lifecycle.END.result_summary` 從 200 字到全文 — 把 high-frequency 事件變成大 blob 容器
+
+每一條都把 ledger 拖向「儲存層」而非「事件層」。Loom 該記錄的內容服務 agent 為主，user 訊息原文沒必要在 ledger 再存一份。
+
+**SessionLog 與 ledger 的職責切分（v0.3 起鎖定）：**
+
+| 用途 | 來源 |
+|---|---|
+| Resume / TUI 重播 / Discord 重連的 message history | SessionLog（`session_log` + `sessions` 兩張表） |
+| 事件流 / replay primitive / TurnSnapshot / 投影出 ExecutionEnvelopeView | AgentLedger |
+| 跨子系統的觀測（judge / memory / task / artifact） | AgentLedger |
+| OpenAI-canonical raw text 持久化 | SessionLog |
+| Secret redaction（API keys、Bearer tokens） | SessionLog 讀取時做（#335）；ledger 端不重複 |
+
+**#335 實際做的事**：把 SessionLog 的 secret redaction 從寫入時搬到讀取時。raw text 在磁碟上保留原貌、未來 regex 改進仍能即時對舊資料生效；同時實作了 `_redact_in_place(node)`，在 parse JSON 後對 leaf string 做 redaction，避開 regex 吞掉 escape quote 破壞 JSON 結構的舊問題（write-time 路徑剛好沒踩到、但 read-time naive 套用會炸）。
+
+未來真需要把 raw text 也納入事件流時（例如 Quest D 想做 corpus 訓練），開新 event types 而不是改 SessionLog 投影方向；那時 ledger 會明確扮演「事件流 + opt-in raw text 副本」雙角色，而不是把 SessionLog 拆掉。
 
 ### 11.3 舊資料 — Leave alone
 

--- a/loom/core/memory/session_log.py
+++ b/loom/core/memory/session_log.py
@@ -78,6 +78,11 @@ def _redact_in_place(node: Any) -> Any:
     ``_redact_secrets``. Lists and dicts are mutated in place for
     cheapness; the return value is the same object so callers can use
     it as an expression.
+
+    Intended for freshly parsed / caller-owned structures — anything
+    sharing the dict will see its strings rewritten. Today's only call
+    site is ``load_messages`` operating on objects it just produced
+    via ``json.loads``.
     """
     if isinstance(node, str):
         return _redact_secrets(node)
@@ -137,11 +142,17 @@ class SessionLog:
         """
         try:
             # #335 — secret redaction is applied at read time in
-            # ``load_messages``, not here. Keeping the raw text on disk
-            # means future regex tweaks can re-redact accurately; a bad
-            # write-time redaction would have permanently corrupted the
-            # log.  Issue #92's contract (best-effort, never raises) is
-            # preserved on the read path.
+            # ``load_messages``. Keeping the raw text on disk lets
+            # future regex improvements re-redact older rows accurately
+            # (a bad write-time redaction would have been one-shot).
+            #
+            # SECURITY NOTE: this is a deliberate threat-model change
+            # from Issue #92. #92's write-time redaction protected
+            # against at-rest exposure (DB backup leak, lost laptop,
+            # file-permission misconfig); this read-time path only
+            # covers the load_messages presentation boundary. Plaintext
+            # secrets remain in ``~/.loom/memory.db`` on disk. At-rest
+            # mitigation tracked in #342.
             await self._db.execute(
                 """
                 INSERT INTO session_log
@@ -291,14 +302,21 @@ class SessionLog:
            the full JSON blob (written before the raw_json column existed).
         3. Plain text reconstruction (user / tool messages).
 
-        #335 — secret redaction (Issue #92) is applied here, on the way
-        out, rather than at write time. The raw text on disk is the
-        ground truth; if the redaction regex misses a pattern today,
-        improving it later still lets old rows surface redacted on the
-        next load. Redaction runs on the JSON / content strings before
-        parsing — the patterns were already designed to be JSON-safe so
-        the resulting bytes still parse. Failures are logged at DEBUG
-        and the row falls through to the next priority tier.
+        #335 — secret redaction is applied here, on the way out, rather
+        than at write time. Raw text on disk is the ground truth; if
+        the redaction regex misses a pattern today, improving it later
+        still lets old rows surface redacted on the next load.
+
+        Structured rows (raw_json, legacy raw_message in content) are
+        parsed first, then ``_redact_in_place`` walks the dict / list
+        and redacts every leaf string. Plain content is redacted via
+        ``_redact_secrets`` directly. The leaf-level walk is required
+        because some patterns (e.g. ``Bearer\\s+\\S{8,}``) greedy-match
+        through escaped quotes if applied to a raw JSON blob, breaking
+        syntax.
+
+        SECURITY: this guards the presentation boundary, not at-rest
+        storage — see ``log_message`` SECURITY NOTE and #342.
         """
         cursor = await self._db.execute(
             """
@@ -312,7 +330,17 @@ class SessionLog:
         rows = await cursor.fetchall()
         result: list[dict[str, Any]] = []
         for role, content, raw_json, metadata_raw in rows:
-            meta: dict[str, Any] = json.loads(metadata_raw)
+            # #335 review S2 — best-effort metadata parse; load_messages
+            # contract is "never raises", so a corrupted metadata blob
+            # falls through to empty rather than aborting the whole
+            # replay.
+            try:
+                meta: dict[str, Any] = json.loads(metadata_raw or "{}")
+            except Exception as meta_exc:
+                logger.debug(
+                    "metadata parse failed; using empty: %s", meta_exc,
+                )
+                meta = {}
 
             # Priority 1: raw_json column (structured, new path)
             if raw_json:

--- a/loom/core/memory/session_log.py
+++ b/loom/core/memory/session_log.py
@@ -52,7 +52,15 @@ _SECRET_PATTERNS: list[tuple[re.Pattern, str]] = [
 
 
 def _redact_secrets(text: str | None) -> str | None:
-    """Best-effort redaction of common secret patterns.  Never raises."""
+    """Best-effort redaction of common secret patterns.  Never raises.
+
+    #335 — applied at read time on plain-text values *after* JSON has
+    been parsed (see ``_redact_in_place``); the patterns assume an
+    unstructured string. Running them on a JSON-encoded blob can break
+    syntax (e.g. ``Bearer\\s+\\S{8,}`` greedy-matches through escaped
+    quotes), so callers walking nested structures should redact at the
+    leaf-string level, not on the serialised form.
+    """
     if not text:
         return text
     try:
@@ -61,6 +69,27 @@ def _redact_secrets(text: str | None) -> str | None:
     except Exception as exc:
         logger.debug("Secret redaction regex failed: %s", exc)
     return text
+
+
+def _redact_in_place(node: Any) -> Any:
+    """Walk a parsed-JSON structure and redact every leaf string.
+
+    Returns the same shape with strings filtered through
+    ``_redact_secrets``. Lists and dicts are mutated in place for
+    cheapness; the return value is the same object so callers can use
+    it as an expression.
+    """
+    if isinstance(node, str):
+        return _redact_secrets(node)
+    if isinstance(node, list):
+        for i, v in enumerate(node):
+            node[i] = _redact_in_place(v)
+        return node
+    if isinstance(node, dict):
+        for k, v in node.items():
+            node[k] = _redact_in_place(v)
+        return node
+    return node
 
 
 class SessionLog:
@@ -107,10 +136,12 @@ class SessionLog:
             ``load_messages()`` will prefer this column for assistant-message replay.
         """
         try:
-            # Issue #92: redact secrets before persisting to disk
-            content = _redact_secrets(content)
-            raw_json = _redact_secrets(raw_json)
-
+            # #335 — secret redaction is applied at read time in
+            # ``load_messages``, not here. Keeping the raw text on disk
+            # means future regex tweaks can re-redact accurately; a bad
+            # write-time redaction would have permanently corrupted the
+            # log.  Issue #92's contract (best-effort, never raises) is
+            # preserved on the read path.
             await self._db.execute(
                 """
                 INSERT INTO session_log
@@ -259,6 +290,15 @@ class SessionLog:
         2. ``metadata.format == "raw_message"`` — legacy fallback; ``content`` is
            the full JSON blob (written before the raw_json column existed).
         3. Plain text reconstruction (user / tool messages).
+
+        #335 — secret redaction (Issue #92) is applied here, on the way
+        out, rather than at write time. The raw text on disk is the
+        ground truth; if the redaction regex misses a pattern today,
+        improving it later still lets old rows surface redacted on the
+        next load. Redaction runs on the JSON / content strings before
+        parsing — the patterns were already designed to be JSON-safe so
+        the resulting bytes still parse. Failures are logged at DEBUG
+        and the row falls through to the next priority tier.
         """
         cursor = await self._db.execute(
             """
@@ -277,7 +317,11 @@ class SessionLog:
             # Priority 1: raw_json column (structured, new path)
             if raw_json:
                 try:
-                    result.append(json.loads(raw_json))
+                    parsed = json.loads(raw_json)
+                    # #335 — redact at the leaf level after parse so
+                    # patterns can't accidentally chew through escaped
+                    # quotes and break JSON.
+                    result.append(_redact_in_place(parsed))
                     continue
                 except Exception as parse_exc:
                     logger.debug("raw_json parse failed, falling back: %s", parse_exc)
@@ -286,13 +330,13 @@ class SessionLog:
             if role == "assistant" and meta.get("format") == "raw_message":
                 try:
                     msg = json.loads(content)
-                    result.append(msg)
+                    result.append(_redact_in_place(msg))
                     continue
                 except Exception as legacy_exc:
                     logger.debug("Legacy raw_message parse failed, falling back: %s", legacy_exc)
 
             # Priority 3: plain text
-            msg: dict[str, Any] = {"role": role, "content": content}
+            msg: dict[str, Any] = {"role": role, "content": _redact_secrets(content)}
             # Re-attach tool_call_id for tool messages (required by OpenAI format)
             if role == "tool" and "tool_call_id" in meta:
                 msg["tool_call_id"] = meta["tool_call_id"]

--- a/tests/test_session_log_redaction.py
+++ b/tests/test_session_log_redaction.py
@@ -1,0 +1,140 @@
+"""#335 / Issue #92 — secret redaction round-trip on the read path.
+
+#335 moved redaction from write-time to read-time. Raw text on disk is
+the ground truth; load_messages applies the regex on the way out so
+future regex tweaks can re-redact accurately. These tests pin that
+contract: writes are not mutated, reads come back with secrets masked.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import aiosqlite
+import pytest_asyncio
+
+from loom.core.memory.session_log import SessionLog
+
+
+@pytest_asyncio.fixture
+async def sl(tmp_path: Path):
+    db = tmp_path / "sessions.db"
+    conn = await aiosqlite.connect(str(db))
+    await conn.execute(
+        """
+        CREATE TABLE sessions (
+            session_id TEXT, model TEXT, title TEXT,
+            started_at TEXT, last_active TEXT, turn_count INTEGER DEFAULT 0
+        )
+        """
+    )
+    await conn.execute(
+        """
+        CREATE TABLE session_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            turn_index INTEGER NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT NOT NULL,
+            raw_json TEXT,
+            metadata TEXT NOT NULL DEFAULT '{}',
+            created_at TEXT NOT NULL
+        )
+        """
+    )
+    await conn.commit()
+    log = SessionLog(conn)
+    await log.create_session("s1", "test-model")
+    yield log, conn
+    await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Round-trip — write raw, read redacted
+# ---------------------------------------------------------------------------
+
+
+async def test_user_message_secret_redacted_on_read(sl) -> None:
+    log, conn = sl
+    await log.log_message("s1", 0, "user", 'export api_key="sk-1234567890abcdef1234"')
+
+    # On disk: raw value preserved.
+    cursor = await conn.execute("SELECT content FROM session_log")
+    (raw_on_disk,) = await cursor.fetchone()
+    assert "sk-1234567890abcdef1234" in raw_on_disk
+
+    # On read: secret masked.
+    msgs = await log.load_messages("s1")
+    assert len(msgs) == 1
+    assert "REDACTED" in msgs[0]["content"]
+    assert "sk-1234567890abcdef1234" not in msgs[0]["content"]
+
+
+async def test_assistant_raw_json_redacted_on_read(sl) -> None:
+    log, conn = sl
+    raw = json.dumps({
+        "role": "assistant",
+        "content": [
+            {"type": "tool_use", "id": "t1", "name": "run_bash",
+             "input": {"cmd": 'curl -H "Authorization: Bearer ghp_abcdef1234567890XYZW"'}},
+        ],
+    })
+    await log.log_message(
+        "s1", 1, "assistant", "[tool_use]",
+        metadata={"format": "raw_message"}, raw_json=raw,
+    )
+
+    # On disk: full bearer preserved.
+    cursor = await conn.execute("SELECT raw_json FROM session_log WHERE turn_index=1")
+    (rj,) = await cursor.fetchone()
+    assert "ghp_abcdef1234567890XYZW" in rj
+
+    # On read: parsed dict with redacted bearer.
+    msgs = await log.load_messages("s1")
+    assert len(msgs) == 1
+    cmd = msgs[0]["content"][0]["input"]["cmd"]
+    assert "REDACTED" in cmd
+    assert "ghp_abcdef1234567890XYZW" not in cmd
+
+
+async def test_tool_message_content_redacted_on_read(sl) -> None:
+    log, conn = sl
+    secret_output = 'token: "AKIAIOSFODNN7EXAMPLE12345"'
+    await log.log_message(
+        "s1", 2, "tool", secret_output,
+        metadata={"tool_call_id": "t1", "tool_name": "run_bash"},
+    )
+
+    msgs = await log.load_messages("s1")
+    assert len(msgs) == 1
+    assert "REDACTED" in msgs[0]["content"]
+    assert "AKIAIOSFODNN7EXAMPLE12345" not in msgs[0]["content"]
+    # tool_call_id passthrough still works
+    assert msgs[0]["tool_call_id"] == "t1"
+
+
+# ---------------------------------------------------------------------------
+# On-disk preservation — the whole point of #335
+# ---------------------------------------------------------------------------
+
+
+async def test_disk_content_is_unredacted_so_future_regex_can_fix(sl) -> None:
+    """Future regex improvements must be able to catch patterns the
+    current redactor missed. Storing the raw text on disk is what
+    enables that — write-time redaction would have been one-shot."""
+    log, conn = sl
+    text = 'password="this-is-12-chars-secret"'
+    await log.log_message("s1", 0, "user", text)
+
+    cursor = await conn.execute("SELECT content FROM session_log")
+    (on_disk,) = await cursor.fetchone()
+    assert on_disk == text  # exact byte preservation
+
+
+async def test_redaction_failure_does_not_break_load(sl) -> None:
+    """_redact_secrets contract: best-effort, never raises."""
+    log, _ = sl
+    await log.log_message("s1", 0, "user", "ordinary message with no secrets")
+    msgs = await log.load_messages("s1")
+    assert msgs == [{"role": "user", "content": "ordinary message with no secrets"}]

--- a/tests/test_session_log_redaction.py
+++ b/tests/test_session_log_redaction.py
@@ -132,9 +132,50 @@ async def test_disk_content_is_unredacted_so_future_regex_can_fix(sl) -> None:
     assert on_disk == text  # exact byte preservation
 
 
-async def test_redaction_failure_does_not_break_load(sl) -> None:
-    """_redact_secrets contract: best-effort, never raises."""
+async def test_no_secret_passes_through_unchanged(sl) -> None:
     log, _ = sl
     await log.log_message("s1", 0, "user", "ordinary message with no secrets")
     msgs = await log.load_messages("s1")
     assert msgs == [{"role": "user", "content": "ordinary message with no secrets"}]
+
+
+async def test_redaction_failure_falls_through_without_raising(
+    sl, monkeypatch
+) -> None:
+    """_redact_secrets contract is best-effort, never raises. Simulate
+    a regex blowing up and confirm load_messages still returns the row
+    (with the unfiltered content rather than a half-mangled version)."""
+    import re
+
+    from loom.core.memory import session_log as sl_mod
+
+    log, _ = sl
+    await log.log_message("s1", 0, "user", "totally fine text")
+
+    # Patch in a single pattern whose .sub raises.
+    class _Bomb:
+        def sub(self, *_a, **_kw):
+            raise RuntimeError("fake regex failure")
+
+    monkeypatch.setattr(sl_mod, "_SECRET_PATTERNS", [(_Bomb(), "")])
+    msgs = await log.load_messages("s1")
+    # The row should still load — _redact_secrets caught the exception
+    # and returned the original text unchanged.
+    assert len(msgs) == 1
+    assert msgs[0]["content"] == "totally fine text"
+
+
+async def test_corrupt_metadata_falls_back_to_empty(sl) -> None:
+    """#335 review S2 — a row with malformed metadata must not abort
+    the whole replay."""
+    log, conn = sl
+    await conn.execute(
+        """
+        INSERT INTO session_log
+            (session_id, turn_index, role, content, raw_json, metadata, created_at)
+        VALUES ('s1', 0, 'user', 'hello', NULL, '{not-json', '2026-05-09T00:00:00')
+        """
+    )
+    await conn.commit()
+    msgs = await log.load_messages("s1")
+    assert msgs == [{"role": "user", "content": "hello"}]


### PR DESCRIPTION
Closes #335.

## Decision change

Issue #335 originally proposed making `SessionLog` a pure `AgentLedger` projection. After surveying the actual data flow we changed direction — see doc/53 §11.2.2 for the full rationale. Short version:

- The ledger is for **events** (turn / tool / memory / judge / artifact). User input, assistant raw_message, full tool output are **content**, not events.
- Forcing raw text into ledger would either bloat existing payloads (`turn_start.user_input`, `tool_lifecycle.result_full`) or require new event types whose only consumer would be SessionLog projection itself — the architectural cost is high and the consumer count is exactly one.
- doc/53 §2 / §3.2 are explicit that the ledger tracks "the things that flow"; raw text doesn't fit.
- Loom 該記錄的內容服務 agent 為主，user 訊息原文沒必要在 ledger 再存一份。

The independently-valuable goal in #335 was **secret redaction at read time, not write time**. Raw text on disk is the ground truth; future regex improvements can re-redact older rows accurately. A bad write-time redaction would have permanently corrupted the log. That's the change this PR ships.

## What changed

- **`session_log.py`**: `log_message` no longer redacts on the way in. `load_messages` applies redaction after JSON parse via the new `_redact_in_place` helper, walking lists/dicts and redacting leaf strings.
- **`_redact_in_place` helper** added because the naive approach (run the regexes on the raw JSON blob) breaks JSON: `Bearer\s+\S{8,}` greedy-matches through escaped quotes. Tests pin this exact contract.
- **doc/53 §11.2.1**: SessionLog projection row flipped from ⚠️ deferred → ✗ wontfix with pointer to the new §11.2.2.
- **doc/53 §11.2.2 (new)**: records the SessionLog/ledger boundary so future contributors don't re-litigate. Includes a side-by-side threat-model table making explicit that read-time redaction does **not** cover at-rest exposure.
- **`tests/test_session_log_redaction.py` (new, 7 tests)**: write-raw/read-redacted round trip on user text, assistant raw_json, tool output; on-disk preservation guarantee; no-secret pass-through; redaction-failure simulation; corrupt-metadata fallback.

## Security

This PR **changes the threat model from #92** (write-time, at-rest protection) to a presentation-boundary guard. Concretely:

| Surface | #92 (write-time) | #335 (read-time) |
|---|---|---|
| `load_messages()` return value | ✅ redacted | ✅ redacted |
| TUI / Discord / resume replay | ✅ redacted | ✅ redacted |
| `~/.loom/memory.db` file at rest | ✅ redacted | ❌ **plaintext** |
| Backup sync leak (iCloud / Dropbox) | ✅ redacted | ❌ **plaintext** |

The trade-off bought "regex is reversible — future improvements still apply to old rows." Until #342 lands at-rest mitigation (chmod 0600 baseline / retention pruning / SQLCipher), assume secrets written via Loom land plaintext in `~/.loom/memory.db`.

Issue #92's `best-effort / never raises` behavioral contract is preserved at the `load_messages()` read boundary; #92's **at-rest security** contract is explicitly deferred to #342.

## Exit Criteria (issue #335 — re-interpreted)

- [x] secret redaction moved from write-time to read-time
- [x] doc/53 §11.2.1 updated; new §11.2.2 explains the boundary decision + threat-model change
- [ ] ~~SessionLog 完全變成 projection~~ — wontfix (see above)
- [ ] ~~移除 SessionLog 自身的 state mutation~~ — wontfix
- [x] 既有 `load_messages` API shape 不變; resume / compress_session / Discord reconnect 路徑不破
- [x] at-rest follow-up filed — #342

## Test plan

- [x] `pytest tests/` — 1620 passed (+7 new), 1 skipped, zero regressions
- [ ] Manual: resume an existing session — confirm history loads with secrets masked
- [ ] Manual: write a message containing a recognised pattern (`api_key="..."`), restart loom, confirm `load_messages` returns it redacted

🤖 Generated with [Claude Code](https://claude.com/claude-code)