### PR TITLE
fix(session): release turn_lock when ContextVar reset raises

### DIFF
--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -2546,44 +2546,69 @@ class LoomSession:
                 stop_reason=_stop_reason,
             )
         finally:
-            # ── AgentLedger turn_end + token reset ────────────────────
-            if self._ledger_emitter is not None and _ledger_turn_token is not None:
-                import sys as _sys
-                _exc_type = _sys.exc_info()[0]
-                if _exc_type is None:
-                    _outcome = "clean"
-                elif isinstance(_exc_type, type) and issubclass(
-                    _exc_type, asyncio.CancelledError
-                ):
-                    _outcome = "abandoned"
-                else:
-                    _outcome = "error"
-                try:
-                    _duration_ms = int(
-                        (time.monotonic() - _turn_start_monotonic) * 1000
-                    )
-                    # #334 — mirror local accumulators into session state so
-                    # commit-or-discard can run after the try/except scope.
+            try:
+                # ── AgentLedger turn_end + token reset ────────────────
+                if self._ledger_emitter is not None and _ledger_turn_token is not None:
+                    import sys as _sys
+                    _exc_type = _sys.exc_info()[0]
+                    if _exc_type is None:
+                        _outcome = "clean"
+                    elif isinstance(_exc_type, type) and issubclass(
+                        _exc_type, asyncio.CancelledError
+                    ):
+                        _outcome = "abandoned"
+                    else:
+                        _outcome = "error"
                     try:
-                        self._turn_thought_text = "".join(_think_parts)
-                    except NameError:
-                        # Exception before _think_parts was declared (rare).
-                        self._turn_thought_text = ""
+                        _duration_ms = int(
+                            (time.monotonic() - _turn_start_monotonic) * 1000
+                        )
+                        # #334 — mirror local accumulators into session state so
+                        # commit-or-discard can run after the try/except scope.
+                        try:
+                            self._turn_thought_text = "".join(_think_parts)
+                        except NameError:
+                            # Exception before _think_parts was declared (rare).
+                            self._turn_thought_text = ""
+                        try:
+                            self._turn_tool_calls_in_turn = tool_count
+                        except NameError:
+                            self._turn_tool_calls_in_turn = 0
+                        await self._commit_or_discard_thought(_turn_id_v2, _outcome)
+                        await self._emit_ledger_turn_end(
+                            _turn_id_v2, _outcome, _duration_ms
+                        )
+                    except Exception:
+                        logger.exception(
+                            "ledger turn_end emit failed; continuing"
+                        )
+                    # ContextVar.reset() raises ValueError when the token was
+                    # created in a different Context — happens when an async
+                    # generator is closed via aclose() from a cancelling task
+                    # that lives in a different Context than the originating
+                    # iteration. The token will be garbage-collected with the
+                    # frame anyway, so swallowing this is safe; what is NOT
+                    # safe is letting the ValueError escape and shadow the
+                    # turn_lock.release() below — which leaks the lock and
+                    # wedges every subsequent stream_turn on this session.
                     try:
-                        self._turn_tool_calls_in_turn = tool_count
-                    except NameError:
-                        self._turn_tool_calls_in_turn = 0
-                    await self._commit_or_discard_thought(_turn_id_v2, _outcome)
-                    await self._emit_ledger_turn_end(
-                        _turn_id_v2, _outcome, _duration_ms
-                    )
-                except Exception:
-                    logger.exception(
-                        "ledger turn_end emit failed; continuing"
-                    )
-                reset_turn_id(_ledger_turn_token)
-                reset_correlation(_ledger_corr_token)
-            self._turn_lock.release()
+                        reset_turn_id(_ledger_turn_token)
+                    except ValueError:
+                        logger.debug(
+                            "turn_id token reset skipped (different Context)"
+                        )
+                    try:
+                        reset_correlation(_ledger_corr_token)
+                    except ValueError:
+                        logger.debug(
+                            "correlation token reset skipped (different Context)"
+                        )
+            finally:
+                # Lock release is the load-bearing invariant of this finally
+                # block. Keep it in its own try/finally so no failure above
+                # (ledger emit, ContextVar reset, etc.) can ever leak the
+                # turn lock and brick the session.
+                self._turn_lock.release()
 
     # ------------------------------------------------------------------
     # Issue #58: Skill self-assessment trigger

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -1381,6 +1381,14 @@ async def _safe_edit(
         await message.edit(**kwargs)
     except discord.HTTPException:
         pass
+    except RuntimeError as exc:
+        # aiohttp raises bare RuntimeError("Session is closed") when the
+        # underlying ClientSession is torn down (Ctrl+C / bot shutdown). The
+        # cancel-cleanup path in _run_turn calls _safe_edit *after* the
+        # shutdown has begun, and we don't want that to surface as
+        # "unhandled exception during asyncio.run() shutdown".
+        if "Session is closed" not in str(exc):
+            raise
 
 
 async def _safe_send(
@@ -1410,6 +1418,10 @@ async def _safe_send(
             return await channel.send(**kwargs)
         except discord.HTTPException:
             return None
+        except RuntimeError as exc:
+            if "Session is closed" in str(exc):
+                return None
+            raise
 
     last: "discord.Message | None" = None
     remaining = content
@@ -1417,6 +1429,10 @@ async def _safe_send(
         chunk, remaining = remaining[:_MAX_CHARS], remaining[_MAX_CHARS:]
         try:
             last = await channel.send(chunk, **kwargs)
+        except RuntimeError as exc:
+            if "Session is closed" in str(exc):
+                return last
+            raise
         except discord.HTTPException:
             # Drop this chunk but keep going — partial delivery beats killing
             # the turn loop. The kwargs (view=, allowed_mentions=, …) only

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -688,6 +688,75 @@ class TestStreamTurnLock:
         with contextlib.suppress(BaseException):
             await task
 
+    async def test_turn_lock_released_when_contextvar_reset_raises(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Regression for the 2026-05-14 Discord incident.
+
+        Sequence observed in production:
+          14:23:11  Task-3770 raises ``ValueError: <Token …> was created
+                    in a different Context`` from session.py reset_turn_id
+                    while an async-generator GeneratorExit is unwinding.
+          14:23:13  next stream_turn warns "another turn still in flight"
+          14:42:00  same warning — session permanently wedged
+          14:51:04  same warning
+
+        Root cause: the ``finally`` block in ``stream_turn`` called
+        ``reset_turn_id`` BEFORE ``self._turn_lock.release()`` without
+        catching ValueError. When ``aclose()`` unwinds the generator from
+        a different async Context than ``set_turn_id`` was called in,
+        ``ContextVar.reset()`` raises, shadowing the release() on the
+        next line — the lock is leaked and every subsequent turn blocks
+        on ``await self._turn_lock.acquire()`` forever.
+
+        Invariant: even if every cleanup step above ``self._turn_lock.release()``
+        explodes, the lock MUST be released so the session can recover.
+        """
+        from loom.core import session as session_module
+        from loom.core.session import LoomSession
+
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        session = LoomSession(
+            model="test-model",
+            db_path=str(tmp_path / "loom.db"),
+            workspace=workspace,
+        )
+
+        # Enable the ledger branch so the finally calls reset_turn_id /
+        # reset_correlation. A bare object() is enough — the emit_turn_*
+        # methods are wrapped in their own try/except inside stream_turn.
+        session._ledger_emitter = object()
+
+        # Simulate the cross-Context ValueError aclose() triggers when
+        # the originating set_turn_id() lived in a different Context.
+        def _raises_cross_context(_token):
+            raise ValueError(
+                "<Token …> was created in a different Context"
+            )
+
+        monkeypatch.setattr(session_module, "reset_turn_id", _raises_cross_context)
+        monkeypatch.setattr(session_module, "reset_correlation", _raises_cross_context)
+
+        async def consume() -> None:
+            async for _ in session.stream_turn("hello"):
+                return
+
+        task = asyncio.create_task(consume())
+        # Let the generator advance past set_turn_id so the finally has
+        # a non-None token to reset (and therefore enters the ValueError
+        # path we are protecting against).
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with contextlib.suppress(BaseException):
+            await task
+
+        assert not session._turn_lock.locked(), (
+            "turn_lock leaked when ContextVar reset raised ValueError — "
+            "see PR for incident 2026-05-14: the session would be wedged "
+            "and every subsequent stream_turn() would hang forever."
+        )
+
 
 class TestSanitizeHistoryAdjacency:
     """Pass 4 (Issue #218): tool_use ↔ tool_result adjacency repair.


### PR DESCRIPTION
## Summary

Fix a **turn_lock leak** in `LoomSession.stream_turn` that wedged Discord sessions until the bot was force-killed, plus a smaller fix for shutdown-noise from `_safe_edit` / `_safe_send`.

- `stream_turn` finally now releases `_turn_lock` even if ledger cleanup or ContextVar reset raises.
- `reset_turn_id` / `reset_correlation` swallow the cross-Context `ValueError` async generators trigger on `aclose()`.
- Discord `_safe_edit` / `_safe_send` catch aiohttp's bare `RuntimeError("Session is closed")` so the Ctrl+C cleanup path doesn't surface as "unhandled exception during asyncio.run() shutdown".

## Incident — 2026-05-14 (the trail that found this)

Reported as "long task on Discord couldn't be stopped, had to force-kill the bot." The user provided two log slices.

### What we initially saw (Ctrl+C shutdown trace — red herring)

```
Compressing session to memory…
14:59:12 HTTP Request: POST https://api.minimax.io/anthropic/v1/messages "HTTP/1.1 200 OK"
14:59:12 unhandled exception during asyncio.run() shutdown
task: <Task finished name='Task-3829' coro=<LoomDiscordBot._handle_message() …>
  ...
  File "/.../loom/core/session.py", line 1787, in stream_turn
    await self._turn_lock.acquire()
asyncio.exceptions.CancelledError
...
  File "/.../loom/platform/discord/bot.py", line 1184, in _run_turn
    await _safe_edit(status_msg, "🛑 *(stopped)*")
  ...
RuntimeError: Session is closed
```

Two queued turns died waiting on `_turn_lock.acquire()`. The cancel-cleanup path then called `_safe_edit`, but aiohttp's `ClientSession` was already torn down → `RuntimeError("Session is closed")` (which `_safe_edit` only caught `discord.HTTPException` for) → escaped into asyncio shutdown.

The compaction in the trace was triggered _by_ the shutdown, not the cause. The lock-wait was the symptom.

### What the runtime log actually showed (root cause)

```
14:14:36 HTTP Request: POST https://api.minimax.io/anthropic/v1/messages "HTTP/1.1 200 OK"
14:23:05 HTTP Request: POST https://chatgpt.com/backend-api/codex/responses "HTTP/1.1 200 OK"
14:23:11 Task exception was never retrieved
future: <Task finished name='Task-3770' coro=<<async_generator_athrow without __name__>()>
exception=ValueError("<Token var=<ContextVar name='loom_ledger_turn_id' default=None …>
                      at 0x11345da00> was created in a different Context")>
Traceback (most recent call last):
  File "/.../loom/core/session.py", line 2350, in stream_turn
    yield EnvelopeUpdated(envelope=await self._build_envelope_view(_batch_t0))
GeneratorExit

During handling of the above exception, another exception occurred:
  File "/.../loom/core/session.py", line 2584, in stream_turn
    reset_turn_id(_ledger_turn_token)
  File "/.../loom/core/ledger/correlation.py", line 92, in reset_turn_id
    _current_turn.reset(token)
ValueError: <Token …> was created in a different Context

14:23:13 stream_turn: another turn still in flight on this session — waiting for it to release (origin=interactive)
14:42:00 stream_turn: another turn still in flight on this session — waiting for it to release (origin=interactive)
14:51:04 stream_turn: another turn still in flight on this session — waiting for it to release (origin=interactive)
```

Causal chain:

1. `stream_turn` is an async generator. At 14:23:11 the consumer (Discord `_run_turn`) was cancelled, so Python injected `GeneratorExit` into the generator via `aclose()`.
2. The `finally` block at session.py:2548 ran. It reached line 2584 `reset_turn_id(_ledger_turn_token)`.
3. The token was created by `set_turn_id()` at the top of `stream_turn` — in the Context of whoever first iterated the generator. `aclose()` runs in the cancelling task's Context. `ContextVar.reset()` raises `ValueError` when the token was created in a different Context.
4. The existing try/except at lines 2580–2583 wrapped only the ledger emit, **not** the `reset_turn_id` / `reset_correlation` calls. The ValueError escaped.
5. **Line 2586 `self._turn_lock.release()` never ran.** The lock was leaked.
6. Every subsequent `stream_turn` blocked forever at `await self._turn_lock.acquire()` — that's the 14:23:13 / 14:42 / 14:51 warnings, almost 30 minutes apart, each one a user message that produced no response.

`asyncio.Lock` has no holder concept, so cancelling the holding task doesn't auto-release. Once leaked, only restarting the process recovers — which is what the user had to do.

## Fix

1. **`loom/core/session.py`** — wrap `reset_turn_id` / `reset_correlation` in their own `try/except ValueError` (cross-Context reset is the documented asyncio gotcha here; the token will be GC'd with its frame, so swallowing is safe). Move `self._turn_lock.release()` into its own `finally` so nothing above it can ever shadow it.

2. **`loom/platform/discord/bot.py`** — `_safe_edit` and `_safe_send` now also catch `RuntimeError` with "Session is closed" in the message, so the cancel-cleanup path during shutdown stays quiet.

## Test plan

- [x] Added `test_turn_lock_released_when_contextvar_reset_raises` in `tests/test_session.py::TestStreamTurnLock`. Monkey-patches `reset_turn_id` / `reset_correlation` to raise `ValueError`, runs a `stream_turn`, then asserts `_turn_lock.locked() is False`. Verified the test FAILS on pre-fix code (stash + re-run).
- [x] Full `pytest tests/` — 1713 passed.
- [x] `gitnexus detect_changes` — risk: low, 0 affected processes.
- [ ] Manual: Discord long-task on next runtime session, observe `/stop` actually interrupts and subsequent messages flow normally.

## Reviewer notes

- Reading order: session.py finally block → new try/finally nesting → test docstring (carries the incident timeline for future archaeology).
- The Discord `_safe_edit` change is independent and could land on its own; bundled here because it surfaced in the same trace and is one-liner-sized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)