### PR TITLE
Quest D Phase 1: Skill Evolution Arena — 觀察基礎

### DIFF
--- a/doc/54-Skill-Evolution-Arena-設計.md
+++ b/doc/54-Skill-Evolution-Arena-設計.md
@@ -1,0 +1,337 @@
+# Skill Evolution Arena 設計文件 — Quest D Phase 1（觀察基礎）
+
+> **狀態**：Round 1 草稿（2026-05-13）
+> **來源**：issue #362（七層 → 兩觸發點）+ doc/52 §1.3 Quest D 願景 + 2026-05-13 閉環報告 + Round 1 對話
+> **下一步**：在對應實作 issue 的 comment 區逐題討論（§8 open questions），鎖定後出實作 issue
+>
+> 本文件是 Skill Evolution Arena Phase 1 的設計權威。實作分歧時以本文件為準；本文件未涵蓋的細節，按 §2「設計原則」推導。
+
+---
+
+## 1. 文件目的
+
+Loom 已有完整的技能演化基礎建設（SkillGenome / SkillMutator / SkillPromoter / SkillGate / CounterFactualReflector / Grader / 七階段工作流），但**從未被完整觸發執行過一次**。
+
+2026-05-13 自我健檢發現：
+
+- 18 個技能中 17 個「從未被 Grader 評估」
+- `loom.db` 存在但 schema 未初始化 → candidate 寫入失敗、promote 永遠 `Candidate not found`
+- Event Ledger 已累積 6584 筆事件，但 `skill_id` 欄位從未被寫入（NULL）
+- code_weaver 是唯一活著的技能 — 但靠的是「使用者陪伴 + 直接 edit SKILL.md」，**不是**任何自動 grading 迴路
+
+問題根因不是「沒人踩油門」這麼簡單。Round 1 的關鍵推論：
+
+> **技能不是工具。工具有結構化成功指標（exit code / return value），技能是工作流程 — 「過程訊號順不順」≠「成品好不好」。** loom reflect 那些數字感受不到價值，是因為它確實只衡量「運行順暢度」，不是成品。
+
+→ 沒有可信的「成品 grading」substrate，所有自動 shadow/promote 機制都是 garbage in / garbage out。
+
+### 1.1 重新定位：本 milestone 是觀察基礎，不是演化系統
+
+Quest D 拆成三段，本文件只負責第一段：
+
+| 階段 | 範圍 | 依賴 |
+|------|------|------|
+| **本文件 — Quest D Phase 1** | 觀察基礎：ledger 追蹤、weekly 現況報告、整併退役 | 無 |
+| **Evaluator Skill**（未來 milestone） | 任務拆解 + 成功標的 + 成果驗證 — 真正的 grader substrate | Phase 1 |
+| **Quest D Phase 2**（更未來） | Self-training：基於 Evaluator 訊號做 mutation/promote | Evaluator |
+
+對應 doc/52 §1.3。Phase 1 不假裝在做演化、不寫沒辦法驗證的 metric。
+
+### 1.2 為什麼即時反饋通道夠用（在 Phase 1）
+
+code_weaver 97% 不是靠任何自動框架，是靠：
+
+```
+使用者反饋 → 絲絲直接 edit SKILL.md → 下次更好
+```
+
+這條已經在跑。Phase 1 不打算改造它、不打算把它「升級為框架」— 它就是 conversational 形式，最簡單也最有效。其他 17 個技能拿不到這條 = 它們還沒被使用者投入足夠注意力，那就讓 weekly worker 在報告裡 surface 它們，由使用者決定要不要花時間。
+
+---
+
+## 2. 設計原則
+
+按優先級排序：
+
+1. **可驗證的才自動化** — 「成品好不好」目前沒有可信判定，那就不自動演化。Phase 1 純觀察、純報告。
+2. **完全刪除 > 暫存** — 退役元件代碼與 config 一併移除。未來 Evaluator 重起時重寫，別讓死代碼長靈藏。
+3. **入口收斂** — Agent 暴露的技能相關 tool 只剩 `load_skill` / `unload_skill`。動詞型 mutate tool 全部移除。
+4. **即時反饋走對話、不走框架** — 「絲絲根據反饋 edit SKILL.md」是 conversational flow，不該被包成 candidate/promote 框架。
+5. **觀察走排程、走 ledger** — weekly worker 從 ledger 抽現況、產報告、附該關注清單。報告是給使用者讀的，不是給 agent 自動消費的。
+6. **Append-only ledger 純度** — Phase 1 不新增 event_type，只把 `skill_id` 寫進既有 `tool_lifecycle` payload。
+7. **預留比 migration 便宜，但別預留死規格** — 未來 Evaluator 需要的新 event_type 留給 Evaluator milestone 定義（屆時設計已成熟）。Phase 1 不預先發明 `skill_evaluation` 之類的 schema。
+
+---
+
+## 3. 退役清單（完全刪除）
+
+| 元件 | 檔案 | 處置 |
+|------|------|------|
+| `SkillGate` (shadow_mode auto_c) | `loom/core/cognition/skill_gate.py` | 刪除整檔 |
+| `SkillPromoter` | `loom/core/cognition/skill_promoter.py` | 刪除整檔 |
+| `SkillMutator` | `loom/core/cognition/skill_mutator.py` | 刪除整檔 |
+| `SkillGenome` dataclass + ProceduralMemory candidate 介面 | `loom/core/memory/procedural.py` | 刪除 candidate / genome 相關函式，保留 procedural memory 其他用途 |
+| `loom.db` skill_genomes / skill_candidates / skill_version_history 表 | `loom/core/memory/store.py` | 刪除 DDL；確認 `loom.db` 整個檔案是否還有其他用途，若無則一併移除 |
+| `generate_skill_candidate_from_batch` tool | `loom/platform/cli/tools.py` | 刪除 tool definition + executor |
+| `promote_skill_candidate` tool | 同上 | 刪除 |
+| `set_skill_maturity` tool | 同上 | 刪除 |
+| `loom.toml [mutation]` section | `loom.toml` + parser | 整節移除 |
+| `meta-skill-engineer` 七階段工作流文件 | `.claude/skills/meta-skill-engineer/` 或 `skills/meta-skill-engineer/` | 移除 skill；相關 Grader / Comparator / Analyzer prompt 一併刪 |
+| `outputs/doc/skill_system_evolution_plan_2026-05-02.md` | doc | 標記為「已被 doc/54 取代」並移到 `outputs/doc/archive/` 或直接刪 |
+
+**保留**：
+
+| 元件 | 理由 |
+|------|------|
+| `CounterFactualReflector` | 寫 anti-pattern 進 SemanticMemory，不依賴 grading。是已在跑的有用副作用 |
+| `load_skill` / `unload_skill` | 主路徑 |
+| `procedural memory` 其他功能（非 candidate 部分） | 通用 procedural memory，不只服務 skill |
+| `SkillCheckManager` / `skill_checks.py` | 與演化無關，是 precondition gate |
+
+---
+
+## 4. 三條訊號通道
+
+### 4.1 通道 A — 對話內即時反饋
+
+這條通道分兩層、已在跑，本文件不重新發明任何一層：
+
+**層 1：系統自動回灌**
+
+`ToolCallDimension`（`loom/core/infra/telemetry.py:128`）在對話中渲染 tool 統計與 anomaly：
+
+- summary 行：`tool:97% | lat:230ms | n=42` 出現在對話 telemetry 渲染
+- failure rate ≥ 30% 且樣本 ≥ 5 → 觸發 anomaly 提示
+- last failure message 在 detail 視圖暴露
+
+→ 使用者「注意到技能有問題」的主要觸發源就是這層，不是憑空察覺。技能載入後緊隨的 tool calls 直接被追蹤，是隱性的即時反饋通道。
+
+**層 2：使用者反饋 → 絲絲 edit SKILL.md**
+
+```
+使用者看到 ToolCallDimension 訊號 / 自行觀察到問題
+        ↓
+口頭說「這裡可以更好」
+        ↓
+絲絲根據反饋直接 Edit SKILL.md（git commit 是版本控制）
+        ↓（同步副作用）
+memorize 寫 SemanticMemory → ledger memory_op 事件
+```
+
+- **不需要框架** — 兩層都本來在跑
+- **不需要 candidate / shadow / promote** — 層 2 直接覆寫 SKILL.md
+- **規模化限制公開承認** — 層 2 只發生在使用者陪伴的技能上。但**層 1 對所有技能無差別作用**，這提升了「使用者察覺低活躍技能問題」的機率
+
+> **注意**：ToolCallDimension 是 per-tool 維度，不是 per-skill。它的 in-memory state 也是 session-local。但 ledger `tool_lifecycle` END payload 帶 `error` 欄位，可從 ledger 派生 per-skill 的失敗率 — weekly worker（§4.2）會用 ledger 重建這個訊號，而不是查 telemetry。
+
+### 4.2 通道 B — Weekly 現況報告（含該關注清單）
+
+```toml
+[[autonomy.schedules]]
+name = "skill_weekly_review"
+cron = "0 10 * * 6"   # 每週六上午十點
+intent = """
+從 ledger 抽過去 7 天的技能使用紀錄、反饋紀錄、turn outcome 統計，
+產出現況報告寫到 outputs/self_check/{date}-skill-weekly.md。
+不評分、不下指導。在報告末段附「該關注清單」，由使用者決定是否花時間。
+"""
+```
+
+**Worker 內部動作**（純查詢 + 模板渲染、沒有 agent loop）：
+
+1. ledger query：過去 7 天 `tool_lifecycle` where `tool_name='load_skill'` group by `skill_id`
+2. ledger query：載入該技能的 turn_id → 看 turn_end outcome 分布
+3. ledger query：載入該技能後 N 分鐘內，使用者觸發的 `memory_op write` 事件（即時反饋訊號）
+4. 渲染報告：每個技能一段、附近期載入次數、turn outcome 分布、反饋密度
+5. 渲染該關注清單（§4.3）
+
+**重要**：worker 不是 LLM agent。它是純 SQL + 模板。Grader agent 整個退役。
+
+### 4.3 通道 C — 對話內 ledger 調閱（最核心的優化迴路）
+
+這是使用者實際走的優化流程，本文件 Round 1 才釘清楚：
+
+```
+觸發時機（任一）：
+  - 技能剛使用完畢（使用者親眼看過該次運用）
+  - Weekly 報告產出後（使用者讀完報告）
+        ↓
+使用者問絲絲：「回顧一下你剛剛使用了 xxx 技能有遇到什麼狀況」
+        ↓
+絲絲呼叫 skill_review(skill_id, since=...) 工具
+        ↓
+回傳 ledger 中該技能的使用回顧（events 摘要）
+        ↓
+絲絲在對話中口述觀察、使用者補充情境
+        ↓
+共識後絲絲直接 Edit SKILL.md / contexts/*.md / checks.py
+        ↓
+git commit（=版本紀錄，取代 candidate/promote 機制）
+```
+
+**這是 Loom 演化的真正主路徑**。即時反饋通道（4.1）是訊號觸發源、Weekly 報告通道（4.2）是低頻全景巡視、本通道 C 才是**深入優化的對話迴路**。
+
+#### 4.3.1 `skill_review` tool 設計
+
+唯一新增的 agent 暴露 tool。**只讀、不 mutate**，trust_level=`SAFE`：
+
+```python
+skill_review(
+    skill_id: str,
+    since: str = "7d",                         # "1d" / "7d" / "30d" / ISO timestamp
+    include: list[str] = ["all"],              # tool_calls / failures / feedback / turns / thoughts
+    max_events: int = 100,                     # cap 回傳體積
+) -> SkillUsageDigest
+```
+
+回傳結構（skill-scoped 而非 session-scoped）：
+
+```python
+@dataclass
+class SkillUsageDigest:
+    skill_id: str
+    window: tuple[float, float]                # since_ts, now_ts
+    load_count: int
+    unload_count: int
+
+    # 跨 session 聚合
+    sessions: list[str]                        # 載入過的 session_id
+    turns_with_load: list[TurnSummary]
+        # turn_id, started_at, outcome (clean/retry/abandoned/error),
+        # 該 turn 內該技能載入後的 tool calls 摘要
+
+    tool_calls: list[ToolCallSummary]
+        # tool_name, args_digest, result (success/error), error_msg, duration_ms
+        # 只包含「載入該技能後 / unload 該技能前」窗口內的 tool call
+
+    feedback_events: list[FeedbackEvent]
+        # 載入該技能後 N 分鐘內、unload 之前，使用者觸發的 memory_op write
+        # (這是「使用者反饋密度」的事件源)
+
+    failures: list[FailureSummary]
+        # tool failure + execution_error + judge_verdict=FAIL（如果未來有）
+```
+
+絲絲消費這份 digest 後**自然產生回顧**，不再需要框架幫忙摘要。
+
+#### 4.3.2 與 Weekly Worker 共用 Query 層
+
+通道 B 跟通道 C 用同一份 ledger 資料、同一個聚合邏輯，差別只在「呈現」：
+
+| 通道 | 呈現 | 觸發 |
+|------|------|------|
+| B（weekly worker） | Markdown 報告寫到 `outputs/self_check/` | cron 排程 |
+| C（skill_review tool） | 結構化 dict 回傳給絲絲 | agent 對話中呼叫 |
+
+實作層：**先寫 pure function `query_skill_ledger(skill_id, since, ...) -> SkillUsageDigest`**，B 跟 C 都呼叫它。B 把結果 render 成 markdown、C 把結果序列化回 agent。
+
+→ 兩條通道的查詢邏輯只寫一次。修 bug、加維度、改聚合策略也只改一處。
+
+放在 `loom/core/skill_review/query.py`（新增模組）。
+
+### 4.4 「該關注清單」判定條件
+
+不下成績、只指出「值得使用者花時間看一眼」的觀察。每條都是**結構性觀察**而非品質判定：
+
+| 觀察類型 | 判定 | 為什麼值得關注 |
+|----------|------|---------------|
+| **悶頭跑** | 使用頻次高、反饋密度低 | 可能在錯誤模式下被反覆呼叫，使用者沒注意到 |
+| **反饋未消化** | 反饋密度高、SKILL.md 久未 commit | 反饋被收進 memory 但沒回灌到 skill 主體 |
+| **異常結尾** | 載入該技能的 turn 中 `outcome=abandoned/error` 占比 > X | 可能正在卡關 |
+| **久未使用** | 過去 30 天從未被載入 | 是否還需要存在？或定義太窄被冷落 |
+| **存在但未啟動** | SKILL.md 存在但從未被載入過 | 17/18 純文案的根本問題 |
+
+清單**只列觀察**，不附「建議動作」— 使用者自己會判斷。
+
+---
+
+## 5. P0 修復清單
+
+實作順序按依賴：
+
+| # | 修復 | 檔案 | 工作量 | 阻擋什麼 |
+|---|------|------|--------|----------|
+| P0-1 | `load_skill` executor 寫入 `skill_id` 進 ledger `tool_lifecycle` payload | `loom/platform/cli/tools.py` `_load_skill` | S | 所有下游查詢 |
+| P0-2 | `unload_skill` executor 同上 | 同上 | S | 同上 |
+| P0-3 | 驗證 ledger pull 對 `skill_id` virtual column 走 index | `loom/core/ledger/pull.py` | S | 查詢效率 |
+| P0-4 | 新增 `loom/core/skill_review/query.py` — `query_skill_ledger()` pure function | 新模組 | M | 通道 B + 通道 C |
+| P0-5 | 新增 `skill_review` tool（包裝 P0-4） | `loom/platform/cli/tools.py` | S | 通道 C |
+| P0-6 | 新增 weekly worker（呼叫 P0-4 + render markdown） | 新檔 | M | 通道 B |
+| P0-7 | `loom.toml` 新增 `skill_weekly_review` schedule 條目 | `loom.toml` + autonomy schedules parser | S | 通道 B 觸發 |
+| P0-8 | `loom.db` schema init bug **不修**，整個 `loom.db` 一併評估退場 | `loom/core/memory/store.py` | — | 廢除路徑 |
+
+**今日優先做 P0-1 與 P0-2**：沒有 `skill_id` payload，下游全部沒資料可吃。其他可以分次。
+
+---
+
+## 6. 與 Evaluator Skill 未來 milestone 的邊界
+
+本文件刻意**不**設計：
+
+- 成品 grading 機制
+- 任務拆解 / 成功標的定義
+- replay corpus（即使是小範圍）
+- shadow A/B
+- 自動 promote 機制
+
+理由：這些都依賴「Evaluator」這個尚未存在的能力 — 「能把任意任務拆解成可驗證 sub-goal、並判定最終成品是否達成」。在 Evaluator 未存在前先設計演化機制，等於替沒有測量儀器的實驗室排實驗順序。
+
+**Evaluator Skill 設計時可能需要新增 ledger event_type**（暫定候選名：`task_outcome` 或 `skill_evaluation`），屆時走 doc/53 §9.4 v1→v2 schema migration。Phase 1 不預先佔位。
+
+---
+
+## 7. Phase 規劃（鎖定後拆 issue）
+
+| Phase | 內容 | 預期 |
+|-------|------|------|
+| **1.A** | P0 修復（§5）— `skill_id` payload + weekly schedule entry | 0.5-1 週 |
+| **1.B** | weekly worker 實作（純 SQL + 模板，無 agent loop）+ 該關注清單渲染（§4.3） | 1 週 |
+| **1.C** | 退役清單執行（§3）— 大刪除 PR，一次性處理 | 0.5-1 週 |
+| **1.D** | 第一份 weekly 報告產出 + 走查 17 個低活躍技能 → 由使用者決定哪些該關注 / 該刪 | 0.5 週 |
+
+預期總時程 **2.5-4 週**。Phase 1.C 大刪除是高 blast radius 動作，要 gitnexus impact 先跑。
+
+---
+
+## 8. Open Questions
+
+| # | 問題 | Round 1 暫定 |
+|---|------|---------------|
+| Q1 | weekly worker 是 sync script（cron 觸發）還是走 autonomy daemon？ | autonomy daemon（既有機制），但 worker 本身是純 SQL，不是 agent |
+| Q2 | 該關注清單的閾值（悶頭跑、異常結尾比例）怎麼定？ | 第一次發報告觀察一兩週後再校準 |
+| Q3 | `loom.db` 整個檔案能不能廢除？除了 skill 表還有沒有別人在用？ | 待 §5 P0 階段確認 |
+| Q4 | `CounterFactualReflector` 寫 anti-pattern 進 SemanticMemory 後，weekly worker 要不要從 SemanticMemory 抽相關 entries 進報告？ | 暫不，避免雙資料源混淆。Phase 1 報告純從 ledger 派生 |
+| Q5 | 17 個純文案技能，要不要在 Phase 1.D 直接刪掉用不到的？ | 由 1.D 走查時使用者個別決定，不在本文件先判 |
+| Q6 | 退役 `[mutation]` config 後，現有 `loom.toml` 用戶設定要不要做 migration 警告？ | 加一行 warning 即可，不做兼容 |
+| Q7 | `ToolCallDimension` 是否該長出 per-skill slice？例如載入 skill X 期間的 tool failure rate 獨立追蹤、在對話 telemetry 渲染中分別顯示？ | Phase 1 不做（純查 ledger 重建）。但這是 Evaluator milestone 之前值得評估的低成本增強 — 即時反饋層 1 變得「skill-aware」對使用者更直觀 |
+
+---
+
+## 9. 與其他文件的關係
+
+- `doc/50-未來改善路線圖.md` — 顧問版 Quest D 出處
+- `doc/51-Agent-能力評級系統.md` — capability sheet 將來吃 Evaluator 訊號（不是本文件）
+- `doc/52-主線與支線.md §1.3` — Loom 自家 Quest D 願景，本文件只接住 Phase 1
+- `doc/53-AgentLedger-設計.md` — ledger schema；本文件不擴充 event_type
+- `issue #362` — 原始七層 → 兩觸發點提案，本文件進一步收斂為「觀察 + 退役」
+- `outputs/self_check/2026-05-13-skill-closed-loop-report.md` — 觸發本文件的閉環報告
+- `outputs/doc/skill_system_evolution_plan_2026-05-02.md` — **舊版規劃，本文件 §3 列入退役**
+
+---
+
+## 10. 設計決策追溯
+
+Round 0 → Round 1 的主要轉變記錄，避免日後重新爭論：
+
+- **Round 0 §5 健康指標表** → **Round 1 刪除**。理由：過程訊號不等於成品品質
+- **Round 0 §6 candidate 改寫進 ledger** → **Round 1 candidate 機制整個退役**。理由：沒可信 grader → candidate 生命週期沒意義
+- **Round 0 §7 Replay corpus** → **Round 1 移除**。理由：replay 需要明確可驗證任務目標，這是 Evaluator milestone 範疇
+- **Round 0 §4.2 weekly Grader batch** → **Round 1 改為純 SQL + 模板的 weekly worker**。理由：沒可信 grading 標準，跑 Grader agent 是 garbage in/out
+- **Round 0 §9 Q1 新 event_type `skill_candidate`** → **Round 1 不新增**。理由：candidate 機制退役，event_type 不需要
+- **Round 0「整併保留」基調** → **Round 1「完全刪除」**。理由：未來 Evaluator 重起會重寫，別讓死代碼長靈藏（使用者明確選擇）
+- **Round 1 §4.1 補強**：明確區分即時反饋的兩層 — `ToolCallDimension` 已是隱性層 1，使用者反饋是層 2。先前只寫層 2 太單薄，等於沒看到系統已暴露的訊號通道
+
+---
+
+*Round 1 草稿：絲絲・Loom 與 Dakai 對話 | 2026-05-13*
+*下一步：在對應實作 issue 的 comment 區逐題討論 §8 open questions*

--- a/doc/54-Skill-Evolution-Arena-設計.md
+++ b/doc/54-Skill-Evolution-Arena-設計.md
@@ -65,19 +65,24 @@ code_weaver 97% 不是靠任何自動框架，是靠：
 
 ## 3. 退役清單（完全刪除）
 
-| 元件 | 檔案 | 處置 |
-|------|------|------|
-| `SkillGate` (shadow_mode auto_c) | `loom/core/cognition/skill_gate.py` | 刪除整檔 |
-| `SkillPromoter` | `loom/core/cognition/skill_promoter.py` | 刪除整檔 |
-| `SkillMutator` | `loom/core/cognition/skill_mutator.py` | 刪除整檔 |
-| `SkillGenome` dataclass + ProceduralMemory candidate 介面 | `loom/core/memory/procedural.py` | 刪除 candidate / genome 相關函式，保留 procedural memory 其他用途 |
-| `loom.db` skill_genomes / skill_candidates / skill_version_history 表 | `loom/core/memory/store.py` | 刪除 DDL；確認 `loom.db` 整個檔案是否還有其他用途，若無則一併移除 |
-| `generate_skill_candidate_from_batch` tool | `loom/platform/cli/tools.py` | 刪除 tool definition + executor |
-| `promote_skill_candidate` tool | 同上 | 刪除 |
-| `set_skill_maturity` tool | 同上 | 刪除 |
-| `loom.toml [mutation]` section | `loom.toml` + parser | 整節移除 |
-| `meta-skill-engineer` 七階段工作流文件 | `.claude/skills/meta-skill-engineer/` 或 `skills/meta-skill-engineer/` | 移除 skill；相關 Grader / Comparator / Analyzer prompt 一併刪 |
-| `outputs/doc/skill_system_evolution_plan_2026-05-02.md` | doc | 標記為「已被 doc/54 取代」並移到 `outputs/doc/archive/` 或直接刪 |
+每一行的「session.py register 行」欄記載**對應 `LoomSession.start()` 中要一併拿掉的註冊呼叫**。Round 1 review（#363）抓到的 dependency ordering 問題：若刪除 module 但留下 register 行，會 ImportError；刪除 register 但留下 module 則該 tool 對 agent 不可見但代碼仍在。**同一個 commit 同時處理才是 atomic**。
+
+| 元件 | 檔案 | 處置 | session.py register 行 |
+|------|------|------|------------------------|
+| `SkillGate` (shadow_mode auto_c) | `loom/core/cognition/skill_gate.py` | 刪除整檔 | `_skill_gate` 欄位 + `make_load_skill_tool(skill_gate=...)` 引用 |
+| `SkillPromoter` | `loom/core/cognition/skill_promoter.py` | 刪除整檔 | `_skill_promoter` 欄位 + `task_reflector` 引用 + `subscribe(_fan_promotion)` |
+| `SkillMutator` | `loom/core/cognition/skill_mutator.py` | 刪除整檔 | `_skill_mutator` 欄位 + `task_reflector(mutator=...)` |
+| `SkillGenome` dataclass + ProceduralMemory candidate 介面 | `loom/core/memory/procedural.py` | 刪除 candidate / genome 相關函式，保留 procedural memory 其他用途 | — |
+| `memory.db` 中的 skill_genomes / skill_candidates / skill_version_history 表 | `loom/core/memory/store.py` (DDL @ lines 46+) | 刪除 DDL；下次 init 時表不再 create。**注意**：實際 host 是 `memory.db` 不是 `loom.db`（後者實際為空，是個 ghost file，可額外刪除） | — |
+| `generate_skill_candidate_from_batch` tool | `loom/platform/cli/tools.py` | 刪除 factory + executor | `make_generate_skill_candidate_from_batch_tool(...)` register (#363 後 session.py:1453) |
+| `promote_skill_candidate` tool | 同上 | 刪除 | **已在 #363 移除** (was session.py:1447) |
+| `skill_rollback` tool | 同上 | 刪除 | **已在 #363 移除** (was session.py:1448) |
+| `set_skill_maturity` tool | 同上 | 刪除 | `make_set_skill_maturity_tool(...)` register (#363 後 session.py:1456) |
+| `loom.toml [mutation]` section | `loom.toml` + parser | 整節移除 | — |
+| `loom review` CLI 子命令（舊版） | `loom/platform/cli/main.py:3041` `cli.command("review")` | 刪除 | — |
+| `meta-skill-engineer` 七階段工作流文件 | `.claude/skills/meta-skill-engineer/` 或 `skills/meta-skill-engineer/` | 移除 skill；相關 Grader / Comparator / Analyzer prompt 一併刪 | — |
+| `~/.loom/loom.db` ghost file | runtime 副作用 | 不用 migration；下次 LoomSession start 不會再寫 | — |
+| `outputs/doc/skill_system_evolution_plan_2026-05-02.md` | doc | 標記為「已被 doc/54 取代」並移到 `outputs/doc/archive/` 或直接刪 | — |
 
 **保留**：
 
@@ -178,11 +183,13 @@ git commit（=版本紀錄，取代 candidate/promote 機制）
 ```python
 skill_review(
     skill_id: str,
-    since: str = "7d",                         # "1d" / "7d" / "30d" / ISO timestamp
-    include: list[str] = ["all"],              # tool_calls / failures / feedback / turns / thoughts
-    max_events: int = 100,                     # cap 回傳體積
+    days: float = 7,                           # window size; numeric for ergonomics
+    max_episodes: int = 30,                    # cap 回傳體積（episodes）
+    max_events_per_episode: int = 30,          # cap 回傳體積（每 episode 內事件）
 ) -> SkillUsageDigest
 ```
+
+> **Round 1 review note (#363)**：原 Round 0 規格寫 `since="7d" / "30d" / ISO timestamp`、`include=[...]`、`max_events=100`。實作（PR #363 `make_skill_review_tool`）採用更扁平的 `days` + 雙層 max — 簡單、ergonomic、不需要 string parsing。`include` 過濾留給 Watch issue #364 收集真實使用反饋後再決定要不要做。本 doc 已對齊實作。
 
 回傳結構（skill-scoped 而非 session-scoped）：
 
@@ -258,7 +265,7 @@ class SkillUsageDigest:
 | P0-5 | 新增 `skill_review` tool（包裝 P0-4） | `loom/platform/cli/tools.py` | S | 通道 C |
 | P0-6 | 新增 weekly worker（呼叫 P0-4 + render markdown） | 新檔 | M | 通道 B |
 | P0-7 | `loom.toml` 新增 `skill_weekly_review` schedule 條目 | `loom.toml` + autonomy schedules parser | S | 通道 B 觸發 |
-| P0-8 | `loom.db` schema init bug **不修**，整個 `loom.db` 一併評估退場 | `loom/core/memory/store.py` | — | 廢除路徑 |
+| P0-8 | `loom.db` 真相確認 — 該檔案實際**完全空白**（no tables），技能表的真實 host 是 `memory.db`。退役工作 = 從 `memory.db` 刪除 skill_genomes / skill_candidates / skill_version_history DDL（Phase 1.C 範圍）；`~/.loom/loom.db` ghost file 不需要 migration | `loom/core/memory/store.py` | — | Phase 1.C |
 
 **今日優先做 P0-1 與 P0-2**：沒有 `skill_id` payload，下游全部沒資料可吃。其他可以分次。
 

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -547,6 +547,31 @@ enabled  = false           # set true to activate daemon
 # notify        = false
 # notify_thread = 0
 
+# ── Example: weekly skill review (doc/54 §4.2) ──────────────────────────────────
+# Surfaces structural observations about skill usage — *not* a grader.
+# Pure SQL + template (no LLM at the worker level); the agent here just
+# fires `loom skill weekly`, then optionally narrates the report's
+# 該關注清單 section if anything fired.
+#
+# Manual run: `loom skill weekly` writes outputs/self_check/<date>-skill-weekly.md
+#
+# [[autonomy.schedules]]
+# name          = "skill_weekly_review"
+# cron          = "0 2 * * 6"        # 02:00 UTC Saturday = 10:00 Asia/Taipei
+# intent        = """Run the weekly skill review. Execute `loom skill weekly`
+#                    via run_bash, then read outputs/self_check/<today>-skill-weekly.md
+#                    and surface any items in the 該關注清單 section. Do not
+#                    edit skills; just observe and report."""
+# trust_level   = "safe"
+# notify        = false
+# notify_thread = 0
+# allowed_tools = ["run_bash", "read_file"]
+# scope_grants  = [
+#   { resource = "exec", action = "execute", selector = "workspace" },
+#   { resource = "path", action = "read", selector = "outputs" },
+# ]
+# attach_outputs = ["outputs/self_check/*-skill-weekly.md"]
+
 # ─────────────────────────────────────────────
 # Notifications
 # ─────────────────────────────────────────────

--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -1444,6 +1444,24 @@ class LifecycleGateMiddleware(Middleware):
         return result
 
 
+_SKILL_PAYLOAD_TOOL_NAMES = frozenset({"load_skill", "unload_skill"})
+
+
+def _skill_id_from_call(call: "ToolCall") -> str | None:
+    """Return the target skill name for load_skill / unload_skill calls.
+
+    Surfaces it as a top-level `skill_id` payload field so the ledger's
+    `skill_id` virtual column (doc/54 §5 P0-1) indexes per-skill usage.
+    Returns None for all other tools.
+    """
+    if call.tool_name not in _SKILL_PAYLOAD_TOOL_NAMES:
+        return None
+    name = call.args.get("name")
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+    return None
+
+
 class LifecycleMiddleware(Middleware):
     """
     Outer lifecycle middleware — ActionRecord bookends and post-execution flow.
@@ -1836,6 +1854,7 @@ class LifecycleMiddleware(Middleware):
                     args_digest=self._args_digest(call.args),
                     args=None,  # full args 留 future debug mode；BEGIN 帶 digest 即可
                     state_history=[],
+                    skill_id=_skill_id_from_call(call),
                 ),
                 event_id=f"evt_tool_begin_{record.id[:12]}",
             )
@@ -1874,6 +1893,7 @@ class LifecycleMiddleware(Middleware):
                         state_history=rec.history_dicts(),
                         rolled_back=rolled_back,
                         error=(result.error if result and not result.success else None),
+                        skill_id=_skill_id_from_call(call),
                         # parent links the END to its sibling BEGIN.
                         # event_id of BEGIN was deterministically derived
                         # from record.id; mirror that here.

--- a/loom/core/ledger/schema.py
+++ b/loom/core/ledger/schema.py
@@ -192,6 +192,7 @@ CREATE_INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_session_recent ON events (branch_id, session_id, timestamp DESC)",
     "CREATE INDEX IF NOT EXISTS idx_tool           ON events (branch_id, tool_name, timestamp)",
     "CREATE INDEX IF NOT EXISTS idx_verdict        ON events (branch_id, verdict, timestamp)",
+    "CREATE INDEX IF NOT EXISTS idx_skill          ON events (branch_id, skill_id, timestamp)",
     "CREATE INDEX IF NOT EXISTS idx_parent         ON events (parent_event_id)",
     "CREATE INDEX IF NOT EXISTS idx_predecessor    ON events (predecessor_memory_id)",
 ]

--- a/loom/core/ledger/schema.py
+++ b/loom/core/ledger/schema.py
@@ -98,6 +98,10 @@ class ToolLifecyclePayload:
     state_history: list[dict] = field(default_factory=list)
     rolled_back: bool = False
     error: str | None = None
+    # Populated for skill-scoped tools (load_skill / unload_skill) so the
+    # `skill_id` virtual column (doc/54 §5 P0-1) can index per-skill usage.
+    # NULL for all other tools.
+    skill_id: str | None = None
     schema_version: int = CURRENT_SCHEMA_VERSION
 
 

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1443,13 +1443,20 @@ class LoomSession:
         from loom.platform.cli.tools import make_skill_review_tool
         self.registry.register(make_skill_review_tool(self._ledger_store))
 
-        # Issue #120 PR 3: promote / rollback lifecycle tools.
-        self.registry.register(make_skill_promote_tool(self._skill_promoter))
-        self.registry.register(make_skill_rollback_tool(self._skill_promoter))
+        # doc/54 §3 retirement (Round 1): promote / rollback tools are no
+        # longer exposed to the agent. The underlying SkillPromoter class
+        # stays for now — task_reflector + auto_c shadow flow still hold
+        # references — and disappears in the Phase 1.C deletion PR. The
+        # tools themselves were structurally broken (promote always
+        # returned "Candidate not found" because no candidate creation
+        # path actually persisted rows); pulling them off the surface is
+        # a UX fix as well as a retirement step.
 
         # Issue #120 PR 4: meta-skill-engineer surface — agent-callable
         # equivalents of the Grader → candidate-pool → maturity workflow so
         # the skill can drive the whole cycle without dropping to Python.
+        # NOTE: these tools survive this PR (Phase 1.C will remove them
+        # together with the SkillMutator / candidate-pool subsystem).
         self.registry.register(make_generate_skill_candidate_from_batch_tool(
             self._skill_mutator, self._memory.procedural, session_id=self.session_id,
         ))

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1437,6 +1437,12 @@ class LoomSession:
             self._skill_check_manager,
         ))
 
+        # doc/54 §4.3 / §5 P0-5: Register skill_review tool — agent's
+        # conversational entry to per-skill ledger history. Read-only;
+        # no-op if the ledger isn't available.
+        from loom.platform.cli.tools import make_skill_review_tool
+        self.registry.register(make_skill_review_tool(self._ledger_store))
+
         # Issue #120 PR 3: promote / rollback lifecycle tools.
         self.registry.register(make_skill_promote_tool(self._skill_promoter))
         self.registry.register(make_skill_rollback_tool(self._skill_promoter))

--- a/loom/core/skill_review/__init__.py
+++ b/loom/core/skill_review/__init__.py
@@ -15,10 +15,22 @@ from loom.core.skill_review.query import (
     query_skill_ledger,
 )
 from loom.core.skill_review.render import render_digest_as_text
+from loom.core.skill_review.weekly import (
+    SkillAttention,
+    WeeklyReport,
+    compute_attention,
+    generate_weekly_report,
+    render_weekly_markdown,
+)
 
 __all__ = [
     "SkillEpisode",
     "SkillUsageDigest",
     "query_skill_ledger",
     "render_digest_as_text",
+    "SkillAttention",
+    "WeeklyReport",
+    "compute_attention",
+    "generate_weekly_report",
+    "render_weekly_markdown",
 ]

--- a/loom/core/skill_review/__init__.py
+++ b/loom/core/skill_review/__init__.py
@@ -1,0 +1,24 @@
+"""Skill review — pure ledger queries that surface per-skill usage history.
+
+Consumers (doc/54 §4.3.2):
+- ``skill_review`` agent tool (conversational pull, real-time)
+- Weekly worker (cron, markdown render to outputs/self_check/)
+
+Both go through the same :func:`query_skill_ledger` pure function so the
+aggregation logic lives in one place. No LLM, no scoring — just shaped
+event evidence the consumer can reason about.
+"""
+
+from loom.core.skill_review.query import (
+    SkillEpisode,
+    SkillUsageDigest,
+    query_skill_ledger,
+)
+from loom.core.skill_review.render import render_digest_as_text
+
+__all__ = [
+    "SkillEpisode",
+    "SkillUsageDigest",
+    "query_skill_ledger",
+    "render_digest_as_text",
+]

--- a/loom/core/skill_review/query.py
+++ b/loom/core/skill_review/query.py
@@ -1,0 +1,180 @@
+"""Per-skill ledger query (doc/54 §4.3, §5 P0-4).
+
+The agent (or weekly worker) asks: "what happened around skill X over
+the last N days?" — this module answers with a shaped digest, not a
+score. The consumer reasons about the evidence.
+
+Shape choices:
+
+- An *episode* is one load_skill activation. It carries the raw events
+  that followed in the same turn (tool_lifecycle, memory_op, judge_verdict,
+  turn_end), capped to keep payloads bounded.
+- Activation window per turn: from the load_skill END event up to either
+  the matching unload_skill in the same turn or the turn_end, whichever
+  comes first. Most turns have at most one activation; multiple loads
+  in the same turn produce overlapping episodes (no de-dup).
+- Distinct sessions are surfaced for cross-session reasoning ("this skill
+  has been active in 3 different sessions this week").
+- No "health score". doc/54 §1 rules out process-signal grading.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from loom.core.ledger.schema import LedgerEvent
+
+if TYPE_CHECKING:
+    from loom.core.ledger.store import LedgerStore
+
+
+_DEFAULT_WINDOW_SECONDS = 7 * 24 * 3600       # one week
+_DEFAULT_MAX_EVENTS_PER_EPISODE = 50
+_DEFAULT_MAX_EPISODES = 100
+
+
+@dataclass(frozen=True)
+class SkillEpisode:
+    """One load_skill activation and the same-turn events that followed."""
+
+    load_event_id: str
+    session_id: str
+    turn_id: str
+    loaded_at: float
+    unloaded_at: float | None
+    turn_outcome: str | None              # from turn_end payload, if present
+    events_after_load: list[LedgerEvent] = field(default_factory=list)
+    truncated: bool = False               # True if events_after_load was capped
+
+
+@dataclass(frozen=True)
+class SkillUsageDigest:
+    """Aggregate digest for a single skill over a time window."""
+
+    skill_id: str
+    since_ts: float
+    until_ts: float
+    load_count: int
+    unload_count: int
+    sessions: tuple[str, ...]
+    episodes: list[SkillEpisode] = field(default_factory=list)
+    episodes_truncated: bool = False      # True if total episodes > cap
+
+
+async def query_skill_ledger(
+    ledger: "LedgerStore",
+    skill_id: str,
+    *,
+    since_ts: float | None = None,
+    until_ts: float | None = None,
+    max_events_per_episode: int = _DEFAULT_MAX_EVENTS_PER_EPISODE,
+    max_episodes: int = _DEFAULT_MAX_EPISODES,
+) -> SkillUsageDigest:
+    """Build a per-skill usage digest from ledger events.
+
+    Args:
+        ledger: open LedgerStore.
+        skill_id: target skill name (matches ``payload.skill_id``).
+        since_ts: window start (Unix seconds). Defaults to 7 days ago.
+        until_ts: window end (Unix seconds). Defaults to now.
+        max_events_per_episode: cap on per-episode follow-on events.
+        max_episodes: cap on total episodes returned.
+
+    Returns:
+        :class:`SkillUsageDigest`. ``episodes`` is sorted by ``loaded_at`` asc.
+    """
+    now = time.time()
+    if until_ts is None:
+        until_ts = now
+    if since_ts is None:
+        since_ts = until_ts - _DEFAULT_WINDOW_SECONDS
+
+    # Skill-scoped events: load_skill / unload_skill tool_lifecycle pairs.
+    skill_events = (
+        await ledger.events
+        .where(skill_id=skill_id)
+        .since(since_ts)
+        .until(until_ts)
+        .order_by("timestamp")
+        .all()
+    )
+
+    load_ends = [
+        e for e in skill_events
+        if e.payload.get("phase") == "END"
+        and e.payload.get("tool_name") == "load_skill"
+    ]
+    unload_ends = [
+        e for e in skill_events
+        if e.payload.get("phase") == "END"
+        and e.payload.get("tool_name") == "unload_skill"
+    ]
+
+    load_count = len(load_ends)
+    unload_count = len(unload_ends)
+    sessions = tuple(sorted({e.session_id for e in skill_events}))
+
+    # Bound work: cap episodes constructed.
+    episodes_truncated = load_count > max_episodes
+    load_ends_for_episodes = load_ends[-max_episodes:] if episodes_truncated else load_ends
+
+    # Build one episode per load. Same-turn events: fetched by turn_id and
+    # filtered to the activation window. We accept the per-turn fetch cost
+    # because turns are short and the alternative (one giant query then
+    # in-memory bucket) is messier with no payoff at Phase 1 scale.
+    episodes: list[SkillEpisode] = []
+    for load in load_ends_for_episodes:
+        loaded_at = load.timestamp
+
+        # Find unload_skill END for the same skill in the same turn, if any.
+        turn_unload_ts: float | None = None
+        for un in unload_ends:
+            if un.turn_id == load.turn_id and un.timestamp > loaded_at:
+                turn_unload_ts = un.timestamp
+                break
+
+        turn_events = await ledger.events.where(turn_id=load.turn_id).order_by("timestamp").all()
+
+        # Window: (loaded_at, unload_ts or +inf]. Strict > on loaded_at so
+        # we don't re-include the load event itself.
+        window_end = turn_unload_ts if turn_unload_ts is not None else float("inf")
+        in_window = [
+            e for e in turn_events
+            if loaded_at < e.timestamp <= window_end
+            and e.event_id != load.event_id
+        ]
+
+        # turn_outcome from the turn's own turn_end, regardless of window
+        # (a turn either ends or it doesn't).
+        turn_outcome: str | None = None
+        for e in turn_events:
+            if e.event_type == "turn_end":
+                turn_outcome = e.payload.get("outcome")
+                break
+
+        truncated = len(in_window) > max_events_per_episode
+        events_kept = in_window[:max_events_per_episode]
+
+        episodes.append(SkillEpisode(
+            load_event_id=load.event_id,
+            session_id=load.session_id,
+            turn_id=load.turn_id,
+            loaded_at=loaded_at,
+            unloaded_at=turn_unload_ts,
+            turn_outcome=turn_outcome,
+            events_after_load=events_kept,
+            truncated=truncated,
+        ))
+
+    return SkillUsageDigest(
+        skill_id=skill_id,
+        since_ts=since_ts,
+        until_ts=until_ts,
+        load_count=load_count,
+        unload_count=unload_count,
+        sessions=sessions,
+        episodes=episodes,
+        episodes_truncated=episodes_truncated,
+    )

--- a/loom/core/skill_review/render.py
+++ b/loom/core/skill_review/render.py
@@ -1,0 +1,95 @@
+"""Default text renderer for SkillUsageDigest (doc/54 §4.3.1).
+
+Produces a dense, agent-readable transcript of skill activity. Used by
+the ``skill_review`` tool; the weekly worker can reuse or replace as
+needed for richer markdown.
+
+Format choices:
+- ISO-ish timestamps (UTC) — readable, sortable, no timezone surprises
+- Per-episode block — agent quotes/cites blocks back during discussion
+- Compact event lines — no syntactic clutter; one event per line
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from loom.core.skill_review.query import SkillUsageDigest, SkillEpisode
+
+
+def _fmt_ts(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _fmt_event_line(e) -> str:
+    """One-line summary of a single LedgerEvent."""
+    ts = datetime.fromtimestamp(e.timestamp, tz=timezone.utc).strftime("%H:%M:%S")
+    et = e.event_type
+    p = e.payload
+
+    if et == "tool_lifecycle":
+        phase = p.get("phase", "?")
+        tool = p.get("tool_name", "?")
+        err = p.get("error")
+        rolled = p.get("rolled_back")
+        flags: list[str] = []
+        if err:
+            flags.append(f'err="{err[:80]}"')
+        if rolled:
+            flags.append("rolled_back")
+        result = "failure" if err else "success"
+        suffix = (" " + " ".join(flags)) if flags else ""
+        return f"  + {ts} tool_lifecycle:{phase:5} {tool:20} {result}{suffix}"
+
+    if et == "memory_op":
+        op = p.get("operation", "?")
+        trust = p.get("trust_tier")
+        trust_s = f" trust={trust}" if trust else ""
+        return f"  + {ts} memory_op:{op:5}{trust_s}"
+
+    if et == "judge_verdict":
+        v = p.get("verdict", "?")
+        conf = p.get("confidence")
+        conf_s = f" conf={conf:.2f}" if isinstance(conf, (int, float)) else ""
+        return f"  + {ts} judge_verdict   {v}{conf_s}"
+
+    if et == "turn_end":
+        outcome = p.get("outcome", "?")
+        return f"  + {ts} turn_end        outcome={outcome}"
+
+    return f"  + {ts} {et}"
+
+
+def _render_episode(ep: SkillEpisode, idx: int) -> str:
+    lines = [
+        f"## Episode {idx} — {ep.session_id} / {ep.turn_id} — {_fmt_ts(ep.loaded_at)}",
+        f"loaded_at:   {_fmt_ts(ep.loaded_at)}",
+        f"unloaded_at: {_fmt_ts(ep.unloaded_at) if ep.unloaded_at else '<no explicit unload>'}",
+        f"turn_outcome: {ep.turn_outcome or '<no turn_end>'}",
+    ]
+    suffix = " (truncated)" if ep.truncated else ""
+    lines.append(f"events_after_load ({len(ep.events_after_load)}{suffix}):")
+    if not ep.events_after_load:
+        lines.append("  (none)")
+    else:
+        lines.extend(_fmt_event_line(e) for e in ep.events_after_load)
+    return "\n".join(lines)
+
+
+def render_digest_as_text(digest: SkillUsageDigest) -> str:
+    """Render a SkillUsageDigest into a dense text block for the agent."""
+    header = [
+        f"# Skill review: {digest.skill_id}",
+        f"Window: {_fmt_ts(digest.since_ts)} ~ {_fmt_ts(digest.until_ts)}",
+        f"Loads: {digest.load_count}, Unloads: {digest.unload_count}",
+        f"Sessions: {len(digest.sessions)}"
+        + (f" ({', '.join(digest.sessions)})" if digest.sessions else ""),
+        f"Episodes: {len(digest.episodes)}"
+        + (" (truncated)" if digest.episodes_truncated else ""),
+    ]
+    if not digest.episodes:
+        header.append("\n(no activations in this window)")
+        return "\n".join(header)
+
+    blocks = [_render_episode(ep, i + 1) for i, ep in enumerate(digest.episodes)]
+    return "\n".join(header) + "\n\n" + "\n\n".join(blocks)

--- a/loom/core/skill_review/weekly.py
+++ b/loom/core/skill_review/weekly.py
@@ -1,0 +1,377 @@
+"""Weekly skill review worker (doc/54 §4.2, §5 P0-6).
+
+Pure SQL + template — no LLM in this layer. Scans the ledger for the
+preceding window, queries per-skill digests via :mod:`skill_review.query`,
+applies the structural "attention list" criteria from doc/54 §4.4, and
+renders a markdown report to ``outputs/self_check/``.
+
+This is what the user reads when asking "回顧一下這週技能用得怎麼樣". It
+does **not** score skills — it surfaces structural observations and lets
+the user decide where to put attention.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from loom.core.skill_review.query import SkillUsageDigest, query_skill_ledger
+
+if TYPE_CHECKING:
+    from loom.core.ledger.store import LedgerStore
+
+
+_WEEK_SECONDS = 7 * 24 * 3600
+
+# doc/54 §8 Q2: thresholds are placeholders; recalibrate after the first
+# few weekly reports surface real distributions.
+_MUFFLED_LOAD_THRESHOLD = 3            # loaded ≥N times with zero feedback
+_UNDIGESTED_FEEDBACK_THRESHOLD = 1     # ≥N feedback events but SKILL.md not touched since
+_ABNORMAL_OUTCOME_RATIO = 0.30         # (abandoned + error) / outcome_known > X
+_STALE_DAYS = 30                       # no load in past N days = "久未使用"
+
+
+# Distinct reason codes that may appear on a skill's "attention" entry.
+# Stable identifiers so future tooling can filter / aggregate.
+ATTENTION_MUFFLED = "muffled_run"            # 悶頭跑
+ATTENTION_UNDIGESTED = "undigested_feedback"  # 反饋未消化
+ATTENTION_ABNORMAL = "abnormal_outcome"      # 異常結尾
+ATTENTION_STALE = "stale"                    # 久未使用
+ATTENTION_UNUSED = "exists_but_unused"       # 存在但未啟動
+
+
+@dataclass(frozen=True)
+class SkillAttention:
+    skill_id: str
+    reasons: list[str]                 # ATTENTION_* codes
+    details: dict[str, str]            # human-readable detail per reason
+
+
+@dataclass(frozen=True)
+class WeeklyReport:
+    window_start_ts: float
+    window_end_ts: float
+    skills_seen: list[str]             # appeared in ledger
+    skills_on_disk: list[str]          # exist as directories under skills_root
+    digests: dict[str, SkillUsageDigest]
+    attention: list[SkillAttention]
+    markdown: str
+    output_path: Path | None = None    # set when written to disk
+
+
+def _outcome_counts(digest: SkillUsageDigest) -> tuple[int, int]:
+    """Return (abnormal, total_known) outcome counts from episodes."""
+    abnormal = 0
+    total_known = 0
+    for ep in digest.episodes:
+        if ep.turn_outcome is None:
+            continue
+        total_known += 1
+        if ep.turn_outcome in ("abandoned", "error"):
+            abnormal += 1
+    return abnormal, total_known
+
+
+def _feedback_count(digest: SkillUsageDigest) -> int:
+    """Total memory_op:write events across all episodes — feedback density signal."""
+    n = 0
+    for ep in digest.episodes:
+        for e in ep.events_after_load:
+            if e.event_type == "memory_op" and e.payload.get("operation") == "write":
+                n += 1
+    return n
+
+
+def _last_load_ts(digest: SkillUsageDigest) -> float | None:
+    if not digest.episodes:
+        return None
+    return max(ep.loaded_at for ep in digest.episodes)
+
+
+def _skill_md_mtime(skill_dir: Path) -> float | None:
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file():
+        return None
+    try:
+        return skill_md.stat().st_mtime
+    except OSError:
+        return None
+
+
+def _scan_filesystem_skills(skills_roots: list[Path]) -> dict[str, Path]:
+    """Map skill_id → its directory across all roots."""
+    found: dict[str, Path] = {}
+    for root in skills_roots:
+        if not root.is_dir():
+            continue
+        for entry in root.iterdir():
+            if not entry.is_dir():
+                continue
+            if entry.name.startswith("."):
+                continue
+            if not (entry / "SKILL.md").is_file():
+                continue
+            # First-wins: earlier roots take precedence.
+            found.setdefault(entry.name, entry)
+    return found
+
+
+def compute_attention(
+    digest: SkillUsageDigest,
+    skill_dir: Path | None,
+    *,
+    now_ts: float,
+) -> SkillAttention | None:
+    """Apply doc/54 §4.4 structural rules. Returns None if no rule fires."""
+    reasons: list[str] = []
+    details: dict[str, str] = {}
+
+    fb_count = _feedback_count(digest)
+    last_load = _last_load_ts(digest)
+
+    # 悶頭跑: 載入次數高且零反饋
+    if digest.load_count >= _MUFFLED_LOAD_THRESHOLD and fb_count == 0:
+        reasons.append(ATTENTION_MUFFLED)
+        details[ATTENTION_MUFFLED] = (
+            f"{digest.load_count} loads with no user feedback in window"
+        )
+
+    # 反饋未消化: 有反饋但 SKILL.md 自首筆反饋後未變更
+    if fb_count >= _UNDIGESTED_FEEDBACK_THRESHOLD and skill_dir is not None:
+        mtime = _skill_md_mtime(skill_dir)
+        first_fb_ts: float | None = None
+        for ep in digest.episodes:
+            for e in ep.events_after_load:
+                if e.event_type == "memory_op" and e.payload.get("operation") == "write":
+                    if first_fb_ts is None or e.timestamp < first_fb_ts:
+                        first_fb_ts = e.timestamp
+        if mtime is not None and first_fb_ts is not None and mtime < first_fb_ts:
+            reasons.append(ATTENTION_UNDIGESTED)
+            details[ATTENTION_UNDIGESTED] = (
+                f"{fb_count} feedback events, but SKILL.md untouched since "
+                f"{datetime.fromtimestamp(first_fb_ts, tz=timezone.utc):%Y-%m-%d}"
+            )
+
+    # 異常結尾
+    abn, total_known = _outcome_counts(digest)
+    if total_known > 0 and abn / total_known > _ABNORMAL_OUTCOME_RATIO:
+        reasons.append(ATTENTION_ABNORMAL)
+        details[ATTENTION_ABNORMAL] = (
+            f"{abn}/{total_known} turns ended abandoned/error "
+            f"({abn / total_known:.0%})"
+        )
+
+    # 久未使用: 在硬碟存在但 STALE_DAYS 內沒被載入
+    if skill_dir is not None and last_load is not None:
+        days_since = (now_ts - last_load) / 86400.0
+        if days_since > _STALE_DAYS:
+            reasons.append(ATTENTION_STALE)
+            details[ATTENTION_STALE] = f"last loaded {days_since:.0f} days ago"
+
+    if not reasons:
+        return None
+    return SkillAttention(
+        skill_id=digest.skill_id, reasons=reasons, details=details,
+    )
+
+
+async def _digest_all_skills(
+    ledger: "LedgerStore",
+    skill_ids: list[str],
+    *,
+    since_ts: float,
+    until_ts: float,
+) -> dict[str, SkillUsageDigest]:
+    digests: dict[str, SkillUsageDigest] = {}
+    for sid in skill_ids:
+        digests[sid] = await query_skill_ledger(
+            ledger, sid, since_ts=since_ts, until_ts=until_ts,
+        )
+    return digests
+
+
+async def _distinct_skills_in_window(
+    ledger: "LedgerStore", *, since_ts: float, until_ts: float,
+) -> list[str]:
+    """Find every skill_id that has a load/unload event in window."""
+    events = (
+        await ledger.events
+        .where(event_type="tool_lifecycle")
+        .since(since_ts).until(until_ts)
+        .all()
+    )
+    seen: set[str] = set()
+    for e in events:
+        sid = e.payload.get("skill_id")
+        if isinstance(sid, str) and sid:
+            seen.add(sid)
+    return sorted(seen)
+
+
+def _fmt_ts(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+
+def render_weekly_markdown(report: WeeklyReport) -> str:
+    lines = [
+        f"# Skill Weekly Review",
+        f"",
+        f"- Window: {_fmt_ts(report.window_start_ts)} ~ {_fmt_ts(report.window_end_ts)}",
+        f"- Skills seen in ledger: {len(report.skills_seen)}",
+        f"- Skills on disk: {len(report.skills_on_disk)}",
+        f"- Attention items: {len(report.attention)}",
+        f"",
+        f"---",
+        f"",
+        f"## 該關注清單",
+        f"",
+    ]
+    if not report.attention:
+        lines.append("(no skills triggered structural attention rules this week)")
+    else:
+        for item in report.attention:
+            lines.append(f"### {item.skill_id}")
+            for code in item.reasons:
+                lines.append(f"- **{code}**: {item.details.get(code, '')}")
+            lines.append("")
+
+    lines.extend([
+        f"",
+        f"---",
+        f"",
+        f"## 技能活動 — 本週載入次數",
+        f"",
+    ])
+    if not report.digests:
+        lines.append("(no skill activity in window)")
+    else:
+        lines.append("| skill | loads | unloads | sessions | episodes_truncated |")
+        lines.append("|-------|-------|---------|----------|--------------------|")
+        for sid in sorted(report.digests.keys()):
+            d = report.digests[sid]
+            trunc = "yes" if d.episodes_truncated else ""
+            lines.append(
+                f"| {sid} | {d.load_count} | {d.unload_count} | "
+                f"{len(d.sessions)} | {trunc} |"
+            )
+
+    # 存在但未啟動: 在 disk 但沒進 digests
+    unused = [s for s in report.skills_on_disk if s not in report.digests]
+    if unused:
+        lines.extend([
+            f"",
+            f"---",
+            f"",
+            f"## 存在但未啟動 ({len(unused)})",
+            f"",
+            f"檔案系統存在但本週未被載入：",
+        ])
+        for sid in sorted(unused):
+            lines.append(f"- {sid}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+async def generate_weekly_report(
+    ledger: "LedgerStore",
+    *,
+    skills_roots: list[Path] | None = None,
+    output_dir: Path | None = None,
+    window_days: int = 7,
+    now_ts: float | None = None,
+    write_to_disk: bool = True,
+) -> WeeklyReport:
+    """Run a full weekly skill review.
+
+    Args:
+        ledger: open LedgerStore.
+        skills_roots: directories containing skill folders (``SKILL.md`` per dir).
+            None = skip filesystem comparisons (no "exists_but_unused" or
+            "undigested_feedback" detection).
+        output_dir: where to write the markdown. None = don't write.
+        window_days: review window length.
+        now_ts: anchor "now" for the window end. Defaults to current time.
+            Test-only override.
+        write_to_disk: if True and output_dir is given, write the report.
+
+    Returns:
+        :class:`WeeklyReport` with markdown + attention list. ``output_path``
+        is populated when the report was written.
+    """
+    end_ts = now_ts if now_ts is not None else time.time()
+    start_ts = end_ts - window_days * 86400
+
+    skills_seen = await _distinct_skills_in_window(
+        ledger, since_ts=start_ts, until_ts=end_ts,
+    )
+    fs_skills = (
+        _scan_filesystem_skills(skills_roots) if skills_roots else {}
+    )
+
+    # Union: ledger-seen + disk-seen so "exists_but_unused" gets noticed.
+    all_skill_ids = sorted(set(skills_seen) | set(fs_skills.keys()))
+
+    digests = await _digest_all_skills(
+        ledger, skills_seen,            # only query digests for skills with events
+        since_ts=start_ts, until_ts=end_ts,
+    )
+
+    attention: list[SkillAttention] = []
+    for sid in all_skill_ids:
+        d = digests.get(sid)
+        skill_dir = fs_skills.get(sid)
+        if d is None:
+            # Skill on disk, no ledger events.
+            if skill_dir is not None:
+                attention.append(SkillAttention(
+                    skill_id=sid,
+                    reasons=[ATTENTION_UNUSED],
+                    details={ATTENTION_UNUSED: "exists on disk but never loaded in window"},
+                ))
+            continue
+        item = compute_attention(d, skill_dir, now_ts=end_ts)
+        if item is not None:
+            attention.append(item)
+
+    report = WeeklyReport(
+        window_start_ts=start_ts,
+        window_end_ts=end_ts,
+        skills_seen=skills_seen,
+        skills_on_disk=sorted(fs_skills.keys()),
+        digests=digests,
+        attention=attention,
+        markdown="",  # filled below
+    )
+    # Markdown render uses the WeeklyReport itself; rebuild with content.
+    markdown = render_weekly_markdown(report)
+    report = WeeklyReport(
+        window_start_ts=report.window_start_ts,
+        window_end_ts=report.window_end_ts,
+        skills_seen=report.skills_seen,
+        skills_on_disk=report.skills_on_disk,
+        digests=report.digests,
+        attention=report.attention,
+        markdown=markdown,
+    )
+
+    if write_to_disk and output_dir is not None:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.fromtimestamp(end_ts, tz=timezone.utc).strftime("%Y-%m-%d")
+        out_path = output_dir / f"{stamp}-skill-weekly.md"
+        out_path.write_text(markdown, encoding="utf-8")
+        report = WeeklyReport(
+            window_start_ts=report.window_start_ts,
+            window_end_ts=report.window_end_ts,
+            skills_seen=report.skills_seen,
+            skills_on_disk=report.skills_on_disk,
+            digests=report.digests,
+            attention=report.attention,
+            markdown=markdown,
+            output_path=out_path,
+        )
+
+    return report

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -3015,6 +3015,62 @@ async def _skill_set_maturity(skill_name: str, tag: str | None, db: str) -> None
     )
 
 
+# ---------------------------------------------------------------------------
+# loom skill weekly — doc/54 §4.2 / §5 P0-6 weekly worker
+# ---------------------------------------------------------------------------
+
+
+@skill.command("weekly")
+@click.option("--days", default=7, show_default=True, type=int,
+              help="Window size in days.")
+@click.option("--output-dir", default="outputs/self_check",
+              show_default=True, type=click.Path(),
+              help="Where to write the markdown report (omit --no-write to skip).")
+@click.option("--no-write", is_flag=True, default=False,
+              help="Print to stdout instead of writing a file.")
+def skill_weekly(days: int, output_dir: str, no_write: bool) -> None:
+    """Run the weekly skill review worker.
+
+    Pure ledger query + structural analysis — no LLM. Produces a markdown
+    report listing per-skill activity and a "該關注清單" of structural
+    observations (doc/54 §4.4).
+    """
+    asyncio.run(_skill_weekly(days, output_dir, no_write))
+
+
+async def _skill_weekly(days: int, output_dir: str, no_write: bool) -> None:
+    from loom.core.ledger import LedgerStore
+    from loom.core.skill_review import generate_weekly_report
+
+    store = LedgerStore()
+    await store.open()
+    try:
+        workspace = Path.cwd()
+        skills_roots = [
+            workspace / "skills",
+            Path.home() / ".loom" / "skills",
+        ]
+        report = await generate_weekly_report(
+            store,
+            skills_roots=skills_roots,
+            output_dir=None if no_write else Path(output_dir),
+            window_days=days,
+            write_to_disk=not no_write,
+        )
+    finally:
+        await store.close()
+
+    if no_write:
+        console.print(report.markdown)
+    else:
+        console.print(
+            f"Weekly skill review written to: [bold]{report.output_path}[/bold]\n"
+            f"Skills seen: {len(report.skills_seen)} | "
+            f"On disk: {len(report.skills_on_disk)} | "
+            f"Attention items: {len(report.attention)}"
+        )
+
+
 async def _resolve_candidate_id(proc: "ProceduralMemory", prefix: str) -> str | None:
     """Accept either a full uuid or a short prefix (≥4 chars).
 

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -24,6 +24,7 @@ import os
 import re
 import signal
 import subprocess
+import time
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
@@ -74,7 +75,7 @@ async def _terminate_proc_group(proc: asyncio.subprocess.Process) -> None:
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from loom.core.ledger import LedgerEmitter
+    from loom.core.ledger import LedgerEmitter, LedgerStore
     from loom.core.cognition.skill_gate import SkillGate
     from loom.core.cognition.skill_mutator import SkillMutator
     from loom.core.cognition.skill_promoter import SkillPromoter
@@ -2016,6 +2017,111 @@ def make_unload_skill_tool(
         executor=_unload_skill,
         tags=["skill", "memory"],
         impact_scope="memory",
+    )
+
+
+# ------------------------------------------------------------------
+# Skill review tool (doc/54 §4.3, §5 P0-5) — read-only ledger digest
+# ------------------------------------------------------------------
+
+
+def make_skill_review_tool(
+    ledger_store: "LedgerStore | None",
+) -> ToolDefinition:
+    """Create a SAFE ``skill_review`` tool — pull per-skill usage history.
+
+    Conversational entry point for the optimization loop described in
+    doc/54 §4.3: user asks "what happened with skill X recently?", agent
+    calls this, agent reads digest, discusses, edits SKILL.md.
+
+    Read-only. Backed by :func:`query_skill_ledger` — same query layer the
+    weekly worker (doc/54 §4.2) will reuse.
+    """
+    from loom.core.skill_review import query_skill_ledger, render_digest_as_text
+
+    async def _skill_review(call: ToolCall) -> ToolResult:
+        skill_id = (call.args.get("skill_id") or "").strip()
+        if not skill_id:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False,
+                error="skill_id required (the skill name to review)",
+            )
+        if ledger_store is None:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False,
+                error="Ledger is not available in this session; cannot review.",
+            )
+
+        days = call.args.get("days", 7)
+        try:
+            days_f = float(days)
+        except (TypeError, ValueError):
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error=f"'days' must be a number; got {days!r}",
+            )
+        if days_f <= 0:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error="'days' must be positive",
+            )
+
+        max_episodes = int(call.args.get("max_episodes", 30))
+        max_events = int(call.args.get("max_events_per_episode", 30))
+
+        since_ts = time.time() - days_f * 86400.0
+        digest = await query_skill_ledger(
+            ledger_store,
+            skill_id,
+            since_ts=since_ts,
+            max_episodes=max_episodes,
+            max_events_per_episode=max_events,
+        )
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=True,
+            output=render_digest_as_text(digest),
+        )
+
+    return ToolDefinition(
+        name="skill_review",
+        description=(
+            "Pull a per-skill usage digest from the event ledger over a "
+            "recent time window. Use this when reviewing how a skill has "
+            "been performing, or before discussing SKILL.md updates. "
+            "Read-only — does not modify any skill."
+        ),
+        trust_level=TrustLevel.SAFE,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "skill_id": {
+                    "type": "string",
+                    "description": "Skill name to review (e.g. 'code_weaver').",
+                },
+                "days": {
+                    "type": "number",
+                    "description": "Window size in days (default 7).",
+                    "default": 7,
+                },
+                "max_episodes": {
+                    "type": "integer",
+                    "description": "Cap on episodes returned (default 30).",
+                    "default": 30,
+                },
+                "max_events_per_episode": {
+                    "type": "integer",
+                    "description": "Cap on per-episode follow-on events (default 30).",
+                    "default": 30,
+                },
+            },
+            "required": ["skill_id"],
+        },
+        executor=_skill_review,
+        tags=["skill", "review", "read-only"],
+        impact_scope="read-only",
     )
 
 

--- a/tests/test_ledger_store.py
+++ b/tests/test_ledger_store.py
@@ -166,6 +166,15 @@ async def test_predecessor_index_used(store: LedgerStore) -> None:
     assert "idx_predecessor" in " ".join(plan)
 
 
+async def test_skill_index_used(store: LedgerStore) -> None:
+    """doc/54 §5 P0-3 — per-skill queries must hit idx_skill, not table-scan."""
+    plan = await store.explain_query_plan(
+        "SELECT * FROM events WHERE branch_id=? AND skill_id=? ORDER BY timestamp",
+        ("main", "code_weaver"),
+    )
+    assert "idx_skill" in " ".join(plan), " ".join(plan)
+
+
 # ---------------------------------------------------------------------------
 # schema_version preserved
 # ---------------------------------------------------------------------------

--- a/tests/test_ledger_tool_lifecycle.py
+++ b/tests/test_ledger_tool_lifecycle.py
@@ -180,6 +180,79 @@ async def test_args_digest_changes_with_args(
 
 
 # ---------------------------------------------------------------------------
+# skill_id payload (doc/54 §5 P0-1 / P0-2)
+# ---------------------------------------------------------------------------
+
+
+async def test_skill_id_in_payload_for_load_skill(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    """load_skill calls must populate skill_id so the virtual column indexes them."""
+    reg = _registry_with(tool_name="load_skill")
+    pipeline = MiddlewarePipeline(
+        [LifecycleMiddleware(registry=reg, ledger_emitter=emitter)]
+    )
+    call = ToolCall(
+        tool_name="load_skill",
+        args={"name": "code_weaver"},
+        trust_level=TrustLevel.SAFE,
+        session_id="sess_mw",
+    )
+
+    async with async_turn_scope("turn_mw"), async_correlation_scope("c1"):
+        await pipeline.execute(call, reg.get("load_skill").executor)
+
+    events = await _fetch(ledger, "turn_mw", "tool_lifecycle")
+    assert [e.payload["phase"] for e in events] == ["BEGIN", "END"]
+    assert events[0].payload["skill_id"] == "code_weaver"
+    assert events[1].payload["skill_id"] == "code_weaver"
+
+    # Virtual column should also surface it for queries via the fluent API.
+    via_query = await ledger.events.where(skill_id="code_weaver").all()
+    assert len(via_query) == 2
+    assert all(e.event_type == "tool_lifecycle" for e in via_query)
+
+
+async def test_skill_id_absent_for_non_skill_tool(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    reg = _registry_with()  # default tool_name="echo"
+    pipeline = MiddlewarePipeline(
+        [LifecycleMiddleware(registry=reg, ledger_emitter=emitter)]
+    )
+
+    async with async_turn_scope("turn_mw"), async_correlation_scope("c1"):
+        await pipeline.execute(_make_call(), reg.get("echo").executor)
+
+    events = await _fetch(ledger, "turn_mw", "tool_lifecycle")
+    assert events[0].payload["skill_id"] is None
+    assert events[1].payload["skill_id"] is None
+
+
+async def test_skill_id_none_when_name_missing(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    """unload_skill with no name (list-mode) must not write a bogus skill_id."""
+    reg = _registry_with(tool_name="unload_skill")
+    pipeline = MiddlewarePipeline(
+        [LifecycleMiddleware(registry=reg, ledger_emitter=emitter)]
+    )
+    call = ToolCall(
+        tool_name="unload_skill",
+        args={},  # list-mode: no skill name
+        trust_level=TrustLevel.SAFE,
+        session_id="sess_mw",
+    )
+
+    async with async_turn_scope("turn_mw"), async_correlation_scope("c1"):
+        await pipeline.execute(call, reg.get("unload_skill").executor)
+
+    events = await _fetch(ledger, "turn_mw", "tool_lifecycle")
+    assert events[0].payload["skill_id"] is None
+    assert events[1].payload["skill_id"] is None
+
+
+# ---------------------------------------------------------------------------
 # rolled_back flag — REVERTED terminal state
 # ---------------------------------------------------------------------------
 

--- a/tests/test_skill_review_query.py
+++ b/tests/test_skill_review_query.py
@@ -1,0 +1,242 @@
+"""Tests for query_skill_ledger (doc/54 §5 P0-4).
+
+Verifies the pure aggregation function shapes skill-scoped ledger events
+into SkillUsageDigest correctly. No LLM, no scoring — just evidence shape.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from loom.core.ledger import (
+    LedgerEmitter,
+    LedgerStore,
+    ToolLifecyclePayload,
+    TurnEndPayload,
+    MemoryOpPayload,
+    JudgeVerdictPayload,
+    async_correlation_scope,
+    async_turn_scope,
+)
+from loom.core.skill_review import query_skill_ledger
+
+
+@pytest_asyncio.fixture
+async def ledger(tmp_path: Path) -> LedgerStore:
+    s = LedgerStore(db_path=tmp_path / "ledger.db", blob_dir=tmp_path / "blobs")
+    await s.open()
+    try:
+        yield s
+    finally:
+        await s.close()
+
+
+@pytest_asyncio.fixture
+def emitter(ledger: LedgerStore) -> LedgerEmitter:
+    return LedgerEmitter(ledger, session_id="sess_test")
+
+
+async def _emit_load(
+    emitter: LedgerEmitter, *, skill: str, suffix: str
+) -> None:
+    """Emit a BEGIN/END pair for load_skill(skill)."""
+    await emitter.emit_tool_lifecycle(
+        payload=ToolLifecyclePayload(
+            phase="BEGIN",
+            tool_name="load_skill",
+            tool_call_id=f"call_{suffix}",
+            args_digest=f"sha256:{suffix}",
+            skill_id=skill,
+        ),
+        event_id=f"evt_load_begin_{suffix}",
+    )
+    await emitter.emit_tool_lifecycle(
+        payload=ToolLifecyclePayload(
+            phase="END",
+            tool_name="load_skill",
+            tool_call_id=f"call_{suffix}",
+            args_digest=f"sha256:{suffix}",
+            result_digest=f"sha256:res_{suffix}",
+            skill_id=skill,
+        ),
+        event_id=f"evt_load_end_{suffix}",
+        parent_event_id=f"evt_load_begin_{suffix}",
+    )
+
+
+async def _emit_unload(
+    emitter: LedgerEmitter, *, skill: str, suffix: str
+) -> None:
+    await emitter.emit_tool_lifecycle(
+        payload=ToolLifecyclePayload(
+            phase="END",
+            tool_name="unload_skill",
+            tool_call_id=f"call_un_{suffix}",
+            args_digest=f"sha256:un_{suffix}",
+            skill_id=skill,
+        ),
+        event_id=f"evt_unload_end_{suffix}",
+    )
+
+
+async def test_empty_window_returns_zero_digest(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    digest = await query_skill_ledger(ledger, "no_such_skill")
+    assert digest.load_count == 0
+    assert digest.unload_count == 0
+    assert digest.sessions == ()
+    assert digest.episodes == []
+
+
+async def test_load_unload_pair_in_single_turn(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    async with async_turn_scope("turn_A"), async_correlation_scope("c_A"):
+        await _emit_load(emitter, skill="code_weaver", suffix="1")
+        # A tool call in between — should land in the episode.
+        await emitter.emit_tool_lifecycle(
+            payload=ToolLifecyclePayload(
+                phase="END",
+                tool_name="write_file",
+                tool_call_id="call_write_1",
+                args_digest="sha256:w1",
+                result_digest="sha256:rw1",
+            ),
+            event_id="evt_write_end_1",
+        )
+        await _emit_unload(emitter, skill="code_weaver", suffix="1")
+
+    digest = await query_skill_ledger(ledger, "code_weaver")
+
+    assert digest.skill_id == "code_weaver"
+    assert digest.load_count == 1
+    assert digest.unload_count == 1
+    assert digest.sessions == ("sess_test",)
+    assert len(digest.episodes) == 1
+
+    ep = digest.episodes[0]
+    assert ep.session_id == "sess_test"
+    assert ep.turn_id == "turn_A"
+    assert ep.unloaded_at is not None
+    assert ep.unloaded_at > ep.loaded_at
+    # Should contain the write_file event between load and unload.
+    tool_names = [
+        e.payload.get("tool_name") for e in ep.events_after_load
+        if e.event_type == "tool_lifecycle"
+    ]
+    assert "write_file" in tool_names
+    # Should NOT contain its own load END (it's the activation marker).
+    assert all(e.event_id != "evt_load_end_1" for e in ep.events_after_load)
+
+
+async def test_other_skill_events_excluded(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    async with async_turn_scope("turn_A"), async_correlation_scope("c_A"):
+        await _emit_load(emitter, skill="code_weaver", suffix="1")
+    async with async_turn_scope("turn_B"), async_correlation_scope("c_B"):
+        await _emit_load(emitter, skill="news_aggregator", suffix="2")
+
+    digest = await query_skill_ledger(ledger, "code_weaver")
+    assert digest.load_count == 1
+    assert len(digest.episodes) == 1
+    assert digest.episodes[0].turn_id == "turn_A"
+
+
+async def test_window_filters_by_timestamp(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    async with async_turn_scope("turn_old"), async_correlation_scope("c_old"):
+        await _emit_load(emitter, skill="code_weaver", suffix="old")
+    # Force window to exclude all current events.
+    future = time.time() + 10_000
+    digest = await query_skill_ledger(
+        ledger, "code_weaver",
+        since_ts=future,
+        until_ts=future + 100,
+    )
+    assert digest.load_count == 0
+
+
+async def test_episode_captures_memory_op_feedback(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    """memory_op write after load should land in events_after_load — this
+    is how feedback density gets surfaced to the agent."""
+    async with async_turn_scope("turn_A"), async_correlation_scope("c_A"):
+        await _emit_load(emitter, skill="code_weaver", suffix="1")
+        await emitter.emit_memory_op(
+            payload=MemoryOpPayload(
+                operation="write",
+                memory_id="mem_feedback",
+                trust_tier="user_explicit",
+            ),
+        )
+
+    digest = await query_skill_ledger(ledger, "code_weaver")
+    assert len(digest.episodes) == 1
+    types = [e.event_type for e in digest.episodes[0].events_after_load]
+    assert "memory_op" in types
+
+
+async def test_turn_outcome_attached_to_episode(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    async with async_turn_scope("turn_A"), async_correlation_scope("c_A"):
+        await _emit_load(emitter, skill="code_weaver", suffix="1")
+        await emitter.emit_turn_end(
+            payload=TurnEndPayload(
+                outcome="error",
+                duration_ms=1234,
+                token_usage={"in": 100, "out": 50},
+            ),
+        )
+
+    digest = await query_skill_ledger(ledger, "code_weaver")
+    assert digest.episodes[0].turn_outcome == "error"
+
+
+async def test_events_per_episode_cap(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    async with async_turn_scope("turn_A"), async_correlation_scope("c_A"):
+        await _emit_load(emitter, skill="code_weaver", suffix="1")
+        for i in range(5):
+            await emitter.emit_tool_lifecycle(
+                payload=ToolLifecyclePayload(
+                    phase="END",
+                    tool_name=f"tool_{i}",
+                    tool_call_id=f"call_t_{i}",
+                    args_digest=f"sha256:t{i}",
+                ),
+                event_id=f"evt_t_end_{i}",
+            )
+
+    digest = await query_skill_ledger(
+        ledger, "code_weaver", max_events_per_episode=2
+    )
+    ep = digest.episodes[0]
+    assert ep.truncated is True
+    assert len(ep.events_after_load) == 2
+
+
+async def test_sessions_distinct_and_sorted(
+    ledger: LedgerStore, ledger_fixture_path: Path = None
+) -> None:
+    """Events from multiple sessions for the same skill aggregate."""
+    e_a = LedgerEmitter(ledger, session_id="sess_a")
+    e_b = LedgerEmitter(ledger, session_id="sess_b")
+
+    async with async_turn_scope("turn_1"), async_correlation_scope("c1"):
+        await _emit_load(e_a, skill="code_weaver", suffix="a1")
+    async with async_turn_scope("turn_2"), async_correlation_scope("c2"):
+        await _emit_load(e_b, skill="code_weaver", suffix="b1")
+
+    digest = await query_skill_ledger(ledger, "code_weaver")
+    assert digest.load_count == 2
+    assert digest.sessions == ("sess_a", "sess_b")

--- a/tests/test_skill_review_tool.py
+++ b/tests/test_skill_review_tool.py
@@ -1,0 +1,108 @@
+"""Tests for the skill_review tool factory (doc/54 §5 P0-5)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from loom.core.harness.middleware import ToolCall
+from loom.core.harness.permissions import TrustLevel
+from loom.core.ledger import (
+    LedgerEmitter,
+    LedgerStore,
+    ToolLifecyclePayload,
+    async_correlation_scope,
+    async_turn_scope,
+)
+from loom.platform.cli.tools import make_skill_review_tool
+
+
+@pytest_asyncio.fixture
+async def ledger(tmp_path: Path) -> LedgerStore:
+    s = LedgerStore(db_path=tmp_path / "ledger.db", blob_dir=tmp_path / "blobs")
+    await s.open()
+    try:
+        yield s
+    finally:
+        await s.close()
+
+
+def _call(args: dict) -> ToolCall:
+    return ToolCall(
+        tool_name="skill_review",
+        args=args,
+        trust_level=TrustLevel.SAFE,
+        session_id="sess_test",
+    )
+
+
+async def test_skill_id_required(ledger: LedgerStore) -> None:
+    tool = make_skill_review_tool(ledger)
+    result = await tool.executor(_call({}))
+    assert result.success is False
+    assert "skill_id required" in (result.error or "")
+
+
+async def test_no_ledger_returns_error() -> None:
+    tool = make_skill_review_tool(None)
+    result = await tool.executor(_call({"skill_id": "code_weaver"}))
+    assert result.success is False
+    assert "ledger" in (result.error or "").lower()
+
+
+async def test_invalid_days_rejected(ledger: LedgerStore) -> None:
+    tool = make_skill_review_tool(ledger)
+    result = await tool.executor(_call({"skill_id": "x", "days": "abc"}))
+    assert result.success is False
+    assert "days" in (result.error or "").lower()
+
+    result = await tool.executor(_call({"skill_id": "x", "days": -1}))
+    assert result.success is False
+
+
+async def test_empty_window_renders_clean_output(ledger: LedgerStore) -> None:
+    tool = make_skill_review_tool(ledger)
+    result = await tool.executor(_call({"skill_id": "no_such_skill"}))
+    assert result.success is True
+    assert "Skill review: no_such_skill" in result.output
+    assert "Loads: 0" in result.output
+    assert "no activations" in result.output
+
+
+async def test_rendered_output_contains_episodes(ledger: LedgerStore) -> None:
+    emitter = LedgerEmitter(ledger, session_id="sess_test")
+    async with async_turn_scope("turn_A"), async_correlation_scope("c_A"):
+        await emitter.emit_tool_lifecycle(
+            payload=ToolLifecyclePayload(
+                phase="END",
+                tool_name="load_skill",
+                tool_call_id="call_1",
+                args_digest="sha256:1",
+                skill_id="code_weaver",
+            ),
+            event_id="evt_load_end_1",
+        )
+        await emitter.emit_tool_lifecycle(
+            payload=ToolLifecyclePayload(
+                phase="END",
+                tool_name="write_file",
+                tool_call_id="call_2",
+                args_digest="sha256:2",
+            ),
+            event_id="evt_write_end_1",
+        )
+
+    tool = make_skill_review_tool(ledger)
+    result = await tool.executor(_call({"skill_id": "code_weaver"}))
+    assert result.success is True
+    assert "Loads: 1" in result.output
+    assert "Episode 1" in result.output
+    assert "write_file" in result.output
+
+
+async def test_trust_level_safe(ledger: LedgerStore) -> None:
+    """Read-only tool must be SAFE — no confirmation prompts."""
+    tool = make_skill_review_tool(ledger)
+    assert tool.trust_level == TrustLevel.SAFE

--- a/tests/test_skill_review_weekly.py
+++ b/tests/test_skill_review_weekly.py
@@ -1,0 +1,235 @@
+"""Tests for the weekly skill review worker (doc/54 §5 P0-6)."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from loom.core.ledger import (
+    LedgerEmitter,
+    LedgerStore,
+    MemoryOpPayload,
+    ToolLifecyclePayload,
+    TurnEndPayload,
+    async_correlation_scope,
+    async_turn_scope,
+)
+from loom.core.skill_review import generate_weekly_report
+from loom.core.skill_review.weekly import (
+    ATTENTION_ABNORMAL,
+    ATTENTION_MUFFLED,
+    ATTENTION_STALE,
+    ATTENTION_UNDIGESTED,
+    ATTENTION_UNUSED,
+)
+
+
+@pytest_asyncio.fixture
+async def ledger(tmp_path: Path) -> LedgerStore:
+    s = LedgerStore(db_path=tmp_path / "ledger.db", blob_dir=tmp_path / "blobs")
+    await s.open()
+    try:
+        yield s
+    finally:
+        await s.close()
+
+
+async def _emit_load_end(
+    emitter: LedgerEmitter, *, skill: str, suffix: str
+) -> None:
+    await emitter.emit_tool_lifecycle(
+        payload=ToolLifecyclePayload(
+            phase="END",
+            tool_name="load_skill",
+            tool_call_id=f"call_{suffix}",
+            args_digest=f"sha256:{suffix}",
+            skill_id=skill,
+        ),
+        event_id=f"evt_load_end_{suffix}",
+    )
+
+
+async def test_empty_ledger_renders_clean_report(
+    ledger: LedgerStore, tmp_path: Path
+) -> None:
+    output_dir = tmp_path / "out"
+    report = await generate_weekly_report(
+        ledger, skills_roots=[], output_dir=output_dir, window_days=7,
+    )
+    assert report.skills_seen == []
+    assert report.attention == []
+    assert "no skill activity in window" in report.markdown
+    assert report.output_path is not None
+    assert report.output_path.read_text(encoding="utf-8") == report.markdown
+
+
+async def test_report_lists_skills_with_loads(
+    ledger: LedgerStore, tmp_path: Path
+) -> None:
+    e = LedgerEmitter(ledger, session_id="sess_a")
+    async with async_turn_scope("turn_A"), async_correlation_scope("c_A"):
+        await _emit_load_end(e, skill="code_weaver", suffix="1")
+    async with async_turn_scope("turn_B"), async_correlation_scope("c_B"):
+        await _emit_load_end(e, skill="news_aggregator", suffix="2")
+        await _emit_load_end(e, skill="news_aggregator", suffix="3")
+
+    report = await generate_weekly_report(
+        ledger, skills_roots=[], output_dir=None, write_to_disk=False,
+    )
+    assert "code_weaver" in report.skills_seen
+    assert "news_aggregator" in report.skills_seen
+    assert report.digests["news_aggregator"].load_count == 2
+    assert "| code_weaver | 1 |" in report.markdown
+    assert "| news_aggregator | 2 |" in report.markdown
+
+
+async def test_attention_muffled_run(
+    ledger: LedgerStore, tmp_path: Path
+) -> None:
+    """Loaded ≥3 times with zero memory_op feedback → muffled."""
+    e = LedgerEmitter(ledger, session_id="sess_a")
+    for i in range(4):
+        async with (
+            async_turn_scope(f"turn_{i}"),
+            async_correlation_scope(f"c_{i}"),
+        ):
+            await _emit_load_end(e, skill="silent_skill", suffix=str(i))
+
+    report = await generate_weekly_report(
+        ledger, skills_roots=[], output_dir=None, write_to_disk=False,
+    )
+    codes_by_skill = {a.skill_id: a.reasons for a in report.attention}
+    assert ATTENTION_MUFFLED in codes_by_skill.get("silent_skill", [])
+
+
+async def test_attention_abnormal_outcome(
+    ledger: LedgerStore, tmp_path: Path
+) -> None:
+    """>30% of outcome-known turns ending abandoned/error → abnormal."""
+    e = LedgerEmitter(ledger, session_id="sess_a")
+    # 1 clean, 2 error → 2/3 abnormal
+    for i, outcome in enumerate(["clean", "error", "error"]):
+        async with (
+            async_turn_scope(f"turn_{i}"),
+            async_correlation_scope(f"c_{i}"),
+        ):
+            await _emit_load_end(e, skill="flaky", suffix=str(i))
+            await e.emit_turn_end(
+                payload=TurnEndPayload(
+                    outcome=outcome, duration_ms=1, token_usage={},
+                ),
+            )
+
+    report = await generate_weekly_report(
+        ledger, skills_roots=[], output_dir=None, write_to_disk=False,
+    )
+    codes_by_skill = {a.skill_id: a.reasons for a in report.attention}
+    assert ATTENTION_ABNORMAL in codes_by_skill.get("flaky", [])
+
+
+async def test_attention_exists_but_unused(
+    ledger: LedgerStore, tmp_path: Path
+) -> None:
+    """Skill on disk but no load event → exists_but_unused."""
+    skills_root = tmp_path / "skills"
+    unused = skills_root / "ghost_skill"
+    unused.mkdir(parents=True)
+    (unused / "SKILL.md").write_text("# ghost\n")
+
+    report = await generate_weekly_report(
+        ledger, skills_roots=[skills_root], output_dir=None, write_to_disk=False,
+    )
+    codes_by_skill = {a.skill_id: a.reasons for a in report.attention}
+    assert ATTENTION_UNUSED in codes_by_skill.get("ghost_skill", [])
+    assert "ghost_skill" in report.markdown
+
+
+async def test_attention_undigested_feedback(
+    ledger: LedgerStore, tmp_path: Path
+) -> None:
+    """Feedback exists but SKILL.md mtime predates first feedback → undigested."""
+    skills_root = tmp_path / "skills"
+    sd = skills_root / "stale_skill"
+    sd.mkdir(parents=True)
+    skill_md = sd / "SKILL.md"
+    skill_md.write_text("# stale\n")
+    # Force mtime to be old
+    old_ts = time.time() - 86400 * 10
+    import os
+    os.utime(skill_md, (old_ts, old_ts))
+
+    e = LedgerEmitter(ledger, session_id="sess_a")
+    async with async_turn_scope("turn_A"), async_correlation_scope("c_A"):
+        await _emit_load_end(e, skill="stale_skill", suffix="1")
+        await e.emit_memory_op(
+            payload=MemoryOpPayload(
+                operation="write", memory_id="mem1", trust_tier="user_explicit",
+            ),
+        )
+
+    report = await generate_weekly_report(
+        ledger, skills_roots=[skills_root], output_dir=None, write_to_disk=False,
+    )
+    codes_by_skill = {a.skill_id: a.reasons for a in report.attention}
+    assert ATTENTION_UNDIGESTED in codes_by_skill.get("stale_skill", [])
+
+
+async def test_no_attention_when_skill_is_healthy(
+    ledger: LedgerStore, tmp_path: Path
+) -> None:
+    """One load + one feedback + clean outcome → nothing fires."""
+    e = LedgerEmitter(ledger, session_id="sess_a")
+    async with async_turn_scope("turn_A"), async_correlation_scope("c_A"):
+        await _emit_load_end(e, skill="healthy", suffix="1")
+        await e.emit_memory_op(
+            payload=MemoryOpPayload(
+                operation="write", memory_id="mem1", trust_tier="user_explicit",
+            ),
+        )
+        await e.emit_turn_end(
+            payload=TurnEndPayload(outcome="clean", duration_ms=1, token_usage={}),
+        )
+
+    report = await generate_weekly_report(
+        ledger, skills_roots=[], output_dir=None, write_to_disk=False,
+    )
+    assert all(a.skill_id != "healthy" for a in report.attention)
+
+
+async def test_window_filters_correctly(
+    ledger: LedgerStore, tmp_path: Path
+) -> None:
+    """Events older than the window must not appear."""
+    e = LedgerEmitter(ledger, session_id="sess_a")
+    async with async_turn_scope("turn_A"), async_correlation_scope("c_A"):
+        await _emit_load_end(e, skill="old_event", suffix="1")
+
+    # Use now_ts far in the future to push everything out of window.
+    future = time.time() + 100 * 86400
+    report = await generate_weekly_report(
+        ledger,
+        skills_roots=[],
+        output_dir=None,
+        write_to_disk=False,
+        now_ts=future,
+        window_days=7,
+    )
+    assert report.skills_seen == []
+
+
+async def test_markdown_has_expected_sections(
+    ledger: LedgerStore, tmp_path: Path
+) -> None:
+    e = LedgerEmitter(ledger, session_id="sess_a")
+    async with async_turn_scope("turn_A"), async_correlation_scope("c_A"):
+        await _emit_load_end(e, skill="x", suffix="1")
+
+    report = await generate_weekly_report(
+        ledger, skills_roots=[], output_dir=None, write_to_disk=False,
+    )
+    assert "# Skill Weekly Review" in report.markdown
+    assert "## 該關注清單" in report.markdown
+    assert "## 技能活動 — 本週載入次數" in report.markdown


### PR DESCRIPTION
## Summary

啟動 Quest D Phase 1（doc/54），重新框架技能演化系統：

- **概念轉向**：從「七層自動演化」改為「觀察基礎」。過程訊號（tool 成功率、verdict）不是成品品質的可信 proxy，所以本 milestone 不做自動 grading，只做追蹤 + 報告 + 對話內調閱。Grading 留給未來 Evaluator Skill milestone。
- **本 PR 內容**：doc/54 設計文 + 完整 P0 清單實作（觀察基礎 + 三條訊號通道）。**不包含退役清單**（doc/54 §3 將在後續 PR 處理）。

## Why

2026-05-13 self-check 發現：

- 18 個技能中 17 個從未被 Grader 評估
- `loom.db` schema 從未初始化、`skill_id` 欄位從未被寫入（NULL）
- 整個七層演化框架實作完整但**從未被完整觸發過一次**

詳見 `outputs/self_check/2026-05-13-skill-closed-loop-report.md`。

## Changes

| Commit | Scope |
|--------|-------|
| `6f7c961` | doc/54 Round 1 + `skill_id` payload on load_skill/unload_skill |
| `9bc408f` | `idx_skill` ledger index |
| `0fdfa9d` | `loom/core/skill_review/` query + render layer |
| `fc5c8e6` | `skill_review` agent tool (read-only, SAFE) |
| `4aa6b23` | weekly worker + 5 attention rules (doc/54 §4.4) |
| `e94cfcc` | `loom skill weekly` CLI + example autonomy schedule |

## Three signal channels now live

doc/54 §4 三條通道全部接通：

**A. 即時反饋（兩層、已在跑）**
- 系統層：`ToolCallDimension` 在對話中渲染 tool failure → 觸發注意
- 對話層：使用者口頭反饋 → 絲絲直接 Edit SKILL.md → git commit

**B. Weekly 報告**
```bash
loom skill weekly                                    # 寫 outputs/self_check/
loom skill weekly --days 30 --no-write              # stdout
```
五條 structural 規則（無 LLM）：
- `muffled_run` / `undigested_feedback` / `abnormal_outcome` / `stale` / `exists_but_unused`

**C. 對話內 ledger 調閱**
```
user: 回顧一下 code_weaver 最近怎麼樣
agent: [skill_review(skill_id="code_weaver", days=7)]
       → 拿到 episode 流，討論 → Edit SKILL.md
```

## Out of scope (follow-up PR)

doc/54 §3 退役清單（完全刪除 SkillGate / SkillPromoter / SkillMutator / `loom.db` skill 表 / 5 個動詞 tool / `[mutation]` config / meta-skill-engineer）將另開 PR，原因：blast radius 性質不同、便於獨立 review 與 revert。

## Test plan

- [x] 282 tests on impacted surface — all pass
- [x] 26 new tests across `test_ledger_tool_lifecycle.py` / `test_ledger_store.py` / `test_skill_review_query.py` / `test_skill_review_tool.py` / `test_skill_review_weekly.py`
- [x] gitnexus impact + detect_changes — LOW risk、0 affected processes
- [ ] **試踩反饋**：請 merge 後實際跑 `loom skill weekly` 一次、用 `skill_review` 工具問絲絲一次，觀察輸出體感。Tool shape 反饋追在 #364

## Related

- doc/52 §1.3 — Quest D 願景
- doc/53 — AgentLedger 設計（本 PR 不改 schema event_type，只加 payload 欄位 + index）
- issue #362 — 原始七層 → 兩觸發點提案，本 PR 進一步收斂為三通道
- issue #364 — skill_review tool real-world usage watch issue（merge 後啟用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)