### PR TITLE
feat(openai): add Codex OAuth chat provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,12 +383,16 @@ loom auth openai                  # Codex CLI login helper + OPENAI_API_KEY setu
 loom chat                          # interactive CLI
 loom chat --tui                    # TUI mode
 loom chat --model gpt-5.5          # OpenAI model
+loom chat --model codex/gpt-5.5    # Codex OAuth backend
 loom chat --model ollama/llama3.2  # local model
 loom discord start --autonomy --channel <id>
 loom autonomy start
 ```
 
-Model routing works by prefix — `gpt-*`, `openai/<model>`, `claude-*`, `ollama/<name>`, `lmstudio/<name>`, `MiniMax-*`. Switch mid-session with `/model`.
+Model routing works by prefix — `gpt-*` and `openai/<model>` use
+`OPENAI_API_KEY`, while `codex/<model>` uses the Codex OAuth token from
+`codex login`. Other prefixes include `claude-*`, `ollama/<name>`,
+`lmstudio/<name>`, and `MiniMax-*`. Switch mid-session with `/model`.
 
 Image generation includes `openai__text_to_image`, which calls `gpt-image-2`
 and writes a PNG/WebP/JPEG under the workspace. With Codex OAuth it uses the

--- a/doc/14-LLM-Router.md
+++ b/doc/14-LLM-Router.md
@@ -86,13 +86,15 @@ LLMRouter.chat(model="ollama/llama3.2", messages=[...])
 
 ```python
 from loom.core.cognition.providers import (
-    MiniMaxProvider, AnthropicProvider, OllamaProvider, LMStudioProvider,
+    MiniMaxProvider, AnthropicProvider, OpenAIProvider, CodexResponsesProvider,
+    OllamaProvider, LMStudioProvider,
 )
 
 router = LLMRouter()
 router.register(MiniMaxProvider(api_key=..., model="MiniMax-M2.7"), default=True)
 router.register(AnthropicProvider(api_key=...))
 router.register(OpenAIProvider(api_key=..., model="gpt-5.5"))
+router.register(CodexResponsesProvider(model="codex/gpt-5.5"), fallback=False)
 router.register(OllamaProvider(base_url="http://localhost:11434"))
 ```
 

--- a/doc/33-CLI-命令.md
+++ b/doc/33-CLI-命令.md
@@ -66,6 +66,9 @@ loom auth openai --skip-codex-login
 `OPENAI_API_KEY` 寫入專案 `.env`，供 Loom 的 OpenAI provider 使用。OpenAI 圖像工具會優先使用
 未過期的 Codex OAuth access token，並在自動模式下 fallback 到 `OPENAI_API_KEY`。
 
+聊天模型路由刻意分開：`gpt-*` / `openai/<model>` 走 `OPENAI_API_KEY`，
+`codex/<model>`（例如 `codex/gpt-5.5`）才走 Codex OAuth backend。
+
 ### `openai__text_to_image`
 
 Agent 可用工具，生成圖片並寫入 workspace。`auth_mode=codex` 走 Codex Responses backend；

--- a/doc/38-環境變數.md
+++ b/doc/38-環境變數.md
@@ -46,7 +46,7 @@ DATABASE_URL=sqlite:///~/.loom/data/loom.db
 | 變數 | 說明 | 必要 |
 |------|------|------|
 | `MINIMAX_API_KEY` | MiniMax API Key | 是 |
-| `OPENAI_API_KEY` | OpenAI API Key；可用 `loom auth openai` 互動式設定；OpenAI 圖像工具在 Codex OAuth 不可用時 fallback 使用 | 用於 gpt-* / openai/<model> / gpt-image-2 |
+| `OPENAI_API_KEY` | OpenAI API Key；可用 `loom auth openai` 互動式設定；OpenAI 圖像工具在 Codex OAuth 不可用時 fallback 使用；不供 codex/<model> 聊天路由使用 | 用於 gpt-* / openai/<model> / gpt-image-2 |
 | `ANTHROPIC_API_KEY` | Anthropic API Key | 用於 claude-* 模型 |
 | `AZURE_OPENAI_API_KEY` | Azure OpenAI API Key | 否 |
 | `AZURE_OPENAI_ENDPOINT` | Azure OpenAI Endpoint | 否 |

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -34,6 +34,7 @@ personality = ""
 #   claude-*                → Anthropic provider                         (ANTHROPIC_API_KEY in .env)
 #   gpt-*                   → OpenAI official API (gpt-5.5, gpt-5.5-pro)  (OPENAI_API_KEY in .env)
 #   openai/<model>          → OpenAI official API with explicit prefix    (OPENAI_API_KEY in .env)
+#   codex/<model>           → Codex OAuth backend (e.g. codex/gpt-5.5)     (`codex login`)
 #   deepseek-*              → DeepSeek official via Anthropic-compatible endpoint  (DEEPSEEK_API_KEY in .env)
 #   openrouter/<vendor>/<m> → OpenRouter aggregator (e.g. openrouter/deepseek/deepseek-v4-pro)  (OPENROUTER_API_KEY in .env)
 #   ollama/<name>           → local Ollama server  (enable [providers.ollama] below)
@@ -104,6 +105,11 @@ reminder_after_turns = 10
 # [providers.openai]
 # base_url      = "https://api.openai.com/v1"
 # default_model = "gpt-5.5"
+
+# [providers.codex]
+# enabled       = true                 # optional; explicit --model codex/... also registers it
+# base_url      = "https://chatgpt.com/backend-api/codex/responses"
+# default_model = "gpt-5.5"            # bare model name — no "codex/" prefix here
 #
 # OpenAI image generation uses the openai__text_to_image tool.
 # It defaults to gpt-image-2. Codex OAuth uses the Codex Responses backend;

--- a/loom/core/cognition/openai_auth.py
+++ b/loom/core/cognition/openai_auth.py
@@ -43,7 +43,7 @@ def _jwt_exp(token: str) -> int | None:
     payload = parts[1] + "=" * ((4 - len(parts[1]) % 4) % 4)
     try:
         data = json.loads(base64.urlsafe_b64decode(payload.encode("ascii")))
-    except (ValueError, json.JSONDecodeError):
+    except Exception:
         return None
     exp = data.get("exp")
     return int(exp) if isinstance(exp, (int, float)) else None

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -1024,6 +1024,8 @@ class CodexResponsesProvider(LLMProvider):
         output_tokens = 0
         response_status = "in_progress"
 
+        # SSE may already have yielded partial output; retrying mid-stream can
+        # duplicate content or tool calls, so failures propagate to the caller.
         async with httpx.AsyncClient(timeout=self._timeout) as client:
             async with client.stream(
                 "POST",

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -8,6 +8,7 @@ a provider SDK directly — it always goes through this interface.
 Supported providers
 -------------------
 OpenAIProvider     — api.openai.com/v1 (OpenAI-compatible chat completions)
+CodexResponsesProvider — chatgpt.com/backend-api/codex/responses (Codex OAuth)
 AnthropicProvider  — api.anthropic.com  (also MiniMax via base_url="https://api.minimax.io/anthropic")
 OpenRouterProvider — openrouter.ai/api/v1 (OpenAI-compatible aggregator)
 DeepSeek           — official api.deepseek.com via Anthropic-compatible endpoint
@@ -878,6 +879,242 @@ class OpenAIProvider(_OpenAICompatibleBase):
     DEFAULT_MODEL = "gpt-5.5"
     DEFAULT_TIMEOUT = 180.0
     MAX_TOKENS_PARAM = "max_completion_tokens"
+
+
+class CodexResponsesProvider(LLMProvider):
+    """
+    OpenAI Codex OAuth chat via ChatGPT's Codex Responses backend.
+
+    Routing prefix: ``codex/``. This provider intentionally does not fall back
+    to ``OPENAI_API_KEY`` so users do not accidentally burn API quota when they
+    selected Codex OAuth mode.
+    """
+
+    name = "codex"
+    ROUTING_PREFIX = "codex/"
+    DEFAULT_MODEL = "gpt-5.5"
+    DEFAULT_BASE_URL = "https://chatgpt.com/backend-api/codex/responses"
+    DEFAULT_TIMEOUT = 180.0
+
+    def __init__(
+        self,
+        model: str = "",
+        base_url: str = "",
+        timeout: float = 0.0,
+    ) -> None:
+        self.model = model or (self.ROUTING_PREFIX + self.DEFAULT_MODEL)
+        self._base_url = base_url or self.DEFAULT_BASE_URL
+        self._timeout = timeout or self.DEFAULT_TIMEOUT
+
+    def _api_model(self) -> str:
+        return self.model.removeprefix(self.ROUTING_PREFIX)
+
+    def _build_payload(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        max_tokens: int,
+    ) -> dict[str, Any]:
+        instructions: list[str] = []
+        input_items: list[dict[str, Any]] = []
+        for msg in messages:
+            role = msg.get("role")
+            content = msg.get("content", "")
+            if role == "system":
+                if content:
+                    instructions.append(str(content))
+                continue
+            if role == "tool":
+                call_id = msg.get("tool_call_id")
+                if call_id:
+                    input_items.append({
+                        "type": "function_call_output",
+                        "call_id": call_id,
+                        "output": str(content),
+                    })
+                continue
+            if role == "assistant":
+                if content:
+                    input_items.append({
+                        "role": "assistant",
+                        "content": [{"type": "input_text", "text": str(content)}],
+                    })
+                for tc in msg.get("tool_calls", []) or []:
+                    fn = tc.get("function", {}) if isinstance(tc, dict) else {}
+                    input_items.append({
+                        "type": "function_call",
+                        "call_id": tc.get("id") or str(uuid.uuid4()),
+                        "name": fn.get("name", ""),
+                        "arguments": fn.get("arguments", "{}"),
+                    })
+                continue
+            input_items.append({
+                "role": "user" if role != "assistant" else "assistant",
+                "content": [{"type": "input_text", "text": str(content)}],
+            })
+
+        payload: dict[str, Any] = {
+            "model": self._api_model(),
+            "instructions": "\n\n".join(instructions) or "You are a helpful assistant.",
+            "input": input_items,
+            "stream": True,
+            "store": False,
+            "max_output_tokens": max_tokens,
+        }
+        if tools:
+            payload["tools"] = self.format_tools(tools)
+        return payload
+
+    def format_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        formatted: list[dict[str, Any]] = []
+        for tool in tools:
+            formatted.append({
+                "type": "function",
+                "name": tool.get("name", ""),
+                "description": tool.get("description", ""),
+                "parameters": tool.get("parameters") or tool.get("input_schema") or {},
+            })
+        return formatted
+
+    async def chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        max_tokens: int = 8096,
+    ) -> LLMResponse:
+        text_parts: list[str] = []
+        final: LLMResponse | None = None
+        async for chunk, resp in self.stream_chat(
+            messages=messages,
+            tools=tools,
+            max_tokens=max_tokens,
+        ):
+            if resp is not None:
+                final = resp
+            elif chunk:
+                text_parts.append(chunk)
+        return final or LLMResponse(
+            text="".join(text_parts) or None,
+            tool_uses=[],
+            stop_reason="end_turn",
+        )
+
+    async def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        max_tokens: int = 8096,
+        *,
+        abort_signal: Any = None,
+    ) -> AsyncIterator[tuple[str, LLMResponse | None]]:
+        import httpx
+        from loom.core.cognition.openai_auth import load_codex_oauth_credential
+
+        credential = load_codex_oauth_credential()
+        if credential is None:
+            raise RuntimeError(
+                "No unexpired Codex OAuth token found. Run `codex login` "
+                "or switch to an API-key OpenAI model such as `gpt-5.5`."
+            )
+
+        payload = self._build_payload(messages, tools, max_tokens)
+        full_content = ""
+        output_items: list[dict[str, Any]] = []
+        input_tokens = 0
+        output_tokens = 0
+        response_status = "in_progress"
+
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            async with client.stream(
+                "POST",
+                self._base_url,
+                headers={
+                    "Authorization": f"Bearer {credential.token}",
+                    "Content-Type": "application/json",
+                    "Accept": "text/event-stream",
+                },
+                json=payload,
+            ) as resp:
+                resp.raise_for_status()
+                event: str | None = None
+                data_lines: list[str] = []
+                async for line in resp.aiter_lines():
+                    if abort_signal is not None and abort_signal.is_set():
+                        break
+                    if line.startswith("event: "):
+                        event = line[7:]
+                    elif line.startswith("data: "):
+                        data_lines.append(line[6:])
+                    elif line == "" and event:
+                        raw = "\n".join(data_lines)
+                        event = None
+                        data_lines = []
+                        try:
+                            data = json.loads(raw)
+                        except json.JSONDecodeError:
+                            continue
+                        delta = data.get("delta")
+                        if isinstance(delta, str):
+                            full_content += delta
+                            yield (delta, None)
+                        item = data.get("item")
+                        if isinstance(item, dict) and data.get("type", "").endswith("output_item.done"):
+                            output_items.append(item)
+                        response = data.get("response")
+                        if isinstance(response, dict):
+                            response_status = str(response.get("status") or response_status)
+                            usage = response.get("usage") or {}
+                            if isinstance(usage, dict):
+                                input_tokens = int(
+                                    usage.get("input_tokens") or usage.get("prompt_tokens") or input_tokens
+                                )
+                                output_tokens = int(
+                                    usage.get("output_tokens") or usage.get("completion_tokens") or output_tokens
+                                )
+
+        tool_uses: list[ToolUse] = []
+        raw_tool_calls: list[dict[str, Any]] = []
+        for item in output_items:
+            if item.get("type") != "function_call":
+                continue
+            args_raw = item.get("arguments") or "{}"
+            try:
+                args = json.loads(args_raw)
+            except (json.JSONDecodeError, ValueError):
+                args = {"_raw": args_raw}
+            call_id = item.get("call_id") or item.get("id") or str(uuid.uuid4())
+            name = item.get("name") or ""
+            tool_uses.append(ToolUse(id=call_id, name=name, args=args))
+            raw_tool_calls.append({
+                "id": call_id,
+                "type": "function",
+                "function": {"name": name, "arguments": args_raw},
+            })
+
+        stop_reason = "tool_use" if tool_uses else "end_turn"
+        if response_status == "incomplete":
+            stop_reason = "max_tokens"
+
+        raw_message: dict[str, Any] = {"role": "assistant", "content": full_content}
+        if raw_tool_calls:
+            raw_message["tool_calls"] = raw_tool_calls
+        yield ("", LLMResponse(
+            text=full_content or None,
+            tool_uses=tool_uses,
+            stop_reason=stop_reason,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            raw_message=raw_message,
+        ))
+
+    def format_tool_result(
+        self, tool_use_id: str, content: str, success: bool = True
+    ) -> dict[str, Any]:
+        return {
+            "role": "tool",
+            "tool_call_id": tool_use_id,
+            "content": content if success else f"Error: {content}",
+        }
 
 
 class LMStudioProvider(_OpenAICompatibleBase):

--- a/loom/core/cognition/router.py
+++ b/loom/core/cognition/router.py
@@ -11,6 +11,7 @@ Model routing rules
 "claude-*"     → AnthropicProvider
 "gpt-*"        → OpenAIProvider
 "openai/*"     → OpenAIProvider
+"codex/*"      → CodexResponsesProvider
 "ollama/*"     → OllamaProvider    (local Ollama server)
 "lmstudio/*"   → LMStudioProvider  (local LM Studio server)
 (default)      → first registered provider
@@ -74,6 +75,7 @@ class LLMRouter:
         ("claude-",    "anthropic"),
         ("gpt-",       "openai"),
         ("openai/",    "openai"),
+        ("codex/",     "codex"),
         ("openrouter/", "openrouter"),
         ("deepseek-",  "deepseek"),
         ("ollama/",    "ollama"),
@@ -84,9 +86,14 @@ class LLMRouter:
         self._providers: dict[str, LLMProvider] = {}
         self._default: str | None = None
 
-    def register(self, provider: LLMProvider, default: bool = False) -> "LLMRouter":
+    def register(
+        self,
+        provider: LLMProvider,
+        default: bool = False,
+        fallback: bool = True,
+    ) -> "LLMRouter":
         self._providers[provider.name] = provider
-        if default or self._default is None:
+        if default or (fallback and self._default is None):
             self._default = provider.name
         return self
 

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -4572,6 +4572,9 @@ class LoomSession:
         and updates the provider's model attribute.  Returns True on success.
         """
         ok = self.router.switch_model(model)
+        if not ok and model.startswith("codex/"):
+            self.router = build_router(active_model=model)
+            ok = self.router.switch_model(model)
         if ok:
             self._model = model
         return ok

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -456,7 +456,7 @@ def _build_jobs_inject_message(jobstore: Any) -> str | None:
     return "\n".join(lines)
 
 
-def build_router() -> LLMRouter:
+def build_router(active_model: str | None = None) -> LLMRouter:
     """
     Build the LLM router with all available providers registered.
 
@@ -468,6 +468,7 @@ def build_router() -> LLMRouter:
       MiniMax    — MINIMAX_API_KEY  (uses Anthropic-compatible endpoint, name="minimax")
       Anthropic  — ANTHROPIC_API_KEY
       OpenAI     — OPENAI_API_KEY
+      Codex      — Codex OAuth from `codex login` (explicit codex/<model> prefix)
       OpenRouter — OPENROUTER_API_KEY (OpenAI-compatible multi-vendor aggregator)
       DeepSeek   — DEEPSEEK_API_KEY   (official DeepSeek API, OpenAI-compatible)
 
@@ -479,6 +480,7 @@ def build_router() -> LLMRouter:
     from loom.core.cognition.providers import (
         OllamaProvider,
         LMStudioProvider,
+        CodexResponsesProvider,
         OpenAIProvider,
         OpenRouterProvider,
     )
@@ -487,6 +489,7 @@ def build_router() -> LLMRouter:
     cfg = _load_loom_config()
     router = LLMRouter()
     default = get_default_model()
+    requested_model = active_model or default
 
     # MiniMax — Anthropic-compatible endpoint, registered under provider name "minimax"
     # so the routing table ("MiniMax-" → "minimax") and switch_model() continue to work.
@@ -541,6 +544,29 @@ def build_router() -> LLMRouter:
                 api_key=openai_key,
             ),
             default=default_is_openai,
+        )
+
+    # Codex OAuth — explicit opt-in via codex/<model>. This avoids silently
+    # burning OPENAI_API_KEY quota when users expect ChatGPT/Codex billing.
+    codex_cfg = cfg.get("providers", {}).get("codex", {})
+    codex_requested = requested_model.startswith("codex/")
+    codex_default = default.startswith("codex/")
+    codex_enabled = bool(codex_cfg.get("enabled", False))
+    if codex_requested or codex_default or codex_enabled:
+        codex_model = codex_cfg.get("default_model", CodexResponsesProvider.DEFAULT_MODEL)
+        if requested_model.startswith("codex/"):
+            codex_model = requested_model
+        elif default.startswith("codex/"):
+            codex_model = default
+        else:
+            codex_model = f"codex/{codex_model}"
+        router.register(
+            CodexResponsesProvider(
+                model=codex_model,
+                base_url=codex_cfg.get("base_url", "") or CodexResponsesProvider.DEFAULT_BASE_URL,
+            ),
+            default=codex_default or codex_requested,
+            fallback=codex_default or codex_requested,
         )
 
     # OpenRouter — OpenAI-compatible aggregator. Single key fronts many vendors.
@@ -686,7 +712,7 @@ class LoomSession:
         self._provisional_title = provisional_title
         # Workspace root — all relative file paths resolve here; defaults to CWD
         self.workspace: Path = (workspace or Path.cwd()).resolve()
-        self.router = build_router()
+        self.router = build_router(self.model)
 
         # AgentLedger handles — opened in start(), closed in stop().
         # Until start() runs, these are None and every subsystem's optional

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -811,6 +811,7 @@ class LoomSession:
         )
         # ``None`` = follow ``_default_tier``; integer = sticky override.
         self._sticky_tier: int | None = None
+        self._manual_model_override: bool = False
         # Counts consecutive turns at the *active* tier (sticky or default).
         # Reset on tier change; surfaces in TierExpiryHint after threshold.
         self._turns_at_current_tier: int = 0
@@ -3354,10 +3355,12 @@ class LoomSession:
     def _active_model(self) -> str:
         """Resolve the model name for the active tier.
 
-        Falls back to ``self._model`` (the constructor / ``set_model`` value)
-        when the tier system isn't configured for this tier — preserves
-        backward compatibility with sessions that don't use #276 at all.
+        A manual ``/model`` selection wins until the user or agent explicitly
+        changes tier again. Otherwise, falls back to ``self._model`` when the
+        tier system isn't configured for this tier.
         """
+        if getattr(self, "_manual_model_override", False):
+            return self._model
         tier = self._active_tier()
         return self._tier_models.get(tier, self._model)
 
@@ -3377,6 +3380,7 @@ class LoomSession:
             new_tier = None
         if new_tier == self._sticky_tier:
             return None  # no-op
+        self._manual_model_override = False
         self._sticky_tier = new_tier
         self._turns_at_current_tier = 0
         self._tier_reminder_emitted = False
@@ -4577,6 +4581,7 @@ class LoomSession:
             ok = self.router.switch_model(model)
         if ok:
             self._model = model
+            self._manual_model_override = True
         return ok
 
 

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -816,6 +816,7 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
                 "[loom.muted]  claude-*            requires ANTHROPIC_API_KEY in .env[/loom.muted]\n"
                 "[loom.muted]  gpt-*               requires OPENAI_API_KEY in .env (try `loom auth openai`)[/loom.muted]\n"
                 "[loom.muted]  openai/<model>      explicit OpenAI prefix (e.g. openai/gpt-5.5)[/loom.muted]\n"
+                "[loom.muted]  codex/<model>       Codex OAuth backend (e.g. codex/gpt-5.5; run `codex login`)[/loom.muted]\n"
                 "[loom.muted]  openrouter/<v>/<m>  requires OPENROUTER_API_KEY in .env (e.g. openrouter/deepseek/deepseek-v4-pro)[/loom.muted]\n"
                 "[loom.muted]  deepseek-*          requires DEEPSEEK_API_KEY in .env  (e.g. deepseek-v4-pro)[/loom.muted]\n"
                 "[loom.muted]  ollama/<name>       enable [providers.ollama] in loom.toml[/loom.muted]\n"
@@ -1101,6 +1102,7 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
                 "    [loom.muted]MiniMax-M2.7            → MiniMax via Anthropic SDK (MINIMAX_API_KEY)[/loom.muted]\n"
                 "    [loom.muted]claude-sonnet-4-6       → Anthropic (ANTHROPIC_API_KEY)[/loom.muted]\n"
                 "    [loom.muted]gpt-5.5 / gpt-5.5-pro   → OpenAI (OPENAI_API_KEY; run `loom auth openai`)[/loom.muted]\n"
+                "    [loom.muted]codex/gpt-5.5           → Codex OAuth backend (run `codex login`)[/loom.muted]\n"
                 "    [loom.muted]ollama/<model>          → local Ollama  (enable in loom.toml)[/loom.muted]\n"
                 "    [loom.muted]lmstudio/<model>        → local LM Studio  (enable in loom.toml)[/loom.muted]\n"
                 "  [loom.warning]/personality[/loom.warning] [loom.muted]<name>[/loom.muted]      Switch cognitive persona\n"
@@ -1509,7 +1511,7 @@ async def _handle_slash_tui(cmd: str, session: "LoomSession", app: Any) -> None:
             providers = ", ".join(session.router.providers)
             app.notify(
                 f"Model: {session.model}  |  providers: {providers}\n"
-                "Prefixes: MiniMax-*  claude-*  gpt-*  openai/<model>  deepseek-*  openrouter/<vendor>/<model>  ollama/<name>  lmstudio/<name>"
+                "Prefixes: MiniMax-*  claude-*  gpt-*  openai/<model>  codex/<model>  deepseek-*  openrouter/<vendor>/<model>  ollama/<name>  lmstudio/<name>"
             )
         else:
             ok = session.set_model(arg)

--- a/tests/test_codex_responses_provider.py
+++ b/tests/test_codex_responses_provider.py
@@ -1,0 +1,128 @@
+import base64
+import json
+import time
+
+import pytest
+
+from loom.core.cognition.providers import CodexResponsesProvider
+
+
+def _jwt(exp: int) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"exp": exp}).encode()
+    ).rstrip(b"=").decode()
+    return f"{header}.{payload}."
+
+
+class _StreamResponse:
+    status_code = 200
+
+    def __init__(self, lines):
+        self._lines = lines
+
+    def raise_for_status(self):
+        return None
+
+    async def aiter_lines(self):
+        for line in self._lines:
+            yield line
+
+
+class _FakeAsyncClient:
+    requests = []
+    lines = []
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def stream(self, method, url, headers=None, json=None):
+        self.requests.append({"method": method, "url": url, "headers": headers, "json": json})
+
+        class _Ctx:
+            async def __aenter__(self_inner):
+                return _StreamResponse(_FakeAsyncClient.lines)
+
+            async def __aexit__(self_inner, *exc):
+                return False
+
+        return _Ctx()
+
+
+@pytest.fixture
+def codex_home(tmp_path, monkeypatch):
+    home = tmp_path / "codex"
+    home.mkdir()
+    (home / "auth.json").write_text(
+        json.dumps({"tokens": {"access_token": _jwt(int(time.time()) + 3600)}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(home))
+    return home
+
+
+@pytest.mark.asyncio
+async def test_codex_provider_streams_text(monkeypatch, codex_home):
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+    _FakeAsyncClient.requests = []
+    _FakeAsyncClient.lines = [
+        "event: response.output_text.delta",
+        'data: {"type":"response.output_text.delta","delta":"pong"}',
+        "",
+        "event: response.completed",
+        'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":3,"output_tokens":4}}}',
+        "",
+    ]
+    provider = CodexResponsesProvider(model="codex/gpt-5.5")
+
+    response = await provider.chat(messages=[{"role": "user", "content": "ping"}])
+
+    assert response.text == "pong"
+    assert response.input_tokens == 3
+    assert response.output_tokens == 4
+    req = _FakeAsyncClient.requests[0]
+    assert req["url"] == "https://chatgpt.com/backend-api/codex/responses"
+    assert req["json"]["model"] == "gpt-5.5"
+    assert req["json"]["store"] is False
+    assert req["json"]["stream"] is True
+
+
+@pytest.mark.asyncio
+async def test_codex_provider_normalizes_tool_call(monkeypatch, codex_home):
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+    _FakeAsyncClient.requests = []
+    _FakeAsyncClient.lines = [
+        "event: response.output_item.done",
+        'data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_1","name":"read_file","arguments":"{\\"path\\":\\"README.md\\"}"}}',
+        "",
+        "event: response.completed",
+        'data: {"type":"response.completed","response":{"status":"completed"}}',
+        "",
+    ]
+    provider = CodexResponsesProvider(model="codex/gpt-5.5")
+
+    response = await provider.chat(
+        messages=[{"role": "user", "content": "read"}],
+        tools=[{
+            "name": "read_file",
+            "description": "Read a file",
+            "parameters": {"type": "object", "properties": {"path": {"type": "string"}}},
+        }],
+    )
+
+    assert response.stop_reason == "tool_use"
+    assert response.tool_uses[0].id == "call_1"
+    assert response.tool_uses[0].name == "read_file"
+    assert response.tool_uses[0].args == {"path": "README.md"}
+    assert response.raw_message["tool_calls"][0]["function"]["name"] == "read_file"
+    assert _FakeAsyncClient.requests[0]["json"]["tools"][0]["type"] == "function"

--- a/tests/test_codex_responses_provider.py
+++ b/tests/test_codex_responses_provider.py
@@ -30,11 +30,9 @@ class _StreamResponse:
 
 
 class _FakeAsyncClient:
-    requests = []
-    lines = []
-
-    def __init__(self, *args, **kwargs):
-        pass
+    def __init__(self, lines):
+        self.lines = lines
+        self.requests = []
 
     async def __aenter__(self):
         return self
@@ -47,7 +45,7 @@ class _FakeAsyncClient:
 
         class _Ctx:
             async def __aenter__(self_inner):
-                return _StreamResponse(_FakeAsyncClient.lines)
+                return _StreamResponse(self.lines)
 
             async def __aexit__(self_inner, *exc):
                 return False
@@ -71,16 +69,15 @@ def codex_home(tmp_path, monkeypatch):
 async def test_codex_provider_streams_text(monkeypatch, codex_home):
     import httpx
 
-    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
-    _FakeAsyncClient.requests = []
-    _FakeAsyncClient.lines = [
+    fake_client = _FakeAsyncClient([
         "event: response.output_text.delta",
         'data: {"type":"response.output_text.delta","delta":"pong"}',
         "",
         "event: response.completed",
         'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":3,"output_tokens":4}}}',
         "",
-    ]
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
     provider = CodexResponsesProvider(model="codex/gpt-5.5")
 
     response = await provider.chat(messages=[{"role": "user", "content": "ping"}])
@@ -88,7 +85,7 @@ async def test_codex_provider_streams_text(monkeypatch, codex_home):
     assert response.text == "pong"
     assert response.input_tokens == 3
     assert response.output_tokens == 4
-    req = _FakeAsyncClient.requests[0]
+    req = fake_client.requests[0]
     assert req["url"] == "https://chatgpt.com/backend-api/codex/responses"
     assert req["json"]["model"] == "gpt-5.5"
     assert req["json"]["store"] is False
@@ -99,16 +96,15 @@ async def test_codex_provider_streams_text(monkeypatch, codex_home):
 async def test_codex_provider_normalizes_tool_call(monkeypatch, codex_home):
     import httpx
 
-    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
-    _FakeAsyncClient.requests = []
-    _FakeAsyncClient.lines = [
+    fake_client = _FakeAsyncClient([
         "event: response.output_item.done",
         'data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_1","name":"read_file","arguments":"{\\"path\\":\\"README.md\\"}"}}',
         "",
         "event: response.completed",
         'data: {"type":"response.completed","response":{"status":"completed"}}',
         "",
-    ]
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
     provider = CodexResponsesProvider(model="codex/gpt-5.5")
 
     response = await provider.chat(
@@ -125,4 +121,4 @@ async def test_codex_provider_normalizes_tool_call(monkeypatch, codex_home):
     assert response.tool_uses[0].name == "read_file"
     assert response.tool_uses[0].args == {"path": "README.md"}
     assert response.raw_message["tool_calls"][0]["function"]["name"] == "read_file"
-    assert _FakeAsyncClient.requests[0]["json"]["tools"][0]["type"] == "function"
+    assert fake_client.requests[0]["json"]["tools"][0]["type"] == "function"

--- a/tests/test_cognition.py
+++ b/tests/test_cognition.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 
 from loom.core.cognition.context import ContextBudget, estimate_tokens
 from loom.core.cognition.providers import (
+    CodexResponsesProvider,
     LLMResponse,
     OpenAIProvider,
     _to_anthropic_messages,
@@ -270,8 +271,21 @@ class TestLLMRouter:
         assert router.get_provider("gpt-5.5-pro") is p_openai
         assert router.get_provider("openai/gpt-5.5") is p_openai
 
+    def test_routing_by_prefix_codex(self):
+        router = LLMRouter()
+        p_default = self._make_mock_provider("minimax")
+        p_codex = self._make_mock_provider("codex")
+        router.register(p_default, default=True)
+        router.register(p_codex, fallback=False)
+        assert router.get_provider("codex/gpt-5.5") is p_codex
+        assert router.get_provider("unknown") is p_default
+
     def test_openai_provider_strips_optional_prefix(self):
         provider = OpenAIProvider(api_key="test", model="openai/gpt-5.5")
+        assert provider._api_model() == "gpt-5.5"
+
+    def test_codex_provider_strips_prefix(self):
+        provider = CodexResponsesProvider(model="codex/gpt-5.5")
         assert provider._api_model() == "gpt-5.5"
 
     def test_fallback_to_default(self):

--- a/tests/test_ledger_session_wiring.py
+++ b/tests/test_ledger_session_wiring.py
@@ -48,7 +48,7 @@ async def _start_session(monkeypatch, tmp_path: Path, session_module):
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
-    monkeypatch.setattr(session_module, "build_router", lambda: MagicMock())
+    monkeypatch.setattr(session_module, "build_router", lambda *a, **k: MagicMock())
     monkeypatch.setattr(session_module, "_load_loom_config", lambda: {})
     monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {})
     monkeypatch.setattr(session_module, "build_embedding_provider", lambda env, cfg: None)
@@ -120,7 +120,7 @@ async def test_disabled_via_config(monkeypatch, tmp_path, session_module):
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
-    monkeypatch.setattr(session_module, "build_router", lambda: MagicMock())
+    monkeypatch.setattr(session_module, "build_router", lambda *a, **k: MagicMock())
     monkeypatch.setattr(
         session_module, "_load_loom_config", lambda: {"ledger": {"enabled": False}}
     )
@@ -283,7 +283,7 @@ async def test_envelope_view_returns_empty_stub_without_ledger(
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
-    monkeypatch.setattr(session_module, "build_router", lambda: MagicMock())
+    monkeypatch.setattr(session_module, "build_router", lambda *a, **k: MagicMock())
     monkeypatch.setattr(
         session_module, "_load_loom_config", lambda: {"ledger": {"enabled": False}}
     )

--- a/tests/test_llm_tier_system.py
+++ b/tests/test_llm_tier_system.py
@@ -157,6 +157,11 @@ class TestActiveTierAndModel:
         assert s._active_tier() == 2
         assert s._active_model() == "deepseek-v4-pro"
 
+    def test_manual_model_override_wins_over_tier(self):
+        s = _mock_session(sticky_tier=2, base_model="codex/gpt-5.5")
+        s._manual_model_override = True
+        assert s._active_model() == "codex/gpt-5.5"
+
     def test_unknown_tier_falls_back_to_base_model(self):
         s = _mock_session(sticky_tier=99)
         # Tier 99 not in config → _active_model falls through to self._model
@@ -204,6 +209,13 @@ class TestSetStickyTier:
         s._set_sticky_tier(2, reason="x", source="skill")
         assert s._turns_at_current_tier == 0
         assert s._tier_reminder_emitted is False
+
+    def test_tier_change_clears_manual_model_override(self):
+        s = _mock_session(sticky_tier=None, base_model="codex/gpt-5.5")
+        s._manual_model_override = True
+        s._set_sticky_tier(2, reason="x", source="user")
+        assert s._manual_model_override is False
+        assert s._active_model() == "deepseek-v4-pro"
 
 
 class TestComputeSkillMaxTier:

--- a/tests/test_memory_facade.py
+++ b/tests/test_memory_facade.py
@@ -137,7 +137,7 @@ async def test_session_holds_facade_aliased_to_subsystems(monkeypatch, tmp_path)
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
-    monkeypatch.setattr(core_session, "build_router", lambda: MagicMock())
+    monkeypatch.setattr(core_session, "build_router", lambda *a, **k: MagicMock())
     monkeypatch.setattr(core_session, "_load_loom_config", lambda: {})
     monkeypatch.setattr(core_session, "_load_env", lambda project_root=None: {})
     monkeypatch.setattr(core_session, "build_embedding_provider", lambda env, cfg: None)
@@ -381,7 +381,7 @@ async def test_session_registers_memory_tools_through_facade(monkeypatch, tmp_pa
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
-    monkeypatch.setattr(core_session, "build_router", lambda: MagicMock())
+    monkeypatch.setattr(core_session, "build_router", lambda *a, **k: MagicMock())
     monkeypatch.setattr(core_session, "_load_loom_config", lambda: {})
     monkeypatch.setattr(core_session, "_load_env", lambda project_root=None: {})
     monkeypatch.setattr(core_session, "build_embedding_provider", lambda env, cfg: None)

--- a/tests/test_parallel_dispatch.py
+++ b/tests/test_parallel_dispatch.py
@@ -53,7 +53,7 @@ async def session(monkeypatch: pytest.MonkeyPatch, tmp_path):
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
-    monkeypatch.setattr(core_session, "build_router", lambda: MagicMock())
+    monkeypatch.setattr(core_session, "build_router", lambda *a, **k: MagicMock())
     monkeypatch.setattr(core_session, "_load_loom_config", lambda: {})
     monkeypatch.setattr(core_session, "_load_env", lambda project_root=None: {})
     monkeypatch.setattr(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -64,6 +64,28 @@ class TestBuildRouter:
         assert router.get_provider("codex/gpt-5.5").name == "codex"
 
 
+class TestSetModel:
+    def test_lazy_registers_codex_provider_on_switch(self, monkeypatch: pytest.MonkeyPatch):
+        from loom.core import session as session_module
+        from loom.core.session import LoomSession
+
+        initial_router = MagicMock()
+        initial_router.switch_model.return_value = False
+        codex_router = MagicMock()
+        codex_router.switch_model.return_value = True
+        monkeypatch.setattr(session_module, "build_router", lambda active_model=None: codex_router)
+
+        session = LoomSession.__new__(LoomSession)
+        session.router = initial_router
+        session._model = "MiniMax-M2.7"
+
+        assert session.set_model("codex/gpt-5.5") is True
+        initial_router.switch_model.assert_called_once_with("codex/gpt-5.5")
+        codex_router.switch_model.assert_called_once_with("codex/gpt-5.5")
+        assert session.router is codex_router
+        assert session.model == "codex/gpt-5.5"
+
+
 class TestLoomSessionStartup:
     @pytest_asyncio.fixture
     async def session_module(self):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -47,6 +47,22 @@ class TestBuildRouter:
         assert "openai" in router.providers
         assert router.get_provider("gpt-5.5").name == "openai"
 
+    def test_registers_codex_provider_only_when_requested(self, monkeypatch: pytest.MonkeyPatch):
+        from loom.core import session as session_module
+
+        monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {})
+        monkeypatch.setattr(session_module, "_load_loom_config", lambda: {
+            "cognition": {"default_model": "MiniMax-M2.7"},
+        })
+
+        with pytest.raises(RuntimeError, match="No LLM provider configured"):
+            session_module.build_router()
+
+        router = session_module.build_router(active_model="codex/gpt-5.5")
+
+        assert "codex" in router.providers
+        assert router.get_provider("codex/gpt-5.5").name == "codex"
+
 
 class TestLoomSessionStartup:
     @pytest_asyncio.fixture
@@ -66,7 +82,7 @@ class TestLoomSessionStartup:
         home = tmp_path / "home"
         home.mkdir()
         monkeypatch.setenv("HOME", str(home))
-        monkeypatch.setattr(session_module, "build_router", lambda: MagicMock())
+        monkeypatch.setattr(session_module, "build_router", lambda *a, **k: MagicMock())
         monkeypatch.setattr(session_module, "_load_loom_config", lambda: {})
         monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {})
         monkeypatch.setattr(session_module, "build_embedding_provider", lambda env, cfg: None)
@@ -122,7 +138,7 @@ async def session_plugin_tool(call):
         home = tmp_path / "home"
         home.mkdir()
         monkeypatch.setenv("HOME", str(home))
-        monkeypatch.setattr(session_module, "build_router", lambda: MagicMock())
+        monkeypatch.setattr(session_module, "build_router", lambda *a, **k: MagicMock())
         monkeypatch.setattr(session_module, "_load_loom_config", lambda: {"mcp": {"servers": [{"name": "minimax"}]}})
         monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {})
         monkeypatch.setattr(session_module, "build_embedding_provider", lambda env, cfg: None)
@@ -401,7 +417,7 @@ class TestProvisionalTitle:
     ):
         from loom.core.session import LoomSession
 
-        monkeypatch.setattr(session_module, "build_router", lambda: MagicMock())
+        monkeypatch.setattr(session_module, "build_router", lambda *a, **k: MagicMock())
         monkeypatch.setattr(session_module, "_load_loom_config", lambda: {})
         monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {})
         monkeypatch.setattr(session_module, "build_embedding_provider", lambda env, cfg: None)
@@ -419,7 +435,7 @@ class TestProvisionalTitle:
     ):
         from loom.core.session import LoomSession
 
-        monkeypatch.setattr(session_module, "build_router", lambda: MagicMock())
+        monkeypatch.setattr(session_module, "build_router", lambda *a, **k: MagicMock())
         monkeypatch.setattr(session_module, "_load_loom_config", lambda: {})
         monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {})
         monkeypatch.setattr(session_module, "build_embedding_provider", lambda env, cfg: None)
@@ -438,7 +454,7 @@ class TestProvisionalTitle:
         from loom.core.memory.session_log import SessionLog
         from rich.prompt import Confirm
 
-        monkeypatch.setattr(session_module, "build_router", lambda: MagicMock())
+        monkeypatch.setattr(session_module, "build_router", lambda *a, **k: MagicMock())
         monkeypatch.setattr(session_module, "_load_loom_config", lambda: {})
         monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {})
         monkeypatch.setattr(session_module, "build_embedding_provider", lambda env, cfg: None)
@@ -472,7 +488,7 @@ class TestProvisionalTitle:
         from loom.core.session import LoomSession
         from rich.prompt import Confirm
 
-        monkeypatch.setattr(session_module, "build_router", lambda: MagicMock())
+        monkeypatch.setattr(session_module, "build_router", lambda *a, **k: MagicMock())
         monkeypatch.setattr(session_module, "_load_loom_config", lambda: {})
         monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {})
         monkeypatch.setattr(session_module, "build_embedding_provider", lambda env, cfg: None)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -84,6 +84,7 @@ class TestSetModel:
         codex_router.switch_model.assert_called_once_with("codex/gpt-5.5")
         assert session.router is codex_router
         assert session.model == "codex/gpt-5.5"
+        assert session._manual_model_override is True
 
 
 class TestLoomSessionStartup:

--- a/tests/test_startup_diagnostic.py
+++ b/tests/test_startup_diagnostic.py
@@ -340,7 +340,7 @@ class TestSessionIntegration:
         home = tmp_path / "home"
         home.mkdir()
         monkeypatch.setenv("HOME", str(home))
-        monkeypatch.setattr(session_module, "build_router", lambda: MagicMock(providers=[object()]))
+        monkeypatch.setattr(session_module, "build_router", lambda *a, **k: MagicMock(providers=[object()]))
         monkeypatch.setattr(session_module, "_load_loom_config", lambda: {})
         monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {})
         monkeypatch.setattr(session_module, "build_embedding_provider", lambda env, cfg: None)


### PR DESCRIPTION
## Summary
- add an explicit codex/<model> chat provider that uses the Codex OAuth token from codex login
- keep gpt-* and openai/<model> on OPENAI_API_KEY so OAuth usage never silently falls back to API quota
- document the routing split and add provider/router/session tests

## Tests
- ./venv/bin/python -m pytest -q tests/test_session.py tests/test_parallel_dispatch.py tests/test_ledger_session_wiring.py tests/test_memory_facade.py tests/test_startup_diagnostic.py tests/test_cognition.py tests/test_codex_responses_provider.py

Closes #345