### PR TITLE
feat(memory): add Discord safety-net compaction

### DIFF
--- a/docs/superpowers/plans/2026-05-11-daily-safety-net-compaction.md
+++ b/docs/superpowers/plans/2026-05-11-daily-safety-net-compaction.md
@@ -1,0 +1,316 @@
+# Daily Safety-Net Compaction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a daily Discord safety-net compaction path that promotes idle episodic memory to semantic memory even when turn-driven thresholds do not fire.
+
+**Architecture:** `LoomSession` exposes `force_compact()` and moves shared compression work into one private helper guarded by `_compaction_lock`. `LoomDiscordBot` schedules one 05:00 local-time daily pass over in-memory sessions and runs a best-effort compaction pass after lazy session resume.
+
+**Tech Stack:** Python async, `discord.ext.tasks`, pytest async tests, existing Loom memory compaction helpers.
+
+---
+
+## File Structure
+
+- Modify `loom/core/session.py`
+  - Add `_compact_memory(force: bool)` as the shared compaction body.
+  - Update `_run_compaction_check()` to lock and call `_compact_memory(force=False)`.
+  - Add public `force_compact()` that locks and calls `_compact_memory(force=True)`.
+  - Update `_compaction_subscriber_loop()` to rely on `_run_compaction_check()` for locking.
+- Modify `loom/platform/discord/bot.py`
+  - Import `datetime`, `time` as needed, and `discord.ext.tasks`.
+  - Add daily compaction loop initialization in `LoomDiscordBot.__init__()`.
+  - Start the loop in `on_ready()` if it is not running.
+  - Add `_run_daily_compaction()` and `_force_compact_active_sessions(reason: str)`.
+  - Add a best-effort resume-time compaction call in `_start_session()`.
+  - Add `close()` to cancel the loop and close active sessions/client.
+- Modify `tests/test_memory_compaction_subscriber.py`
+  - Bind `force_compact()` onto the stub.
+  - Add tests for below-threshold forced compaction and forced/threshold serialization.
+- Modify or create `tests/test_discord_daily_compaction.py`
+  - Test active-session daily pass calls each session's `force_compact()`.
+  - Test failures in one session do not stop the rest.
+  - Test `_start_session()` runs the resume-time pass on the newly created session.
+
+## Tasks
+
+### Task 1: Core Forced Compaction
+
+**Files:**
+- Modify: `tests/test_memory_compaction_subscriber.py`
+- Modify: `loom/core/session.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add two tests:
+
+```python
+async def test_force_compact_bypasses_threshold_and_buffers_done(monkeypatch) -> None:
+    s = _make_stub(ep_count=5, threshold=30, fact_count=6)
+    monkeypatch.setattr(s._session_module, "compress_session", s._fake_compress)
+    await s.force_compact()
+    assert s.compress_called == 1
+    assert s.refresh_called == 1
+    assert len(s._pending_compactions) == 1
+    assert isinstance(s._pending_compactions[0], CompressDone)
+    assert s._pending_compactions[0].fact_count == 6
+
+
+async def test_force_and_threshold_checks_share_compaction_lock(monkeypatch) -> None:
+    s = _make_stub(ep_count=30, threshold=30, fact_count=2)
+    in_flight = 0
+    max_in_flight = 0
+
+    async def _slow_compress(*_a, **_kw):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(0.05)
+        in_flight -= 1
+        return 2
+
+    monkeypatch.setattr(s._session_module, "compress_session", _slow_compress)
+    await asyncio.gather(s.force_compact(), s._run_compaction_check())
+    assert max_in_flight == 1
+```
+
+Update `_make_stub()` to bind `s.force_compact = LoomSession.force_compact.__get__(s)`.
+
+- [ ] **Step 2: Run tests to verify red**
+
+Run:
+
+```bash
+pytest -q tests/test_memory_compaction_subscriber.py::test_force_compact_bypasses_threshold_and_buffers_done tests/test_memory_compaction_subscriber.py::test_force_and_threshold_checks_share_compaction_lock
+```
+
+Expected: fails because `LoomSession.force_compact` does not exist.
+
+- [ ] **Step 3: Implement minimal core behavior**
+
+In `loom/core/session.py`, add:
+
+```python
+async def _compact_memory(self, *, force: bool = False) -> None:
+    ep_count = await self._memory.episodic.count_session(
+        self.session_id, uncompressed_only=True,
+    )
+    if not force and ep_count < self._episodic_compress_threshold:
+        return
+    fact_count = await compress_session(...)
+    if fact_count:
+        self._pending_compactions.append(CompressDone(fact_count=fact_count))
+    await self._refresh_memory_index()
+```
+
+Then wrap `_run_compaction_check()` and `force_compact()` in:
+
+```python
+try:
+    async with self._compaction_lock:
+        await self._compact_memory(force=False)
+except Exception:
+    logger.exception(...)
+```
+
+and:
+
+```python
+async def force_compact(self) -> None:
+    try:
+        async with self._compaction_lock:
+            await self._compact_memory(force=True)
+    except Exception:
+        logger.exception(...)
+```
+
+Update `_compaction_subscriber_loop()` so the event body calls `await self._run_compaction_check()` directly.
+
+- [ ] **Step 4: Verify green**
+
+Run:
+
+```bash
+pytest -q tests/test_memory_compaction_subscriber.py
+```
+
+Expected: all tests in the file pass.
+
+### Task 2: Discord Daily Compaction
+
+**Files:**
+- Create or modify: `tests/test_discord_daily_compaction.py`
+- Modify: `loom/platform/discord/bot.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create tests with fake sessions:
+
+```python
+class _FakeSession:
+    def __init__(self, name: str, fail: bool = False):
+        self.name = name
+        self.fail = fail
+        self.calls = 0
+
+    async def force_compact(self) -> None:
+        self.calls += 1
+        if self.fail:
+            raise RuntimeError(f"{self.name} failed")
+
+
+async def test_daily_compaction_runs_for_all_active_sessions() -> None:
+    bot = LoomDiscordBot(model="test-model", db_path="/tmp/loom-test.db")
+    s1 = _FakeSession("one")
+    s2 = _FakeSession("two")
+    bot._sessions = {1: s1, 2: s2}
+    await bot._force_compact_active_sessions(reason="test")
+    assert s1.calls == 1
+    assert s2.calls == 1
+
+
+async def test_daily_compaction_continues_after_session_failure() -> None:
+    bot = LoomDiscordBot(model="test-model", db_path="/tmp/loom-test.db")
+    s1 = _FakeSession("one", fail=True)
+    s2 = _FakeSession("two")
+    bot._sessions = {1: s1, 2: s2}
+    await bot._force_compact_active_sessions(reason="test")
+    assert s1.calls == 1
+    assert s2.calls == 1
+```
+
+- [ ] **Step 2: Run tests to verify red**
+
+Run:
+
+```bash
+pytest -q tests/test_discord_daily_compaction.py::test_daily_compaction_runs_for_all_active_sessions tests/test_discord_daily_compaction.py::test_daily_compaction_continues_after_session_failure
+```
+
+Expected: fails because `_force_compact_active_sessions` does not exist.
+
+- [ ] **Step 3: Implement Discord pass**
+
+In `loom/platform/discord/bot.py`:
+
+```python
+from datetime import datetime, time as datetime_time
+from discord.ext import tasks
+```
+
+In `__init__()`:
+
+```python
+local_tz = datetime.now().astimezone().tzinfo
+self._daily_compaction_loop = tasks.loop(
+    time=datetime_time(hour=5, minute=0, tzinfo=local_tz)
+)(self._run_daily_compaction)
+```
+
+Add:
+
+```python
+async def _run_daily_compaction(self) -> None:
+    await self._force_compact_active_sessions(reason="daily")
+
+async def _force_compact_active_sessions(self, *, reason: str) -> None:
+    for thread_id, session in list(self._sessions.items()):
+        try:
+            await session.force_compact()
+        except Exception:
+            logger.exception(...)
+```
+
+Start the loop from `on_ready()` only if it is not running.
+
+- [ ] **Step 4: Verify green**
+
+Run:
+
+```bash
+pytest -q tests/test_discord_daily_compaction.py
+```
+
+Expected: tests pass.
+
+### Task 3: Resume-Time Pass and Shutdown
+
+**Files:**
+- Modify: `tests/test_discord_daily_compaction.py`
+- Modify: `loom/platform/discord/bot.py`
+
+- [ ] **Step 1: Write failing resume test**
+
+Patch `loom.platform.discord.bot.LoomSession`, middleware setup, and tool registration as needed, then assert `_start_session()` calls `force_compact()` once on the new session.
+
+- [ ] **Step 2: Run test to verify red**
+
+Run:
+
+```bash
+pytest -q tests/test_discord_daily_compaction.py::test_start_session_runs_resume_compaction_pass
+```
+
+Expected: fails because `_start_session()` does not call the helper.
+
+- [ ] **Step 3: Implement resume pass and close**
+
+After `self._sessions[thread_id] = session` in `_start_session()`:
+
+```python
+await self._force_compact_active_sessions(reason="resume")
+```
+
+or call a single-session helper if implemented. Add `close()` that cancels
+`_daily_compaction_loop`, closes all active sessions, and closes the Discord
+client.
+
+- [ ] **Step 4: Verify green**
+
+Run:
+
+```bash
+pytest -q tests/test_discord_daily_compaction.py tests/test_discord_slash_commands.py tests/test_memory_compaction_subscriber.py
+```
+
+Expected: all pass.
+
+### Task 4: Final Verification and PR
+
+**Files:**
+- All touched files.
+
+- [ ] **Step 1: Run focused suite**
+
+```bash
+pytest -q tests/test_memory_compaction_subscriber.py tests/test_discord_daily_compaction.py tests/test_discord_slash_commands.py tests/test_memory.py tests/test_memory_search.py tests/test_memory_facade.py tests/test_session.py
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Static cleanup**
+
+```bash
+git diff --check
+npx gitnexus detect-changes
+```
+
+Expected: no whitespace errors; GitNexus affected scope matches memory compaction and Discord bot.
+
+- [ ] **Step 3: Commit and open PR**
+
+```bash
+git status --short
+git add docs/superpowers/specs/2026-05-11-daily-safety-net-compaction-design.md docs/superpowers/plans/2026-05-11-daily-safety-net-compaction.md loom/core/session.py loom/platform/discord/bot.py tests/test_memory_compaction_subscriber.py tests/test_discord_daily_compaction.py
+git commit -m "feat(memory): add Discord safety-net compaction"
+git push -u origin codex/daily-safety-net-compaction
+gh pr create --title "feat(memory): add Discord safety-net compaction" --body "..."
+```
+
+Expected: PR links issue #356 and lists verification output.
+
+## Self-Review
+
+- Spec coverage: The plan covers forced compaction below threshold, daily Discord scheduling, resume-time safety pass, lock serialization, and existing-suite verification.
+- Placeholder scan: No task relies on an undefined "TODO"; code examples name the exact methods and files.
+- Type consistency: The plan uses `force_compact()`, `_force_compact_active_sessions(reason=...)`, and `_run_daily_compaction()` consistently across tests and implementation.

--- a/docs/superpowers/specs/2026-05-11-daily-safety-net-compaction-design.md
+++ b/docs/superpowers/specs/2026-05-11-daily-safety-net-compaction-design.md
@@ -1,0 +1,78 @@
+# Daily Safety-Net Compaction Design
+
+## Context
+
+Episodic-to-semantic compaction currently runs from the turn-driven subscriber:
+`LoomSession._compaction_subscriber_loop()` listens for ledger `turn_end` events,
+then calls `_run_compaction_check()`. That path protects normal active sessions,
+but it leaves Discord sessions with sparse or interrupted traffic exposed:
+episodic entries can sit uncompressed for days when the threshold is not reached,
+when no new turn occurs, or when the bot restarts before a final turn-driven check.
+
+PR #355 added time-aware reads as a recovery path. This change adds the write-side
+safety net so long-running Discord bots periodically promote idle episodic memory
+into semantic memory.
+
+## Goals
+
+- Add `LoomSession.force_compact()` as a public async method that runs the same
+  compression path as `_run_compaction_check()` without the episodic threshold gate.
+- Keep all compaction serialized by the existing `_compaction_lock`, including
+  concurrent forced and turn-driven triggers.
+- Add a Discord daily task that calls `force_compact()` on every in-memory
+  `LoomSession` at 05:00 in the bot host's local timezone.
+- Add a resume-time safety pass: when Discord lazily resumes a thread into an
+  in-memory session, run `force_compact()` once so historical uncompressed entries
+  for that resumed session are handled.
+- Preserve the existing turn-driven threshold logic and event display behavior.
+
+## Non-Goals
+
+- Do not compact sessions that are only present in SQLite but not currently loaded
+  as a `LoomSession`; that needs a standalone compressor bootstrap and is a later
+  iteration.
+- Do not add idle-minute timers or CLI/TUI idle compaction.
+- Do not change the default `episodic_compress_threshold` or the subscriber's
+  turn-driven behavior.
+
+## Architecture
+
+`LoomSession.force_compact()` will acquire `_compaction_lock` and call a shared
+private compaction helper with `force=True`. `_run_compaction_check()` will acquire
+the same lock and call the helper with `force=False`. The helper owns the common
+count, `compress_session`, pending `CompressDone`, refresh, and exception logging
+logic. This avoids duplicating the LLM compression path while making the lock
+contract explicit for all callers.
+
+The subscriber loop will stop taking the lock itself and simply call
+`_run_compaction_check()`, because the method will become the lock boundary. This
+lets tests and external callers exercise the same serialization behavior without
+needing to know about internal locking.
+
+`LoomDiscordBot` will create a `discord.ext.tasks.loop` instance in `__init__`,
+start it from `on_ready()` if it is not already running, and cancel it from a new
+`close()` method before closing all active sessions and the Discord client. The
+loop body will snapshot `self._sessions.items()` and call `force_compact()` on
+each session independently, logging failures and continuing with the rest.
+
+The resume-time pass will run near the end of `_start_session()`, after the
+session has started and Discord-specific tools/middleware are installed but before
+the session is returned to message handling. This targets only sessions that are
+already in memory, matching the issue's scope.
+
+## Error Handling
+
+Forced compaction should be best-effort. A failed session logs the exception and
+does not stop the daily pass. `LoomSession` keeps the existing behavior where
+`compress_session` failures are swallowed and logged, because compaction must not
+break user turns or Discord startup.
+
+## Testing
+
+- Extend `tests/test_memory_compaction_subscriber.py` with a failing test proving
+  `force_compact()` compresses below threshold and appends `CompressDone`.
+- Add a concurrency test proving a forced compaction and threshold check cannot
+  run `compress_session` at the same time.
+- Add Discord bot tests covering the daily safety pass over in-memory sessions
+  and the resume-time pass in `_start_session()`.
+- Re-run the focused memory/session/Discord tests plus the existing memory suite.

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -3715,6 +3715,35 @@ class LoomSession:
     # #336 — memory compaction subscriber (doc/53 §6.4 push pattern)
     # ------------------------------------------------------------------
 
+    async def _compact_memory(self, *, force: bool = False) -> None:
+        """Run one episodic-to-semantic compaction pass.
+
+        The caller owns ``_compaction_lock``. ``force=True`` skips the
+        configured threshold gate but still avoids a no-op LLM call when
+        there are no uncompressed episodic rows.
+        """
+        ep_count = await self._memory.episodic.count_session(
+            self.session_id, uncompressed_only=True,
+        )
+        if ep_count <= 0:
+            return
+        if not force and ep_count < self._episodic_compress_threshold:
+            return
+        fact_count = await compress_session(
+            self.session_id,
+            self._memory.episodic, self._memory.semantic,
+            self.router, self.model,
+            governor=self._governor,
+            telemetry=self._telemetry,
+        )
+        if fact_count:
+            self._pending_compactions.append(
+                CompressDone(fact_count=fact_count)
+            )
+        # Rebuild MemoryIndex so long-running sessions (Discord)
+        # see updated fact/anti-pattern counts without restarting.
+        await self._refresh_memory_index()
+
     async def _run_compaction_check(self) -> None:
         """One pass of the threshold-driven compaction logic.
 
@@ -3729,33 +3758,31 @@ class LoomSession:
         Race contract: a new turn writing fresh episodic entries
         during this call is safe — ``compress_session`` reads a
         snapshot up front, marks only that snapshot at the end.
-        Concurrent compaction runs are blocked by ``_compaction_lock``
-        in the subscriber loop.
+        Concurrent compaction runs are blocked by ``_compaction_lock``.
         """
         try:
-            ep_count = await self._memory.episodic.count_session(
-                self.session_id, uncompressed_only=True,
-            )
-            if ep_count < self._episodic_compress_threshold:
-                return
-            fact_count = await compress_session(
-                self.session_id,
-                self._memory.episodic, self._memory.semantic,
-                self.router, self.model,
-                governor=self._governor,
-                telemetry=self._telemetry,
-            )
-            if fact_count:
-                self._pending_compactions.append(
-                    CompressDone(fact_count=fact_count)
-                )
-            # Rebuild MemoryIndex so long-running sessions (Discord)
-            # see updated fact/anti-pattern counts without restarting.
-            await self._refresh_memory_index()
+            async with self._compaction_lock:
+                await self._compact_memory(force=False)
         except Exception:
             logger.exception(
                 "memory compaction subscriber: compress_session failed; "
                 "continuing"
+            )
+
+    async def force_compact(self) -> None:
+        """Force one compaction pass, bypassing the episodic count threshold.
+
+        Used by long-running platform frontends as a safety net for idle
+        sessions. The implementation intentionally shares the same lock,
+        compression path, pending ``CompressDone`` buffer, and memory-index
+        refresh as the turn-driven subscriber.
+        """
+        try:
+            async with self._compaction_lock:
+                await self._compact_memory(force=True)
+        except Exception:
+            logger.exception(
+                "memory force_compact: compress_session failed; continuing"
             )
 
     async def _compaction_subscriber_loop(self) -> None:
@@ -3781,8 +3808,7 @@ class LoomSession:
                     # while the previous compaction is still mid-LLM,
                     # the second attempt waits rather than running in
                     # parallel and double-writing semantic facts.
-                    async with self._compaction_lock:
-                        await self._run_compaction_check()
+                    await self._run_compaction_check()
         except asyncio.CancelledError:
             raise
         except Exception:

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -53,14 +53,17 @@ showing the TTL or grant scope.
 from __future__ import annotations
 
 import asyncio
+import logging
 import json
 import os
 import time
+from datetime import datetime, time as datetime_time, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 try:
     import discord
+    from discord.ext import tasks
     from discord import ButtonStyle, Interaction, app_commands
     from discord.ui import Button, View
 except ImportError as exc:  # pragma: no cover
@@ -87,6 +90,8 @@ from loom.platform.discord.tools import (
     make_send_discord_select_tool,
 )
 from loom.platform.discord.reactions import REACTION
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from loom.core.session import LoomSession
@@ -271,6 +276,11 @@ class LoomDiscordBot:
         # Turn summary display mode: "off" | "on" | "detail"
         self._summary_mode: str = "on"
 
+        local_tz = datetime.now().astimezone().tzinfo or timezone.utc
+        self._daily_compaction_loop = tasks.loop(
+            time=datetime_time(hour=5, minute=0, tzinfo=local_tz),
+        )(self._run_daily_compaction)
+
         # Persistent thread → session_id mapping so existing threads resume
         # their context after a bot restart.
         # Stored at ~/.loom/discord_threads.json as {str(thread_id): session_id}
@@ -304,6 +314,8 @@ class LoomDiscordBot:
                 print(f"[Loom Discord] Accepting messages from user IDs: {bot._allowed_users}")
             if bot._allowed_channels:
                 print(f"[Loom Discord] Operating in channels: {bot._allowed_channels}")
+            if not bot._daily_compaction_loop.is_running():
+                bot._daily_compaction_loop.start()
 
             # Sync slash commands. LOOM_DISCORD_DEV_GUILD_ID makes iteration
             # bearable (per-guild syncs are instant; the global tree takes up
@@ -573,6 +585,7 @@ class LoomDiscordBot:
         session.subscribe_promotion(_discord_promotion)
 
         self._sessions[thread_id] = session
+        await self._force_compact_active_sessions(reason="resume")
         return session
 
     async def _close_session(self, thread_id: int) -> None:
@@ -582,6 +595,22 @@ class LoomDiscordBot:
                 await session.stop()
             except Exception:
                 pass
+
+    async def _run_daily_compaction(self) -> None:
+        """Scheduled Discord safety net for idle in-memory sessions."""
+        await self._force_compact_active_sessions(reason="daily")
+
+    async def _force_compact_active_sessions(self, *, reason: str) -> None:
+        """Best-effort forced compaction over currently loaded sessions."""
+        for thread_id, session in list(self._sessions.items()):
+            try:
+                await session.force_compact()
+            except Exception:
+                logger.exception(
+                    "Discord %s memory compaction failed for thread %s",
+                    reason,
+                    thread_id,
+                )
 
     # ------------------------------------------------------------------
     # Slash commands
@@ -1338,6 +1367,8 @@ class LoomDiscordBot:
 
     async def close(self) -> None:
         """Stop all sessions and disconnect."""
+        if self._daily_compaction_loop.is_running():
+            self._daily_compaction_loop.cancel()
         for tid in list(self._sessions):
             await self._close_session(tid)
         await self._client.close()

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -585,7 +585,7 @@ class LoomDiscordBot:
         session.subscribe_promotion(_discord_promotion)
 
         self._sessions[thread_id] = session
-        await self._force_compact_active_sessions(reason="resume")
+        await self._force_compact_session(thread_id, session, reason="resume")
         return session
 
     async def _close_session(self, thread_id: int) -> None:
@@ -603,14 +603,20 @@ class LoomDiscordBot:
     async def _force_compact_active_sessions(self, *, reason: str) -> None:
         """Best-effort forced compaction over currently loaded sessions."""
         for thread_id, session in list(self._sessions.items()):
-            try:
-                await session.force_compact()
-            except Exception:
-                logger.exception(
-                    "Discord %s memory compaction failed for thread %s",
-                    reason,
-                    thread_id,
-                )
+            await self._force_compact_session(thread_id, session, reason=reason)
+
+    async def _force_compact_session(
+        self, thread_id: int, session: "LoomSession", *, reason: str
+    ) -> None:
+        """Best-effort forced compaction for one loaded Discord session."""
+        try:
+            await session.force_compact()
+        except Exception:
+            logger.exception(
+                "Discord %s memory compaction failed for thread %s",
+                reason,
+                thread_id,
+            )
 
     # ------------------------------------------------------------------
     # Slash commands
@@ -1367,6 +1373,8 @@ class LoomDiscordBot:
 
     async def close(self) -> None:
         """Stop all sessions and disconnect."""
+        # A crashed discord.ext.tasks loop reports not-running; cancel only
+        # when this instance still owns an active daily compaction loop.
         if self._daily_compaction_loop.is_running():
             self._daily_compaction_loop.cancel()
         for tid in list(self._sessions):

--- a/tests/test_discord_daily_compaction.py
+++ b/tests/test_discord_daily_compaction.py
@@ -50,7 +50,7 @@ async def test_start_session_runs_resume_compaction_pass(monkeypatch) -> None:
     bot._thread_map = {"123": "sess-existing"}
     bot._save_thread_map = MagicMock()
     bot._client.get_channel = MagicMock(return_value=None)
-    bot._force_compact_active_sessions = AsyncMock()
+    bot._force_compact_session = AsyncMock()
 
     session = MagicMock()
     session.session_id = "sess-existing"
@@ -69,4 +69,36 @@ async def test_start_session_runs_resume_compaction_pass(monkeypatch) -> None:
     started = await bot._start_session(123)
 
     assert started is session
-    bot._force_compact_active_sessions.assert_awaited_once_with(reason="resume")
+    bot._force_compact_session.assert_awaited_once_with(
+        123, session, reason="resume"
+    )
+
+
+async def test_start_session_resume_compacts_only_new_session(monkeypatch) -> None:
+    import loom.core.session as session_module
+
+    bot = LoomDiscordBot(model="test-model", db_path="/tmp/loom-test.db")
+    bot._sessions[999] = _FakeSession("already-active")
+    bot._thread_map = {"123": "sess-existing"}
+    bot._save_thread_map = MagicMock()
+    bot._client.get_channel = MagicMock(return_value=None)
+
+    session = MagicMock()
+    session.session_id = "sess-existing"
+    session.workspace = MagicMock()
+    session.registry.register = MagicMock()
+    session.perm.authorize = MagicMock()
+    session._pipeline._middlewares = []
+    session._pipeline.use = MagicMock()
+    session._loom_config = {"task_write": {"discord_reminder": False}}
+    session.subscribe_diagnostic = MagicMock()
+    session.subscribe_promotion = MagicMock()
+    session.start = AsyncMock()
+    session.force_compact = AsyncMock()
+
+    monkeypatch.setattr(session_module, "LoomSession", MagicMock(return_value=session))
+
+    await bot._start_session(123)
+
+    assert bot._sessions[999].calls == 0
+    session.force_compact.assert_awaited_once()

--- a/tests/test_discord_daily_compaction.py
+++ b/tests/test_discord_daily_compaction.py
@@ -1,0 +1,72 @@
+"""Issue #356 — Discord daily safety-net memory compaction."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from loom.platform.discord.bot import LoomDiscordBot
+
+
+class _FakeSession:
+    def __init__(self, name: str, *, fail: bool = False):
+        self.name = name
+        self.fail = fail
+        self.calls = 0
+
+    async def force_compact(self) -> None:
+        self.calls += 1
+        if self.fail:
+            raise RuntimeError(f"{self.name} failed")
+
+
+async def test_daily_compaction_runs_for_all_active_sessions() -> None:
+    bot = LoomDiscordBot(model="test-model", db_path="/tmp/loom-test.db")
+    s1 = _FakeSession("one")
+    s2 = _FakeSession("two")
+    bot._sessions = {1: s1, 2: s2}
+
+    await bot._force_compact_active_sessions(reason="test")
+
+    assert s1.calls == 1
+    assert s2.calls == 1
+
+
+async def test_daily_compaction_continues_after_session_failure() -> None:
+    bot = LoomDiscordBot(model="test-model", db_path="/tmp/loom-test.db")
+    s1 = _FakeSession("one", fail=True)
+    s2 = _FakeSession("two")
+    bot._sessions = {1: s1, 2: s2}
+
+    await bot._force_compact_active_sessions(reason="test")
+
+    assert s1.calls == 1
+    assert s2.calls == 1
+
+
+async def test_start_session_runs_resume_compaction_pass(monkeypatch) -> None:
+    import loom.core.session as session_module
+
+    bot = LoomDiscordBot(model="test-model", db_path="/tmp/loom-test.db")
+    bot._thread_map = {"123": "sess-existing"}
+    bot._save_thread_map = MagicMock()
+    bot._client.get_channel = MagicMock(return_value=None)
+    bot._force_compact_active_sessions = AsyncMock()
+
+    session = MagicMock()
+    session.session_id = "sess-existing"
+    session.workspace = MagicMock()
+    session.registry.register = MagicMock()
+    session.perm.authorize = MagicMock()
+    session._pipeline._middlewares = []
+    session._pipeline.use = MagicMock()
+    session._loom_config = {"task_write": {"discord_reminder": False}}
+    session.subscribe_diagnostic = MagicMock()
+    session.subscribe_promotion = MagicMock()
+    session.start = AsyncMock()
+
+    monkeypatch.setattr(session_module, "LoomSession", MagicMock(return_value=session))
+
+    started = await bot._start_session(123)
+
+    assert started is session
+    bot._force_compact_active_sessions.assert_awaited_once_with(reason="resume")

--- a/tests/test_memory_compaction_subscriber.py
+++ b/tests/test_memory_compaction_subscriber.py
@@ -162,6 +162,7 @@ async def test_zero_facts_no_compress_done_emitted(monkeypatch) -> None:
 async def test_force_compact_bypasses_threshold_and_buffers_done(
     monkeypatch,
 ) -> None:
+    # Deliberately below threshold; force_compact must skip that gate.
     s = _make_stub(ep_count=5, threshold=30, fact_count=6)
     monkeypatch.setattr(s._session_module, "compress_session", s._fake_compress)
     await s.force_compact()

--- a/tests/test_memory_compaction_subscriber.py
+++ b/tests/test_memory_compaction_subscriber.py
@@ -112,7 +112,9 @@ def _make_stub(
     s._fake_refresh = _fake_refresh
     s._session_module = session_module
 
+    s._compact_memory = LoomSession._compact_memory.__get__(s)
     s._run_compaction_check = LoomSession._run_compaction_check.__get__(s)
+    s.force_compact = LoomSession.force_compact.__get__(s)
     s._refresh_memory_index = _fake_refresh
     s._compaction_subscriber_loop = (
         LoomSession._compaction_subscriber_loop.__get__(s)
@@ -157,6 +159,19 @@ async def test_zero_facts_no_compress_done_emitted(monkeypatch) -> None:
     assert s._pending_compactions == []  # 0 facts → no signal
 
 
+async def test_force_compact_bypasses_threshold_and_buffers_done(
+    monkeypatch,
+) -> None:
+    s = _make_stub(ep_count=5, threshold=30, fact_count=6)
+    monkeypatch.setattr(s._session_module, "compress_session", s._fake_compress)
+    await s.force_compact()
+    assert s.compress_called == 1
+    assert s.refresh_called == 1
+    assert len(s._pending_compactions) == 1
+    assert isinstance(s._pending_compactions[0], CompressDone)
+    assert s._pending_compactions[0].fact_count == 6
+
+
 async def test_compress_failure_swallowed_no_pending_compaction(
     monkeypatch,
 ) -> None:
@@ -195,11 +210,29 @@ async def test_lock_serialises_concurrent_compactions(monkeypatch) -> None:
 
     monkeypatch.setattr(s._session_module, "compress_session", _slow_compress)
 
-    async def _gated() -> None:
-        async with s._compaction_lock:
-            await s._run_compaction_check()
+    await asyncio.gather(s._run_compaction_check(), s._run_compaction_check())
+    assert max_in_flight == 1  # never two parallel compress calls
 
-    await asyncio.gather(_gated(), _gated())
+
+async def test_force_and_threshold_checks_share_compaction_lock(
+    monkeypatch,
+) -> None:
+    s = _make_stub(ep_count=30, threshold=30, fact_count=2)
+
+    in_flight = 0
+    max_in_flight = 0
+
+    async def _slow_compress(*_a, **_kw):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(0.05)
+        in_flight -= 1
+        return 2
+
+    monkeypatch.setattr(s._session_module, "compress_session", _slow_compress)
+
+    await asyncio.gather(s.force_compact(), s._run_compaction_check())
     assert max_in_flight == 1  # never two parallel compress calls
 
 


### PR DESCRIPTION
## Summary
- add `LoomSession.force_compact()` for threshold-bypassing episodic-to-semantic compaction through the existing lock and compression path
- add a Discord daily 05:00 local-time safety-net pass over in-memory sessions
- add a resume-time Discord compaction pass for lazily restored thread sessions
- document the design and implementation plan for issue #356

## Verification
- `pytest -q tests/test_memory_compaction_subscriber.py tests/test_discord_daily_compaction.py tests/test_discord_slash_commands.py tests/test_memory.py tests/test_memory_search.py tests/test_memory_facade.py tests/test_session.py` — 191 passed
- `git diff --check`
- `npx gitnexus detect-changes --scope staged` — risk low, affected processes 0

Closes #356