### PR TITLE
feat(discord): share dynamic personality catalog

### DIFF
--- a/loom/core/cognition/prompt_stack.py
+++ b/loom/core/cognition/prompt_stack.py
@@ -125,6 +125,17 @@ class PromptStack:
     # Runtime switching
     # ------------------------------------------------------------------
 
+    def _personality_file_for(self, name: str) -> Path | None:
+        """Return the matching personality file, ignoring filename case."""
+        candidate = self._personalities_dir / f"{name}.md"
+        if candidate.exists():
+            return candidate
+        wanted = name.lower()
+        for path in self._personalities_dir.glob("*.md"):
+            if path.is_file() and path.stem.lower() == wanted:
+                return path
+        return None
+
     def switch_personality(self, name: str) -> bool:
         """
         Load a personality by name from the personalities directory.
@@ -135,8 +146,8 @@ class PromptStack:
 
         Returns True if the file was found and loaded; False otherwise.
         """
-        candidate = self._personalities_dir / f"{name}.md"
-        if not candidate.exists():
+        candidate = self._personality_file_for(name)
+        if candidate is None:
             return False
 
         content = candidate.read_text(encoding="utf-8")
@@ -163,7 +174,9 @@ class PromptStack:
         """List personality stem names available in the personalities directory."""
         if not self._personalities_dir.exists():
             return []
-        return sorted(p.stem for p in self._personalities_dir.glob("*.md"))
+        return sorted(
+            {p.stem.lower() for p in self._personalities_dir.glob("*.md") if p.is_file()}
+        )
 
     # ------------------------------------------------------------------
     # Factory

--- a/loom/platform/cli/tui/components/input_area.py
+++ b/loom/platform/cli/tui/components/input_area.py
@@ -11,6 +11,8 @@ from textual.widget import Widget
 from textual.widgets import OptionList, TextArea
 from textual.widgets.option_list import Option
 
+from loom.platform.command_catalog import personality_slash_commands
+
 
 _NEWLINE_KEYS = ("alt+enter", "shift+enter", "ctrl+j", "ctrl+o")
 
@@ -88,13 +90,7 @@ class InputArea(Widget):
         "/new",
         "/sessions",
         "/model",
-        "/personality",
-        "/personality off",
-        "/personality adversarial",
-        "/personality minimalist",
-        "/personality architect",
-        "/personality researcher",
-        "/personality operator",
+        *personality_slash_commands(),
         "/tier",
         "/tier 1",
         "/tier 2",

--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -68,6 +68,7 @@ from loom.core.events import (  # noqa: E402, F401
     TurnDropped,
     TurnPaused,
 )
+from loom.platform.command_catalog import personality_command_entries
 
 
 # ---------------------------------------------------------------------------
@@ -88,13 +89,7 @@ SLASH_COMMANDS: list[tuple[str, str]] = [
     ("/name",                       "rename the current session"),
     ("/new",                        "start a fresh session"),
     ("/pause",                      "toggle HITL pause after each tool batch"),
-    ("/personality",                "show active persona + available list"),
-    ("/personality off",            "clear active persona"),
-    ("/personality adversarial",    "switch persona → adversarial"),
-    ("/personality architect",      "switch persona → architect"),
-    ("/personality minimalist",     "switch persona → minimalist"),
-    ("/personality operator",       "switch persona → operator"),
-    ("/personality researcher",     "switch persona → researcher"),
+    *personality_command_entries(),
     ("/scope",                      "list active scope grants"),
     ("/scope clear",                "revoke all non-system grants"),
     ("/scope revoke",               "revoke a specific grant by index"),

--- a/loom/platform/command_catalog.py
+++ b/loom/platform/command_catalog.py
@@ -10,7 +10,7 @@ def discover_personality_names(personalities_dir: str | Path = "personalities") 
     root = Path(personalities_dir)
     if not root.exists():
         return []
-    return sorted(p.stem for p in root.glob("*.md") if p.is_file())
+    return sorted({p.stem.lower() for p in root.glob("*.md") if p.is_file()})
 
 
 def personality_slash_commands(

--- a/loom/platform/command_catalog.py
+++ b/loom/platform/command_catalog.py
@@ -1,0 +1,41 @@
+"""Shared command catalog helpers for CLI, TUI, and Discord surfaces."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def discover_personality_names(personalities_dir: str | Path = "personalities") -> list[str]:
+    """Return available personality names from a directory of ``*.md`` files."""
+    root = Path(personalities_dir)
+    if not root.exists():
+        return []
+    return sorted(p.stem for p in root.glob("*.md") if p.is_file())
+
+
+def personality_slash_commands(
+    personalities_dir: str | Path = "personalities",
+) -> list[str]:
+    """Return slash-command completions for runtime personality switching."""
+    return [
+        "/personality",
+        "/personality off",
+        *[
+            f"/personality {name}"
+            for name in discover_personality_names(personalities_dir)
+        ],
+    ]
+
+
+def personality_command_entries(
+    personalities_dir: str | Path = "personalities",
+) -> list[tuple[str, str]]:
+    """Return CLI completer entries for personality commands."""
+    return [
+        ("/personality", "show active persona + available list"),
+        ("/personality off", "clear active persona"),
+        *[
+            (f"/personality {name}", f"switch persona -> {name}")
+            for name in discover_personality_names(personalities_dir)
+        ],
+    ]

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -658,6 +658,7 @@ class LoomDiscordBot:
 
         names = discover_personality_names()
         if not names:
+            # Omit the Personalities line when the configured directory is empty.
             return self.HELP_TEXT
         rendered = " \xb7 ".join(f"`{name}`" for name in names)
         return self.HELP_TEXT.replace(

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -650,12 +650,20 @@ class LoomDiscordBot:
         "`/help` — Show this message\n\n"
         "Every command is also registered as a native `/loom-*` slash command — "
         "type `/loom` to see them in Discord's autocomplete.\n\n"
-        "Personalities: `adversarial` \xb7 `minimalist` \xb7 `architect` \xb7 `researcher` \xb7 `operator`\n\n"
         "*Send any message in the main channel to start a new session thread.*"
     )
 
     def _cmd_help(self) -> str:
-        return self.HELP_TEXT
+        from loom.platform.command_catalog import discover_personality_names
+
+        names = discover_personality_names()
+        if not names:
+            return self.HELP_TEXT
+        rendered = " \xb7 ".join(f"`{name}`" for name in names)
+        return self.HELP_TEXT.replace(
+            "\n*Send any message",
+            f"\nPersonalities: {rendered}\n\n*Send any message",
+        )
 
     async def _cmd_sessions(self, session: "LoomSession") -> str:
         from loom.core.memory.session_log import SessionLog as _SL

--- a/loom/platform/discord/commands.py
+++ b/loom/platform/discord/commands.py
@@ -25,23 +25,15 @@ from typing import TYPE_CHECKING
 import discord
 from discord import app_commands
 
+from loom.platform.command_catalog import discover_personality_names
+
 if TYPE_CHECKING:
     from loom.platform.discord.bot import LoomDiscordBot
     from loom.core.session import LoomSession
 
 
-# Personalities and summary modes are static enough that hard-coded Choices
-# are clearer than dynamic autocomplete. Models and grant IDs *are* dynamic
-# and use autocomplete callbacks below.
-_PERSONALITY_CHOICES = [
-    app_commands.Choice(name="adversarial", value="adversarial"),
-    app_commands.Choice(name="minimalist", value="minimalist"),
-    app_commands.Choice(name="architect", value="architect"),
-    app_commands.Choice(name="researcher", value="researcher"),
-    app_commands.Choice(name="operator", value="operator"),
-    app_commands.Choice(name="off (clear)", value="off"),
-]
-
+# Summary modes are static enough for hard-coded Choices. Models, grant IDs,
+# and personalities use autocomplete callbacks below.
 _SUMMARY_CHOICES = [
     app_commands.Choice(name="off", value="off"),
     app_commands.Choice(name="on", value="on"),
@@ -191,20 +183,40 @@ def register_slash_commands(bot: "LoomDiscordBot") -> None:
         )
 
     # ── /loom-personality ─────────────────────────────────────────────
+    async def _personality_autocomplete(
+        interaction: discord.Interaction, current: str,
+    ) -> list[app_commands.Choice[str]]:
+        session = _session_for(bot, interaction)
+        names = (
+            session._stack.available_personalities()
+            if session is not None
+            else discover_personality_names()
+        )
+        choices = [app_commands.Choice(name="off (clear)", value="off")]
+        choices.extend(
+            app_commands.Choice(name=name, value=name)
+            for name in names
+        )
+        current_l = current.lower()
+        return [
+            choice for choice in choices
+            if not current_l or current_l in choice.name.lower()
+        ][:25]
+
     @tree.command(
         name="loom-personality",
         description="Switch cognitive persona, or omit to show the active one.",
     )
     @app_commands.describe(name="Persona to activate. Choose 'off (clear)' to remove.")
-    @app_commands.choices(name=_PERSONALITY_CHOICES)
+    @app_commands.autocomplete(name=_personality_autocomplete)
     async def loom_personality(
         interaction: discord.Interaction,
-        name: app_commands.Choice[str] | None = None,
+        name: str | None = None,
     ) -> None:
         session = await _require_session(bot, interaction)
         if session is None:
             return
-        arg = name.value if name is not None else ""
+        arg = name or ""
         await interaction.response.send_message(
             bot._cmd_personality(session, arg), ephemeral=True,
         )

--- a/loom/platform/discord/commands.py
+++ b/loom/platform/discord/commands.py
@@ -192,6 +192,7 @@ def register_slash_commands(bot: "LoomDiscordBot") -> None:
             if session is not None
             else discover_personality_names()
         )
+        # "off" is a command sentinel, not a personality file.
         choices = [app_commands.Choice(name="off (clear)", value="off")]
         choices.extend(
             app_commands.Choice(name=name, value=name)

--- a/tests/test_command_catalog.py
+++ b/tests/test_command_catalog.py
@@ -19,6 +19,20 @@ def test_personality_commands_are_built_from_directory(tmp_path: Path) -> None:
     ]
 
 
+def test_personality_commands_normalize_filename_case(tmp_path: Path) -> None:
+    from loom.platform.command_catalog import personality_slash_commands
+
+    personalities = tmp_path / "personalities"
+    personalities.mkdir()
+    (personalities / "Sisi_Tarot_Mood.md").write_text("tarot", encoding="utf-8")
+
+    assert personality_slash_commands(personalities) == [
+        "/personality",
+        "/personality off",
+        "/personality sisi_tarot_mood",
+    ]
+
+
 def test_cli_slash_catalog_includes_dynamic_personality_files() -> None:
     from loom.platform.cli.ui import SLASH_COMMANDS
 

--- a/tests/test_command_catalog.py
+++ b/tests/test_command_catalog.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_personality_commands_are_built_from_directory(tmp_path: Path) -> None:
+    from loom.platform.command_catalog import personality_slash_commands
+
+    personalities = tmp_path / "personalities"
+    personalities.mkdir()
+    (personalities / "operator.md").write_text("operator", encoding="utf-8")
+    (personalities / "barista.md").write_text("barista", encoding="utf-8")
+
+    assert personality_slash_commands(personalities) == [
+        "/personality",
+        "/personality off",
+        "/personality barista",
+        "/personality operator",
+    ]
+
+
+def test_cli_slash_catalog_includes_dynamic_personality_files() -> None:
+    from loom.platform.cli.ui import SLASH_COMMANDS
+
+    commands = [command for command, _description in SLASH_COMMANDS]
+
+    assert "/personality barista" in commands
+
+
+def test_tui_input_catalog_includes_dynamic_personality_files() -> None:
+    from loom.platform.cli.tui.components.input_area import InputArea
+
+    assert "/personality barista" in InputArea.SLASH_COMMANDS
+
+
+def test_discord_personality_command_uses_autocomplete_not_static_choices() -> None:
+    from loom.platform.discord.bot import LoomDiscordBot
+
+    bot = LoomDiscordBot(model="claude-opus-4-7", db_path="/tmp/loom-test.db")
+    command = next(cmd for cmd in bot._tree.get_commands() if cmd.name == "loom-personality")
+    param = next(param for param in command.parameters if param.name == "name")
+
+    assert not param.choices
+    assert param.autocomplete is not None
+
+
+def test_discord_help_lists_dynamic_personalities() -> None:
+    from loom.platform.discord.bot import LoomDiscordBot
+
+    bot = LoomDiscordBot(model="claude-opus-4-7", db_path="/tmp/loom-test.db")
+
+    assert "barista" in bot._cmd_help()

--- a/tests/test_prompt_stack.py
+++ b/tests/test_prompt_stack.py
@@ -189,6 +189,19 @@ class TestSwitchPersonality:
         stack.switch_personality("minimalist")
         assert stack.current_personality == "minimalist"
 
+    def test_switch_matches_filename_case_insensitively(self, tmp_soul, tmp_path):
+        personalities = tmp_path / "personalities"
+        personalities.mkdir()
+        (personalities / "Sisi_Tarot_Mood.md").write_text("tarot lens", encoding="utf-8")
+        stack = PromptStack(soul_path=tmp_soul, personalities_dir=personalities)
+        stack.load()
+
+        ok = stack.switch_personality("sisi_tarot_mood")
+
+        assert ok is True
+        assert "tarot lens" in stack.composed_prompt
+        assert stack.current_personality == "sisi_tarot_mood"
+
     def test_switch_appends_layer_when_none_active(self, tmp_soul, tmp_personalities):
         stack = PromptStack(soul_path=tmp_soul, personalities_dir=tmp_personalities)
         stack.load()
@@ -260,6 +273,15 @@ class TestAvailablePersonalities:
     def test_sorted_alphabetically(self, tmp_personalities):
         avail = PromptStack(personalities_dir=tmp_personalities).available_personalities()
         assert avail == sorted(avail)
+
+    def test_normalizes_filename_case(self, tmp_path):
+        personalities = tmp_path / "personalities"
+        personalities.mkdir()
+        (personalities / "Sisi_Tarot_Mood.md").write_text("tarot", encoding="utf-8")
+
+        avail = PromptStack(personalities_dir=personalities).available_personalities()
+
+        assert avail == ["sisi_tarot_mood"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a shared command catalog helper for personality discovery from `personalities/*.md`
- use dynamic personality entries in CLI and TUI slash autocomplete, including `barista`
- switch Discord `/loom-personality` from static choices to autocomplete and render Discord help from the same discovery source

## Verification
- `pytest -q tests` — 1718 passed, 60 warnings
- `python -m py_compile loom/platform/command_catalog.py loom/platform/discord/commands.py loom/platform/discord/bot.py loom/platform/cli/ui.py loom/platform/cli/tui/components/input_area.py`
- `git diff --cached --check`
- `npx gitnexus detect-changes --scope staged` — risk medium, affected processes 3

Follow-up: Discord `/tier` and `/name`/`/title` aliases will be handled in a separate PR.