### PR TITLE
chore(skill): rename mutation_suggestions + post-Phase-1.C doc alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,38 +262,30 @@ Drop a `SKILL.md` into your `skills/` directory — Loom auto-imports it at sess
 
 ### Structured Diagnostic Feedback Loop
 
-After each turn where a skill was used, `TaskReflector` runs a background LLM self-assessment that produces a `TaskDiagnostic` — a structured record of which instructions were followed or violated, failure and success patterns, concrete `mutation_suggestions`, and a `quality_score` (1–5). The score feeds into the skill's `confidence` via EMA (α = 0.15). Skills whose confidence drops below a configurable threshold are deprecated and removed from the Tier 1 catalog.
+After each turn where a skill was used, `TaskReflector` runs a background LLM self-assessment that produces a `TaskDiagnostic` — a structured record of which instructions were followed or violated, failure and success patterns, concrete `skill_edit_suggestions`, and a `quality_score` (1–5). The score feeds into the skill's `confidence` via EMA (α = 0.15). Skills whose confidence drops below a configurable threshold are deprecated and removed from the Tier 1 catalog.
 
-### Skill Evolution Lifecycle
+### Skill Optimization Loop
 
-`TaskDiagnostic` data feeds a full candidate-pool evolution pipeline:
+> v0.3.7.2 (Quest D Phase 1.C): the prior automated candidate-pool pipeline (`SkillMutator` / `SkillPromoter` / `SkillGate` / shadow_mode / fast_track) was retired. Process signals (tool success rate, verdict ratio, shadow delta) are not a credible proxy for skill output quality — without an Evaluator substrate, automated promotion is garbage-in/out. See [doc/54-Skill-Evolution-Arena-設計.md](doc/54-Skill-Evolution-Arena-設計.md).
 
-```
-TaskReflector → TaskDiagnostic
-                      ↓
-              SkillMutator.propose_candidate()   ← single-turn background path
-              SkillMutator.from_batch_diagnostic() ← meta-skill-engineer batch path
-                      ↓
-              SkillCandidate (skill_candidates table)
-                      ↓
-         generated → shadow → promoted   (or deprecated / rolled_back)
-```
+Skills now improve through three observation channels, with **edits made by the user/agent in conversation** — git commits replace the old candidate/promote mechanism:
 
-**Shadow mode** — a promoted candidate serves alongside the parent. `SkillGate` A/B-routes turns to shadow or parent body, accumulating a win record before promotion is confirmed.
+**1. Real-time feedback (in-conversation)**
+- *System layer*: `ToolCallDimension` surfaces tool failure rate + anomalies inline during the turn — the user sees a skill stumbling without having to dig.
+- *Conversation layer*: user observes → tells the agent → agent edits `SKILL.md` directly → `git commit`.
 
-**Fast-track** — when the `meta-skill-engineer` Grader proves ≥ 20% pass-rate improvement over the previous version, the candidate is flagged `fast_track=True` and can be promoted immediately without the shadow N-wins phase — Grader is the ground truth.
-
-**Maturity tag** — `SkillGenome.maturity_tag` (`mature` / `needs_improvement`) is set by the operator after reviewing eval history; visible in `loom review <name>`.
-
-**Version history** — every `promote` and `rollback` snapshots the previous body to `skill_version_history`. Full rollback is always available: `loom skill rollback <name>`.
-
+**2. Weekly worker** — pure SQL + template, no LLM
 ```bash
-loom skill candidates          # browse the candidate pool
-loom skill promote <id>       # promote a shadow candidate
-loom skill rollback <name>    # restore the previous body
-loom skill history <name>     # full version archive
-loom skill review <name>      # one-stop: genome · eval history · candidates · insights
+loom skill weekly                            # writes outputs/self_check/<date>-skill-weekly.md
+loom skill weekly --days 30 --no-write       # print to stdout
 ```
+The worker scans the ledger for the past window and renders a *該關注清單* with five structural codes: `muffled_run` / `undigested_feedback` / `abnormal_outcome` / `stale` / `exists_but_unused`. It does **not** score or rank skills — just surfaces structural observations for the user to act on.
+
+**3. Conversational ledger pull** — `skill_review` agent tool
+- The agent calls `skill_review(skill_id="code_weaver", days=7)` to pull per-skill activation episodes (load events + same-turn tool calls + memory writes + turn outcomes) from the ledger.
+- Typical flow: user asks "回顧一下 X 技能最近的狀況" → agent reads the digest → discussion → agent edits `SKILL.md` based on the conversation.
+
+Behind the scenes, `load_skill` / `unload_skill` calls now carry a `skill_id` on their `tool_lifecycle` ledger events (indexed by `idx_skill`), so per-skill queries are O(log n). The weekly worker and `skill_review` tool share a common query layer (`loom.core.skill_review.query_skill_ledger`).
 
 ### Precondition Checks — Framework-Enforced Safety Rails
 
@@ -413,7 +405,7 @@ The `doc/` directory contains full technical documentation for every subsystem:
 | Trust levels & blast radius | `doc/05-Trust-Level.md` |
 | Scope-aware authorization design | `doc/44-Scope-Aware-Permission-規劃.md` |
 | Memory system & governance | `doc/08-Memory-概述.md`, `doc/08b-Memory-Governance.md` |
-| Skill Genome & self-assessment | `doc/10-Skill-Genome.md`, `doc/10b-Skill-Evolution.md` |
+| Skill Genome & self-assessment | `doc/10-Skill-Genome.md`; `doc/54-Skill-Evolution-Arena-設計.md` (current). `doc/10b-Skill-Evolution.md` retired by Phase 1.C |
 | Memory Pulse & Lifecycle | `doc/12b-Memory-Health.md` |
 | Execution visualization | `doc/43-Harness-Execution-可視化規劃.md` |
 | Autonomy engine | `doc/19-Autonomy-概述.md`, `doc/21-Action-Planner.md` |

--- a/doc/10-Skill-Genome.md
+++ b/doc/10-Skill-Genome.md
@@ -17,7 +17,6 @@ precondition_checks:
   - ref: checks.reject_write_operations
     applies_to: [write_file]
     description: "分析技能為唯讀模式，禁止寫入任何檔案"
-maturity_tag: mature  # optional
 ---
 ```
 
@@ -29,7 +28,6 @@ maturity_tag: mature  # optional
 | `description` | str | 一句話觸發描述 |
 | `tags` | list[str] | 技能分類標籤 |
 | `precondition_checks` | list[dict] | Issue #64：技能聲明的執行前置條件 |
-| `maturity_tag` | str | 成熟度標籤（`mature` / `needs_improvement` / null）|
 
 ### precondition_checks 格式（Issue #64 Phase B）
 
@@ -85,9 +83,10 @@ skills/
 | `deprecation_threshold` | 固定 0.3 |
 | `tags` | frontmatter `tags` |
 | `precondition_check_refs` | frontmatter `precondition_checks` |
-| `maturity_tag` | frontmatter `maturity_tag` |
 
-`body` 包含完整的 frontmatter，這樣 LLM rewrite（SkillMutator）時保有完整上下文。
+> **v0.3.7.3 (Quest D Phase 1.C)**：移除 `maturity_tag` 欄位。原本服務於 SkillMutator/SkillPromoter 的 mature/needs_improvement 標籤已不再被任何邏輯讀取。對應自動演化流程退役，詳見 [doc/54-Skill-Evolution-Arena-設計.md](54-Skill-Evolution-Arena-設計.md)。
+
+`body` 包含完整的 frontmatter，作為技能載入後 LLM 自然能讀到的上下文（過去 SkillMutator 自動 rewrite 路徑已退役，現在 SKILL.md 更新走「使用者 + 絲絲對話 → 手動 Edit」通道，見 doc/54 §4.1）。
 
 ---
 

--- a/doc/10b-Skill-Evolution.md
+++ b/doc/10b-Skill-Evolution.md
@@ -1,6 +1,21 @@
 # Skill Evolution（更新版）
 
-> 依據實際 `skill_promoter.py` / `skill_mutator.py` 更新。
+> ## ⚠️ RETIRED — Quest D Phase 1.C
+>
+> 本文件描述的整套系統（`SkillMutator` / `SkillPromoter` / `SkillGate` / `skill_candidates` table / shadow_mode auto_c / fast_track promote）**已於 v0.3.7.2 完全退役**（PR #367）。
+>
+> 主因：過程訊號（tool 成功率、verdict ratio、shadow delta）不是「技能成品品質」的可信 proxy。沒有可信 grading substrate，自動 shadow/promote 是 garbage-in / garbage-out。
+>
+> **目前替代設計**：[doc/54-Skill-Evolution-Arena-設計.md](54-Skill-Evolution-Arena-設計.md)
+>
+> 三條觀察通道取代七層演化：
+> 1. 即時反饋（`ToolCallDimension` 系統層 + 對話內 `Edit SKILL.md`）
+> 2. Weekly worker（`loom skill weekly`，純 SQL + 模板）
+> 3. 對話內 ledger 調閱（`skill_review` agent tool）
+>
+> 真正的 grading 留給未來 Evaluator Skill milestone（依賴明確可驗證任務目標）。
+>
+> 以下內容**僅作歷史參考**。具體代碼引用全部失效。
 
 ---
 

--- a/doc/MISSING-DOC-AUDIT.md
+++ b/doc/MISSING-DOC-AUDIT.md
@@ -20,9 +20,9 @@ loom/
 │   │                   index.py, maintenance.py, embeddings.py, facade.py, store.py,
 │   │                   session_log.py, skill_outcome.py
 │   ├── cognition/     prompt_stack.py, router.py, providers.py, reflection.py,
-│   │                   task_reflector.py, skill_promoter.py, skill_mutator.py,
-│   │                   skill_gate.py, dreaming.py, counter_factual.py,
-│   │                   context.py, skill_gate.py
+│   │                   task_reflector.py, dreaming.py, counter_factual.py,
+│   │                   context.py
+│   │                   (Quest D Phase 1.C 退役了 skill_promoter / skill_mutator / skill_gate)
 │   ├── agent/         subagent.py
 │   ├── tasks/          manager.py, tasklist.py
 │   ├── jobs/           store.py, scratchpad.py
@@ -124,10 +124,10 @@ loom/
 **舊版 doc**：描述 async `build()` + `AgentPromptGenerator` + `PersonalityLoader`
 **實作**：純同步讀檔、字串組合，runtime 可切換 personality
 
-### 6. Skill Evolution — 缺少 `from_batch_diagnostic()`
+### 6. Skill Evolution — ⚠️ 整節廢棄
 
-**舊版 doc**：只描述 `propose_candidate()`
-**實作**：還有 `from_batch_diagnostic()`（Grader 批量路徑）和 `fast_track` 機制
+**狀態**：Quest D Phase 1.C（PR #367）已退役 `SkillMutator` / `SkillPromoter` / `SkillGate` / `from_batch_diagnostic()` / `fast_track` 整套機制。
+**現行設計**：見 [doc/54-Skill-Evolution-Arena-設計.md](54-Skill-Evolution-Arena-設計.md)（三條觀察通道 + `skill_review` agent 工具）。
 
 ---
 

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -34,7 +34,7 @@
 | [08b-Memory-Governance.md](08b-Memory-Governance.md) | Trust Tier 分級、矛盾偵測 + 自動解決、Admission Gate、Decay Cycle |
 | [09-四種記憶詳解.md](09-四種記憶詳解.md) | Episodic / Semantic（含 Trust Tier + Anti-pattern）/ Procedural / Relational |
 | [10-Skill-Genome.md](10-Skill-Genome.md) | EMA confidence 機制與自動廢棄（含 SKILL.md frontmatter schema）|
-| [10b-Skill-Evolution.md](10b-Skill-Evolution.md) | Issue #120：TaskReflector → SkillMutator → SkillPromoter + SkillGate 的三段式進化生命週期 |
+| [10b-Skill-Evolution.md](10b-Skill-Evolution.md) | **⚠️ RETIRED** — Issue #120 七層演化（Quest D Phase 1.C 退役）。現行設計見 [54-Skill-Evolution-Arena-設計.md](54-Skill-Evolution-Arena-設計.md) |
 | [11-Memory-Search.md](11-Memory-Search.md) | Phase 5 向量相似度 → FTS5 BM25 → recency 三層混合搜尋 |
 | [12-Memory-Index.md](12-Memory-Index.md) | 輕量目錄，含 Anti-pattern count 與 Self-Portrait |
 | **[12b-Memory-Health.md](12b-Memory-Health.md)** | MemoryHealthTracker 操作手冊（Issue #133）|

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -177,7 +177,7 @@ threshold       = 0.1    # overrides [memory.governance].semantic_decay_threshol
 # trajectory.  The diagnostic produces a ``TaskDiagnostic`` with:
 #   - instructions_followed / instructions_violated
 #   - failure_patterns / success_patterns
-#   - mutation_suggestions      (concrete SKILL.md edit proposals)
+#   - skill_edit_suggestions    (concrete SKILL.md edit proposals you/絲絲 read)
 #   - task_type                 (closed label set, see task_reflector.py)
 #   - quality_score             (1.0-5.0, also drives the confidence EMA)
 #
@@ -191,7 +191,7 @@ threshold       = 0.1    # overrides [memory.governance].semantic_decay_threshol
 auto_reflect = true
 # "off"     — disables diagnostics entirely (no LLM call, no writes)
 # "summary" — one-line live notification per diagnostic (default)
-# "verbose" — full diagnostic summary + top mutation suggestion
+# "verbose" — full diagnostic summary + top skill_edit_suggestion
 visibility = "summary"
 
 # ─────────────────────────────────────────────

--- a/loom/core/cognition/task_reflector.py
+++ b/loom/core/cognition/task_reflector.py
@@ -79,7 +79,7 @@ class TaskDiagnostic:
     instructions_violated: list[str]
     failure_patterns: list[str]
     success_patterns: list[str]
-    mutation_suggestions: list[str]
+    skill_edit_suggestions: list[str]
     quality_score: float  # 1.0 - 5.0
     envelope_ids: list[str] = field(default_factory=list)
     timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
@@ -92,17 +92,24 @@ class TaskDiagnostic:
 
     @classmethod
     def from_json(cls, raw: str) -> "TaskDiagnostic":
-        """Inverse of ``to_json`` — hydrate a diagnostic from storage."""
+        """Inverse of ``to_json`` — hydrate a diagnostic from storage.
+
+        Backwards-compat: pre-Quest D Phase 1.C diagnostics stored the
+        field as ``mutation_suggestions``. Map it forward so ``loom
+        diagnostic recent`` keeps surfacing historical entries.
+        """
         data = json.loads(raw)
         data["timestamp"] = datetime.fromisoformat(data["timestamp"])
+        if "mutation_suggestions" in data and "skill_edit_suggestions" not in data:
+            data["skill_edit_suggestions"] = data.pop("mutation_suggestions")
         return cls(**data)
 
     def one_line_summary(self) -> str:
         """Compact summary for terminal / status-bar display."""
         suggestion = ""
-        if self.mutation_suggestions:
-            suggestion = self.mutation_suggestions[0][:60]
-            if len(self.mutation_suggestions[0]) > 60:
+        if self.skill_edit_suggestions:
+            suggestion = self.skill_edit_suggestions[0][:60]
+            if len(self.skill_edit_suggestions[0]) > 60:
                 suggestion += "…"
         return (
             f"{self.skill_name} · {self.task_type} · {self.quality_score:.1f}/5"
@@ -144,14 +151,14 @@ Output ONLY a JSON object (no markdown fencing, no explanation):
   "instructions_violated": [strings, each citing a specific SKILL.md instruction you ignored or misinterpreted],
   "failure_patterns": [strings, recurring failure modes observed in this execution],
   "success_patterns": [strings, effective approaches worth distilling],
-  "mutation_suggestions": [strings, each a concrete SKILL.md edit like "add a step X after Y" or "clarify phrase Z to mean W"],
+  "skill_edit_suggestions": [strings, each a concrete SKILL.md edit like "add a step X after Y" or "clarify phrase Z to mean W"],
   "quality_score": float 1.0-5.0 (1=poor, 3=adequate, 5=excellent)
 }}
 
 Rules:
 - Each list item must be under 200 characters.
 - Empty list [] is allowed if nothing applies.
-- "mutation_suggestions" must be directly applicable to the SKILL.md text, not abstract advice.
+- "skill_edit_suggestions" must be directly applicable to the SKILL.md text, not abstract advice.
 """
 
 
@@ -324,7 +331,7 @@ class TaskReflector:
             instructions_violated=parsed["instructions_violated"],
             failure_patterns=parsed["failure_patterns"],
             success_patterns=parsed["success_patterns"],
-            mutation_suggestions=parsed["mutation_suggestions"],
+            skill_edit_suggestions=parsed["skill_edit_suggestions"],
             quality_score=parsed["quality_score"],
             envelope_ids=[e.envelope_id for e in envelopes[-3:]],
         )
@@ -469,7 +476,7 @@ _REQUIRED_FIELDS: tuple[str, ...] = (
     "instructions_violated",
     "failure_patterns",
     "success_patterns",
-    "mutation_suggestions",
+    "skill_edit_suggestions",
     "quality_score",
 )
 
@@ -515,7 +522,10 @@ def _parse_diagnostic(raw: str) -> dict[str, Any] | None:
             "instructions_violated": _list(data.get("instructions_violated")),
             "failure_patterns": _list(data.get("failure_patterns")),
             "success_patterns": _list(data.get("success_patterns")),
-            "mutation_suggestions": _list(data.get("mutation_suggestions")),
+            # Accept the legacy key from older prompts / model habits.
+            "skill_edit_suggestions": _list(
+                data.get("skill_edit_suggestions") or data.get("mutation_suggestions")
+            ),
             "quality_score": _clamp(float(data.get("quality_score", 3.0)), 1.0, 5.0),
         }
     except (TypeError, ValueError):

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -239,8 +239,8 @@ async def _chat(
         if vis == "off":
             return
         console.print(f"[loom.muted]  ⇢ diagnosed {diagnostic.one_line_summary()}[/loom.muted]")
-        if vis == "verbose" and diagnostic.mutation_suggestions:
-            for hint in diagnostic.mutation_suggestions[:2]:
+        if vis == "verbose" and diagnostic.skill_edit_suggestions:
+            for hint in diagnostic.skill_edit_suggestions[:2]:
                 console.print(f"[loom.muted]      · {hint}[/loom.muted]")
 
     session.subscribe_diagnostic(_cli_diagnostic)
@@ -1760,10 +1760,10 @@ async def _chat_tui(model: str, db: str, resume_session_id: str | None = None) -
             if vis == "off":
                 return
             try:
-                if vis == "verbose" and diagnostic.mutation_suggestions:
+                if vis == "verbose" and diagnostic.skill_edit_suggestions:
                     body = (
                         f"{diagnostic.one_line_summary()}\n"
-                        f"→ {diagnostic.mutation_suggestions[0][:100]}"
+                        f"→ {diagnostic.skill_edit_suggestions[0][:100]}"
                     )
                     app.notify(body, title="Skill diagnostic", timeout=6)
                 else:
@@ -2717,9 +2717,9 @@ async def _diagnostic_recent(skill: str | None, limit: int, db: str) -> None:
         if diag.instructions_violated:
             for v in diag.instructions_violated[:3]:
                 console.print(f"   [loom.error]✗[/loom.error] {v}")
-        if diag.mutation_suggestions:
+        if diag.skill_edit_suggestions:
             console.print("   [bold]→ suggestions:[/bold]")
-            for s in diag.mutation_suggestions[:3]:
+            for s in diag.skill_edit_suggestions[:3]:
                 console.print(f"     • {s}")
         console.print()
 

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -555,12 +555,12 @@ class LoomDiscordBot:
                         lines.append("violated:")
                         for v in diagnostic.instructions_violated[:2]:
                             lines.append(f"• {v[:180]}")
-                    if diagnostic.mutation_suggestions:
+                    if diagnostic.skill_edit_suggestions:
                         lines.append("suggest:")
-                        for s in diagnostic.mutation_suggestions[:2]:
+                        for s in diagnostic.skill_edit_suggestions[:2]:
                             lines.append(f"• {s[:180]}")
-                elif diagnostic.mutation_suggestions:
-                    lines.append(f"› {diagnostic.mutation_suggestions[0][:180]}")
+                elif diagnostic.skill_edit_suggestions:
+                    lines.append(f"› {diagnostic.skill_edit_suggestions[0][:180]}")
                 await _safe_send(thread_ref, "\n".join(lines))
             except Exception:
                 pass

--- a/tests/test_task_reflector.py
+++ b/tests/test_task_reflector.py
@@ -46,7 +46,7 @@ def _make_diagnostic(**overrides) -> TaskDiagnostic:
         instructions_violated=["Skipped step 3"],
         failure_patterns=["Rushed final check"],
         success_patterns=["Used grep before editing"],
-        mutation_suggestions=["Add explicit 'verify with tests' after step 3"],
+        skill_edit_suggestions=["Add explicit 'verify with tests' after step 3"],
         quality_score=3.5,
         envelope_ids=["e1", "e2"],
     )
@@ -91,7 +91,7 @@ def _valid_llm_payload() -> str:
             "instructions_violated": ["Did not run tests"],
             "failure_patterns": ["Skipped verification"],
             "success_patterns": ["Used minimal edits"],
-            "mutation_suggestions": ["Insert 'run pytest' after every edit"],
+            "skill_edit_suggestions": ["Insert 'run pytest' after every edit"],
             "quality_score": 3.5,
         }
     )
@@ -114,21 +114,21 @@ class TestTaskDiagnostic:
         assert rehydrated.timestamp.isoformat() == d.timestamp.isoformat()
 
     def test_one_line_summary_includes_suggestion(self):
-        d = _make_diagnostic(mutation_suggestions=["Add explicit 'verify' step"])
+        d = _make_diagnostic(skill_edit_suggestions=["Add explicit 'verify' step"])
         s = d.one_line_summary()
         assert "test-skill" in s
         assert "3.5" in s
         assert "verify" in s
 
     def test_one_line_summary_without_suggestion(self):
-        d = _make_diagnostic(mutation_suggestions=[])
+        d = _make_diagnostic(skill_edit_suggestions=[])
         s = d.one_line_summary()
         assert "test-skill" in s
         assert "·" in s  # separator present
 
     def test_one_line_summary_truncates_long_suggestion(self):
         long = "x" * 200
-        d = _make_diagnostic(mutation_suggestions=[long])
+        d = _make_diagnostic(skill_edit_suggestions=[long])
         s = d.one_line_summary()
         assert "…" in s
         assert len(s) < 160
@@ -192,17 +192,17 @@ class TestParseDiagnostic:
 
     def test_non_list_fields_coerced_to_empty_list(self):
         bad = json.loads(_valid_llm_payload())
-        bad["mutation_suggestions"] = "not a list"
+        bad["skill_edit_suggestions"] = "not a list"
         parsed = _parse_diagnostic(json.dumps(bad))
         assert parsed is not None
-        assert parsed["mutation_suggestions"] == []
+        assert parsed["skill_edit_suggestions"] == []
 
     def test_list_item_truncation(self):
         bad = json.loads(_valid_llm_payload())
-        bad["mutation_suggestions"] = ["x" * 500]
+        bad["skill_edit_suggestions"] = ["x" * 500]
         parsed = _parse_diagnostic(json.dumps(bad))
         assert parsed is not None
-        assert len(parsed["mutation_suggestions"][0]) == 200
+        assert len(parsed["skill_edit_suggestions"][0]) == 200
 
     def test_garbage_returns_none(self):
         assert _parse_diagnostic("I did a great job!") is None


### PR DESCRIPTION
## Summary

Quest D Phase 1.C (PR #367) 退役了 SkillMutator pipeline，但 `TaskDiagnostic.mutation_suggestions` 欄位名沒改 — 整個 codebase + docs 留下「mutation」這個 vestige。

這個 PR 處理：
- **Code rename**: `mutation_suggestions` → `skill_edit_suggestions`（field + LLM prompt + 所有 consumers + tests）
- **Backwards-compat**: 兩條 read path 仍接受舊 key（`from_json` map / `_parse_diagnostic` fallback），歷史 SemanticMemory 紀錄不會變 unparseable
- **Documentation alignment**: README + doc/10 + doc/10b + doc/SUMMARY + doc/MISSING-DOC-AUDIT + loom.toml.example 一併校正

## Why now

PR #367 review 留下的 watch item：

> 未來小掃（非本 PR 範圍）：把 `TaskDiagnostic.mutation_suggestions` 重命名為 `skill_edit_suggestions` 或類似，把 prompt + 註解一併對齊。

User confirmed and asked for this cleanup PR explicitly. Additional doc scope (README + doc/) added per follow-up.

## Changes

| 檔案 | 變更 |
|------|------|
| `loom/core/cognition/task_reflector.py` | field rename + prompt update + 兩條 backwards-compat read path |
| `loom/platform/cli/main.py` | 4 個 consumer 處改名 |
| `loom/platform/discord/bot.py` | 4 個 consumer 處改名 |
| `tests/test_task_reflector.py` | 7 處改名 |
| `loom.toml.example` | 2 處 [reflection] 章節說明對齊 |
| `README.md` | 重寫 \"Skill Evolution Lifecycle\" 章節為 \"Skill Optimization Loop\"（doc/54 三通道）；更新 doc reference |
| `doc/10-Skill-Genome.md` | 移除 `maturity_tag` 欄位（已從 dataclass 退役）；body/frontmatter 用途說明改為對話編輯框架 |
| `doc/10b-Skill-Evolution.md` | 頂部加 RETIRED banner 指向 doc/54；歷史內容保留 |
| `doc/SUMMARY.md` | 10b 條目加 retired 標記 |
| `doc/MISSING-DOC-AUDIT.md` | cognition 清單移除退役檔案；Skill Evolution gap 標 obsolete |

## Backwards compatibility

兩條 read path 接受舊 key：

```python
# from_json (loading stored SemanticMemory entries)
if "mutation_suggestions" in data and "skill_edit_suggestions" not in data:
    data["skill_edit_suggestions"] = data.pop("mutation_suggestions")

# _parse_diagnostic (parsing raw LLM JSON output)
\"skill_edit_suggestions\": _list(
    data.get(\"skill_edit_suggestions\") or data.get(\"mutation_suggestions\")
),
```

→ 歷史 stored diagnostic 仍能正確顯示在 `loom diagnostic recent`；模型若沿用舊 key 不會丟掉資料。

## Test plan

- [x] `python -m pytest tests/ -q` — 1712 passed, 0 regression
- [x] grep 確認除了 backwards-compat 兩行 + doc/10b banner 引用，無其他 `mutation_suggestion` 殘留
- [ ] Loom 重啟後（user 提到目前關閉）手動跑一輪 `loom diagnostic recent` 確認既有歷史 entry 仍可解析

## Notes

- doc/10b 採「banner + 歷史保留」處理，沒整檔刪除 — 該文件的歷史值在記錄當時技術決策，未來 review 設計演變時仍有參考價值
- README 的 \"Skill Optimization Loop\" 章節是新寫的、不是搬運 — 對外文檔需要把 doc/54 的核心訊息（三通道、無自動 grading、Evaluator 留給未來）傳達清楚

🤖 Generated with [Claude Code](https://claude.com/claude-code)