### PR TITLE
feat(openai): support image subject references

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,8 @@ Model routing works by prefix — `gpt-*` and `openai/<model>` use
 
 Image generation includes `openai__text_to_image`, which calls `gpt-image-2`
 and writes a PNG/WebP/JPEG under the workspace. With Codex OAuth it uses the
-Codex Responses backend; with `OPENAI_API_KEY` it uses the OpenAI Images API.
+Codex Responses backend and supports workspace image `subject_reference`
+anchors; with `OPENAI_API_KEY` it uses the OpenAI Images API.
 
 ---
 

--- a/doc/33-CLI-命令.md
+++ b/doc/33-CLI-命令.md
@@ -79,12 +79,17 @@ Agent 可用工具，生成圖片並寫入 workspace。`auth_mode=codex` 走 Cod
   "prompt": "a clean product mockup",
   "model": "gpt-image-2",
   "output_path": "outputs/mockup.png",
-  "auth_mode": "auto"
+  "auth_mode": "auto",
+  "subject_reference": [
+    {"type": "character", "image_file": "refs/anchor.png"}
+  ]
 }
 ```
 
 `auth_mode` 可為 `auto`、`codex`、`api_key`。`auto` 會優先使用 `codex login` 產生的
 Codex OAuth access token；若 Codex backend 拒絕且 `.env` 有 `OPENAI_API_KEY`，則 fallback 到 API key。
+`subject_reference` 目前支援 Codex OAuth path，會把 workspace 內的參照圖轉成 Codex Responses
+`input_image`，用於角色或主體一致性；API key path 會明確拒絕而非靜默忽略。
 
 ---
 

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -2915,13 +2915,31 @@ def _build_openai_subject_reference_content(
             raise ValueError(
                 f"Could not read subject_reference[{idx}].image_file: {image_file}"
             ) from exc
-        mime_type = mimetypes.guess_type(str(image_path))[0] or "image/png"
+        mime_type = (
+            mimetypes.guess_type(str(image_path))[0]
+            or _detect_image_mime_type(image_bytes)
+            or "image/png"
+        )
         encoded = base64.b64encode(image_bytes).decode("ascii")
         content.append({
             "type": "input_image",
             "image_url": f"data:{mime_type};base64,{encoded}",
         })
     return content
+
+
+def _detect_image_mime_type(image_bytes: bytes) -> str | None:
+    """Best-effort image MIME detection from magic bytes."""
+
+    if image_bytes.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if image_bytes.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if image_bytes.startswith(b"RIFF") and image_bytes[8:12] == b"WEBP":
+        return "image/webp"
+    if image_bytes.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    return None
 
 
 def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
@@ -3104,12 +3122,16 @@ def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
                         credential_source = fallback.source
                 else:
                     if subject_reference_content:
+                        reason = (
+                            "You selected auth_mode=api_key, which does not support subject_reference. "
+                            if auth_mode == "api_key" else ""
+                        )
                         return ToolResult(
                             call_id=call.id,
                             tool_name=call.tool_name,
                             success=False,
                             error=(
-                                "subject_reference currently requires Codex OAuth "
+                                f"{reason}subject_reference currently requires Codex OAuth "
                                 "(use auth_mode=codex or run `codex login` with auth_mode=auto)."
                             ),
                         )

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import mimetypes
 import os
 import re
 import signal
@@ -176,32 +177,50 @@ def _make_openai_image_scope_resolver(workspace: Path):
             selector = str(resolved.parent.relative_to(_workspace_resolved))
         except ValueError:
             selector = os.path.normpath(str(resolved.parent))
+        requirements = [
+            ScopeRequirement(
+                resource="path",
+                action="write",
+                selector=selector,
+                tool_name=call.tool_name,
+                capabilities=call.capabilities,
+            ),
+            ScopeRequirement(
+                resource="network",
+                action="connect",
+                selector="api.openai.com",
+                tool_name=call.tool_name,
+                capabilities=call.capabilities,
+            ),
+            ScopeRequirement(
+                resource="network",
+                action="connect",
+                selector="chatgpt.com",
+                tool_name=call.tool_name,
+                capabilities=call.capabilities,
+            ),
+        ]
+        for ref in call.args.get("subject_reference") or []:
+            if not isinstance(ref, dict) or not ref.get("image_file"):
+                continue
+            ref_path = _resolve_workspace_path(str(ref["image_file"]), workspace)
+            try:
+                ref_selector = str(ref_path.relative_to(_workspace_resolved))
+            except ValueError:
+                ref_selector = os.path.normpath(str(ref_path))
+            requirements.append(
+                ScopeRequirement(
+                    resource="path",
+                    action="read",
+                    selector=ref_selector,
+                    tool_name=call.tool_name,
+                    capabilities=call.capabilities,
+                )
+            )
         return ScopeRequest(
             tool_name=call.tool_name,
             capabilities=call.capabilities,
-            requirements=[
-                ScopeRequirement(
-                    resource="path",
-                    action="write",
-                    selector=selector,
-                    tool_name=call.tool_name,
-                    capabilities=call.capabilities,
-                ),
-                ScopeRequirement(
-                    resource="network",
-                    action="connect",
-                    selector="api.openai.com",
-                    tool_name=call.tool_name,
-                    capabilities=call.capabilities,
-                ),
-                ScopeRequirement(
-                    resource="network",
-                    action="connect",
-                    selector="chatgpt.com",
-                    tool_name=call.tool_name,
-                    capabilities=call.capabilities,
-                ),
-            ],
+            requirements=requirements,
         )
     return _resolve
 
@@ -2871,6 +2890,40 @@ async def _decode_openai_image_response(
     raise RuntimeError("OpenAI image response did not include b64_json or url.")
 
 
+def _build_openai_subject_reference_content(
+    raw_refs: Any,
+    workspace: Path,
+) -> list[dict[str, Any]]:
+    """Convert subject_reference entries into Codex Responses input_image items."""
+
+    if raw_refs in (None, ""):
+        return []
+    if not isinstance(raw_refs, list):
+        raise ValueError("subject_reference must be an array.")
+
+    content: list[dict[str, Any]] = []
+    for idx, ref in enumerate(raw_refs):
+        if not isinstance(ref, dict):
+            raise ValueError(f"subject_reference[{idx}] must be an object.")
+        image_file = str(ref.get("image_file", "")).strip()
+        if not image_file:
+            raise ValueError(f"subject_reference[{idx}].image_file is required.")
+        image_path = _resolve_workspace_path(image_file, workspace)
+        try:
+            image_bytes = image_path.read_bytes()
+        except OSError as exc:
+            raise ValueError(
+                f"Could not read subject_reference[{idx}].image_file: {image_file}"
+            ) from exc
+        mime_type = mimetypes.guess_type(str(image_path))[0] or "image/png"
+        encoded = base64.b64encode(image_bytes).decode("ascii")
+        content.append({
+            "type": "input_image",
+            "image_url": f"data:{mime_type};base64,{encoded}",
+        })
+    return content
+
+
 def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
     """Build an OpenAI GPT Image generation tool."""
 
@@ -2936,6 +2989,18 @@ def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
             value = call.args.get(key)
             if isinstance(value, str) and value.strip():
                 image_options[key] = value.strip()
+        try:
+            subject_reference_content = _build_openai_subject_reference_content(
+                call.args.get("subject_reference"),
+                workspace,
+            )
+        except ValueError as exc:
+            return ToolResult(
+                call_id=call.id,
+                tool_name=call.tool_name,
+                success=False,
+                error=str(exc),
+            )
 
         async def _request_openai_images(client: httpx.AsyncClient, bearer: str):
             payload = {"prompt": prompt, **image_options}
@@ -2971,7 +3036,10 @@ def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
                 ),
                 "input": [{
                     "role": "user",
-                    "content": [{"type": "input_text", "text": prompt}],
+                    "content": [
+                        {"type": "input_text", "text": prompt},
+                        *subject_reference_content,
+                    ],
                 }],
                 "tools": [tool_spec],
                 "stream": True,
@@ -3027,6 +3095,7 @@ def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
                             and fallback is not None
                             and fallback.source == "api_key"
                             and exc.response.status_code in {401, 403}
+                            and not subject_reference_content
                         )
                         if not can_fallback:
                             raise
@@ -3034,6 +3103,16 @@ def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
                         image_bytes = await _decode_openai_image_response(client, data)
                         credential_source = fallback.source
                 else:
+                    if subject_reference_content:
+                        return ToolResult(
+                            call_id=call.id,
+                            tool_name=call.tool_name,
+                            success=False,
+                            error=(
+                                "subject_reference currently requires Codex OAuth "
+                                "(use auth_mode=codex or run `codex login` with auth_mode=auto)."
+                            ),
+                        )
                     data = await _request_openai_images(client, credential.token)
                     image_bytes = await _decode_openai_image_response(client, data)
                     credential_source = credential.source
@@ -3106,6 +3185,29 @@ def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
                     "enum": ["auto", "codex", "api_key"],
                     "default": "auto",
                     "description": "auto prefers Codex OAuth and falls back to OPENAI_API_KEY.",
+                },
+                "subject_reference": {
+                    "type": "array",
+                    "description": (
+                        "Reference images for subject or character consistency. "
+                        "Currently supported on the Codex OAuth path."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "description": "Reference type, e.g. character.",
+                                "default": "character",
+                            },
+                            "image_file": {
+                                "type": "string",
+                                "description": "Workspace-relative reference image path.",
+                            },
+                        },
+                        "required": ["image_file"],
+                        "additionalProperties": False,
+                    },
                 },
                 "n": {"type": "integer", "minimum": 1, "maximum": 1, "default": 1},
             },

--- a/tests/test_openai_image_tool.py
+++ b/tests/test_openai_image_tool.py
@@ -216,6 +216,46 @@ async def test_openai_image_tool_includes_subject_reference_in_codex_payload(
 
 
 @pytest.mark.asyncio
+async def test_openai_image_tool_detects_reference_mime_without_extension(
+    tmp_path,
+    monkeypatch,
+):
+    from loom.core import session as session_module
+
+    codex_home = tmp_path / "codex"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text(
+        json.dumps({"tokens": {"access_token": "codex-token"}}),
+        encoding="utf-8",
+    )
+    reference = tmp_path / "refs" / "portrait"
+    reference.parent.mkdir()
+    reference.write_bytes(b"\xff\xd8\xff\xe0jpeg-bytes")
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {})
+    monkeypatch.setattr(cli_tools.httpx, "AsyncClient", _CodexStreamAsyncClient)
+    _CodexStreamAsyncClient.requests = []
+    tool = make_openai_image_generation_tool(tmp_path)
+    call = ToolCall(
+        tool_name=tool.name,
+        args={
+            "prompt": "draw the same character",
+            "output_path": "renders/codex-ref.png",
+            "auth_mode": "codex",
+            "subject_reference": [{"image_file": "refs/portrait"}],
+        },
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    result = await tool.executor(call)
+
+    assert result.success
+    content = _CodexStreamAsyncClient.requests[0]["json"]["input"][0]["content"]
+    assert content[1]["image_url"].startswith("data:image/jpeg;base64,")
+
+
+@pytest.mark.asyncio
 async def test_openai_image_tool_rejects_subject_reference_on_api_key_path(
     tmp_path,
     monkeypatch,
@@ -245,6 +285,7 @@ async def test_openai_image_tool_rejects_subject_reference_on_api_key_path(
     result = await tool.executor(call)
 
     assert not result.success
+    assert "You selected auth_mode=api_key" in result.error
     assert "subject_reference currently requires Codex OAuth" in result.error
     assert _FakeAsyncClient.requests == []
 

--- a/tests/test_openai_image_tool.py
+++ b/tests/test_openai_image_tool.py
@@ -171,6 +171,112 @@ async def test_openai_image_tool_uses_codex_responses_backend(tmp_path, monkeypa
 
 
 @pytest.mark.asyncio
+async def test_openai_image_tool_includes_subject_reference_in_codex_payload(
+    tmp_path,
+    monkeypatch,
+):
+    from loom.core import session as session_module
+
+    codex_home = tmp_path / "codex"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text(
+        json.dumps({"tokens": {"access_token": "codex-token"}}),
+        encoding="utf-8",
+    )
+    reference = tmp_path / "refs" / "siluyi.png"
+    reference.parent.mkdir()
+    reference.write_bytes(b"reference-png")
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {})
+    monkeypatch.setattr(cli_tools.httpx, "AsyncClient", _CodexStreamAsyncClient)
+    _CodexStreamAsyncClient.requests = []
+    tool = make_openai_image_generation_tool(tmp_path)
+    call = ToolCall(
+        tool_name=tool.name,
+        args={
+            "prompt": "draw the same character",
+            "output_path": "renders/codex-ref.png",
+            "auth_mode": "codex",
+            "subject_reference": [
+                {"type": "character", "image_file": "refs/siluyi.png"},
+            ],
+        },
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    result = await tool.executor(call)
+
+    assert result.success
+    content = _CodexStreamAsyncClient.requests[0]["json"]["input"][0]["content"]
+    assert content[0] == {"type": "input_text", "text": "draw the same character"}
+    assert content[1]["type"] == "input_image"
+    assert content[1]["image_url"].startswith("data:image/png;base64,")
+    assert content[1]["image_url"].endswith(base64.b64encode(b"reference-png").decode())
+
+
+@pytest.mark.asyncio
+async def test_openai_image_tool_rejects_subject_reference_on_api_key_path(
+    tmp_path,
+    monkeypatch,
+):
+    from loom.core import session as session_module
+
+    reference = tmp_path / "refs" / "siluyi.png"
+    reference.parent.mkdir()
+    reference.write_bytes(b"reference-png")
+    monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {
+        "OPENAI_API_KEY": "sk-test",
+    })
+    monkeypatch.setattr(cli_tools.httpx, "AsyncClient", _FakeAsyncClient)
+    _FakeAsyncClient.requests = []
+    tool = make_openai_image_generation_tool(tmp_path)
+    call = ToolCall(
+        tool_name=tool.name,
+        args={
+            "prompt": "draw",
+            "auth_mode": "api_key",
+            "subject_reference": [{"image_file": "refs/siluyi.png"}],
+        },
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    result = await tool.executor(call)
+
+    assert not result.success
+    assert "subject_reference currently requires Codex OAuth" in result.error
+    assert _FakeAsyncClient.requests == []
+
+
+def test_openai_image_tool_schema_and_scope_include_subject_reference(tmp_path):
+    tool = make_openai_image_generation_tool(tmp_path)
+    reference = tmp_path / "refs" / "siluyi.png"
+    reference.parent.mkdir()
+    reference.write_bytes(b"reference-png")
+    call = ToolCall(
+        tool_name=tool.name,
+        args={
+            "prompt": "draw",
+            "output_path": "renders/out.png",
+            "subject_reference": [{"image_file": "refs/siluyi.png"}],
+        },
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    assert "subject_reference" in tool.input_schema["properties"]
+    scope = tool.scope_resolver(call)
+
+    assert any(
+        req.resource == "path"
+        and req.action == "read"
+        and req.selector == "refs/siluyi.png"
+        for req in scope.requirements
+    )
+
+
+@pytest.mark.asyncio
 async def test_openai_image_tool_auto_falls_back_when_codex_token_rejected(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- add subject_reference to openai__text_to_image input schema
- encode workspace reference images as Codex Responses input_image content on the Codex OAuth path
- add read scope requirements for reference images and reject API-key transport instead of silently ignoring references

## Tests
- ./venv/bin/python -m pytest -q tests/test_openai_image_tool.py
- ./venv/bin/python -m pytest -q tests/test_openai_image_tool.py tests/test_ledger_deferred_events.py tests/test_scope_phase_b.py tests/test_scope_phase_cd.py tests/test_scoped_approval.py tests/test_session.py::TestLoomSessionStartup

Closes #328