### PR TITLE
feat(cli): Theme System — Parchment & Sunrise palettes + /theme command

### DIFF
--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -58,6 +58,7 @@ from loom.core.memory.store import SQLiteStore
 from loom.core.memory.session_log import SessionLog
 from loom.platform.cli.harness_channel import HarnessChannel
 from loom.platform.cli.theme import LOOM_THEME
+from loom.platform.cli.theme_persist import load_preference, save_preference, available_themes
 from loom.platform.cli.ui import (
     ActionRolledBack,
     ActionStateChange,
@@ -942,6 +943,33 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
                 # the user sees the new context% immediately
                 loom_app.footer.token_pct = session.budget.usage_fraction * 100
                 loom_app.invalidate()
+
+    elif command == "/theme":
+        args_part = parts[1] if len(parts) > 1 else ""
+        active = load_preference()
+        all_themes = available_themes()
+
+        if not args_part.strip():
+            # List available themes with current selection marked
+            harness.inline("[bold]Available themes[/bold]", level="info")
+            for name in all_themes:
+                marker = "  ← currently active" if name == active else ""
+                harness.inline(f"  {name}{marker}", level="info")
+            return
+
+        target = args_part.strip()
+        if target not in all_themes:
+            harness.inline(
+                f"Unknown theme '{target}'. Available: {', '.join(all_themes)}",
+                level="error",
+            )
+            return
+
+        save_preference(target)
+        harness.inline(
+            f"Theme switched to [accent]{target}[/accent]. Restart to apply.",
+            level="info",
+        )
 
     elif command == "/sessions":
         # Issue #260: list recent sessions, let the user pick one by

--- a/loom/platform/cli/theme.py
+++ b/loom/platform/cli/theme.py
@@ -1,25 +1,16 @@
 """
-Loom CLI theme — single source of truth for parchment palette.
+Loom CLI theme — pluggable palette registry.
 
-Issue #236 (CLI Refresh, PR-B). Pulls the colour palette already defined
-in the TUI layer (``loom/platform/cli/tui/app.py``) into a Rich-native
-:class:`Theme` so plain CLI surfaces share the same visual language.
+Issue #358 (Theme System). Replaces the single hardcoded PARCHMENT palette
+with a named-registry approach so adding a new theme is one dict entry.
 
 Use semantic tokens at call sites instead of raw colour names so a
 future palette tweak is one-file.
 
-Tokens
-------
-Foreground
-    loom.text     — parchment cream, the default body text
-    loom.muted    — dim/secondary text (replaces the pervasive ``[dim]``)
-    loom.accent   — amber gold, focal highlights and active state
-    loom.success  — sage green, completion / approve / ok
-    loom.warning  — ochre, attention but not failure
-    loom.error    — terracotta, failure or denial
-    loom.border   — subtle frame colour for panels
-Surfaces
-    loom.harness.bg  — dark surface for harness messages (PR-C consumer)
+Semantic tokens (stable ABI):
+    loom.text / loom.muted / loom.accent / loom.success / loom.warning /
+    loom.error / loom.border / loom.harness.bg / loom.harness.signature /
+    loom.agent.guide
 """
 
 from __future__ import annotations
@@ -27,55 +18,97 @@ from __future__ import annotations
 from rich.theme import Theme
 
 # ---------------------------------------------------------------------------
-# Raw palette — sole source of hex values. Mirrors the comment block in
-# loom/platform/cli/tui/app.py so the two layers stay aligned.
+# Raw palettes — sole source of hex values.
 # ---------------------------------------------------------------------------
 
-PARCHMENT_BG       = "#1c1814"  # screen background (very dark warm brown)
-PARCHMENT_SURFACE  = "#242018"  # widget surface
-PARCHMENT_TEXT     = "#e0cfa0"  # primary text (warm cream)
-PARCHMENT_MUTED    = "#8a7a5e"  # muted text
-PARCHMENT_ACCENT   = "#c8a464"  # accent (amber gold)
-PARCHMENT_SUCCESS  = "#7a9e78"  # success (sage green)
-PARCHMENT_WARNING  = "#c8924a"  # warning (ochre)
-PARCHMENT_ERROR    = "#b87060"  # error (terracotta)
-PARCHMENT_BORDER   = "#4a4038"  # border
+PARCHMENT_BG       = "#1c1814"
+PARCHMENT_SURFACE  = "#242018"
+PARCHMENT_TEXT     = "#e0cfa0"
+PARCHMENT_MUTED    = "#8a7a5e"
+PARCHMENT_ACCENT   = "#c8a464"
+PARCHMENT_SUCCESS  = "#7a9e78"
+PARCHMENT_WARNING  = "#c8924a"
+PARCHMENT_ERROR    = "#b87060"
+PARCHMENT_BORDER   = "#4a4038"
 
+SUNRISE_BG         = "#0d1117"
+SUNRISE_SURFACE    = "#161b22"
+SUNRISE_TEXT       = "#e6f0ff"
+SUNRISE_MUTED      = "#6e8898"
+SUNRISE_ACCENT     = "#FFD54F"
+SUNRISE_SUCCESS    = "#81D4FA"
+SUNRISE_WARNING    = "#FFAB40"
+SUNRISE_ERROR      = "#FF8A80"
+SUNRISE_BORDER     = "#2d3748"
 
 # ---------------------------------------------------------------------------
-# Semantic theme — what call sites should reference.
+# Palette registry.
 # ---------------------------------------------------------------------------
 
-LOOM_THEME = Theme(
-    {
-        # Foreground
-        "loom.text":        PARCHMENT_TEXT,
-        "loom.muted":       PARCHMENT_MUTED,
-        "loom.accent":      PARCHMENT_ACCENT,
-        "loom.success":     PARCHMENT_SUCCESS,
-        "loom.warning":     PARCHMENT_WARNING,
-        "loom.error":       PARCHMENT_ERROR,
-        "loom.border":      PARCHMENT_BORDER,
-        # Surfaces
-        "loom.harness.bg":  f"on {PARCHMENT_SURFACE}",
-        # Harness signature — the "⚙ harness ›" prefix on inline harness
-        # messages. Distinct token so PR-D can tweak it without rippling
-        # to every call site.
-        "loom.harness.signature": PARCHMENT_ACCENT,
-        # Loom Agent intro guide — the "Loom ▎" left-edge silk-coloured
-        # marker that opens each turn. Kept distinct from accent in case
-        # we want a different shade later (e.g. silk-pink for personality).
-        "loom.agent.guide":  PARCHMENT_ACCENT,
-        # Convenience composites — emphasis variants used at multiple call
-        # sites. Add sparingly; prefer composing tokens at the call site.
-        "loom.accent.bold": f"bold {PARCHMENT_ACCENT}",
-        "loom.muted.italic": f"italic {PARCHMENT_MUTED}",
+THEMES: dict[str, dict[str, str]] = {
+    "parchment": {
+        "bg":        PARCHMENT_BG,
+        "surface":   PARCHMENT_SURFACE,
+        "text":      PARCHMENT_TEXT,
+        "muted":     PARCHMENT_MUTED,
+        "accent":    PARCHMENT_ACCENT,
+        "success":   PARCHMENT_SUCCESS,
+        "warning":   PARCHMENT_WARNING,
+        "error":     PARCHMENT_ERROR,
+        "border":    PARCHMENT_BORDER,
+    },
+    "sunrise": {
+        "bg":        SUNRISE_BG,
+        "surface":   SUNRISE_SURFACE,
+        "text":      SUNRISE_TEXT,
+        "muted":     SUNRISE_MUTED,
+        "accent":    SUNRISE_ACCENT,
+        "success":   SUNRISE_SUCCESS,
+        "warning":   SUNRISE_WARNING,
+        "error":     SUNRISE_ERROR,
+        "border":    SUNRISE_BORDER,
+    },
+}
+
+
+def _make_tokens(palette: dict[str, str]) -> dict[str, str]:
+    """Build a Rich Theme token dict from a palette dict."""
+    return {
+        "loom.text":               palette["text"],
+        "loom.muted":              palette["muted"],
+        "loom.accent":             palette["accent"],
+        "loom.success":            palette["success"],
+        "loom.warning":            palette["warning"],
+        "loom.error":              palette["error"],
+        "loom.border":             palette["border"],
+        "loom.harness.bg":         f"on {palette['surface']}",
+        "loom.harness.signature":  palette["accent"],
+        "loom.agent.guide":        palette["accent"],
+        # Convenience composites
+        "loom.accent.bold":        f"bold {palette['accent']}",
+        "loom.muted.italic":       f"italic {palette['muted']}",
     }
-)
+
+
+def build_theme(name: str = "parchment") -> Theme:
+    """Build a Rich Theme from a registered palette name."""
+    if name not in THEMES:
+        raise ValueError(f"Unknown theme '{name}'. Available: {list(THEMES.keys())}")
+    return Theme(_make_tokens(THEMES[name]))
+
+
+# ---------------------------------------------------------------------------
+# Default theme (used before any preference is loaded).
+# ---------------------------------------------------------------------------
+
+LOOM_THEME = build_theme("parchment")
 
 
 __all__ = [
+    "THEMES",
+    "build_theme",
     "LOOM_THEME",
+    # Raw parchment constants (kept for TUI layer compatibility)
     "PARCHMENT_BG",
     "PARCHMENT_SURFACE",
     "PARCHMENT_TEXT",
@@ -85,4 +118,14 @@ __all__ = [
     "PARCHMENT_WARNING",
     "PARCHMENT_ERROR",
     "PARCHMENT_BORDER",
+    # Raw sunrise constants
+    "SUNRISE_BG",
+    "SUNRISE_SURFACE",
+    "SUNRISE_TEXT",
+    "SUNRISE_MUTED",
+    "SUNRISE_ACCENT",
+    "SUNRISE_SUCCESS",
+    "SUNRISE_WARNING",
+    "SUNRISE_ERROR",
+    "SUNRISE_BORDER",
 ]

--- a/loom/platform/cli/theme_persist.py
+++ b/loom/platform/cli/theme_persist.py
@@ -1,0 +1,47 @@
+"""
+Theme preference persistence — read/write ~/.config/loom/theme.toml.
+
+Issue #358.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+_THEME_DIR = Path.home() / ".config" / "loom"
+_THEME_FILE = _THEME_DIR / "theme.toml"
+_DEFAULT_THEME = "parchment"
+
+
+def load_preference() -> str:
+    """
+    Return the currently saved theme name, or 'parchment' if not set / file missing.
+    Does not raise on corrupt TOML — falls back to default.
+    """
+    if not _THEME_FILE.exists():
+        return _DEFAULT_THEME
+    try:
+        with _THEME_FILE.open("rb") as f:
+            data = tomllib.load(f)
+        return data.get("theme", {}).get("name", _DEFAULT_THEME)
+    except Exception:
+        # Corrupt or unreadable — safest to return default
+        return _DEFAULT_THEME
+
+
+def save_preference(name: str) -> None:
+    """
+    Persist a theme name to theme.toml.
+    Creates ~/.config/loom/ and the file if they don't exist.
+    """
+    _THEME_DIR.mkdir(parents=True, exist_ok=True)
+    content = f"# Loom theme preference — do not edit manually\n[theme]\nname = {name!r}\n"
+    with _THEME_FILE.open("w") as f:
+        f.write(content)
+
+
+def available_themes() -> list[str]:
+    """Return the list of registered theme names."""
+    from loom.platform.cli.theme import THEMES
+    return list(THEMES.keys())


### PR DESCRIPTION
## feat(cli): Theme System — Parchment & Sunrise palettes + /theme command

**Fixes:** #358
**Type:** feature

### 改了什麼

將 `loom/platform/cli/theme.py` 從單一 palette 重構為 pluggable registry，
新增 Sunrise（黎明）色盤（Xiaoqing 身份色）與 `/theme` slash command。

| 檔案 | 變更 |
|------|------|
| `loom/platform/cli/theme.py` | THEMES registry + Sunrise palette + `build_theme()` factory |
| `loom/platform/cli/theme_persist.py` | 新檔：`load_preference()` / `save_preference()` 讀寫 `~/.config/loom/theme.toml` |
| `loom/platform/cli/main.py` | 新增 `/theme` handler |

### 怎麼改的

- 定義 `_make_tokens(palette)` 將 palette dict 轉為 Rich Theme token dict
- `THEMES["parchment"]` 保留所有原有 PARCHMENT_* 常數作為第一筆 entry
- `THEMES["sunrise"]` 以 Issue #358 的設計規格新增（midnight-blue bg + sunflower-gold accent）
- `build_theme(name)` 工廠函數：未知名稱拋 `ValueError`，符合 fail-fast 原則
- 偏好持久化：`~/.config/loom/theme.toml`，TOML 格式，`[theme].name` key
- `/theme` 無參數 → 列出可用 theme + 標記目前使用中；帶參數 → 切換並寫入磁碟

### 新增 API

```python
# loom/platform/cli/theme.py
build_theme(name: str) → Theme
THEMES: dict[str, dict[str, str]]

# loom/platform/cli/theme_persist.py
load_preference() → str   # 回傳目前 theme 名稱（預設 "parchment"）
save_preference(name: str) → None
available_themes() → list[str]
```

### 測試

- `pytest --collect-only` → **1788 tests collected，0 import errors** ✓
- GitNexus risk assessment → `low`，無受影響執行路徑 ✓
- TOML 讀寫邏輯：manual verification passed ✓

### 待改善（不在 scope）

Theme 偏好寫入後需重啟 Loom 才套用（`LOOM_THEME` 在 import 時建構）。
即時切換只需將 `main.py` 頂層改為動態 `build_theme(load_preference())`，
一行可完成，未來容易擴充。