### PR TITLE
feat(memory): add time-aware recall

### DIFF
--- a/docs/superpowers/plans/2026-05-11-time-aware-memory-recall.md
+++ b/docs/superpowers/plans/2026-05-11-time-aware-memory-recall.md
@@ -1,0 +1,373 @@
+# Time-Aware Memory Recall Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add safe, time-aware memory retrieval across semantic, episodic, and session-log layers so Loom can answer period questions like "what did we discuss yesterday?"
+
+**Architecture:** Add additive range-query methods to each memory layer, thread `since` / `until` through semantic recall, then expose a new SAFE `recall_period` tool that returns grouped evidence from semantic facts, episodic events, and optionally sessions/messages. Keep all existing recall behavior backward compatible.
+
+**Tech Stack:** Python 3.11+, SQLite via `aiosqlite`, pytest + pytest-asyncio, existing Loom memory/tool abstractions.
+
+---
+
+## File Structure
+
+- Modify `loom/core/memory/semantic.py`: add `list_between`.
+- Modify `loom/core/memory/episodic.py`: add `list_between`.
+- Modify `loom/core/memory/session_log.py`: add `list_sessions_between` and `messages_between`.
+- Modify `loom/core/memory/search.py`: add time bounds to semantic embedding, BM25, and fallback paths.
+- Modify `loom/core/memory/facade.py`: forward time bounds and expose period recall helper.
+- Modify `loom/platform/cli/tools.py`: add `since` / `until` to `recall`; add `make_recall_period_tool`.
+- Modify `loom/core/session.py`: register `recall_period`.
+- Modify `tests/test_memory.py`: semantic and episodic range tests.
+- Modify `tests/test_session.py`: session-log range tests.
+- Modify `tests/test_memory_search.py`: recall time filter and tool tests.
+- Modify `tests/test_memory_facade.py`: facade period helper tests.
+
+---
+
+### Task 1: Memory Layer Time Range APIs
+
+**Files:**
+- Modify: `loom/core/memory/semantic.py`
+- Modify: `loom/core/memory/episodic.py`
+- Modify: `loom/core/memory/session_log.py`
+- Test: `tests/test_memory.py`
+- Test: `tests/test_session.py`
+
+- [ ] **Step 1: Run GitNexus impact analysis**
+
+Run:
+
+```bash
+npx gitnexus impact list_recent --direction upstream
+npx gitnexus impact read_session --direction upstream
+npx gitnexus impact list_sessions --direction upstream
+```
+
+Expected: LOW or UNKNOWN for newly-added sibling methods. If HIGH or CRITICAL appears, stop and report before editing.
+
+- [ ] **Step 2: Write failing semantic and episodic tests**
+
+Add tests that insert rows with explicit timestamps, then assert:
+
+```python
+semantic_results = await sm.list_between(
+    since=datetime(2026, 5, 10, tzinfo=UTC),
+    until=datetime(2026, 5, 11, tzinfo=UTC),
+)
+assert [e.key for e in semantic_results] == ["inside:new", "inside:old"]
+```
+
+and:
+
+```python
+episodic_results = await em.list_between(
+    since=datetime(2026, 5, 10, tzinfo=UTC),
+    until=datetime(2026, 5, 11, tzinfo=UTC),
+    session_id="s1",
+)
+assert [e.content for e in episodic_results] == ["inside s1"]
+```
+
+- [ ] **Step 3: Verify RED**
+
+Run:
+
+```bash
+pytest -q tests/test_memory.py::TestSemanticMemory::test_list_between_filters_updated_at tests/test_memory.py::TestEpisodicMemory::test_list_between_filters_created_at_and_session
+```
+
+Expected: FAIL because `list_between` does not exist.
+
+- [ ] **Step 4: Implement minimal APIs**
+
+Implement signatures:
+
+```python
+async def list_between(
+    self,
+    since: datetime,
+    until: datetime | None = None,
+    *,
+    limit: int = 20,
+) -> list[SemanticEntry]:
+```
+
+and:
+
+```python
+async def list_between(
+    self,
+    since: datetime,
+    until: datetime | None = None,
+    *,
+    session_id: str | None = None,
+    limit: int = 50,
+) -> list[EpisodicEntry]:
+```
+
+Use `updated_at >= ? AND updated_at < ?` for semantic and `created_at >= ? AND created_at < ?` for episodic. Order semantic newest first and episodic chronological.
+
+- [ ] **Step 5: Add session-log tests and APIs**
+
+Test:
+
+```python
+sessions = await log.list_sessions_between(
+    since=datetime(2026, 5, 10, tzinfo=UTC),
+    until=datetime(2026, 5, 11, tzinfo=UTC),
+)
+assert [s["session_id"] for s in sessions] == ["active-inside"]
+```
+
+Implement:
+
+```python
+async def list_sessions_between(self, since: datetime, until: datetime | None = None, limit: int = 20) -> list[dict[str, Any]]
+async def messages_between(self, since: datetime, until: datetime | None = None, *, session_id: str | None = None, limit: int = 100) -> list[dict[str, Any]]
+```
+
+- [ ] **Step 6: Verify GREEN**
+
+Run:
+
+```bash
+pytest -q tests/test_memory.py tests/test_session.py
+```
+
+Expected: new tests pass; existing tests remain green.
+
+---
+
+### Task 2: Thread Time Bounds Through Semantic Recall
+
+**Files:**
+- Modify: `loom/core/memory/search.py`
+- Modify: `loom/core/memory/facade.py`
+- Modify: `loom/platform/cli/tools.py`
+- Test: `tests/test_memory_search.py`
+- Test: `tests/test_memory_facade.py`
+
+- [ ] **Step 1: Run GitNexus impact analysis**
+
+Run:
+
+```bash
+npx gitnexus impact recall --direction upstream
+npx gitnexus impact Function:loom/core/memory/facade.py:MemoryFacade.search --direction upstream
+npx gitnexus impact make_recall_tool --direction upstream
+```
+
+Expected: LOW. If HIGH or CRITICAL appears, stop and report.
+
+- [ ] **Step 2: Write failing search test**
+
+Add a test that writes one semantic fact inside and one outside a date range, then:
+
+```python
+results = await search.recall(
+    "loom",
+    type="semantic",
+    since=datetime(2026, 5, 10, tzinfo=UTC),
+    until=datetime(2026, 5, 11, tzinfo=UTC),
+)
+assert [r.key for r in results] == ["inside"]
+```
+
+- [ ] **Step 3: Verify RED**
+
+Run:
+
+```bash
+pytest -q tests/test_memory_search.py::TestMemorySearch::test_recall_filters_by_updated_at_range
+```
+
+Expected: FAIL because `recall()` does not accept `since`.
+
+- [ ] **Step 4: Implement semantic time filters**
+
+Add optional `since: datetime | None = None` and `until: datetime | None = None` through:
+
+- `MemorySearch.recall`
+- `_search_semantic_embedding`
+- `_search_semantic`
+- `_recent_fallback`
+- `MemoryFacade.search`
+
+Build SQL fragments using `e.updated_at >= ?` and `e.updated_at < ?` on joined queries, and pass bounds to `SemanticMemory.list_between` for fallback when any time bound is present.
+
+- [ ] **Step 5: Write failing recall tool forwarding test**
+
+Create a mock facade and assert `make_recall_tool` parses and forwards `since` / `until`:
+
+```python
+call = _make_call("recall", {
+    "query": "loom",
+    "type": "semantic",
+    "since": "2026-05-10",
+    "until": "2026-05-11",
+})
+await tool.executor(call)
+facade.search.assert_awaited_once()
+assert facade.search.await_args.kwargs["since"].isoformat().startswith("2026-05-10")
+```
+
+- [ ] **Step 6: Verify GREEN**
+
+Run:
+
+```bash
+pytest -q tests/test_memory_search.py tests/test_memory_facade.py
+```
+
+Expected: all pass.
+
+---
+
+### Task 3: Add `recall_period` Tool
+
+**Files:**
+- Modify: `loom/core/memory/facade.py`
+- Modify: `loom/platform/cli/tools.py`
+- Modify: `loom/core/session.py`
+- Test: `tests/test_memory_facade.py`
+- Test: `tests/test_memory_search.py`
+- Test: `tests/test_session.py`
+
+- [ ] **Step 1: Run GitNexus impact analysis**
+
+Run:
+
+```bash
+npx gitnexus impact memorize --direction upstream
+npx gitnexus impact make_recall_tool --direction upstream
+npx gitnexus impact start --direction upstream
+```
+
+Expected: LOW or known broad session impact for registration. If HIGH or CRITICAL appears, stop and report.
+
+- [ ] **Step 2: Write failing facade period test**
+
+Add:
+
+```python
+result = await facade.recall_period(
+    since=datetime(2026, 5, 10, tzinfo=UTC),
+    until=datetime(2026, 5, 11, tzinfo=UTC),
+    include_episodic=True,
+    include_sessions=True,
+    limit=5,
+)
+assert result["semantic"]
+assert result["episodic"]
+assert result["sessions"]
+```
+
+- [ ] **Step 3: Implement facade helper**
+
+Add:
+
+```python
+async def recall_period(
+    self,
+    *,
+    since: datetime,
+    until: datetime | None = None,
+    session_id: str | None = None,
+    limit: int = 10,
+    include_episodic: bool = True,
+    include_sessions: bool = False,
+) -> dict[str, list[Any]]:
+```
+
+Return semantic facts from `semantic.list_between`, episodic entries from `episodic.list_between`, and sessions plus message rows from `session_log` only when a session-log handle is available.
+
+- [ ] **Step 4: Write failing tool test**
+
+Add a tool-level test:
+
+```python
+tool = make_recall_period_tool(facade)
+call = _make_call("recall_period", {
+    "since": "2026-05-10",
+    "until": "2026-05-11",
+    "include_episodic": True,
+    "include_sessions": True,
+})
+result = await tool.executor(call)
+assert result.success is True
+assert "Semantic facts" in result.output
+assert "Episodic events" in result.output
+assert "Sessions" in result.output
+assert "Session messages" in result.output
+```
+
+- [ ] **Step 5: Implement tool and registration**
+
+Add `make_recall_period_tool(memory)` next to `make_recall_tool`, parse dates via a small helper, clamp `limit` to 20, and register it in `LoomSession.start()` after `recall`.
+
+- [ ] **Step 6: Verify GREEN**
+
+Run:
+
+```bash
+pytest -q tests/test_memory_search.py tests/test_memory_facade.py tests/test_session.py tests/test_memory.py
+```
+
+Expected: all pass.
+
+---
+
+### Task 4: Final Verification and PR
+
+**Files:**
+- All changed implementation/test/spec/plan files.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+pytest -q tests/test_memory.py tests/test_memory_search.py tests/test_memory_facade.py tests/test_session.py
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run GitNexus detect changes**
+
+Run:
+
+```bash
+npx gitnexus detect-changes
+```
+
+Expected: changed symbols match memory-time retrieval work.
+
+- [ ] **Step 3: Stage and commit**
+
+Run:
+
+```bash
+git add docs/superpowers/specs/2026-05-11-time-aware-memory-recall-design.md docs/superpowers/plans/2026-05-11-time-aware-memory-recall.md loom/core/memory/semantic.py loom/core/memory/episodic.py loom/core/memory/session_log.py loom/core/memory/search.py loom/core/memory/facade.py loom/platform/cli/tools.py loom/core/session.py tests/test_memory.py tests/test_session.py tests/test_memory_search.py tests/test_memory_facade.py
+git commit -m "feat(memory): add time-aware recall"
+```
+
+- [ ] **Step 4: Push and open PR**
+
+Run:
+
+```bash
+git push -u origin codex/time-aware-memory-recall
+gh pr create --repo Dakai666/Loom --title "feat(memory): add time-aware recall" --body "Closes #354"
+```
+
+Expected: PR created against the default branch.
+
+---
+
+## Self-Review
+
+- Spec coverage: semantic time filter, episodic range query, session-log range query, and SAFE period tool are covered.
+- Placeholder scan: no TBD/TODO placeholders.
+- Type consistency: date parameters are `datetime` internally and strings at the tool boundary.

--- a/docs/superpowers/specs/2026-05-11-time-aware-memory-recall-design.md
+++ b/docs/superpowers/specs/2026-05-11-time-aware-memory-recall-design.md
@@ -57,6 +57,8 @@ Output groups entries by source layer:
 
 Each line includes timestamp, key or session id, and a short value. The tool does not summarize with an LLM; it returns traceable evidence that the agent can use to answer naturally.
 
+`Session messages` are forensic rows from `session_log`, not reconstructed chat replay messages. They preserve the stored `session_id`, `turn_index`, `role`, redacted `content`, and `created_at` for diary-style investigation.
+
 ## Data Flow
 
 For "what did we talk about yesterday?":
@@ -71,6 +73,7 @@ For "what did we talk about yesterday?":
 
 - Invalid dates return a tool error with a concise message.
 - Missing `since` returns a tool error.
+- Providing `until` without `since` returns a tool error at the tool boundary.
 - `until <= since` returns a tool error.
 - Empty ranges return success with "No memories found for this period."
 - Limits are clamped to a small maximum to protect context.

--- a/docs/superpowers/specs/2026-05-11-time-aware-memory-recall-design.md
+++ b/docs/superpowers/specs/2026-05-11-time-aware-memory-recall-design.md
@@ -1,0 +1,91 @@
+# Time-Aware Memory Recall Design
+
+## Problem
+
+Loom stores time information in all memory strata, but agent-facing retrieval cannot ask time-shaped questions. A user can ask "what did we talk about yesterday?" or "what happened last week?", yet `recall` only performs semantic relevance search with ontology filters. The data exists, but the access path does not.
+
+## Goal
+
+Add time-aware memory access that follows the existing memory stack:
+
+1. Semantic memory first for distilled facts.
+2. Episodic memory next for time-stamped events and tool traces.
+3. Session log last for raw conversation history when deeper recall is needed.
+
+## Non-Goals
+
+- Do not replace semantic recall ranking.
+- Do not build an LLM summarizer in this pass.
+- Do not expose unrestricted SQL or arbitrary DB queries.
+- Do not migrate existing memory rows beyond indexes or additive columns if required.
+
+## Architecture
+
+### Semantic Layer
+
+Add a bounded time query API to `SemanticMemory` and thread it through `MemorySearch.recall`, `MemoryFacade.search`, and the `recall` tool. The tool accepts ISO-like `since` and `until` arguments and applies them to `semantic_entries.updated_at`.
+
+When a query has both semantic terms and time bounds, results should still rank by embedding/BM25 inside the time window. When a query is generic but time-bound, the caller can request recent facts in the range by using the new period tool rather than abusing keyword recall.
+
+### Episodic Layer
+
+Add `EpisodicMemory.list_between(since, until, session_id=None, limit=...)`. It returns chronological episodic entries for a date range, optionally scoped to one session. This lets tools inspect the compressed source layer without needing a known session id first.
+
+### Session Log Layer
+
+Add `SessionLog.list_sessions_between(since, until, limit=...)` and `SessionLog.messages_between(since, until, session_id=None, limit=...)`. The first answers "which sessions were active in this window"; the second supports deep recall for diary-style use.
+
+### Agent Tool
+
+Add a SAFE tool named `recall_period`.
+
+Inputs:
+
+- `since`: required ISO timestamp or date string.
+- `until`: optional ISO timestamp or date string.
+- `limit`: capped result count.
+- `include_episodic`: optional boolean, default `true`.
+- `include_sessions`: optional boolean, default `false`.
+- `session_id`: optional scope.
+
+Output groups entries by source layer:
+
+- `Semantic facts`
+- `Episodic events`
+- `Sessions`
+- `Session messages`
+
+Each line includes timestamp, key or session id, and a short value. The tool does not summarize with an LLM; it returns traceable evidence that the agent can use to answer naturally.
+
+## Data Flow
+
+For "what did we talk about yesterday?":
+
+1. Agent resolves "yesterday" using current time context.
+2. Agent calls `recall_period(since="2026-05-10", until="2026-05-11")`.
+3. Tool returns semantic facts updated in that range.
+4. If facts are too sparse, the same call includes episodic events.
+5. If deeper inspection is needed, `include_sessions=true` surfaces matching sessions and optional raw messages.
+
+## Error Handling
+
+- Invalid dates return a tool error with a concise message.
+- Missing `since` returns a tool error.
+- `until <= since` returns a tool error.
+- Empty ranges return success with "No memories found for this period."
+- Limits are clamped to a small maximum to protect context.
+
+## Testing
+
+Add tests before implementation:
+
+- `SemanticMemory.list_between` filters by `updated_at`.
+- `MemorySearch.recall` respects `since` / `until`.
+- `make_recall_tool` forwards time filters.
+- `EpisodicMemory.list_between` works globally and per session.
+- `SessionLog.list_sessions_between` finds active sessions in a range.
+- `recall_period` returns grouped semantic/episodic/session output.
+
+## Rollout
+
+This is additive and backward compatible. Existing callers of `recall` continue working. New arguments are optional. The period tool is SAFE because it only reads local memory and caps output.

--- a/loom/core/memory/episodic.py
+++ b/loom/core/memory/episodic.py
@@ -85,6 +85,51 @@ class EpisodicMemory:
             for r in rows
         ]
 
+    async def list_between(
+        self,
+        since: datetime,
+        until: datetime | None = None,
+        *,
+        session_id: str | None = None,
+        limit: int = 50,
+    ) -> list[EpisodicEntry]:
+        """Read episodic entries created in ``[since, until)``.
+
+        ``session_id`` narrows the range query when the caller already knows
+        which conversation to inspect. Without it, this is the time-window
+        entry point that ``read_session`` cannot express.
+        """
+        where = ["created_at >= ?"]
+        params: list[Any] = [since.isoformat()]
+        if until is not None:
+            where.append("created_at < ?")
+            params.append(until.isoformat())
+        if session_id is not None:
+            where.append("session_id = ?")
+            params.append(session_id)
+        params.append(limit)
+        cursor = await self._db.execute(
+            "SELECT id, session_id, event_type, content, metadata, "
+            "created_at, compressed_at "
+            "FROM episodic_entries "
+            f"WHERE {' AND '.join(where)} "
+            "ORDER BY created_at ASC LIMIT ?",
+            tuple(params),
+        )
+        rows = await cursor.fetchall()
+        return [
+            EpisodicEntry(
+                id=r[0],
+                session_id=r[1],
+                event_type=r[2],
+                content=r[3],
+                metadata=json.loads(r[4]),
+                created_at=datetime.fromisoformat(r[5]),
+                compressed_at=datetime.fromisoformat(r[6]) if r[6] else None,
+            )
+            for r in rows
+        ]
+
     async def count_session(
         self,
         session_id: str,

--- a/loom/core/memory/facade.py
+++ b/loom/core/memory/facade.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+from datetime import datetime
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
@@ -39,6 +40,7 @@ if TYPE_CHECKING:
     from loom.core.memory.procedural import ProceduralMemory
     from loom.core.memory.relational import RelationalEntry, RelationalMemory
     from loom.core.memory.search import MemorySearch, MemorySearchResult
+    from loom.core.memory.session_log import SessionLog
     from loom.core.memory.semantic import SemanticEntry, SemanticMemory
 
 
@@ -70,6 +72,7 @@ class MemoryFacade:
         relational: "RelationalMemory",
         episodic: "EpisodicMemory",
         search: "MemorySearch",
+        session_log: "SessionLog | None" = None,
         governor: "MemoryGovernor | None" = None,
         ledger_emitter: "LedgerEmitter | None" = None,
     ) -> None:
@@ -78,6 +81,7 @@ class MemoryFacade:
         self.relational = relational
         self.episodic = episodic
         self.search_index = search
+        self.session_log = session_log
         self.governor = governor
         # ledger_emitter is None in the dual-emit transition until
         # LoomSession.start() wires one (Step 2 commit 6). Tests and
@@ -93,6 +97,8 @@ class MemoryFacade:
         limit: int = 5,
         domain: str | None = None,
         temporal: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
     ) -> list["MemorySearchResult"]:
         """BM25 + embedding ranked retrieval across semantic + procedural memory.
 
@@ -111,6 +117,7 @@ class MemoryFacade:
         results = await self.search_index.recall(
             query, type=kind, limit=limit,
             domain=domain, temporal=temporal,
+            since=since, until=until,
         )
         await self._emit_memory_op(
             operation="read",
@@ -150,6 +157,56 @@ class MemoryFacade:
             trigger="agent_query_relations",
         )
         return results
+
+    async def recall_period(
+        self,
+        *,
+        since: datetime,
+        until: datetime | None = None,
+        session_id: str | None = None,
+        limit: int = 10,
+        include_episodic: bool = True,
+        include_sessions: bool = False,
+    ) -> dict[str, list]:
+        """Return grouped memory evidence for a time window.
+
+        Semantic facts are always included. Episodic events and session
+        metadata are optional so callers can start with distilled facts and
+        deepen only when needed.
+        """
+        capped = min(max(int(limit), 1), 20)
+        semantic = await self.semantic.list_between(
+            since, until, limit=capped,
+        )
+        episodic = (
+            await self.episodic.list_between(
+                since, until, session_id=session_id, limit=capped,
+            )
+            if include_episodic else []
+        )
+        sessions = (
+            await self.session_log.list_sessions_between(
+                since, until, limit=capped,
+            )
+            if include_sessions and self.session_log is not None else []
+        )
+        messages = (
+            await self.session_log.messages_between(
+                since, until, session_id=session_id, limit=capped,
+            )
+            if include_sessions and self.session_log is not None else []
+        )
+        await self._emit_memory_op(
+            operation="read",
+            type_summary="period_recall",
+            trigger="agent_recall_period",
+        )
+        return {
+            "semantic": semantic,
+            "episodic": episodic,
+            "sessions": sessions,
+            "messages": messages,
+        }
 
     # ── write API ────────────────────────────────────────────────────────
 

--- a/loom/core/memory/search.py
+++ b/loom/core/memory/search.py
@@ -67,6 +67,23 @@ def _axis_filter_sql(
     return (" " + " ".join(parts) if parts else ""), tuple(params)
 
 
+def _time_filter_sql(
+    since: datetime | None,
+    until: datetime | None,
+    prefix: str = "",
+) -> tuple[str, tuple[str, ...]]:
+    """Build SQL filters for semantic ``updated_at`` time windows."""
+    parts: list[str] = []
+    params: list[str] = []
+    if since is not None:
+        parts.append(f"AND {prefix}updated_at >= ?")
+        params.append(since.isoformat())
+    if until is not None:
+        parts.append(f"AND {prefix}updated_at < ?")
+        params.append(until.isoformat())
+    return (" " + " ".join(parts) if parts else ""), tuple(params)
+
+
 # ---------------------------------------------------------------------------
 # Result type
 # ---------------------------------------------------------------------------
@@ -124,6 +141,8 @@ class MemorySearch:
         limit: int = 5,
         domain: str | None = None,
         temporal: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
     ) -> list[MemorySearchResult]:
         """
         Return the top-*limit* memory entries most relevant to *query*.
@@ -142,6 +161,8 @@ class MemorySearch:
                   only semantic entries with this domain are returned. Skills
                   are unaffected — domain/temporal apply to facts, not skills.
         temporal: Optional temporal axis filter (same semantics as ``domain``).
+        since:    Optional lower bound on semantic ``updated_at``.
+        until:    Optional exclusive upper bound on semantic ``updated_at``.
         """
         if not query.strip():
             return []
@@ -153,6 +174,7 @@ class MemorySearch:
             try:
                 emb_results = await self._search_semantic_embedding(
                     query, limit, domain=domain, temporal=temporal,
+                    since=since, until=until,
                 )
                 if emb_results:
                     # Skills are not embedding-indexed; mix in BM25 skill results
@@ -178,6 +200,7 @@ class MemorySearch:
             results.extend(
                 await self._search_semantic(
                     query, limit, domain=domain, temporal=temporal,
+                    since=since, until=until,
                 )
             )
         if type in ("skill", "all"):
@@ -188,7 +211,7 @@ class MemorySearch:
 
         # ── Tier 3: recency fallback ──────────────────────────────────────────
         if not ranked:
-            ranked = await self._recent_fallback(type, limit)
+            ranked = await self._recent_fallback(type, limit, since=since, until=until)
 
         await self._mark_accessed(ranked)
         return ranked
@@ -203,6 +226,8 @@ class MemorySearch:
         self, query: str, limit: int,
         domain: str | None = None,
         temporal: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
     ) -> list[MemorySearchResult]:
         """Rank semantic entries by cosine similarity using sqlite-vec."""
         provider = self._semantic._embeddings
@@ -214,17 +239,24 @@ class MemorySearch:
             return []
         query_vec = query_vectors[0]
 
-        where, axis_params = _axis_filter_sql(domain, temporal)
+        axis_where, axis_params = _axis_filter_sql(domain, temporal)
+        time_where, time_params = _time_filter_sql(since, until)
         cursor = await self._semantic._db.execute(
             f"""
             SELECT {_SEMANTIC_SELECT_COLS},
                    1.0 - vec_distance_cosine(embedding, ?) AS score
             FROM semantic_entries
-            WHERE embedding IS NOT NULL{where}
+            WHERE embedding IS NOT NULL{axis_where}{time_where}
             ORDER BY vec_distance_cosine(embedding, ?) ASC
             LIMIT ?
             """,
-            (json.dumps(query_vec), *axis_params, json.dumps(query_vec), limit)
+            (
+                json.dumps(query_vec),
+                *axis_params,
+                *time_params,
+                json.dumps(query_vec),
+                limit,
+            )
         )
         rows = await cursor.fetchall()
 
@@ -251,13 +283,22 @@ class MemorySearch:
         return results
 
     async def _recent_fallback(
-        self, type: MemoryType, limit: int
+        self,
+        type: MemoryType,
+        limit: int,
+        *,
+        since: datetime | None = None,
+        until: datetime | None = None,
     ) -> list[MemorySearchResult]:
         """Return the most recently updated entries with score=0 (recency order)."""
         results: list[MemorySearchResult] = []
 
         if type in ("semantic", "all"):
-            entries = await self._semantic.list_recent(limit)
+            if since is not None or until is not None:
+                floor = since or datetime.min
+                entries = await self._semantic.list_between(floor, until, limit=limit)
+            else:
+                entries = await self._semantic.list_recent(limit)
             results.extend(
                 MemorySearchResult(
                     type="semantic",
@@ -296,6 +337,8 @@ class MemorySearch:
         self, query: str, limit: int,
         domain: str | None = None,
         temporal: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
     ) -> list[MemorySearchResult]:
         if not query.strip():
             return []
@@ -304,7 +347,8 @@ class MemorySearch:
         if not safe_query:
             return []
 
-        where, axis_params = _axis_filter_sql(domain, temporal, prefix="e.")
+        axis_where, axis_params = _axis_filter_sql(domain, temporal, prefix="e.")
+        time_where, time_params = _time_filter_sql(since, until, prefix="e.")
         # SELECT mirrors _SEMANTIC_SELECT_COLS aliased onto the joined table
         # so _semantic_row_to_entry can parse rows uniformly with the
         # embedding path.
@@ -318,11 +362,11 @@ class MemorySearch:
                 bm25(semantic_fts) AS fts_score
             FROM semantic_fts
             JOIN semantic_entries e ON semantic_fts.rowid = e.rowid
-            WHERE semantic_fts MATCH ?{where}
+            WHERE semantic_fts MATCH ?{axis_where}{time_where}
             ORDER BY rank
             LIMIT ?
             """,
-            (safe_query, *axis_params, limit)
+            (safe_query, *axis_params, *time_params, limit)
         )
         rows = await cursor.fetchall()
 

--- a/loom/core/memory/semantic.py
+++ b/loom/core/memory/semantic.py
@@ -290,6 +290,29 @@ class SemanticMemory:
         rows = await cursor.fetchall()
         return [_row_to_entry(r) for r in rows]
 
+    async def list_between(
+        self,
+        since: datetime,
+        until: datetime | None = None,
+        *,
+        limit: int = 20,
+    ) -> list[SemanticEntry]:
+        """Return entries updated in ``[since, until)`` newest first."""
+        where = ["updated_at >= ?"]
+        params: list[Any] = [since.isoformat()]
+        if until is not None:
+            where.append("updated_at < ?")
+            params.append(until.isoformat())
+        params.append(limit)
+        cursor = await self._db.execute(
+            f"SELECT {_SELECT_COLS} FROM semantic_entries "
+            f"WHERE {' AND '.join(where)} "
+            "ORDER BY updated_at DESC LIMIT ?",
+            tuple(params),
+        )
+        rows = await cursor.fetchall()
+        return [_row_to_entry(r) for r in rows]
+
     async def get_random(
         self,
         limit: int = 15,
@@ -451,4 +474,3 @@ class SemanticMemory:
             (now, *keys),
         )
         await self._db.commit()
-

--- a/loom/core/memory/session_log.py
+++ b/loom/core/memory/session_log.py
@@ -271,6 +271,38 @@ class SessionLog:
             for r in rows
         ]
 
+    async def list_sessions_between(
+        self,
+        since: datetime,
+        until: datetime | None = None,
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        """Return sessions whose ``last_active`` falls in ``[since, until)``."""
+        where = ["last_active >= ?"]
+        params: list[Any] = [since.isoformat()]
+        if until is not None:
+            where.append("last_active < ?")
+            params.append(until.isoformat())
+        params.append(limit)
+        cursor = await self._db.execute(
+            "SELECT session_id, model, title, started_at, last_active, turn_count "
+            f"FROM sessions WHERE {' AND '.join(where)} "
+            "ORDER BY last_active DESC LIMIT ?",
+            tuple(params),
+        )
+        rows = await cursor.fetchall()
+        return [
+            {
+                "session_id": r[0],
+                "model": r[1],
+                "title": r[2],
+                "started_at": r[3],
+                "last_active": r[4],
+                "turn_count": r[5],
+            }
+            for r in rows
+        ]
+
     async def get_session(self, session_id: str) -> dict[str, Any] | None:
         """Return session metadata for one session, or None if not found."""
         cursor = await self._db.execute(
@@ -289,6 +321,53 @@ class SessionLog:
             "last_active": row[4],
             "turn_count": row[5],
         }
+
+    async def messages_between(
+        self,
+        since: datetime,
+        until: datetime | None = None,
+        *,
+        session_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Return raw message rows created in ``[since, until)``.
+
+        This intentionally returns rows rather than reconstructed chat
+        messages. It is a diary/forensics primitive for time-window recall,
+        while ``load_messages`` remains the replay API.
+        """
+        where = ["created_at >= ?", "role != 'system'"]
+        params: list[Any] = [since.isoformat()]
+        if until is not None:
+            where.append("created_at < ?")
+            params.append(until.isoformat())
+        if session_id is not None:
+            where.append("session_id = ?")
+            params.append(session_id)
+        params.append(limit)
+        cursor = await self._db.execute(
+            "SELECT session_id, turn_index, role, content, raw_json, metadata, created_at "
+            f"FROM session_log WHERE {' AND '.join(where)} "
+            "ORDER BY created_at ASC, id ASC LIMIT ?",
+            tuple(params),
+        )
+        rows = await cursor.fetchall()
+        result: list[dict[str, Any]] = []
+        for r in rows:
+            try:
+                metadata: dict[str, Any] = json.loads(r[5] or "{}")
+            except Exception:
+                metadata = {}
+            result.append({
+                "session_id": r[0],
+                "turn_index": r[1],
+                "role": r[2],
+                "content": _redact_secrets(r[3]) or "",
+                "raw_json": r[4],
+                "metadata": metadata,
+                "created_at": r[6],
+            })
+        return result
 
     async def load_messages(self, session_id: str) -> list[dict[str, Any]]:
         """Return all non-system messages in replay order (turn_index ASC, id ASC).

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1161,6 +1161,7 @@ class LoomSession:
             relational=relational,
             episodic=episodic,
             search=search,
+            session_log=self._session_log,
             governor=self._governor,
             ledger_emitter=self._ledger_emitter,
         )
@@ -1249,6 +1250,7 @@ class LoomSession:
             make_memorize_tool,
             make_memory_health_tool,
             make_query_relations_tool,
+            make_recall_period_tool,
             make_recall_tool,
             make_skill_promote_tool,
             make_skill_rollback_tool,
@@ -1261,6 +1263,7 @@ class LoomSession:
         # ``self._memory`` was built up-front (right after governor init).
         # See "Issue #147 Phase C: build the facade up-front" above.
         self.registry.register(make_recall_tool(self._memory))
+        self.registry.register(make_recall_period_tool(self._memory))
         # PR-C4: when the governor blocks a write, fire the session-level
         # hook so the platform layer can surface a "governor rejected"
         # harness inline. Accept stays silent.

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -983,6 +983,9 @@ def make_recall_tool(memory: "MemoryFacade") -> ToolDefinition:
         if not query:
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
                               success=False, error="'query' argument is required")
+        if since is None and until is not None:
+            return ToolResult(call_id=call.id, tool_name=call.tool_name,
+                              success=False, error="'since' is required when 'until' is provided")
         if since is not None and until is not None and until <= since:
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
                               success=False, error="'until' must be after 'since'")

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -24,6 +24,7 @@ import re
 import signal
 import subprocess
 import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -936,6 +937,24 @@ async def _run_bash_job(
 # Close over live memory store instances; call from LoomSession.start().
 # ------------------------------------------------------------------
 
+def _parse_memory_datetime(value: str | None) -> datetime | None:
+    """Parse a tool-facing date/datetime string into an aware UTC datetime."""
+    if not value:
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+    try:
+        if len(raw) == 10 and raw[4] == "-" and raw[7] == "-":
+            return datetime.fromisoformat(raw).replace(tzinfo=UTC)
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"Invalid datetime {value!r}; use YYYY-MM-DD or ISO datetime") from exc
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
 def make_recall_tool(memory: "MemoryFacade") -> ToolDefinition:
     """
     Create a SAFE ``recall`` tool bound to the given MemoryFacade.
@@ -954,10 +973,19 @@ def make_recall_tool(memory: "MemoryFacade") -> ToolDefinition:
         limit = min(max(int(call.args.get("limit", 5)), 1), 10)
         domain = (call.args.get("domain") or "").strip().lower() or None
         temporal = (call.args.get("temporal") or "").strip().lower() or None
+        try:
+            since = _parse_memory_datetime(call.args.get("since"))
+            until = _parse_memory_datetime(call.args.get("until"))
+        except ValueError as exc:
+            return ToolResult(call_id=call.id, tool_name=call.tool_name,
+                              success=False, error=str(exc))
 
         if not query:
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
                               success=False, error="'query' argument is required")
+        if since is not None and until is not None and until <= since:
+            return ToolResult(call_id=call.id, tool_name=call.tool_name,
+                              success=False, error="'until' must be after 'since'")
 
         if mem_type not in ("semantic", "skill", "all"):
             mem_type = "all"
@@ -971,6 +999,7 @@ def make_recall_tool(memory: "MemoryFacade") -> ToolDefinition:
         results = await memory.search(  # type: ignore[arg-type]
             query, kind=mem_type, limit=limit,
             domain=domain, temporal=temporal,
+            since=since, until=until,
         )
 
         if not results:
@@ -1028,11 +1057,154 @@ def make_recall_tool(memory: "MemoryFacade") -> ToolDefinition:
                         "permanent anchors only."
                     ),
                 },
+                "since": {
+                    "type": "string",
+                    "description": (
+                        "Optional lower bound for semantic updated_at "
+                        "(YYYY-MM-DD or ISO datetime)."
+                    ),
+                },
+                "until": {
+                    "type": "string",
+                    "description": (
+                        "Optional exclusive upper bound for semantic updated_at "
+                        "(YYYY-MM-DD or ISO datetime)."
+                    ),
+                },
             },
             "required": ["query"],
         },
         executor=_recall,
         tags=["memory", "search", "recall"],
+        impact_scope="memory",
+    )
+
+
+def _format_period_results(groups: dict[str, list]) -> str:
+    """Format grouped period recall evidence for the agent."""
+    sections: list[str] = []
+    semantic = groups.get("semantic", [])
+    if semantic:
+        lines = ["Semantic facts"]
+        for entry in semantic:
+            stamp = entry.updated_at.isoformat()[:10] if entry.updated_at else ""
+            lines.append(f"- [{stamp}] {entry.key}: {entry.value[:240]}")
+        sections.append("\n".join(lines))
+
+    episodic = groups.get("episodic", [])
+    if episodic:
+        lines = ["Episodic events"]
+        for entry in episodic:
+            stamp = entry.created_at.isoformat()[:16] if entry.created_at else ""
+            lines.append(
+                f"- [{stamp}] {entry.session_id} {entry.event_type}: "
+                f"{entry.content[:240]}"
+            )
+        sections.append("\n".join(lines))
+
+    sessions = groups.get("sessions", [])
+    if sessions:
+        lines = ["Sessions"]
+        for session in sessions:
+            title = session.get("title") or "(untitled)"
+            lines.append(
+                f"- [{session.get('last_active', '')[:16]}] "
+                f"{session.get('session_id')}: {title} "
+                f"({session.get('turn_count', 0)} turns)"
+            )
+        sections.append("\n".join(lines))
+
+    messages = groups.get("messages", [])
+    if messages:
+        lines = ["Session messages"]
+        for message in messages:
+            lines.append(
+                f"- [{message.get('created_at', '')[:16]}] "
+                f"{message.get('session_id')} {message.get('role')}: "
+                f"{str(message.get('content') or '')[:240]}"
+            )
+        sections.append("\n".join(lines))
+
+    return "\n\n".join(sections) if sections else "No memories found for this period."
+
+
+def make_recall_period_tool(memory: "MemoryFacade") -> ToolDefinition:
+    """Create a SAFE period recall tool across memory layers."""
+
+    async def _recall_period(call: ToolCall) -> ToolResult:
+        try:
+            since = _parse_memory_datetime(call.args.get("since"))
+            until = _parse_memory_datetime(call.args.get("until"))
+        except ValueError as exc:
+            return ToolResult(call_id=call.id, tool_name=call.tool_name,
+                              success=False, error=str(exc))
+        if since is None:
+            return ToolResult(call_id=call.id, tool_name=call.tool_name,
+                              success=False, error="'since' argument is required")
+        if until is not None and until <= since:
+            return ToolResult(call_id=call.id, tool_name=call.tool_name,
+                              success=False, error="'until' must be after 'since'")
+
+        limit = min(max(int(call.args.get("limit", 10)), 1), 20)
+        include_episodic = bool(call.args.get("include_episodic", True))
+        include_sessions = bool(call.args.get("include_sessions", False))
+        session_id = (call.args.get("session_id") or "").strip() or None
+
+        groups = await memory.recall_period(
+            since=since,
+            until=until,
+            session_id=session_id,
+            limit=limit,
+            include_episodic=include_episodic,
+            include_sessions=include_sessions,
+        )
+        return ToolResult(
+            call_id=call.id,
+            tool_name=call.tool_name,
+            success=True,
+            output=_format_period_results(groups),
+        )
+
+    return ToolDefinition(
+        name="recall_period",
+        description=(
+            "Retrieve time-window memory evidence. Use for questions like "
+            "'what did we discuss yesterday?' Start with semantic facts and "
+            "include episodic/session evidence when deeper recall is needed."
+        ),
+        trust_level=TrustLevel.SAFE,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "since": {
+                    "type": "string",
+                    "description": "Required lower bound (YYYY-MM-DD or ISO datetime).",
+                },
+                "until": {
+                    "type": "string",
+                    "description": "Optional exclusive upper bound (YYYY-MM-DD or ISO datetime).",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results per layer (1-20, default 10).",
+                },
+                "include_episodic": {
+                    "type": "boolean",
+                    "description": "Include episodic events (default true).",
+                },
+                "include_sessions": {
+                    "type": "boolean",
+                    "description": "Include matching session metadata (default false).",
+                },
+                "session_id": {
+                    "type": "string",
+                    "description": "Optional session scope for episodic events.",
+                },
+            },
+            "required": ["since"],
+        },
+        executor=_recall_period,
+        tags=["memory", "search", "recall", "period"],
         impact_scope="memory",
     )
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -18,6 +18,7 @@ import pytest
 import pytest_asyncio
 import tempfile
 import os
+from datetime import UTC, datetime
 from pathlib import Path
 
 from loom.core.memory.store import SQLiteStore
@@ -273,6 +274,39 @@ class TestEpisodicMemory:
         em = EpisodicMemory(db_conn)
         assert await em.mark_compressed([]) == 0
 
+    @pytest.mark.asyncio
+    async def test_list_between_filters_created_at_and_session(self, db_conn):
+        em = EpisodicMemory(db_conn)
+        before = datetime(2026, 5, 9, 23, 59, tzinfo=UTC)
+        inside_old = datetime(2026, 5, 10, 1, 0, tzinfo=UTC)
+        inside_new = datetime(2026, 5, 10, 2, 0, tzinfo=UTC)
+        after = datetime(2026, 5, 11, 0, 0, tzinfo=UTC)
+
+        await em.write(EpisodicEntry(
+            session_id="s1", event_type="message", content="before",
+            created_at=before,
+        ))
+        await em.write(EpisodicEntry(
+            session_id="s1", event_type="message", content="inside s1",
+            created_at=inside_old,
+        ))
+        await em.write(EpisodicEntry(
+            session_id="s2", event_type="message", content="inside s2",
+            created_at=inside_new,
+        ))
+        await em.write(EpisodicEntry(
+            session_id="s1", event_type="message", content="after",
+            created_at=after,
+        ))
+
+        results = await em.list_between(
+            since=datetime(2026, 5, 10, tzinfo=UTC),
+            until=datetime(2026, 5, 11, tzinfo=UTC),
+            session_id="s1",
+        )
+
+        assert [e.content for e in results] == ["inside s1"]
+
 
 # ---------------------------------------------------------------------------
 # SemanticMemory
@@ -331,6 +365,39 @@ class TestSemanticMemory:
             await sm.upsert(SemanticEntry(key=f"key:{i}", value=f"fact {i}"))
         results = await sm.list_recent(limit=5)
         assert len(results) == 5
+
+    @pytest.mark.asyncio
+    async def test_list_between_filters_updated_at(self, db_conn):
+        sm = SemanticMemory(db_conn)
+        await sm.upsert(SemanticEntry(key="before", value="loom before"))
+        await sm.upsert(SemanticEntry(key="inside:old", value="loom old"))
+        await sm.upsert(SemanticEntry(key="inside:new", value="loom new"))
+        await sm.upsert(SemanticEntry(key="after", value="loom after"))
+
+        await db_conn.execute(
+            "UPDATE semantic_entries SET updated_at = ? WHERE key = ?",
+            (datetime(2026, 5, 9, 23, 59, tzinfo=UTC).isoformat(), "before"),
+        )
+        await db_conn.execute(
+            "UPDATE semantic_entries SET updated_at = ? WHERE key = ?",
+            (datetime(2026, 5, 10, 1, 0, tzinfo=UTC).isoformat(), "inside:old"),
+        )
+        await db_conn.execute(
+            "UPDATE semantic_entries SET updated_at = ? WHERE key = ?",
+            (datetime(2026, 5, 10, 2, 0, tzinfo=UTC).isoformat(), "inside:new"),
+        )
+        await db_conn.execute(
+            "UPDATE semantic_entries SET updated_at = ? WHERE key = ?",
+            (datetime(2026, 5, 11, 0, 0, tzinfo=UTC).isoformat(), "after"),
+        )
+        await db_conn.commit()
+
+        results = await sm.list_between(
+            since=datetime(2026, 5, 10, tzinfo=UTC),
+            until=datetime(2026, 5, 11, tzinfo=UTC),
+        )
+
+        assert [e.key for e in results] == ["inside:new", "inside:old"]
 
     @pytest.mark.asyncio
     async def test_metadata_round_trips(self, db_conn):

--- a/tests/test_memory_facade.py
+++ b/tests/test_memory_facade.py
@@ -10,19 +10,21 @@ handle identity so ``LoomSession`` callers that still reach through
 """
 from __future__ import annotations
 
+from datetime import UTC, datetime
 import logging
 from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
 
-from loom.core.memory.episodic import EpisodicMemory
+from loom.core.memory.episodic import EpisodicEntry, EpisodicMemory
 from loom.core.memory.facade import MemoryFacade
 from loom.core.memory.governance import GovernedWriteResult, MemoryGovernor
 from loom.core.memory.procedural import ProceduralMemory
 from loom.core.memory.relational import RelationalEntry, RelationalMemory
 from loom.core.memory.search import MemorySearch
 from loom.core.memory.semantic import SemanticEntry, SemanticMemory
+from loom.core.memory.session_log import SessionLog
 from loom.core.memory.store import SQLiteStore
 
 
@@ -36,9 +38,11 @@ async def facade(tmp_path):
         relational = RelationalMemory(db)
         episodic = EpisodicMemory(db)
         search = MemorySearch(semantic, procedural)
+        session_log = SessionLog(db)
         yield MemoryFacade(
             semantic=semantic, procedural=procedural,
             relational=relational, episodic=episodic, search=search,
+            session_log=session_log,
         )
 
 
@@ -111,6 +115,52 @@ async def test_search_delegates_to_search_index(facade):
     results = await facade.search("memory framework", kind="semantic", limit=5)
     assert results, "facade.search should hit the BM25 index for matching content"
     assert any("loom is a memory-native" in r.value for r in results)
+
+
+@pytest.mark.asyncio
+async def test_recall_period_returns_grouped_memory_layers(facade):
+    await facade.semantic.upsert(SemanticEntry(
+        key="inside:fact", value="Loom discussed time-aware recall",
+        confidence=0.9, source="memorize",
+    ))
+    await facade.semantic.upsert(SemanticEntry(
+        key="outside:fact", value="Outside range", confidence=0.9,
+    ))
+    await facade.semantic._db.execute(
+        "UPDATE semantic_entries SET updated_at = ? WHERE key = ?",
+        (datetime(2026, 5, 10, 12, 0, tzinfo=UTC).isoformat(), "inside:fact"),
+    )
+    await facade.semantic._db.execute(
+        "UPDATE semantic_entries SET updated_at = ? WHERE key = ?",
+        (datetime(2026, 5, 9, 12, 0, tzinfo=UTC).isoformat(), "outside:fact"),
+    )
+    await facade.episodic.write(EpisodicEntry(
+        session_id="s1", event_type="message", content="User asked about yesterday",
+        created_at=datetime(2026, 5, 10, 13, 0, tzinfo=UTC),
+    ))
+    await facade.session_log.create_session("s1", "model", title="Memory chat")
+    await facade.session_log.update_session(
+        "s1", 1, datetime(2026, 5, 10, 14, 0, tzinfo=UTC).isoformat(), None,
+    )
+    await facade.session_log.log_message("s1", 0, "user", "raw session message")
+    await facade.session_log._db.execute(
+        "UPDATE session_log SET created_at = ? WHERE content = ?",
+        (datetime(2026, 5, 10, 14, 30, tzinfo=UTC).isoformat(), "raw session message"),
+    )
+    await facade.semantic._db.commit()
+
+    result = await facade.recall_period(
+        since=datetime(2026, 5, 10, tzinfo=UTC),
+        until=datetime(2026, 5, 11, tzinfo=UTC),
+        include_episodic=True,
+        include_sessions=True,
+        limit=5,
+    )
+
+    assert [e.key for e in result["semantic"]] == ["inside:fact"]
+    assert [e.content for e in result["episodic"]] == ["User asked about yesterday"]
+    assert [s["session_id"] for s in result["sessions"]] == ["s1"]
+    assert [m["content"] for m in result["messages"]] == ["raw session message"]
 
 
 # ── session integration ────────────────────────────────────────────────────

--- a/tests/test_memory_search.py
+++ b/tests/test_memory_search.py
@@ -404,6 +404,21 @@ class TestRecallTool:
         assert kwargs["since"] == datetime(2026, 5, 10, tzinfo=UTC)
         assert kwargs["until"] == datetime(2026, 5, 11, tzinfo=UTC)
 
+    async def test_until_without_since_returns_error(self):
+        facade = MagicMock()
+        facade.search = AsyncMock(return_value=[])
+        tool = make_recall_tool(facade)
+        call = _make_call("recall", {
+            "query": "loom",
+            "until": "2026-05-11",
+        })
+
+        result = await tool.executor(call)
+
+        assert result.success is False
+        assert "since" in result.error
+        facade.search.assert_not_awaited()
+
     def test_tool_is_safe_trust_level(self):
         # Metadata-only check; facade handles can be mocks.
         tool = make_recall_tool(MagicMock())
@@ -471,6 +486,20 @@ class TestRecallPeriodTool:
         kwargs = facade.recall_period.await_args.kwargs
         assert kwargs["since"] == datetime(2026, 5, 10, tzinfo=UTC)
         assert kwargs["until"] == datetime(2026, 5, 11, tzinfo=UTC)
+
+    async def test_until_without_since_returns_error(self):
+        facade = MagicMock()
+        facade.recall_period = AsyncMock(return_value={})
+        tool = make_recall_period_tool(facade)
+        call = _make_call("recall_period", {
+            "until": "2026-05-11",
+        })
+
+        result = await tool.executor(call)
+
+        assert result.success is False
+        assert "since" in result.error
+        facade.recall_period.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_memory_search.py
+++ b/tests/test_memory_search.py
@@ -33,6 +33,8 @@ make_memorize_tool (integration)
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import pytest
 import pytest_asyncio
 from unittest.mock import AsyncMock, MagicMock
@@ -47,7 +49,11 @@ from loom.core.memory.search import MemorySearch, MemorySearchResult
 from loom.core.memory.index import MemoryIndex, MemoryIndexer
 from loom.core.harness.middleware import ToolCall, ToolResult
 from loom.core.harness.permissions import TrustLevel
-from loom.platform.cli.tools import make_recall_tool, make_memorize_tool
+from loom.platform.cli.tools import (
+    make_recall_period_tool,
+    make_recall_tool,
+    make_memorize_tool,
+)
 
 
 def _facade(
@@ -193,6 +199,29 @@ class TestMemorySearch:
         assert r.value == "my fact value"
         assert r.score > 0.0
         assert r.metadata["confidence"] == 0.9
+
+    async def test_recall_filters_by_updated_at_range(self, db_conn, semantic, procedural):
+        await semantic.upsert(SemanticEntry(key="outside", value="loom outside"))
+        await semantic.upsert(SemanticEntry(key="inside", value="loom inside"))
+        await db_conn.execute(
+            "UPDATE semantic_entries SET updated_at = ? WHERE key = ?",
+            (datetime(2026, 5, 9, 23, 0, tzinfo=UTC).isoformat(), "outside"),
+        )
+        await db_conn.execute(
+            "UPDATE semantic_entries SET updated_at = ? WHERE key = ?",
+            (datetime(2026, 5, 10, 12, 0, tzinfo=UTC).isoformat(), "inside"),
+        )
+        await db_conn.commit()
+
+        search = MemorySearch(semantic, procedural)
+        results = await search.recall(
+            "loom",
+            type="semantic",
+            since=datetime(2026, 5, 10, tzinfo=UTC),
+            until=datetime(2026, 5, 11, tzinfo=UTC),
+        )
+
+        assert [r.key for r in results] == ["inside"]
 
 
 # ---------------------------------------------------------------------------
@@ -350,6 +379,31 @@ class TestRecallTool:
         result = await tool.executor(call)
         assert result.success is True
 
+    async def test_time_filters_forwarded(self):
+        facade = MagicMock()
+        facade.search = AsyncMock(return_value=[
+            MemorySearchResult(
+                type="semantic",
+                key="k",
+                value="loom fact",
+                score=1.0,
+            )
+        ])
+        tool = make_recall_tool(facade)
+        call = _make_call("recall", {
+            "query": "loom",
+            "type": "semantic",
+            "since": "2026-05-10",
+            "until": "2026-05-11",
+        })
+
+        result = await tool.executor(call)
+
+        assert result.success is True
+        kwargs = facade.search.await_args.kwargs
+        assert kwargs["since"] == datetime(2026, 5, 10, tzinfo=UTC)
+        assert kwargs["until"] == datetime(2026, 5, 11, tzinfo=UTC)
+
     def test_tool_is_safe_trust_level(self):
         # Metadata-only check; facade handles can be mocks.
         tool = make_recall_tool(MagicMock())
@@ -360,6 +414,63 @@ class TestRecallTool:
         tool = make_recall_tool(MagicMock())
         assert "query" in tool.input_schema["properties"]
         assert "query" in tool.input_schema["required"]
+
+
+class TestRecallPeriodTool:
+    async def test_success_returns_grouped_output(self):
+        facade = MagicMock()
+        facade.recall_period = AsyncMock(return_value={
+            "semantic": [
+                SemanticEntry(
+                    key="k",
+                    value="Loom discussed time-aware recall",
+                    updated_at=datetime(2026, 5, 10, 12, 0, tzinfo=UTC),
+                )
+            ],
+            "episodic": [
+                EpisodicEntry(
+                    session_id="s1",
+                    event_type="message",
+                    content="User asked about yesterday",
+                    created_at=datetime(2026, 5, 10, 13, 0, tzinfo=UTC),
+                )
+            ],
+            "sessions": [
+                {
+                    "session_id": "s1",
+                    "title": "Memory chat",
+                    "last_active": datetime(2026, 5, 10, 14, 0, tzinfo=UTC).isoformat(),
+                    "turn_count": 2,
+                }
+            ],
+            "messages": [
+                {
+                    "session_id": "s1",
+                    "turn_index": 0,
+                    "role": "user",
+                    "content": "raw session message",
+                    "created_at": datetime(2026, 5, 10, 14, 30, tzinfo=UTC).isoformat(),
+                }
+            ],
+        })
+        tool = make_recall_period_tool(facade)
+        call = _make_call("recall_period", {
+            "since": "2026-05-10",
+            "until": "2026-05-11",
+            "include_episodic": True,
+            "include_sessions": True,
+        })
+
+        result = await tool.executor(call)
+
+        assert result.success is True
+        assert "Semantic facts" in result.output
+        assert "Episodic events" in result.output
+        assert "Sessions" in result.output
+        assert "Session messages" in result.output
+        kwargs = facade.recall_period.await_args.kwargs
+        assert kwargs["since"] == datetime(2026, 5, 10, tzinfo=UTC)
+        assert kwargs["until"] == datetime(2026, 5, 11, tzinfo=UTC)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -425,6 +426,75 @@ class TestSessionLogTitle:
         # No row added
         rows = await sl.list_sessions()
         assert all(r["session_id"] != "does-not-exist" for r in rows)
+
+    async def test_list_sessions_between_filters_last_active(self, sl_conn):
+        from loom.core.memory.session_log import SessionLog
+
+        sl = SessionLog(sl_conn)
+        await sl.create_session("before", "model", title="Before")
+        await sl.create_session("inside", "model", title="Inside")
+        await sl.create_session("after", "model", title="After")
+        await sl_conn.execute(
+            "UPDATE sessions SET last_active = ? WHERE session_id = ?",
+            (datetime(2026, 5, 9, 23, 59, tzinfo=UTC).isoformat(), "before"),
+        )
+        await sl_conn.execute(
+            "UPDATE sessions SET last_active = ? WHERE session_id = ?",
+            (datetime(2026, 5, 10, 12, 0, tzinfo=UTC).isoformat(), "inside"),
+        )
+        await sl_conn.execute(
+            "UPDATE sessions SET last_active = ? WHERE session_id = ?",
+            (datetime(2026, 5, 11, 0, 0, tzinfo=UTC).isoformat(), "after"),
+        )
+        await sl_conn.commit()
+
+        rows = await sl.list_sessions_between(
+            since=datetime(2026, 5, 10, tzinfo=UTC),
+            until=datetime(2026, 5, 11, tzinfo=UTC),
+        )
+
+        assert [r["session_id"] for r in rows] == ["inside"]
+
+    async def test_messages_between_filters_created_at_and_session(self, tmp_path):
+        from loom.core.memory.session_log import SessionLog
+        from loom.core.memory.store import SQLiteStore
+
+        store = SQLiteStore(str(tmp_path / "messages-between.db"))
+        await store.initialize()
+        async with store.connect() as conn:
+            sl = SessionLog(conn)
+            await sl.create_session("s1", "model")
+            await sl.create_session("s2", "model")
+            await sl.log_message(
+                "s1", 0, "user", "before",
+            )
+            await sl.log_message(
+                "s1", 1, "user", "inside s1",
+            )
+            await sl.log_message(
+                "s2", 1, "user", "inside s2",
+            )
+            await conn.execute(
+                "UPDATE session_log SET created_at = ? WHERE content = ?",
+                (datetime(2026, 5, 9, 23, 59, tzinfo=UTC).isoformat(), "before"),
+            )
+            await conn.execute(
+                "UPDATE session_log SET created_at = ? WHERE content = ?",
+                (datetime(2026, 5, 10, 12, 0, tzinfo=UTC).isoformat(), "inside s1"),
+            )
+            await conn.execute(
+                "UPDATE session_log SET created_at = ? WHERE content = ?",
+                (datetime(2026, 5, 10, 13, 0, tzinfo=UTC).isoformat(), "inside s2"),
+            )
+            await conn.commit()
+
+            rows = await sl.messages_between(
+                since=datetime(2026, 5, 10, tzinfo=UTC),
+                until=datetime(2026, 5, 11, tzinfo=UTC),
+                session_id="s1",
+            )
+
+        assert [r["content"] for r in rows] == ["inside s1"]
 
 
 class TestProvisionalTitle:


### PR DESCRIPTION
## Summary
- add time-window APIs for semantic, episodic, and session_log memory layers
- thread `since` / `until` through semantic `recall`
- add SAFE `recall_period` tool with semantic facts, episodic events, sessions, and session messages
- add design spec and implementation plan docs

## Verification
- `pytest -q tests/test_memory.py tests/test_memory_search.py tests/test_memory_facade.py tests/test_session.py` -> 152 passed
- `git diff --check` -> clean
- `npx gitnexus detect-changes` -> high risk; expected cross-layer memory retrieval impact. Affected flows: Check_all_skills recall paths and Load_messages redaction-adjacent session_log path.

Closes #354
