### PR TITLE
fix(security): #342 — chmod 0700/0600 baseline for ~/.loom/

### DIFF
--- a/doc/53-AgentLedger-設計.md
+++ b/doc/53-AgentLedger-設計.md
@@ -947,7 +947,15 @@ ledger 設計初衷是「事件流動的東西」（§2 / §3.2），存的是 t
 
 換取的是「regex 可逆、未來改進仍能套用到舊資料」。這個取捨在「私人開發環境、單機使用」假設下成立；若未來 Loom 進入多用戶 / 共用主機 / cloud-synced 場景，需要重新評估。
 
-at-rest 防護現在沒有 first-class 機制，獨立追蹤於 **#342**（候選方案：DB 檔案 chmod 0600 baseline / opt-in retention pruning / SQLCipher）。在 #342 落地前，使用 Loom 應視同把 secret 寫進 `~/.loom/memory.db` plaintext。
+at-rest 防護分三階段在 **#342** 收：
+
+| 階段 | 狀態 | 內容 |
+|---|---|---|
+| Baseline — chmod 0700/0600 | ✅ 已 ship | `~/.loom/` 目錄收 0700、`memory.db` / `ledger.db`（含 WAL/SHM）收 0600；helper 在 `loom/core/infra/file_permissions.py`，`SQLiteStore.initialize` 與 `LedgerStore.open` 接線。Block 同主機其他 user，但**擋不住**檔案被搬走（備份外流、lost laptop） |
+| Retention pruning（opt-in） | ⚠️ deferred | 由 user 在 `loom.toml` 設定 `[session_log] retention_days=N`，超期 row 由背景 prune。處理「老備份外流」場景 |
+| SQLCipher | ⚠️ deferred | 真 at-rest encryption，需要 key management / 額外 dependency；等實際需求訊號 |
+
+在後兩階段落地前，使用 Loom 仍應視同把 secret 寫進 `~/.loom/memory.db` plaintext —— baseline 只擋同機其他 user，不擋備份/實體竊取。
 
 未來真需要把 raw text 也納入事件流時（例如 Quest D 想做 corpus 訓練），開新 event types 而不是改 SessionLog 投影方向；那時 ledger 會明確扮演「事件流 + opt-in raw text 副本」雙角色，而不是把 SessionLog 拆掉。
 

--- a/loom/core/infra/file_permissions.py
+++ b/loom/core/infra/file_permissions.py
@@ -18,6 +18,11 @@ This is a baseline, not full at-rest encryption. Cloud-sync leaks
 (iCloud / Dropbox auto-include) and lost-laptop full-disk reads still
 expose plaintext content. Stronger options (SQLCipher, retention
 pruning) tracked in #342.
+
+POSIX limit (#343 review S2): ``0o700`` blocks other local users from
+listing directory contents or reading files, but the home-directory
+owner can always see that ``~/.loom/`` exists. Hiding presence is
+out of scope — that needs containerisation or a relocated store path.
 """
 
 from __future__ import annotations

--- a/loom/core/infra/file_permissions.py
+++ b/loom/core/infra/file_permissions.py
@@ -1,0 +1,132 @@
+"""POSIX file-permission baseline for the Loom store directory.
+
+#342 — minimal at-rest hardening:
+
+- ``~/.loom/`` is tightened to ``0o700`` (owner-only traversal) so other
+  users on the same host can't enumerate session DB / blob files.
+- ``memory.db`` / ``ledger.db`` (plus their SQLite WAL / SHM siblings)
+  are tightened to ``0o600`` (owner-only read/write).
+- A single warning fires per process when files are found with looser
+  permissions; subsequent encounters stay silent so resume / Discord
+  reconnect don't re-spam the log.
+
+Windows / non-POSIX: every helper is a no-op. Read/write perms on those
+platforms are governed by ACLs, which the SQLite open path doesn't
+expose; we leave that to follow-up work if there's a real demand signal.
+
+This is a baseline, not full at-rest encryption. Cloud-sync leaks
+(iCloud / Dropbox auto-include) and lost-laptop full-disk reads still
+expose plaintext content. Stronger options (SQLCipher, retention
+pruning) tracked in #342.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+_LOOSE_FILE_MASK = 0o077  # any group / other bit set → loose
+_TARGET_FILE_MODE = 0o600
+_TARGET_DIR_MODE = 0o700
+
+# Module-scoped flag so a single process logs at most one "tightened
+# loose perms" warning. Subsequent calls during the same process stay
+# quiet — the user's already been told once.
+_warned_loose: bool = False
+
+
+def _is_posix() -> bool:
+    return os.name == "posix"
+
+
+def tighten_file(path: Path) -> None:
+    """chmod ``path`` to 0o600 on POSIX. Missing files / non-POSIX are no-ops.
+
+    Logs at most one process-wide warning when an existing file was
+    found with looser permissions; the chmod itself is silent.
+    """
+    if not _is_posix():
+        return
+    try:
+        st = path.stat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        logger.debug("file_permissions: stat(%s) failed: %s", path, exc)
+        return
+
+    was_loose = (st.st_mode & _LOOSE_FILE_MASK) != 0
+    if not was_loose and (st.st_mode & 0o777) == _TARGET_FILE_MODE:
+        return
+
+    try:
+        os.chmod(path, _TARGET_FILE_MODE)
+    except OSError as exc:
+        logger.debug("file_permissions: chmod(%s) failed: %s", path, exc)
+        return
+
+    if was_loose:
+        _warn_loose_once(path)
+
+
+def tighten_dir(path: Path) -> None:
+    """chmod ``path`` to 0o700 on POSIX. Missing dirs / non-POSIX are no-ops."""
+    if not _is_posix():
+        return
+    try:
+        st = path.stat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        logger.debug("file_permissions: stat(%s) failed: %s", path, exc)
+        return
+
+    was_loose = (st.st_mode & _LOOSE_FILE_MASK) != 0
+    if not was_loose and (st.st_mode & 0o777) == _TARGET_DIR_MODE:
+        return
+
+    try:
+        os.chmod(path, _TARGET_DIR_MODE)
+    except OSError as exc:
+        logger.debug("file_permissions: chmod(%s) failed: %s", path, exc)
+        return
+
+    if was_loose:
+        _warn_loose_once(path)
+
+
+def tighten_sqlite_db(path: Path) -> None:
+    """Tighten a SQLite DB file plus its WAL / SHM / rollback-journal siblings.
+
+    SQLite in WAL mode keeps two side files (``*-wal``, ``*-shm``) that
+    contain plaintext content too; rollback-journal mode adds
+    ``*-journal``. All three are tightened if present so an attacker
+    can't read state by reaching for the side file.
+    """
+    tighten_file(path)
+    base = str(path)
+    for suffix in ("-wal", "-shm", "-journal"):
+        tighten_file(Path(base + suffix))
+
+
+def _warn_loose_once(path: Path) -> None:
+    global _warned_loose
+    if _warned_loose:
+        return
+    _warned_loose = True
+    logger.warning(
+        "Tightened loose permissions on %s. Loom stores raw session "
+        "content and secrets here; future sessions will keep this path "
+        "owner-only. (#342)",
+        path,
+    )
+
+
+def reset_warning_state_for_tests() -> None:
+    """Test hook — reset the once-per-process warning flag."""
+    global _warned_loose
+    _warned_loose = False

--- a/loom/core/ledger/store.py
+++ b/loom/core/ledger/store.py
@@ -217,6 +217,16 @@ class LedgerStore:
             return
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self.blob_dir.mkdir(parents=True, exist_ok=True)
+        # #342 — at-rest baseline. Tighten parent dir before the first
+        # write so the connection inherits a private directory; tighten
+        # the DB itself plus the blob_dir afterwards. Thought-event blob
+        # files are written via store_thought_text into blob_dir, so
+        # locking down the directory protects them too.
+        from loom.core.infra.file_permissions import (
+            tighten_dir, tighten_sqlite_db,
+        )
+        tighten_dir(self.db_path.parent)
+        tighten_dir(self.blob_dir)
         self._conn = await aiosqlite.connect(self.db_path)
         await self._conn.execute("PRAGMA journal_mode=WAL")
         await self._conn.execute("PRAGMA synchronous=NORMAL")
@@ -225,6 +235,7 @@ class LedgerStore:
         for stmt in CREATE_INDEXES:
             await self._conn.execute(stmt)
         await self._conn.commit()
+        tighten_sqlite_db(self.db_path)
 
     async def close(self) -> None:
         if self._conn is not None:

--- a/loom/core/memory/store.py
+++ b/loom/core/memory/store.py
@@ -251,6 +251,12 @@ class SQLiteStore:
 
     async def initialize(self) -> None:
         """Create tables and indexes if they do not exist."""
+        # #342 — at-rest baseline. Tighten the parent dir before the
+        # first connect so the freshly-created DB inherits a private
+        # directory; tighten the DB + WAL/SHM siblings on the way out
+        # of initialize.
+        from loom.core.infra.file_permissions import tighten_dir, tighten_sqlite_db
+        tighten_dir(self.path.parent)
         async with aiosqlite.connect(self.path) as db:
             # Issue #166: wait up to 5s on a write lock instead of failing
             # immediately with `database is locked`. Pairs with WAL mode set in
@@ -317,6 +323,10 @@ class SQLiteStore:
                 await db.commit()
             except Exception:
                 pass
+
+        # #342 — tighten the DB file + WAL/SHM siblings now that the
+        # connection has been closed and any side files have flushed.
+        tighten_sqlite_db(self.path)
 
     @asynccontextmanager
     async def connect(self):

--- a/tests/test_file_permissions.py
+++ b/tests/test_file_permissions.py
@@ -1,0 +1,139 @@
+"""#342 — POSIX file-permission baseline for ~/.loom/.
+
+Tests the helper plus its integration into SQLiteStore.initialize and
+LedgerStore.open. POSIX-only; the helpers are no-ops on Windows so the
+non-POSIX cases pass through trivially.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from loom.core.infra import file_permissions as fp
+
+
+posix_only = pytest.mark.skipif(
+    os.name != "posix", reason="POSIX file permissions only"
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_warning():
+    """Each test starts with a fresh warning flag — the helper warns
+    at most once per process and we don't want one test to mask another."""
+    fp.reset_warning_state_for_tests()
+    yield
+    fp.reset_warning_state_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Unit — helper itself
+# ---------------------------------------------------------------------------
+
+
+@posix_only
+def test_tighten_file_locks_loose_perms(tmp_path: Path) -> None:
+    f = tmp_path / "x.db"
+    f.write_text("secret")
+    os.chmod(f, 0o644)
+    fp.tighten_file(f)
+    assert stat.S_IMODE(f.stat().st_mode) == 0o600
+
+
+@posix_only
+def test_tighten_file_idempotent(tmp_path: Path, caplog) -> None:
+    f = tmp_path / "x.db"
+    f.write_text("secret")
+    os.chmod(f, 0o600)
+    with caplog.at_level("WARNING", logger="loom.core.infra.file_permissions"):
+        fp.tighten_file(f)
+        fp.tighten_file(f)
+    assert stat.S_IMODE(f.stat().st_mode) == 0o600
+    # Already-tight files don't trigger the warning.
+    assert not any("Tightened loose" in r.message for r in caplog.records)
+
+
+def test_tighten_file_missing_is_silent(tmp_path: Path) -> None:
+    fp.tighten_file(tmp_path / "does-not-exist")
+    # Just shouldn't raise.
+
+
+@posix_only
+def test_tighten_dir_locks_loose_perms(tmp_path: Path) -> None:
+    d = tmp_path / "store"
+    d.mkdir()
+    os.chmod(d, 0o755)
+    fp.tighten_dir(d)
+    assert stat.S_IMODE(d.stat().st_mode) == 0o700
+
+
+@posix_only
+def test_warning_fires_once_then_silent(tmp_path: Path, caplog) -> None:
+    a = tmp_path / "a.db"
+    b = tmp_path / "b.db"
+    a.write_text("x")
+    b.write_text("y")
+    os.chmod(a, 0o644)
+    os.chmod(b, 0o644)
+    with caplog.at_level("WARNING", logger="loom.core.infra.file_permissions"):
+        fp.tighten_file(a)
+        fp.tighten_file(b)
+    warns = [r for r in caplog.records if "Tightened loose" in r.message]
+    assert len(warns) == 1
+
+
+@posix_only
+def test_tighten_sqlite_db_covers_wal_shm_journal(tmp_path: Path) -> None:
+    db = tmp_path / "session.db"
+    wal = tmp_path / "session.db-wal"
+    shm = tmp_path / "session.db-shm"
+    journal = tmp_path / "session.db-journal"
+    for f in (db, wal, shm, journal):
+        f.write_text("x")
+        os.chmod(f, 0o644)
+    fp.tighten_sqlite_db(db)
+    for f in (db, wal, shm, journal):
+        assert stat.S_IMODE(f.stat().st_mode) == 0o600, f"{f} not tightened"
+
+
+# ---------------------------------------------------------------------------
+# Integration — SQLiteStore + LedgerStore
+# ---------------------------------------------------------------------------
+
+
+@posix_only
+async def test_sqlite_store_tightens_dir_and_file(tmp_path: Path) -> None:
+    from loom.core.memory.store import SQLiteStore
+
+    db_path = tmp_path / "store" / "memory.db"
+    store = SQLiteStore(str(db_path))
+    # Pre-create the parent dir loose so we exercise the tighten path.
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    os.chmod(db_path.parent, 0o755)
+
+    await store.initialize()
+
+    assert stat.S_IMODE(db_path.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
+
+
+@posix_only
+async def test_ledger_store_tightens_dir_blob_and_file(tmp_path: Path) -> None:
+    from loom.core.ledger import LedgerStore
+
+    db_path = tmp_path / "ledger.db"
+    blob_dir = tmp_path / "ledger_blobs"
+    store = LedgerStore(db_path=db_path, blob_dir=blob_dir)
+    # blob_dir doesn't exist yet — open() creates it.
+    await store.open()
+    try:
+        assert stat.S_IMODE(db_path.parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(blob_dir.stat().st_mode) == 0o700
+    finally:
+        await store.close()


### PR DESCRIPTION
Partial fix for #342 — at-rest mitigation phase 1 (Baseline). Retention pruning + SQLCipher remain deferred.

#335 moved SessionLog redaction to read time, leaving plaintext secrets in `~/.loom/memory.db`. #341 explicitly deferred at-rest mitigation to #342 across three candidate paths. This PR ships the cheapest one — tighten POSIX file permissions — as a baseline that costs no dependencies and no user config.

## What lands

- **`loom/core/infra/file_permissions.py`** (new):
  - `tighten_file(path)` → 0600 if loose, no-op otherwise
  - `tighten_dir(path)` → 0700
  - `tighten_sqlite_db(path)` → main file + `-wal` / `-shm` / `-journal` siblings (WAL mode keeps plaintext content in side files, so locking only the main file isn't enough)
  - Process-wide single warning when looser perms get tightened (avoids re-spamming on resume / Discord reconnect)
  - Non-POSIX: every helper is a no-op since ACLs aren't reachable from the SQLite open path
- **`SQLiteStore.initialize`** tightens the parent dir *before* connect (so the freshly-created DB inherits a private dir) and the DB + WAL/SHM siblings after init
- **`LedgerStore.open`** tightens parent dir, `blob_dir` (thought-event blobs land there), and the DB file
- **doc/53 §11.2.2** expanded the at-rest section into a 3-phase table: Baseline ✅ (this PR) / Retention pruning ⚠️ / SQLCipher ⚠️

## Threat model

| Surface | Pre-#342 | Post-baseline |
|---|---|---|
| Other users on the same POSIX host | ❌ readable | ✅ blocked |
| Backup leak (iCloud / Dropbox auto-include) | ❌ readable | ❌ still readable (chmod doesn't follow files) |
| Lost laptop (full-disk read) | ❌ readable | ❌ still readable |
| Plaintext in DB at all | ❌ yes | ❌ still yes |

Baseline blocks the same-host case. Backup-leak and full-disk reads need retention pruning or SQLCipher — both deferred per #342.

## Test plan

- [x] `pytest tests/` — 1628 passed (+8 new), 1 skipped, zero regressions
- [ ] Manual: `chmod 0755 ~/.loom && chmod 0644 ~/.loom/memory.db && loom chat` — confirm dir/file tightened on next session start, single WARNING in log
- [ ] Manual: `chmod 0600 ~/.loom/memory.db && loom chat` — confirm no warning (already tight)

## Diff stat

```
 5 files changed, 301 insertions(+), 1 deletion(-)
```

Most lines are the helper module + tests; integration touches are tiny (4 lines each in the two store classes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)