### PR TITLE
feat(discord): add tier command and title aliases

### DIFF
--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -627,7 +627,7 @@ class LoomDiscordBot:
     _SLASH_NEEDS_SESSION = frozenset({
         "/think", "/compact", "/pause", "/stop", "/budget",
         "/auto", "/scope", "/summary", "/title", "/sessions",
-        "/model", "/personality",
+        "/name", "/model", "/personality", "/tier",
     })
 
     HELP_TEXT = (
@@ -635,10 +635,13 @@ class LoomDiscordBot:
         "`/new` — Open a new session thread\n"
         "`/sessions` — List recent sessions\n"
         "`/title <name>` — Set or show the session title\n"
+        "`/name <name>` — Alias for `/title <name>`\n"
         "`/model` — Show current model + registered providers\n"
         "`/model <name>` — Switch model  e.g. `deepseek-v4-pro`  `claude-sonnet-4-6`\n"
         "`/personality [name]` — Switch cognitive persona\n"
         "`/personality off` — Remove active persona\n"
+        "`/tier` — Show active LLM tier\n"
+        "`/tier <N>` — Switch tier (1 = daily · 2 = deep reasoning)\n"
         "`/think` — View last turn's reasoning chain\n"
         "`/compact` — Compress older context\n"
         "`/auto` — Toggle run_bash auto-approve (requires strict_sandbox)\n"
@@ -771,6 +774,35 @@ class LoomDiscordBot:
             await _SL(conn).update_title(session.session_id, arg)
         return f"✅ Session title → **{arg}**"
 
+    def _cmd_tier(self, session: "LoomSession", arg: str) -> str:
+        if not session._tier_models:
+            return "Tier system not configured. Add `[cognition.tiers]` to `loom.toml` to enable."
+        if not arg:
+            active = session._active_tier()
+            sticky = session._sticky_tier
+            model = session._active_model()
+            sticky_str = f"sticky on Tier {sticky}" if sticky is not None else "follows default"
+            lines = [
+                f"Active: **Tier {active}** · `{model}` ({sticky_str}, {session._turns_at_current_tier} turns)"
+            ]
+            for tier in sorted(session._tier_models):
+                marker = " ← active" if tier == active else ""
+                lines.append(f"Tier {tier}: `{session._tier_models[tier]}`{marker}")
+            return "\n".join(lines)
+        try:
+            target_tier = int(arg.split()[0])
+        except (TypeError, ValueError):
+            return f"Invalid tier `{arg}`. Use `/tier` for status or `/tier N` to switch."
+        if target_tier not in session._tier_models:
+            return f"Tier {target_tier} is not configured."
+        new_sticky = None if target_tier == session._default_tier else target_tier
+        ev = session._set_sticky_tier(
+            new_sticky, reason="user /tier", source="user",
+        )
+        if ev is not None:
+            session._lifecycle_events.put_nowait(ev)
+        return f"Tier → **{session._active_tier()}** · `{session._active_model()}`"
+
     def _cmd_summary(self, arg: str) -> str:
         valid_modes = ("off", "on", "detail")
         if not arg:
@@ -898,8 +930,10 @@ class LoomDiscordBot:
             reply = self._cmd_stop(message.channel.id)
         elif command == "/budget":
             reply = self._cmd_budget(session)  # type: ignore[arg-type]
-        elif command == "/title":
+        elif command in ("/title", "/name"):
             reply = await self._cmd_title(session, arg)  # type: ignore[arg-type]
+        elif command == "/tier":
+            reply = self._cmd_tier(session, arg)  # type: ignore[arg-type]
         elif command == "/summary":
             reply = self._cmd_summary(arg)
         elif command == "/scope":

--- a/loom/platform/discord/commands.py
+++ b/loom/platform/discord/commands.py
@@ -265,6 +265,33 @@ def register_slash_commands(bot: "LoomDiscordBot") -> None:
         reply = await bot._cmd_title(session, title or "")
         await interaction.response.send_message(reply, ephemeral=True)
 
+    @tree.command(name="loom-name", description="Alias for /loom-title.")
+    @app_commands.describe(name="New title. Omit to display the current one.")
+    async def loom_name(
+        interaction: discord.Interaction,
+        name: str | None = None,
+    ) -> None:
+        session = await _require_session(bot, interaction)
+        if session is None:
+            return
+        reply = await bot._cmd_title(session, name or "")
+        await interaction.response.send_message(reply, ephemeral=True)
+
+    # ── /loom-tier ────────────────────────────────────────────────────
+    @tree.command(name="loom-tier", description="Show or switch the active LLM tier.")
+    @app_commands.describe(tier="Tier number. Omit to show current tier status.")
+    async def loom_tier(
+        interaction: discord.Interaction,
+        tier: int | None = None,
+    ) -> None:
+        session = await _require_session(bot, interaction)
+        if session is None:
+            return
+        await interaction.response.send_message(
+            bot._cmd_tier(session, "" if tier is None else str(tier)),
+            ephemeral=True,
+        )
+
     # ── /loom-summary ─────────────────────────────────────────────────
     @tree.command(
         name="loom-summary",

--- a/tests/test_discord_slash_commands.py
+++ b/tests/test_discord_slash_commands.py
@@ -69,6 +69,17 @@ def _fake_session(
     session.perm.exec_auto = False
     session.perm._usage = {}
     session.perm.revoke_matching = MagicMock()
+    session._tier_models = {
+        1: "MiniMax-M2.7",
+        2: "claude-opus-4-7",
+    }
+    session._default_tier = 1
+    session._sticky_tier = None
+    session._turns_at_current_tier = 0
+    session._active_tier = MagicMock(return_value=1)
+    session._active_model = MagicMock(return_value="MiniMax-M2.7")
+    session._set_sticky_tier = MagicMock(return_value=None)
+    session._lifecycle_events = MagicMock()
     return session
 
 
@@ -81,7 +92,7 @@ def test_help_text_lists_every_command():
     for cmd in (
         "/new", "/sessions", "/title", "/model", "/personality", "/think",
         "/compact", "/auto", "/pause", "/stop", "/budget", "/scope",
-        "/summary", "/help",
+        "/summary", "/tier", "/name", "/help",
     ):
         assert cmd in text
 
@@ -205,6 +216,62 @@ def test_summary_rejects_unknown_mode():
     assert "Unknown mode" in out
 
 
+def test_tier_status_lists_configured_tiers():
+    bot = _bot()
+    sess = _fake_session()
+
+    out = bot._cmd_tier(sess, "")
+
+    assert "Tier 1" in out
+    assert "MiniMax-M2.7" in out
+
+
+def test_tier_switch_sets_sticky_tier():
+    bot = _bot()
+    sess = _fake_session()
+    sess._active_tier.return_value = 2
+    sess._active_model.return_value = "claude-opus-4-7"
+
+    out = bot._cmd_tier(sess, "2")
+
+    sess._set_sticky_tier.assert_called_once_with(
+        2, reason="user /tier", source="user",
+    )
+    assert "Tier" in out
+    assert "claude-opus-4-7" in out
+
+
+@pytest.mark.asyncio
+async def test_text_prefix_tier_dispatches_to_tier_backend(monkeypatch):
+    bot = _bot()
+    sess = _fake_session()
+    message = MagicMock()
+    message.channel = SimpleNamespace(id=123)
+    safe_send = AsyncMock()
+    monkeypatch.setattr("loom.platform.discord.bot._safe_send", safe_send)
+
+    await bot._handle_slash(message, "/tier 2", sess, is_thread=True)
+
+    safe_send.assert_awaited_once()
+    assert "Tier" in safe_send.await_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_text_prefix_name_alias_uses_title_backend(monkeypatch):
+    bot = _bot()
+    sess = _fake_session()
+    message = MagicMock()
+    message.channel = SimpleNamespace(id=123)
+    bot._cmd_title = AsyncMock(return_value="renamed")
+    safe_send = AsyncMock()
+    monkeypatch.setattr("loom.platform.discord.bot._safe_send", safe_send)
+
+    await bot._handle_slash(message, "/name Field Notes", sess, is_thread=True)
+
+    bot._cmd_title.assert_awaited_once_with(sess, "Field Notes")
+    safe_send.assert_awaited_once_with(message.channel, "renamed")
+
+
 # ── /scope subcommands ───────────────────────────────────────────────
 
 
@@ -268,7 +335,8 @@ def test_every_expected_loom_command_is_registered():
     expected = {
         "loom-help", "loom-new", "loom-sessions", "loom-think", "loom-compact",
         "loom-model", "loom-personality", "loom-auto", "loom-pause",
-        "loom-stop", "loom-budget", "loom-title", "loom-summary", "loom-scope",
+        "loom-stop", "loom-budget", "loom-title", "loom-name", "loom-summary",
+        "loom-scope", "loom-tier",
     }
     missing = expected - registered
     assert not missing, f"missing slash commands: {missing}"


### PR DESCRIPTION
## Summary
- add Discord text-prefix and native slash support for `/tier` / `/loom-tier`
- add `/name` text-prefix and `/loom-name` native slash aliases for session title changes
- update Discord help text and regression tests for the aligned command surface

## Verification
- `pytest -q tests/test_discord_slash_commands.py` — 28 passed, 56 warnings
- `pytest -q tests` — 1717 passed, 64 warnings
- `python -m py_compile loom/platform/discord/bot.py loom/platform/discord/commands.py tests/test_discord_slash_commands.py`
- `git diff --check`
- `npx gitnexus detect-changes --scope staged` — risk low, affected processes 0

Note: model selection help/autocomplete is intentionally left unchanged; Discord lightweight model control is now `/tier 1` / `/tier 2`.