### PR TITLE
feat(judge): #339 — plumb confidence axis into JudgeVerdict + ledger

### DIFF
--- a/loom/core/cognition/judge.py
+++ b/loom/core/cognition/judge.py
@@ -47,6 +47,7 @@ VERDICT_UNCERTAIN = "uncertain"
 class JudgeVerdict:
     verdict: str               # pass / fail / uncertain
     reason: str = ""
+    confidence: float = 0.0    # 0.0–1.0; #339, see parse_verdict for defaults
     blocking: bool = False     # True iff verdict was rendered synchronously
     raw_response: str = ""     # for telemetry / debugging
     error: str = ""            # set when judge itself failed
@@ -259,8 +260,9 @@ Look specifically for "say-do gap" patterns:
 - claim implies an effect external to the trace (e.g. "已 push 到 master")
   but no corresponding tool ran
 
-Respond with EXACTLY one line, in this format:
+Respond with EXACTLY two lines, in this format:
 VERDICT: <pass|fail|uncertain> — <one-sentence reason in the same language as the agent>
+CONFIDENCE: <0.00–1.00>
 
 - pass:      claim is consistent with the trace
 - fail:      claim contradicts the trace, or claims an outcome the trace
@@ -268,15 +270,54 @@ VERDICT: <pass|fail|uncertain> — <one-sentence reason in the same language as 
 - uncertain: trace is genuinely ambiguous; do NOT use this as a hedge,
              use it only when neither pass nor fail is defensible
 
+Confidence reflects how sure you are in the verdict itself, not the
+strength of the agent's evidence:
+- 0.90+ : the trace makes the verdict unambiguous
+- 0.60–0.89 : verdict is well-supported but not airtight
+- 0.30–0.59 : a reasonable-but-fragile read of the trace
+- <0.30 : you're guessing; prefer "uncertain" verdict at this level
+
 Be terse. The reason becomes a system-reminder the agent reads next turn,
 so it must point at the specific gap, not philosophize.
 """
 
 
 _VERDICT_LINE = re.compile(
-    r"VERDICT\s*:\s*(pass|fail|uncertain)\s*[—\-:]\s*(.+)",
-    re.IGNORECASE | re.DOTALL,
+    # The reason runs until we hit the CONFIDENCE line (or end-of-text).
+    # `[\s\S]+?` is the dotall-equivalent lazy match; lookahead pins the
+    # boundary so multi-line reasons still parse cleanly.
+    r"VERDICT\s*:\s*(pass|fail|uncertain)\s*[—\-:]\s*([\s\S]+?)(?=\s*CONFIDENCE\s*:|$)",
+    re.IGNORECASE,
 )
+_CONFIDENCE_LINE = re.compile(
+    # Accept any signed decimal so out-of-range values (e.g. "-0.4",
+    # "1.7") still parse — _parse_confidence then clamps into [0, 1].
+    # Without this the value would silently fall back to default,
+    # masking a confused model.
+    r"CONFIDENCE\s*:\s*(-?(?:\d+(?:\.\d+)?|\.\d+))",
+    re.IGNORECASE,
+)
+
+# #339 — confidence defaults when the model didn't comply with the
+# new two-line format. Pre-#339 prompts didn't ask for confidence at
+# all; legacy responses get a moderate default rather than 0.0 so
+# downstream consumers don't read "no answer" as "high uncertainty".
+_DEFAULT_CONFIDENCE_PARSED = 0.5     # verdict parsed cleanly, no CONFIDENCE line
+_DEFAULT_CONFIDENCE_FALLBACK = 0.3   # malformed_verdict fallback word search
+_DEFAULT_CONFIDENCE_EMPTY = 0.0      # judge returned nothing
+
+
+def _parse_confidence(raw: str, default: float) -> float:
+    m = _CONFIDENCE_LINE.search(raw)
+    if not m:
+        return default
+    try:
+        v = float(m.group(1))
+    except ValueError:
+        return default
+    # Clamp into [0, 1]; out-of-range hints at a confused model, treat
+    # as low-trust without losing the verdict itself.
+    return max(0.0, min(1.0, v))
 
 
 def parse_verdict(raw: str) -> JudgeVerdict:
@@ -284,6 +325,7 @@ def parse_verdict(raw: str) -> JudgeVerdict:
         return JudgeVerdict(
             verdict=VERDICT_UNCERTAIN,
             reason="judge returned empty response",
+            confidence=_DEFAULT_CONFIDENCE_EMPTY,
             raw_response="",
             error="empty_response",
         )
@@ -292,6 +334,7 @@ def parse_verdict(raw: str) -> JudgeVerdict:
         return JudgeVerdict(
             verdict=m.group(1).lower(),
             reason=m.group(2).strip()[:600],
+            confidence=_parse_confidence(raw, _DEFAULT_CONFIDENCE_PARSED),
             raw_response=raw,
         )
     # Fallback: if the model wrote prose, try to extract a verdict word.
@@ -307,6 +350,7 @@ def parse_verdict(raw: str) -> JudgeVerdict:
     return JudgeVerdict(
         verdict=verdict,
         reason=raw.strip()[:600],
+        confidence=_parse_confidence(raw, _DEFAULT_CONFIDENCE_FALLBACK),
         raw_response=raw,
         error="malformed_verdict",
     )

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -2748,8 +2748,9 @@ class LoomSession:
         """Best-effort log; never raises. Pass verdicts only land here, not
         in the agent's context — keeps the noise floor low."""
         logger.info(
-            "judge.verdict turn=%d sync=%s verdict=%s reason=%r error=%r",
+            "judge.verdict turn=%d sync=%s verdict=%s confidence=%.2f reason=%r error=%r",
             self._turn_index, sync, verdict.verdict,
+            float(getattr(verdict, "confidence", 0.0) or 0.0),
             verdict.reason[:160], verdict.error or "",
         )
 
@@ -3591,7 +3592,7 @@ class LoomSession:
             await self._ledger_emitter.emit_judge_verdict(
                 payload=JudgeVerdictPayload(
                     verdict=mapped,
-                    confidence=0.0,  # judge prompt has no confidence axis today
+                    confidence=float(getattr(verdict, "confidence", 0.0) or 0.0),
                     reason=(verdict.reason or "")[:500],
                     judged_subject=judged_subject,
                 ),

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -457,3 +457,7 @@ def test_judge_system_prompt_describes_format():
     assert "pass" in JUDGE_SYSTEM_PROMPT
     assert "fail" in JUDGE_SYSTEM_PROMPT
     assert "uncertain" in JUDGE_SYSTEM_PROMPT
+    # #339 review S1 — without this guard, removing the CONFIDENCE
+    # line from the prompt would silently fall back to default=0.5
+    # for every verdict, with no test failure to flag the drift.
+    assert "CONFIDENCE:" in JUDGE_SYSTEM_PROMPT

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -288,6 +288,69 @@ class TestVerdictParsing:
         assert v.verdict == VERDICT_PASS
 
 
+class TestVerdictConfidence:
+    """#339 — confidence axis on JudgeVerdict.
+
+    Format: VERDICT line followed by CONFIDENCE: <0–1> on its own line.
+    """
+
+    def test_confidence_parsed(self):
+        v = parse_verdict(
+            "VERDICT: pass — looks good.\nCONFIDENCE: 0.87"
+        )
+        assert v.verdict == VERDICT_PASS
+        assert v.reason == "looks good."
+        assert v.confidence == 0.87
+
+    def test_confidence_clamped_to_01(self):
+        v_high = parse_verdict("VERDICT: fail — bad.\nCONFIDENCE: 1.7")
+        v_low = parse_verdict("VERDICT: fail — bad.\nCONFIDENCE: -0.4")
+        assert v_high.confidence == 1.0
+        assert v_low.confidence == 0.0
+
+    def test_confidence_default_when_omitted(self):
+        """Pre-#339 prompts didn't ask for confidence; legacy responses
+        get a moderate default rather than 0.0 so downstream readers
+        don't conflate "no answer" with "high uncertainty"."""
+        v = parse_verdict("VERDICT: pass — looks good.")
+        assert v.verdict == VERDICT_PASS
+        assert v.confidence == 0.5
+
+    def test_confidence_default_on_malformed(self):
+        v = parse_verdict("Hmm, no comment.")
+        assert v.error == "malformed_verdict"
+        # Fallback word search → low default, not the parsed-but-missing
+        # default. We're guessing here, signal that to readers.
+        assert v.confidence == 0.3
+
+    def test_confidence_zero_on_empty(self):
+        v = parse_verdict("")
+        assert v.error == "empty_response"
+        assert v.confidence == 0.0
+
+    def test_confidence_with_dot_only_form(self):
+        # Some models like to write ".85" instead of "0.85".
+        v = parse_verdict("VERDICT: pass — ok.\nCONFIDENCE: .85")
+        assert v.confidence == 0.85
+
+    def test_confidence_garbage_falls_back(self):
+        v = parse_verdict("VERDICT: pass — ok.\nCONFIDENCE: very high")
+        assert v.verdict == VERDICT_PASS
+        assert v.confidence == 0.5  # fell back to parsed-default
+
+    def test_multiline_reason_does_not_swallow_confidence(self):
+        v = parse_verdict(
+            "VERDICT: fail — first line of reason\n"
+            "  spilling onto a second line.\n"
+            "CONFIDENCE: 0.92"
+        )
+        assert v.verdict == VERDICT_FAIL
+        assert "first line" in v.reason
+        assert "spilling" in v.reason
+        assert "CONFIDENCE" not in v.reason
+        assert v.confidence == 0.92
+
+
 # ── dispatch policy ─────────────────────────────────────────────────────────
 
 

--- a/tests/test_ledger_deferred_events.py
+++ b/tests/test_ledger_deferred_events.py
@@ -162,12 +162,15 @@ async def test_judge_verdict_pass_emits_and_no_capture_signal(
     s = _make_session_stub(emitter, ledger)
     async with async_turn_scope("turn_j"), async_correlation_scope("c1"):
         await s._emit_ledger_judge_verdict(
-            JudgeVerdict(verdict="pass", reason="ok"), "turn_final_text"
+            JudgeVerdict(verdict="pass", reason="ok", confidence=0.82),
+            "turn_final_text",
         )
     rows = [r for r in await ledger.fetch_by_turn("turn_j")
             if r.event_type == "judge_verdict"]
     assert len(rows) == 1
     assert rows[0].payload["verdict"] == "PASS"
+    # #339 — confidence flows from JudgeVerdict to the ledger payload.
+    assert rows[0].payload["confidence"] == 0.82
     assert s._turn_judge_capture_signal is False
 
 


### PR DESCRIPTION
Closes #339. Clears the placeholder TODO left by PR #338 (#334 review N2): the ledger's `JudgeVerdictPayload.confidence` was already a `float`, but `JudgeVerdict` didn't carry one and we hardcoded `0.0` at the emit site.

## What changed

- `JudgeVerdict` gains a `confidence: float = 0.0` field.
- `JUDGE_SYSTEM_PROMPT` asks for an explicit second line:
  ```
  CONFIDENCE: <0.00–1.00>
  ```
  with a calibration ladder (0.90+ unambiguous, 0.30 guessing → prefer "uncertain" verdict instead).
- `_VERDICT_LINE` regex rewritten to lazy-match through multi-line reasons until it sees the `CONFIDENCE` line.
- `_CONFIDENCE_LINE` accepts signed decimals so `1.7` / `-0.4` parse and then clamp into `[0, 1]`, rather than silently falling back to default — the latter would mask a confused model.
- `parse_verdict` default ladder when `CONFIDENCE` is missing:
  | Parse path | Default |
  |---|---|
  | parsed verdict, no CONFIDENCE line | `0.5` (legacy/transitional, e.g. older response) |
  | fallback keyword search | `0.3` (we're guessing — flag low) |
  | empty response | `0.0` (already an error case) |
- `LoomSession._emit_ledger_judge_verdict` reads `JudgeVerdict.confidence` instead of hardcoding `0.0`.
- `_record_verdict_telemetry` log line carries `confidence` too.

## Where confidence does NOT show up

Per the issue's open question, confidence is **telemetry / ledger only** — it is *not* surfaced in `format_verdict_reminder`. Pushing a confidence float back at the agent feels gimmicky unless we can prove it changes behaviour. Easy to thread later if a real use case appears.

## Test plan

- [x] `pytest tests/` — 1636 passed (+8 new), 1 skipped, zero regressions
- [x] `TestVerdictConfidence` covers: parse / clamp / default ladder / `.85` form / garbage fallback / multiline reason doesn't swallow CONFIDENCE
- [x] `test_judge_verdict_pass_emits_and_no_capture_signal` pins the round-trip from `JudgeVerdict.confidence=0.82` into `judge_verdict.payload.confidence` in the ledger
- [ ] Manual: trigger a sync judge call (high-stakes tool batch + `is_high_stakes=True`), verify log line shows `confidence=0.XX`, ledger `judge_verdict` event has matching float

🤖 Generated with [Claude Code](https://claude.com/claude-code)