### PR TITLE
feat(memory): #336 — compaction subscriber on ledger turn_end

### DIFF
--- a/doc/53-AgentLedger-設計.md
+++ b/doc/53-AgentLedger-設計.md
@@ -908,7 +908,7 @@ Deferred 事件類型不阻擋 Step 5 cutover：它們是 additive event types�
 | Step 4 — Push subscriber + Pull fluent + raw SQL | ✅ 完成（#332） | `subscribe(...)` async ctx、`events.where().since().all()` 等、`execute_sql`；`is_live` monotonic 語意（一旦 drop 永久 False，`re-subscribe` 重置） |
 | Step 5 — ExecutionEnvelope 投影切換 | ✅ 完成（#333 + #337） | `LedgerEnvelopeProjector` + `_build_envelope_view` async 委派；#337 移除 `_live_record_for` / `envelope.records` transitional bridge — projector 純從 ledger 讀取，`ExecutionEnvelope` 退成 thin marker。`[ledger].enabled=false` 改 graceful empty-view fallback：EnvelopeStarted/Completed 仍 fire（shape 一致），但 nodes 為空 — tool detail 改由 `ToolBegin` / `ToolEnd` stream 提供，不保證 full envelope UI parity。把 ledger disable 視為 safety/diagnostic opt-out，不是支援 tier |
 | Step 5 — SessionLog 投影 | ✗ wontfix（#335） | 重新審視後決定不做純投影。理由見下方 §11.2.2。#335 改去處理可獨立分離的痛點：secret redaction 從寫入時搬到讀取時 |
-| Step 5 — Memory compaction subscribe `turn_end` 觸發 | ⚠️ deferred | 目前 inline trigger 在 stream_turn 內、行為正確；移成 background subscriber 為 architectural improvement，timing 細節需評估，獨立 follow-up issue |
+| Step 5 — Memory compaction subscribe `turn_end` 觸發 | ✅ 完成（#336） | `LoomSession._compaction_subscriber_loop` 訂閱 `turn_end` events for own session_id；`_compaction_lock` 序列化並發呼叫；compaction 不再阻塞 turn return，`CompressDone` 從 stream_turn 改為 buffer 在 `_pending_compactions` 由下一個 stream_turn 開頭 yield。Race：新 turn 與 in-flight compaction 並發時，compaction 已在開始時讀過 episodic snapshot，新寫入留待下次觸發；MemoryGovernor 自身的 admission gate 處理並發 semantic upsert |
 
 ### 11.2.2 SessionLog 與 ledger 的邊界（#335 決策）
 

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -839,7 +839,7 @@ class LoomSession:
         # old inline behaviour when the turn that triggered compaction
         # was itself the last one.
         self._compaction_lock: asyncio.Lock = asyncio.Lock()
-        self._pending_compactions: list[Any] = []
+        self._pending_compactions: list[CompressDone] = []
         self._compaction_task: asyncio.Task | None = None
 
         self.registry = ToolRegistry()
@@ -1110,6 +1110,13 @@ class LoomSession:
         # ledger; if ledger init failed above, no subscriber spawns and
         # compaction never fires (which matches Discord-without-ledger
         # mode's existing behaviour for envelope projection).
+        #
+        # Spawning here (before facade build below) is safe even though
+        # ``_run_compaction_check`` reaches into ``self._memory``: the
+        # subscriber blocks on ``turn_end`` events, which only fire
+        # from inside ``stream_turn``. ``stream_turn`` is only called
+        # after ``start()`` returns, by which point the facade has been
+        # built. (#346 review S1.)
         if self._ledger_store is not None:
             self._compaction_task = asyncio.create_task(
                 self._compaction_subscriber_loop(),
@@ -1616,12 +1623,19 @@ class LoomSession:
         # #336 — cancel the compaction subscriber loop. Same rationale
         # as judge tasks: a torn-down router / governor / facade must
         # not have a background task still trying to call into them.
-        if getattr(self, "_compaction_task", None):
+        if self._compaction_task is not None:
             self._compaction_task.cancel()
             try:
                 await self._compaction_task
-            except (asyncio.CancelledError, Exception):
+            except asyncio.CancelledError:
                 pass
+            except Exception:
+                # Subscriber loop has its own outer except Exception,
+                # so this branch should never fire. If it does, surface
+                # the trace rather than silently swallow. (#346 review N2.)
+                logger.exception(
+                    "memory compaction subscriber raised during shutdown"
+                )
             self._compaction_task = None
         if hasattr(self, "_scratchpad"):
             self._scratchpad.clear()

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -828,6 +828,19 @@ class LoomSession:
         # In-flight judge background tasks — kept so stop() can cancel them
         # cleanly and so a single turn can't fire judge twice.
         self._judge_tasks: set[asyncio.Task] = set()
+        # #336 — memory compaction subscriber. The inline trigger from
+        # stream_turn is replaced by a background task that subscribes
+        # to ledger ``turn_end`` events. _compaction_lock serialises
+        # concurrent runs (rare but possible when turn_end events
+        # arrive faster than the LLM call inside compress_session can
+        # finish). _pending_compactions buffers CompressDone events
+        # for the next stream_turn to yield; if the session ends
+        # before that yield, the signal is lost — which mirrors the
+        # old inline behaviour when the turn that triggered compaction
+        # was itself the last one.
+        self._compaction_lock: asyncio.Lock = asyncio.Lock()
+        self._pending_compactions: list[Any] = []
+        self._compaction_task: asyncio.Task | None = None
 
         self.registry = ToolRegistry()
         # Issue #154: JobStore + Scratchpad must exist before tools that may
@@ -1092,6 +1105,16 @@ class LoomSession:
                 self._ledger_store = None
                 self._ledger_emitter = None
                 self._envelope_projector = None
+
+        # #336 — start the memory compaction subscriber. Bound to the
+        # ledger; if ledger init failed above, no subscriber spawns and
+        # compaction never fires (which matches Discord-without-ledger
+        # mode's existing behaviour for envelope projection).
+        if self._ledger_store is not None:
+            self._compaction_task = asyncio.create_task(
+                self._compaction_subscriber_loop(),
+                name=f"memory_compaction:{self.session_id}",
+            )
 
         # Issue #147 Phase C: build the facade up-front so every later step
         # in start() (auto-import, MemoryIndexer, tool registration, etc.)
@@ -1590,6 +1613,16 @@ class LoomSession:
             for _t in list(self._judge_tasks):
                 _t.cancel()
             self._judge_tasks.clear()
+        # #336 — cancel the compaction subscriber loop. Same rationale
+        # as judge tasks: a torn-down router / governor / facade must
+        # not have a background task still trying to call into them.
+        if getattr(self, "_compaction_task", None):
+            self._compaction_task.cancel()
+            try:
+                await self._compaction_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._compaction_task = None
         if hasattr(self, "_scratchpad"):
             self._scratchpad.clear()
         # Issue #64: unmount all skill-declared checks before closing
@@ -1829,6 +1862,15 @@ class LoomSession:
                 )
         try:
             self._current_origin = origin
+
+            # #336 — surface CompressDone events buffered by the
+            # compaction subscriber from the previous turn. Yielded
+            # before any other turn-level events so Discord shows the
+            # status message at the natural turn boundary.
+            if self._pending_compactions:
+                for _ev in self._pending_compactions:
+                    yield _ev
+                self._pending_compactions.clear()
 
             # Issue #131: Reset abort signal from previous turn so the session
             # is not permanently stuck after a circuit-breaker trip.
@@ -2211,30 +2253,13 @@ class LoomSession:
                     # Issue #58: trigger skill self-assessment before TurnDone
                     self._trigger_skill_assessment()
 
-                    # Mid-session episodic compression: configurable via loom.toml
-                    # [memory] episodic_compress_threshold (default 30).
-                    # Count only *uncompressed* rows so soft-deleted entries from
-                    # prior compressions don't keep the threshold permanently
-                    # satisfied (would re-trigger the LLM every turn).
-                    try:
-                        ep_count = await self._memory.episodic.count_session(
-                            self.session_id, uncompressed_only=True,
-                        )
-                        if ep_count >= self._episodic_compress_threshold:
-                            fact_count = await compress_session(
-                                self.session_id,
-                                self._memory.episodic, self._memory.semantic,
-                                self.router, self.model,
-                                governor=self._governor,
-                                telemetry=self._telemetry,
-                            )
-                            if fact_count:
-                                yield CompressDone(fact_count=fact_count)
-                            # Rebuild MemoryIndex so long-running sessions (Discord)
-                            # see updated fact/anti-pattern counts without restarting.
-                            await self._refresh_memory_index()
-                    except Exception:
-                        pass  # never block the turn on compression failure
+                    # #336 — mid-session episodic compaction was previously
+                    # an inline ``ep_count >= threshold`` check here. The
+                    # trigger is now ``_compaction_subscriber_loop``, fed
+                    # by ledger ``turn_end`` events. ``CompressDone`` lands
+                    # in ``self._pending_compactions`` and surfaces at the
+                    # start of the next stream_turn; this turn's TurnDone
+                    # no longer waits on the LLM compaction call.
 
                     self._last_think = "".join(_think_parts).strip()
                     _tier_hint = self._tick_tier_counter()
@@ -3638,6 +3663,85 @@ class LoomSession:
             )
         except Exception:
             logger.exception("ledger thought emit failed; continuing")
+
+    # ------------------------------------------------------------------
+    # #336 — memory compaction subscriber (doc/53 §6.4 push pattern)
+    # ------------------------------------------------------------------
+
+    async def _run_compaction_check(self) -> None:
+        """One pass of the threshold-driven compaction logic.
+
+        Extracted from the prior inline trigger in ``stream_turn``.
+        Behaviour is unchanged: count uncompressed episodic rows, run
+        ``compress_session`` if past threshold, refresh the memory
+        index. The CompressDone signal is appended to
+        ``_pending_compactions`` so the next ``stream_turn`` yields
+        it for Discord/CLI consumers; if no next turn fires, the
+        signal is lost — same as before #336 for late-turn triggers.
+
+        Race contract: a new turn writing fresh episodic entries
+        during this call is safe — ``compress_session`` reads a
+        snapshot up front, marks only that snapshot at the end.
+        Concurrent compaction runs are blocked by ``_compaction_lock``
+        in the subscriber loop.
+        """
+        try:
+            ep_count = await self._memory.episodic.count_session(
+                self.session_id, uncompressed_only=True,
+            )
+            if ep_count < self._episodic_compress_threshold:
+                return
+            fact_count = await compress_session(
+                self.session_id,
+                self._memory.episodic, self._memory.semantic,
+                self.router, self.model,
+                governor=self._governor,
+                telemetry=self._telemetry,
+            )
+            if fact_count:
+                self._pending_compactions.append(
+                    CompressDone(fact_count=fact_count)
+                )
+            # Rebuild MemoryIndex so long-running sessions (Discord)
+            # see updated fact/anti-pattern counts without restarting.
+            await self._refresh_memory_index()
+        except Exception:
+            logger.exception(
+                "memory compaction subscriber: compress_session failed; "
+                "continuing"
+            )
+
+    async def _compaction_subscriber_loop(self) -> None:
+        """Background task: subscribe to ``turn_end`` events for this
+        session and trigger compaction. Runs for the lifetime of the
+        session; cancelled by ``stop()`` alongside other background
+        tasks.
+
+        Subscribing rather than polling means compaction is decoupled
+        from stream_turn's hot path: the turn returns immediately
+        after ``turn_end`` is emitted, and the LLM compaction call
+        happens off the user-visible timeline.
+        """
+        if self._ledger_store is None:
+            return
+        try:
+            async with self._ledger_store.subscribe(
+                event_types=["turn_end"],
+                session_id=self.session_id,
+            ) as subscriber:
+                async for _event in subscriber:
+                    # Serialise concurrent runs. If a turn_end fires
+                    # while the previous compaction is still mid-LLM,
+                    # the second attempt waits rather than running in
+                    # parallel and double-writing semantic facts.
+                    async with self._compaction_lock:
+                        await self._run_compaction_check()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception(
+                "memory compaction subscriber loop crashed; will not restart"
+            )
 
     async def _on_trace(self, call: ToolCall, result: ToolResult) -> None:
         # #334 / doc/53 §3.3 — feed the per-turn artifact size accumulator

--- a/tests/test_memory_compaction_subscriber.py
+++ b/tests/test_memory_compaction_subscriber.py
@@ -1,0 +1,287 @@
+"""#336 — memory compaction subscriber.
+
+Tests the shape of the new background trigger:
+
+- ``_run_compaction_check`` does the threshold gate + ``compress_session``
+  call extracted from the prior inline trigger
+- ``_compaction_subscriber_loop`` reacts to ledger ``turn_end`` events
+- ``_compaction_lock`` serialises concurrent runs so two near-simultaneous
+  turn_end events don't cause double-write of semantic facts
+- ``_pending_compactions`` buffers CompressDone signals for the next
+  stream_turn to yield (Discord display path)
+
+The actual ``compress_session`` is heavy (LLM call) — every test
+monkeypatches the module-level binding so we can drive the gate logic
+deterministically and instrument call counts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest_asyncio
+
+from loom.core.events import CompressDone
+from loom.core.ledger import (
+    LedgerEmitter,
+    LedgerStore,
+    TurnEndPayload,
+    async_correlation_scope,
+    async_turn_scope,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + stub session
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def ledger(tmp_path: Path) -> LedgerStore:
+    s = LedgerStore(
+        db_path=tmp_path / "ledger.db",
+        blob_dir=tmp_path / "blobs",
+    )
+    await s.open()
+    try:
+        yield s
+    finally:
+        await s.close()
+
+
+@pytest_asyncio.fixture
+def emitter(ledger: LedgerStore) -> LedgerEmitter:
+    return LedgerEmitter(ledger, session_id="sess_compact")
+
+
+def _make_stub(
+    *,
+    ep_count: int,
+    threshold: int = 30,
+    fact_count: int = 4,
+    raise_in_compress: bool = False,
+):
+    """Bind the three #336 helpers from LoomSession onto an Any-shaped
+    stub. Avoids spinning up a full LoomSession (which needs router /
+    Discord / Anthropic creds). The helpers only touch episodic /
+    semantic / governor / telemetry / threshold / lock / pending list."""
+    from loom.core.session import LoomSession
+
+    class _StubMemory:
+        class episodic:
+            @staticmethod
+            async def count_session(_sid: str, *, uncompressed_only: bool = False):
+                return ep_count
+
+        semantic = None  # not touched in fake compress
+
+    s = types.SimpleNamespace()
+    s.session_id = "sess_compact"
+    s._memory = _StubMemory()
+    s.router = None
+    s.model = "test-model"
+    s._governor = None
+    s._telemetry = None
+    s._episodic_compress_threshold = threshold
+    s._compaction_lock = asyncio.Lock()
+    s._pending_compactions: list[Any] = []
+    s._ledger_store = None  # subscriber path tests set this when needed
+
+    # Track calls via attributes on the stub.
+    s.compress_called = 0
+    s.refresh_called = 0
+
+    async def _fake_compress(*_a, **_kw):
+        s.compress_called += 1
+        if raise_in_compress:
+            raise RuntimeError("simulated compress_session failure")
+        return fact_count
+
+    async def _fake_refresh():
+        s.refresh_called += 1
+
+    # Monkey-patch the module-level binding via session_module import path.
+    # _run_compaction_check resolves compress_session via the module-level
+    # binding — patching the imported reference is sufficient.
+    import loom.core.session as session_module
+
+    s._fake_compress = _fake_compress
+    s._fake_refresh = _fake_refresh
+    s._session_module = session_module
+
+    s._run_compaction_check = LoomSession._run_compaction_check.__get__(s)
+    s._refresh_memory_index = _fake_refresh
+    s._compaction_subscriber_loop = (
+        LoomSession._compaction_subscriber_loop.__get__(s)
+    )
+    return s
+
+
+# ---------------------------------------------------------------------------
+# _run_compaction_check — threshold gate
+# ---------------------------------------------------------------------------
+
+
+async def test_under_threshold_no_compress_call(monkeypatch) -> None:
+    s = _make_stub(ep_count=10, threshold=30)
+    monkeypatch.setattr(s._session_module, "compress_session", s._fake_compress)
+    await s._run_compaction_check()
+    assert s.compress_called == 0
+    assert s.refresh_called == 0
+    assert s._pending_compactions == []
+
+
+async def test_at_threshold_compresses_and_buffers_compress_done(
+    monkeypatch,
+) -> None:
+    s = _make_stub(ep_count=30, threshold=30, fact_count=7)
+    monkeypatch.setattr(s._session_module, "compress_session", s._fake_compress)
+    await s._run_compaction_check()
+    assert s.compress_called == 1
+    assert s.refresh_called == 1
+    assert len(s._pending_compactions) == 1
+    assert isinstance(s._pending_compactions[0], CompressDone)
+    assert s._pending_compactions[0].fact_count == 7
+
+
+async def test_zero_facts_no_compress_done_emitted(monkeypatch) -> None:
+    """compress_session can return 0 (LLM produced nothing useful);
+    nothing to surface to Discord in that case."""
+    s = _make_stub(ep_count=50, threshold=30, fact_count=0)
+    monkeypatch.setattr(s._session_module, "compress_session", s._fake_compress)
+    await s._run_compaction_check()
+    assert s.compress_called == 1
+    assert s._pending_compactions == []  # 0 facts → no signal
+
+
+async def test_compress_failure_swallowed_no_pending_compaction(
+    monkeypatch,
+) -> None:
+    """Compression failures must not propagate — turn flow can't break
+    on a background subsystem."""
+    s = _make_stub(
+        ep_count=50, threshold=30, fact_count=4, raise_in_compress=True,
+    )
+    monkeypatch.setattr(s._session_module, "compress_session", s._fake_compress)
+    await s._run_compaction_check()  # must not raise
+    assert s.compress_called == 1
+    assert s._pending_compactions == []
+
+
+# ---------------------------------------------------------------------------
+# _compaction_lock — serialisation
+# ---------------------------------------------------------------------------
+
+
+async def test_lock_serialises_concurrent_compactions(monkeypatch) -> None:
+    """Two near-simultaneous turn_end events must not double-compact.
+    Drive _run_compaction_check twice in parallel under the lock and
+    confirm one waits for the other."""
+    s = _make_stub(ep_count=30, threshold=30, fact_count=2)
+
+    in_flight = 0
+    max_in_flight = 0
+
+    async def _slow_compress(*_a, **_kw):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(0.05)
+        in_flight -= 1
+        return 2
+
+    monkeypatch.setattr(s._session_module, "compress_session", _slow_compress)
+
+    async def _gated() -> None:
+        async with s._compaction_lock:
+            await s._run_compaction_check()
+
+    await asyncio.gather(_gated(), _gated())
+    assert max_in_flight == 1  # never two parallel compress calls
+
+
+# ---------------------------------------------------------------------------
+# _compaction_subscriber_loop — wired to ledger turn_end events
+# ---------------------------------------------------------------------------
+
+
+async def test_subscriber_triggers_on_turn_end_event(
+    monkeypatch, ledger: LedgerStore, emitter: LedgerEmitter,
+) -> None:
+    s = _make_stub(ep_count=40, threshold=30, fact_count=3)
+    s._ledger_store = ledger
+
+    monkeypatch.setattr(s._session_module, "compress_session", s._fake_compress)
+
+    task = asyncio.create_task(s._compaction_subscriber_loop())
+    # Give the subscriber a chance to register.
+    await asyncio.sleep(0.05)
+
+    async with async_turn_scope("turn_sub"), async_correlation_scope("c1"):
+        await emitter.emit_turn_end(
+            turn_id="turn_sub",
+            payload=TurnEndPayload(
+                outcome="clean", duration_ms=100, token_usage={},
+            ),
+        )
+
+    # Wait for the subscriber to drain and run compaction.
+    for _ in range(50):
+        if s.compress_called >= 1:
+            break
+        await asyncio.sleep(0.02)
+
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert s.compress_called == 1
+    assert len(s._pending_compactions) == 1
+
+
+async def test_subscriber_ignores_other_event_types(
+    monkeypatch, ledger: LedgerStore, emitter: LedgerEmitter,
+) -> None:
+    """Subscriber filters event_types=[turn_end]; turn_start / other
+    events must not trigger compaction."""
+    s = _make_stub(ep_count=40, threshold=30, fact_count=3)
+    s._ledger_store = ledger
+
+    monkeypatch.setattr(s._session_module, "compress_session", s._fake_compress)
+
+    task = asyncio.create_task(s._compaction_subscriber_loop())
+    await asyncio.sleep(0.05)
+
+    from loom.core.ledger import TurnStartPayload
+
+    async with async_turn_scope("turn_other"), async_correlation_scope("c1"):
+        await emitter.emit_turn_start(
+            turn_id="turn_other",
+            payload=TurnStartPayload(
+                prompt_stack_hash="sha256:x", prompt_stack_components={},
+            ),
+        )
+
+    await asyncio.sleep(0.1)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert s.compress_called == 0
+
+
+async def test_subscriber_no_op_without_ledger_store() -> None:
+    """If ledger init failed (or [ledger].enabled=false), the subscriber
+    loop is a no-op rather than crashing."""
+    s = _make_stub(ep_count=40)
+    s._ledger_store = None
+    # Should return immediately without raising.
+    await s._compaction_subscriber_loop()
+    assert s.compress_called == 0


### PR DESCRIPTION
Closes #336. Last open follow-up under epic #320.

doc/53 §6.4 prescribed memory compaction as a push (turn_end trigger) + pull projection pattern. Pre-#336 the trigger lived inline in `stream_turn`, blocking the turn return on the LLM compaction call. This PR moves it to a session-scoped background subscriber on ledger `turn_end` events — the architectural cleanup that #336 was filed for.

## What changed

- **`LoomSession.__init__`** — three new fields:
  - `_compaction_lock: asyncio.Lock` — serialises concurrent runs so two near-simultaneous `turn_end` events can't double-write semantic facts
  - `_pending_compactions: list[CompressDone]` — buffer for the next `stream_turn` to yield (Discord status display path)
  - `_compaction_task: asyncio.Task | None` — background task handle for clean shutdown
- **`_run_compaction_check`** — extracted from the inline trigger; same threshold + `compress_session` + `refresh_memory_index` flow, but appends `CompressDone` to the buffer instead of yielding directly. Failures swallowed (turn flow can't break on a background subsystem).
- **`_compaction_subscriber_loop`** — subscribes to `turn_end` events for its own `session_id`, runs `_run_compaction_check` under the lock. No-op when `_ledger_store is None` (ledger-disabled mode).
- **`start()` / `stop()`** — spawn after ledger init; cancel + await alongside `_judge_tasks` so torn-down router/governor/facade isn't called from a zombie task.
- **`stream_turn`** — inline trigger block removed. `CompressDone` drains at the *start* of the next turn (before any other yields, so Discord shows the status message at a natural turn boundary).

## Race contract (per #336 exit criteria)

A new turn writing fresh episodic entries during an in-flight compaction is safe:

- `compress_session` reads its episodic snapshot up front and only marks *that snapshot* at the end
- New entries land on the uncompressed pile and get picked up by the next compaction
- `_compaction_lock` blocks two `turn_end` events from triggering parallel `compress_session` runs (which would double-write semantic facts before the mark step)
- `MemoryGovernor`'s admission gate already serialises concurrent semantic upserts at its layer

## Trade-off

If the session ends before the next `stream_turn` drains `_pending_compactions`, the `CompressDone` signal is lost — same as the pre-#336 inline behaviour when the triggering turn was itself the last one. Acceptable for an architectural cleanup with no behavioural improvement promised by the issue.

## Exit Criteria (issue #336)

- [x] inline trigger removed from `stream_turn`
- [x] subscriber lives in `LoomSession`, lifecycle bound to `start()` / `stop()`
- [x] race contract documented (commit message + doc/53 §11.2.1)
- [x] doc/53 §11.2.1 row → ✅
- [x] existing memory compaction tests still green; 8 new tests pin the new path

## Test plan

- [x] `pytest tests/` — 1644 passed (+8 new), 1 skipped, zero regressions
- [x] New tests cover: threshold gate (under / at / zero-fact / failure), lock serialisation under concurrent `gather()`, subscriber triggers on `turn_end`, subscriber filters out non-`turn_end` events, no-op when `_ledger_store is None`
- [ ] Manual: `loom chat` with `[memory] episodic_compress_threshold = 5` (low for testability), fire 6 turns rapid-fire, observe that turn responses don't visibly stall on the LLM compaction call and `CompressDone` shows up on the *next* turn boundary

## Diff stat

```
 3 files changed, 416 insertions(+), 25 deletions(-)
```

Most lines are the new test file + helper docstrings; the actual refactor on session.py is small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)