### PR TITLE
feat(autonomy): chime triggers for scheduled wake into active sessions

### DIFF
--- a/Agent.md.example
+++ b/Agent.md.example
@@ -131,3 +131,29 @@ Loom 是**編織的**：接指令 → 評估 → 執行 → 記憶 → 推演 �
 大多數 agent 是**串列的**：接指令 → 執行 → 忘記。
 
 紡織的核心邏輯是 **一條線單獨什麼都不是，但許多多線精確交錯時，能織出任何形狀**。你的每一次行動，都是那條被妥善安置的線。
+
+---
+
+## 排程喚醒（`<system_chime>`）
+
+> issue #369
+
+對話中可能出現這樣的訊息：
+
+```
+<system_chime schedule="morning_greeting" fired_at="2026-05-14T09:00:00+08:00">
+向 user 道早安，並簡述今天行程
+</system_chime>
+```
+
+這代表此 turn **不是 user 發言**，而是 autonomy 的 cron 排程到了，系統把你從這個 session 中喚醒。標籤屬性：
+
+- `schedule`：對應 `loom.toml` 的 `[[autonomy.schedules]].name`，用於追蹤是哪個排程觸發
+- `fired_at`：觸發時刻（ISO 8601，含時區）
+
+### 處理原則
+
+- **意識到 user 沒有剛說話**。回應對象仍是 user，但語氣不該預設「他剛問了我什麼」。可以是主動關心、提醒、或執行排程交辦的任務。
+- **內容是 intent，不是逐字稿**。`<system_chime>` 內的文字描述「該做什麼」，由你決定怎麼表達。不要照唸 intent。
+- **chime 期間的工具權限與 trust_level 仍受 harness 控管**，跟一般 turn 沒有差別。
+- 不要在回覆中再包一層 `<system_chime>`，這個標籤只屬於系統 → agent 的單向訊號。

--- a/loom/autonomy/chime.py
+++ b/loom/autonomy/chime.py
@@ -1,0 +1,49 @@
+"""
+Chime — scheduled wake into an existing session (issue #369).
+
+A chime is the autonomy daemon's way to nudge an *already-active* session
+instead of opening a fresh independent one. The nudge is delivered as a
+``<system_chime>``-wrapped message so the agent can tell at a glance that
+this turn was triggered by a cron schedule, not by the user speaking.
+
+This module is intentionally tiny: just the request dataclass and the
+formatting helper. Routing, dispatch, and rendering live in the platform
+layer (Discord bot for v1) so the autonomy package stays platform-agnostic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ChimeRequest:
+    """One scheduled wake-up for a target session."""
+
+    schedule_name: str
+    intent: str
+    fired_at: datetime
+    target: dict[str, Any] = field(default_factory=dict)
+    """Routing hint, e.g. ``{"type": "discord_thread", "id": "12345"}``."""
+    trust_level: str | None = None
+    allowed_tools: tuple[str, ...] = ()
+    scope_grants: tuple[dict[str, Any], ...] = ()
+
+
+def format_chime_content(req: ChimeRequest) -> str:
+    """Build the ``<system_chime>`` wrapper the agent sees in its history.
+
+    The wrapper is the contract that lets the agent (and any future tooling)
+    detect "this turn was triggered by a schedule" without parsing free text.
+    Keep the attribute set stable: schedule + fired_at are load-bearing for
+    audits and dedupe.
+    """
+    iso = req.fired_at.isoformat()
+    intent = req.intent.strip()
+    return (
+        f'<system_chime schedule="{req.schedule_name}" fired_at="{iso}">\n'
+        f"{intent}\n"
+        f"</system_chime>"
+    )

--- a/loom/autonomy/daemon.py
+++ b/loom/autonomy/daemon.py
@@ -20,6 +20,9 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+from typing import Awaitable, Callable
+
+from loom.autonomy.chime import ChimeRequest
 from loom.autonomy.evaluator import TriggerEvaluator
 from loom.autonomy.history import TriggerHistory
 from loom.autonomy.maintenance import MaintenanceLoop
@@ -29,6 +32,12 @@ from loom.core.infra import AbortController, wait_aborted
 from loom.notify.confirm import ConfirmFlow
 from loom.notify.router import NotificationRouter
 from loom.notify.types import Notification, NotificationType
+
+
+ChimeDelivery = Callable[[ChimeRequest], Awaitable[bool]]
+"""Platform-supplied callback that delivers a chime to its target session.
+Returns True if the chime was accepted (target found & queued), False if the
+caller should fall back per ``target['fallback']``."""
 
 
 # ---------------------------------------------------------------------------
@@ -150,11 +159,13 @@ class AutonomyDaemon:
         confirm_flow: ConfirmFlow,
         loom_session=None,   # LoomSession for executing prompts
         db=None,            # open aiosqlite.Connection for trigger_history persistence
+        chime_delivery: ChimeDelivery | None = None,
     ) -> None:
         self._notify = notify_router
         self._confirm = confirm_flow
         self._session = loom_session
         self._abort = AbortController()
+        self._chime_delivery = chime_delivery
 
         history = TriggerHistory(db) if db is not None else None
         # Issue #147 Phase C.2: pull semantic via the facade. ``_memory``
@@ -178,6 +189,25 @@ class AutonomyDaemon:
             return
 
         if plan.decision == ActionDecision.EXECUTE:
+            # Chime mode: wake an existing session via the platform-supplied
+            # delivery callback. Fall back to independent execution only when
+            # explicitly requested (target.fallback == "independent").
+            if plan.context.get("mode") == "chime":
+                accepted = await self._deliver_chime(plan)
+                if accepted:
+                    return
+                fallback = plan.context.get("target", {}).get("fallback", "skip")
+                if fallback != "independent":
+                    logger.info(
+                        "[autonomy] chime trigger=%s — no target session and "
+                        "fallback=%s, skipping",
+                        plan.trigger_name, fallback,
+                    )
+                    return
+                logger.info(
+                    "[autonomy] chime trigger=%s — falling back to independent",
+                    plan.trigger_name,
+                )
             await self._run_agent(plan)
             return
 
@@ -204,6 +234,41 @@ class AutonomyDaemon:
                 body="No response within timeout — action was skipped.",
                 trigger_name=plan.trigger_name,
             ))
+
+    async def _deliver_chime(self, plan: PlannedAction) -> bool:
+        """Route a chime-mode plan to the platform delivery callback.
+        Returns True on accept, False if no callback or target missed."""
+        if self._chime_delivery is None:
+            logger.warning(
+                "[autonomy] chime trigger=%s fired but no delivery callback "
+                "is wired (daemon constructed without chime_delivery)",
+                plan.trigger_name,
+            )
+            return False
+        target = plan.context.get("target") or {}
+        if not target:
+            logger.warning(
+                "[autonomy] chime trigger=%s has no target — cannot route",
+                plan.trigger_name,
+            )
+            return False
+        req = ChimeRequest(
+            schedule_name=plan.trigger_name,
+            intent=plan.prompt,
+            fired_at=datetime.now(UTC),
+            target=dict(target),
+            trust_level=plan.context.get("trust_level"),
+            allowed_tools=tuple(plan.context.get("allowed_tools", [])),
+            scope_grants=tuple(plan.context.get("scope_grants", [])),
+        )
+        try:
+            return bool(await self._chime_delivery(req))
+        except Exception:
+            logger.exception(
+                "[autonomy] chime delivery raised for trigger=%s",
+                plan.trigger_name,
+            )
+            return False
 
     async def _run_agent(self, plan: PlannedAction) -> None:
         if self._session is None:
@@ -331,6 +396,26 @@ class AutonomyDaemon:
 
         count = 0
         for sched in autonomy_cfg.get("schedules", []):
+            mode = sched.get("mode", "independent")
+            target = dict(sched.get("target", {}))
+            if mode == "chime":
+                _t_type = target.get("type")
+                if _t_type != "discord_thread":
+                    logger.warning(
+                        "[autonomy] schedule %r mode=chime requires "
+                        "target.type='discord_thread' (got %r); skipping",
+                        sched["name"], _t_type,
+                    )
+                    continue
+                if "id" not in target:
+                    logger.warning(
+                        "[autonomy] schedule %r mode=chime missing target.id; "
+                        "skipping", sched["name"],
+                    )
+                    continue
+                # Normalise id to string for label matching
+                target["id"] = str(target["id"])
+                target.setdefault("fallback", "skip")
             trigger = CronTrigger(
                 name=sched["name"],
                 intent=sched["intent"],
@@ -344,6 +429,8 @@ class AutonomyDaemon:
                 allowed_tools=sched.get("allowed_tools", []),
                 scope_grants=sched.get("scope_grants", []),
                 attach_outputs=sched.get("attach_outputs", []),
+                mode=mode,
+                target=target,
             )
             self._evaluator.register(trigger)
             count += 1

--- a/loom/autonomy/planner.py
+++ b/loom/autonomy/planner.py
@@ -89,6 +89,11 @@ class ActionPlanner:
         context["allowed_tools"] = getattr(trigger, "allowed_tools", [])
         context["scope_grants"] = getattr(trigger, "scope_grants", [])
         context["attach_outputs"] = getattr(trigger, "attach_outputs", [])
+        # Chime routing (issue #369) — propagated so AutonomyDaemon._execute_plan
+        # can branch to chime delivery instead of spawning an independent run.
+        context["mode"] = getattr(trigger, "mode", "independent")
+        context["target"] = getattr(trigger, "target", {}) or {}
+        context["trust_level"] = trigger.trust_level
 
         if self._semantic is not None:
             try:

--- a/loom/autonomy/triggers.py
+++ b/loom/autonomy/triggers.py
@@ -94,9 +94,21 @@ class CronTrigger(TriggerDefinition):
     """Fires on a 5-field cron schedule (minute hour dom month dow)."""
     cron: str = "0 9 * * *"
     timezone: str = "UTC"
+    mode: str = "independent"
+    """``"independent"`` (default) → spawn a fresh autonomy session.
+    ``"chime"`` (issue #369) → wake an already-active session via
+    SessionRegistry + bot.deliver_chime."""
+    target: dict[str, Any] = field(default_factory=dict)
+    """Routing for ``mode="chime"``, e.g.
+    ``{"type": "discord_thread", "id": "<thread_id>", "fallback": "skip"}``.
+    Ignored for independent mode."""
 
     def __post_init__(self):
         _validate_cron(self.cron)
+        if self.mode not in ("independent", "chime"):
+            raise ValueError(
+                f"CronTrigger.mode must be 'independent' or 'chime', got {self.mode!r}"
+            )
 
     @property
     def kind(self) -> TriggerKind:

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -3301,6 +3301,7 @@ async def _discord_with_autonomy(
         notify_router=notify_router,
         confirm_flow=confirm_flow,
         loom_session=session,
+        chime_delivery=bot.deliver_chime,
     )
     import logging
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s", datefmt="%H:%M:%S")

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -83,6 +83,7 @@ from loom.platform.cli.ui import (
     TierChanged, TierExpiryHint,
     ToolBegin, ToolEnd, TurnDone, TurnDropped, TurnPaused,
 )
+from loom.autonomy.chime import ChimeRequest, format_chime_content
 from loom.platform.discord.tools import (
     make_add_discord_reaction_tool,
     make_send_discord_embed_tool,
@@ -273,6 +274,11 @@ class LoomDiscordBot:
         # target for `add_discord_reaction` when the agent doesn't pass
         # an explicit message_id.
         self._last_user_msg: dict[int, int] = {}
+        # Chime delivery (issue #369). Pending chimes are deduped by
+        # (thread_id, schedule_name): firing the same-named chime twice
+        # before delivery keeps only the latest. One dispatcher per thread.
+        self._chime_pending: dict[int, dict[str, ChimeRequest]] = {}
+        self._chime_dispatcher: dict[int, asyncio.Task] = {}
         # Turn summary display mode: "off" | "on" | "detail"
         self._summary_mode: str = "on"
 
@@ -568,6 +574,14 @@ class LoomDiscordBot:
         session.subscribe_diagnostic(_discord_diagnostic)
 
         self._sessions[thread_id] = session
+        # Register in process-wide registry so the autonomy daemon can find
+        # this session for chime triggers (issue #369).
+        from loom.platform.session_registry import get_registry
+        get_registry().register(
+            session.session_id,
+            session,
+            labels={"discord_thread": str(thread_id)},
+        )
         await self._force_compact_session(thread_id, session, reason="resume")
         return session
 
@@ -575,9 +589,139 @@ class LoomDiscordBot:
         session = self._sessions.pop(thread_id, None)
         if session:
             try:
+                from loom.platform.session_registry import get_registry
+                get_registry().unregister(session.session_id)
+            except Exception:
+                pass
+            try:
                 await session.stop()
             except Exception:
                 pass
+
+    # ------------------------------------------------------------------
+    # Chime delivery (issue #369)
+    # ------------------------------------------------------------------
+
+    async def deliver_chime(self, req: ChimeRequest) -> bool:
+        """Accept a chime from the autonomy daemon, queue it for the target
+        thread, and ensure a dispatcher is draining.
+
+        Returns False when the target can't be resolved (no thread, no
+        session yet started) so the daemon can apply its fallback.
+        """
+        if req.target.get("type") != "discord_thread":
+            return False
+        try:
+            thread_id = int(req.target.get("id", ""))
+        except (TypeError, ValueError):
+            return False
+        # v1: only deliver to threads with an already-loaded session. A
+        # cold thread (bot restarted, user hasn't spoken) is not implicitly
+        # resumed by a chime — the chime would arrive into a freshly
+        # initialized session and surprise the user. Daemon fallback owns
+        # this case.
+        if thread_id not in self._sessions:
+            return False
+
+        # Latest-wins dedupe within one thread, keyed by schedule name.
+        per_thread = self._chime_pending.setdefault(thread_id, {})
+        per_thread[req.schedule_name] = req
+
+        existing = self._chime_dispatcher.get(thread_id)
+        if existing is None or existing.done():
+            task = asyncio.ensure_future(self._chime_dispatcher_loop(thread_id))
+            self._chime_dispatcher[thread_id] = task
+            task.add_done_callback(
+                lambda _t, k=thread_id: self._chime_dispatcher.pop(k, None)
+                if self._chime_dispatcher.get(k) is _t else None
+            )
+        return True
+
+    async def _chime_dispatcher_loop(self, thread_id: int) -> None:
+        """Drain pending chimes for one thread, serialised against user turns."""
+        while True:
+            pending = self._chime_pending.get(thread_id)
+            if not pending:
+                break
+            # Pop one (insertion-order). Latest-wins dedupe already ran at
+            # enqueue time, so each name here represents one to deliver.
+            name = next(iter(pending))
+            req = pending.pop(name)
+            if not pending:
+                self._chime_pending.pop(thread_id, None)
+
+            # Wait for any in-flight user turn to finish before chiming —
+            # don't interrupt a user mid-thought. (We could cancel like the
+            # user-message handler does, but that's the opposite intent.)
+            existing = self._running_turns.get(thread_id)
+            if existing is not None and not existing.done():
+                try:
+                    await existing
+                except Exception:
+                    pass
+
+            task = asyncio.ensure_future(self._run_chime_turn(thread_id, req))
+            self._running_turns[thread_id] = task
+            try:
+                await task
+            except Exception:
+                logger.exception(
+                    "chime dispatcher: turn failed for thread=%s schedule=%s",
+                    thread_id, req.schedule_name,
+                )
+            finally:
+                if self._running_turns.get(thread_id) is task:
+                    self._running_turns.pop(thread_id, None)
+
+    async def _run_chime_turn(self, thread_id: int, req: ChimeRequest) -> None:
+        """Render one chime turn into the target Discord thread.
+
+        Lightweight v1 renderer: marker line → stream_turn(origin="chime") →
+        single send of the assistant reply. Skips the rich envelope display
+        used for user-driven turns; chime turns are typically short and the
+        marker already disambiguates them from user replies.
+        """
+        channel = self._client.get_channel(thread_id)
+        session = self._sessions.get(thread_id)
+        if channel is None or session is None:
+            return
+
+        # Local-time stamp so the marker is human-readable in chat.
+        try:
+            local_dt = req.fired_at.astimezone()
+            stamp = local_dt.strftime("%H:%M %Z").strip()
+        except Exception:
+            stamp = req.fired_at.isoformat()
+
+        await _safe_send(
+            channel,
+            f"-# ⏰ **Chime · {req.schedule_name}** · {stamp}",
+        )
+
+        content = format_chime_content(req)
+        narration_buf = ""
+        try:
+            async with channel.typing():
+                async for event in session.stream_turn(content, origin="chime"):
+                    if isinstance(event, TextChunk):
+                        narration_buf += event.text
+                    elif isinstance(event, TurnDropped):
+                        await _safe_send(
+                            channel,
+                            f"-# ⚠️ Chime turn dropped: {event.stop_reason}",
+                        )
+        except Exception as exc:
+            await _safe_send(channel, f"❌ Chime error: {exc}")
+            logger.exception(
+                "chime turn raised for thread=%s schedule=%s",
+                thread_id, req.schedule_name,
+            )
+            return
+
+        final = narration_buf.strip()
+        if final:
+            payload = final if final.startswith("⬥") else f"⬥ {final}"
+            await _safe_send(channel, payload)
 
     async def _run_daily_compaction(self) -> None:
         """Scheduled Discord safety net for idle in-memory sessions."""

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -384,6 +384,17 @@ class LoomDiscordBot:
             existing = bot._running_turns.get(key)
             if existing and not existing.done():
                 existing.cancel()
+                # Wait briefly for the cancelled task to finish its cleanup
+                # (finally blocks). Otherwise a chime task's temporary
+                # session.perm grants — revoked in its own finally — would
+                # still be visible when the replacement user turn starts on
+                # the very next event-loop tick (PR #373 re-review).
+                try:
+                    await asyncio.wait_for(existing, timeout=2.0)
+                except (asyncio.CancelledError, asyncio.TimeoutError):
+                    pass
+                except Exception:
+                    pass
             # Remember this message id so add_discord_reaction has a default
             # target when the agent doesn't pass message_id explicitly (#188).
             bot._last_user_msg[key] = message.id
@@ -683,12 +694,10 @@ class LoomDiscordBot:
             if not pending_now:
                 self._chime_pending.pop(thread_id, None)
 
-            # Apply schedule-scoped permissions for the duration of this
-            # chime, mirroring AutonomyDaemon._run_agent. Revoked in
-            # ``finally`` so chimes never accumulate cross-schedule grants.
-            session = self._sessions.get(thread_id)
-            added_tools, grant_source = self._apply_chime_permissions(req, session)
-
+            # Apply + revoke of schedule-scoped grants happens inside
+            # _run_chime_turn (same task as cancellation), so a user-message
+            # preemption can't observe leaked grants between the chime task
+            # being cancelled and the dispatcher reaching this finally block.
             task = asyncio.ensure_future(self._run_chime_turn(thread_id, req))
             self._running_turns[thread_id] = task
             try:
@@ -707,7 +716,6 @@ class LoomDiscordBot:
             finally:
                 if self._running_turns.get(thread_id) is task:
                     self._running_turns.pop(thread_id, None)
-                self._revoke_chime_permissions(session, added_tools, grant_source)
 
     def _apply_chime_permissions(
         self,
@@ -766,6 +774,13 @@ class LoomDiscordBot:
         single send of the assistant reply. Skips the rich envelope display
         used for user-driven turns; chime turns are typically short and the
         marker already disambiguates them from user replies.
+
+        Schedule-scoped permissions (allowed_tools / scope_grants) are
+        applied here — not in the dispatcher — so that on cancellation the
+        revoke runs as part of this task's finally, before the dispatcher's
+        ``await task`` returns. Combined with on_message awaiting the
+        cancelled task, this closes the window where a preempting user
+        turn could observe leaked chime grants.
         """
         channel = self._client.get_channel(thread_id)
         session = self._sessions.get(thread_id)
@@ -779,35 +794,42 @@ class LoomDiscordBot:
         except Exception:
             stamp = req.fired_at.isoformat()
 
-        await _safe_send(
-            channel,
-            f"-# ⏰ **Chime · {req.schedule_name}** · {stamp}",
-        )
-
-        content = format_chime_content(req)
-        narration_buf = ""
+        added_tools, grant_source = self._apply_chime_permissions(req, session)
         try:
-            async with channel.typing():
-                async for event in session.stream_turn(content, origin="chime"):
-                    if isinstance(event, TextChunk):
-                        narration_buf += event.text
-                    elif isinstance(event, TurnDropped):
-                        await _safe_send(
-                            channel,
-                            f"-# ⚠️ Chime turn dropped: {event.stop_reason}",
-                        )
-        except Exception as exc:
-            await _safe_send(channel, f"❌ Chime error: {exc}")
-            logger.exception(
-                "chime turn raised for thread=%s schedule=%s",
-                thread_id, req.schedule_name,
+            await _safe_send(
+                channel,
+                f"-# ⏰ **Chime · {req.schedule_name}** · {stamp}",
             )
-            return
 
-        final = narration_buf.strip()
-        if final:
-            payload = final if final.startswith("⬥") else f"⬥ {final}"
-            await _safe_send(channel, payload)
+            content = format_chime_content(req)
+            narration_buf = ""
+            try:
+                async with channel.typing():
+                    async for event in session.stream_turn(content, origin="chime"):
+                        if isinstance(event, TextChunk):
+                            narration_buf += event.text
+                        elif isinstance(event, TurnDropped):
+                            await _safe_send(
+                                channel,
+                                f"-# ⚠️ Chime turn dropped: {event.stop_reason}",
+                            )
+            except Exception as exc:
+                await _safe_send(channel, f"❌ Chime error: {exc}")
+                logger.exception(
+                    "chime turn raised for thread=%s schedule=%s",
+                    thread_id, req.schedule_name,
+                )
+                return
+
+            final = narration_buf.strip()
+            if final:
+                payload = final if final.startswith("⬥") else f"⬥ {final}"
+                await _safe_send(channel, payload)
+        finally:
+            # Revoke schedule grants as part of *this* task's unwind, so a
+            # cancellation immediately yields the session back to a clean
+            # permission state before any preempting turn starts.
+            self._revoke_chime_permissions(session, added_tools, grant_source)
 
     async def _run_daily_compaction(self) -> None:
         """Scheduled Discord safety net for idle in-memory sessions."""

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -638,32 +638,67 @@ class LoomDiscordBot:
         return True
 
     async def _chime_dispatcher_loop(self, thread_id: int) -> None:
-        """Drain pending chimes for one thread, serialised against user turns."""
+        """Drain pending chimes for one thread, serialised against user turns.
+
+        Key invariants (PR #373 review):
+        - Pick a candidate name *before* waiting on the user turn, but pop
+          *after*. That way a same-name chime arriving during the wait
+          still collapses onto the candidate (latest-wins through the
+          wait window).
+        - A cancelled user turn (Discord cancel-and-replace pattern in
+          ``_handle_message``) must not drop the queued chime. Only the
+          dispatcher's own cancellation propagates.
+        """
         while True:
             pending = self._chime_pending.get(thread_id)
             if not pending:
                 break
-            # Pop one (insertion-order). Latest-wins dedupe already ran at
-            # enqueue time, so each name here represents one to deliver.
             name = next(iter(pending))
-            req = pending.pop(name)
-            if not pending:
-                self._chime_pending.pop(thread_id, None)
 
-            # Wait for any in-flight user turn to finish before chiming —
-            # don't interrupt a user mid-thought. (We could cancel like the
-            # user-message handler does, but that's the opposite intent.)
+            # Wait for any in-flight user turn to finish before chiming.
+            # CancelledError on ``existing`` (a new user message cancelled
+            # the previous one) is distinct from our own cancellation —
+            # if we don't differentiate, the popped chime gets dropped.
             existing = self._running_turns.get(thread_id)
             if existing is not None and not existing.done():
+                self_task = asyncio.current_task()
                 try:
                     await existing
+                except asyncio.CancelledError:
+                    if self_task is not None and self_task.cancelling():
+                        raise
+                    # The awaited user turn was cancelled, not us —
+                    # fall through and proceed with the chime.
                 except Exception:
                     pass
+
+            # Pop *now*: a late same-name chime arriving during the wait
+            # has overwritten the entry, so this pop returns the latest
+            # request. An external drain (unregister) may have removed it
+            # entirely — in that case loop and try the next candidate.
+            pending_now = self._chime_pending.get(thread_id)
+            if not pending_now or name not in pending_now:
+                continue
+            req = pending_now.pop(name)
+            if not pending_now:
+                self._chime_pending.pop(thread_id, None)
+
+            # Apply schedule-scoped permissions for the duration of this
+            # chime, mirroring AutonomyDaemon._run_agent. Revoked in
+            # ``finally`` so chimes never accumulate cross-schedule grants.
+            session = self._sessions.get(thread_id)
+            added_tools, grant_source = self._apply_chime_permissions(req, session)
 
             task = asyncio.ensure_future(self._run_chime_turn(thread_id, req))
             self._running_turns[thread_id] = task
             try:
                 await task
+            except asyncio.CancelledError:
+                self_task = asyncio.current_task()
+                if self_task is not None and self_task.cancelling():
+                    raise
+                # Chime turn pre-empted by a new user message — that's
+                # acceptable for a polite, non-blocking nudge.
             except Exception:
                 logger.exception(
                     "chime dispatcher: turn failed for thread=%s schedule=%s",
@@ -672,6 +707,57 @@ class LoomDiscordBot:
             finally:
                 if self._running_turns.get(thread_id) is task:
                     self._running_turns.pop(thread_id, None)
+                self._revoke_chime_permissions(session, added_tools, grant_source)
+
+    def _apply_chime_permissions(
+        self,
+        req: ChimeRequest,
+        session: "LoomSession | None",
+    ) -> tuple[list[str], str | None]:
+        """Pre-authorize tools + scope grants declared on the schedule.
+
+        Returns ``(added_tools, grant_source)`` to be passed to
+        ``_revoke_chime_permissions`` after the chime turn.
+        """
+        if session is None:
+            return [], None
+        from loom.core.harness.scope import ScopeGrant
+
+        added: list[str] = []
+        for tool_name in req.allowed_tools:
+            if tool_name not in session.perm.session_authorized:
+                session.perm.authorize(tool_name)
+                added.append(tool_name)
+
+        source = f"autonomy:{req.schedule_name}" if req.scope_grants else None
+        for g in req.scope_grants:
+            session.perm.grant(ScopeGrant(
+                resource=g["resource"],
+                action=g["action"],
+                selector=g.get("selector", "*"),
+                constraints=g.get("constraints", {}),
+                source=source or f"autonomy:{req.schedule_name}",
+            ))
+        return added, source
+
+    def _revoke_chime_permissions(
+        self,
+        session: "LoomSession | None",
+        added_tools: list[str],
+        grant_source: str | None,
+    ) -> None:
+        if session is None:
+            return
+        for tool_name in added_tools:
+            try:
+                session.perm.revoke(tool_name)
+            except Exception:
+                logger.debug("chime revoke tool %s failed", tool_name, exc_info=True)
+        if grant_source:
+            try:
+                session.perm.revoke_matching(lambda g, s=grant_source: g.source == s)
+            except Exception:
+                logger.debug("chime revoke grants failed", exc_info=True)
 
     async def _run_chime_turn(self, thread_id: int, req: ChimeRequest) -> None:
         """Render one chime turn into the target Discord thread.

--- a/loom/platform/session_registry.py
+++ b/loom/platform/session_registry.py
@@ -1,0 +1,91 @@
+"""
+SessionRegistry — in-process index of active LoomSessions.
+
+Lets the autonomy daemon find Discord thread sessions (or future CLI sessions)
+so cron-triggered ``chime`` events can wake an existing conversation instead
+of spawning an independent session.
+
+Scope (v1):
+- Single process only. The Discord bot and AutonomyDaemon must share an event
+  loop (i.e. ``loom discord start --autonomy``).
+- Sessions are registered under one or more string labels (e.g.
+  ``discord_thread=<id>``). Lookup is exact match on a label pair.
+
+Not in v1:
+- Cross-process discovery, persistence, or RPC.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from loom.core.session import LoomSession
+
+
+@dataclass(frozen=True)
+class SessionInfo:
+    """Read-only snapshot of one registered session."""
+
+    session_id: str
+    labels: dict[str, str]
+
+
+class SessionRegistry:
+    """In-process registry of live LoomSession instances."""
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, "LoomSession"] = {}
+        self._labels: dict[str, dict[str, str]] = {}
+
+    def register(
+        self,
+        session_id: str,
+        session: "LoomSession",
+        *,
+        labels: dict[str, str] | None = None,
+    ) -> None:
+        """Add or replace a session entry. Existing labels are overwritten."""
+        self._sessions[session_id] = session
+        self._labels[session_id] = dict(labels or {})
+
+    def unregister(self, session_id: str) -> None:
+        self._sessions.pop(session_id, None)
+        self._labels.pop(session_id, None)
+
+    def get(self, session_id: str) -> "LoomSession | None":
+        return self._sessions.get(session_id)
+
+    def find_by_label(self, key: str, value: str) -> list["LoomSession"]:
+        """Return every session whose label ``key`` equals ``value``."""
+        out: list["LoomSession"] = []
+        for sid, labels in self._labels.items():
+            if labels.get(key) == value:
+                sess = self._sessions.get(sid)
+                if sess is not None:
+                    out.append(sess)
+        return out
+
+    def list_active(self) -> list[SessionInfo]:
+        return [
+            SessionInfo(session_id=sid, labels=dict(self._labels.get(sid, {})))
+            for sid in self._sessions
+        ]
+
+
+_registry: SessionRegistry | None = None
+
+
+def get_registry() -> SessionRegistry:
+    """Module-level singleton."""
+    global _registry
+    if _registry is None:
+        _registry = SessionRegistry()
+    return _registry
+
+
+def reset_registry() -> None:
+    """Test helper — drops all registered sessions."""
+    global _registry
+    _registry = None

--- a/tests/test_chime.py
+++ b/tests/test_chime.py
@@ -567,6 +567,55 @@ class TestChimeDispatcherEdgeCases:
 # ===========================================================================
 
 
+def _make_chime_session_stub(authorized_list, granted_list, revoked_list, revoke_matching_list):
+    """Build a session mock where perm.* mutations are recorded."""
+    session = MagicMock()
+    session.perm.session_authorized = set()
+
+    def _authorize(name):
+        authorized_list.append(name)
+        session.perm.session_authorized.add(name)
+
+    def _revoke(name):
+        revoked_list.append(name)
+
+    def _grant(g):
+        granted_list.append(g)
+
+    def _revoke_matching(pred):
+        revoke_matching_list.append(pred)
+
+    session.perm.authorize = MagicMock(side_effect=_authorize)
+    session.perm.revoke = MagicMock(side_effect=_revoke)
+    session.perm.grant = MagicMock(side_effect=_grant)
+    session.perm.revoke_matching = MagicMock(side_effect=_revoke_matching)
+    return session
+
+
+def _patch_channel_and_stream(bot, session, stream_impl=None):
+    """Wire up the minimum surface _run_chime_turn touches: a channel with
+    typing() / send(), and a session.stream_turn that yields nothing by
+    default."""
+
+    class _TypingCM:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *_): return False
+
+    channel = MagicMock()
+    channel.typing = MagicMock(return_value=_TypingCM())
+    channel.send = AsyncMock(return_value=MagicMock())
+    bot._client.get_channel = MagicMock(return_value=channel)
+
+    if stream_impl is None:
+        async def _empty(content, *, origin):
+            if False:
+                yield  # pragma: no cover
+        session.stream_turn = _empty
+    else:
+        session.stream_turn = stream_impl
+    return channel
+
+
 class TestChimePermissions:
     @pytest.mark.asyncio
     async def test_chime_applies_and_revokes_schedule_grants(self):
@@ -576,38 +625,22 @@ class TestChimePermissions:
         from loom.autonomy.chime import ChimeRequest
 
         bot = _make_bot_stub()
-
-        # Fake session.perm capturing all permission calls.
-        session = MagicMock()
-        session.perm.session_authorized = set()
         authorized: list[str] = []
         revoked: list[str] = []
         granted: list = []
         revoke_matching_calls: list = []
-
-        def _authorize(name):
-            authorized.append(name)
-            session.perm.session_authorized.add(name)
-        def _revoke(name):
-            revoked.append(name)
-        def _grant(g):
-            granted.append(g)
-        def _revoke_matching(pred):
-            revoke_matching_calls.append(pred)
-
-        session.perm.authorize = MagicMock(side_effect=_authorize)
-        session.perm.revoke = MagicMock(side_effect=_revoke)
-        session.perm.grant = MagicMock(side_effect=_grant)
-        session.perm.revoke_matching = MagicMock(side_effect=_revoke_matching)
+        session = _make_chime_session_stub(authorized, granted, revoked, revoke_matching_calls)
         bot._sessions[111] = session
 
         applied_during_turn: dict[str, list[str]] = {}
 
-        async def fake_turn(thread_id, req):
-            # Snapshot the state *during* the turn — should reflect grants.
+        async def stream_capture(content, *, origin):
             applied_during_turn["authorized"] = list(authorized)
             applied_during_turn["granted_count"] = len(granted)
-        bot._run_chime_turn = AsyncMock(side_effect=fake_turn)
+            applied_during_turn["origin"] = origin
+            if False:
+                yield  # pragma: no cover — generator marker
+        _patch_channel_and_stream(bot, session, stream_impl=stream_capture)
 
         req = ChimeRequest(
             schedule_name="morning",
@@ -621,10 +654,6 @@ class TestChimePermissions:
         )
         assert await bot.deliver_chime(req)
 
-        # Wait for dispatcher to fully complete — including the finally
-        # block where revoke happens. The done_callback that clears
-        # _chime_dispatcher fires after the dispatcher coroutine fully
-        # returns, so it's a safe completion signal.
         for _ in range(50):
             if not bot._chime_dispatcher and not bot._chime_pending:
                 break
@@ -633,6 +662,7 @@ class TestChimePermissions:
         # Authorized during the turn, revoked after.
         assert applied_during_turn["authorized"] == ["write_file", "memorize"]
         assert applied_during_turn["granted_count"] == 1
+        assert applied_during_turn["origin"] == "chime"
         assert sorted(revoked) == ["memorize", "write_file"]
         assert len(revoke_matching_calls) == 1
 
@@ -640,3 +670,71 @@ class TestChimePermissions:
         # so revoke_matching's predicate can target it.
         assert granted[0].source == "autonomy:morning"
         assert revoke_matching_calls[0](granted[0]) is True
+
+    @pytest.mark.asyncio
+    async def test_grants_revoked_before_replacement_user_turn_starts(self):
+        """PR #373 re-review: simulate Discord's cancel-and-replace path.
+
+        While the chime is mid-stream_turn, a new user message arrives, the
+        chime task is cancelled, and a replacement user turn would normally
+        start on the next event-loop tick. The replacement must NOT see
+        chime grants on session.perm — they have to be revoked first.
+        """
+        from loom.autonomy.chime import ChimeRequest
+
+        bot = _make_bot_stub()
+        authorized: list[str] = []
+        revoked: list[str] = []
+        granted: list = []
+        revoke_matching_calls: list = []
+        session = _make_chime_session_stub(authorized, granted, revoked, revoke_matching_calls)
+        bot._sessions[111] = session
+
+        chime_started = asyncio.Event()
+
+        async def slow_stream(content, *, origin):
+            chime_started.set()
+            # Park forever so we can cancel the chime task in mid-flight.
+            await asyncio.sleep(60)
+            if False:
+                yield  # pragma: no cover
+        _patch_channel_and_stream(bot, session, stream_impl=slow_stream)
+
+        req = ChimeRequest(
+            schedule_name="morning",
+            intent="hi",
+            fired_at=datetime.now(timezone.utc),
+            target={"type": "discord_thread", "id": "111"},
+            allowed_tools=("write_file",),
+            scope_grants=(
+                {"resource": "path", "action": "write", "selector": "news/*"},
+            ),
+        )
+        assert await bot.deliver_chime(req)
+
+        # Wait until the chime is mid-stream and grants are live.
+        await chime_started.wait()
+        assert "write_file" in session.perm.session_authorized
+
+        # Cancel the chime task (this is what on_message's cancel-and-replace
+        # path does). The chime task's own finally must revoke before any
+        # replacement user-driven work starts.
+        chime_task = bot._running_turns.get(111)
+        assert chime_task is not None
+        chime_task.cancel()
+
+        # Yield until the task is done — chime task's finally runs as part
+        # of cancellation cleanup.
+        for _ in range(50):
+            if chime_task.done():
+                break
+            await asyncio.sleep(0)
+
+        # By the time the cancelled chime task is done, the schedule grants
+        # are no longer on session.perm — a replacement user turn scheduled
+        # next would start with a clean slate.
+        assert sorted(revoked) == ["write_file"], (
+            f"revoke must run as part of cancelled chime's cleanup; "
+            f"observed revoked={revoked}"
+        )
+        assert len(revoke_matching_calls) == 1

--- a/tests/test_chime.py
+++ b/tests/test_chime.py
@@ -1,0 +1,442 @@
+"""
+Tests for scheduled chime delivery (issue #369).
+
+Covers:
+- ``ChimeRequest`` formatting and the ``<system_chime>`` wrapper
+- ``CronTrigger`` mode/target validation
+- ``SessionRegistry`` register / lookup / unregister
+- ``AutonomyDaemon._execute_plan`` mode="chime" routing + fallback behaviour
+- ``daemon.load_config`` parsing of chime schedules (incl. invalid targets)
+- ``LoomDiscordBot.deliver_chime`` dedupe + dispatcher draining
+
+The Discord-bot tests use a lightweight stand-in for the heavy
+``discord.Client`` to avoid the cost (and IO) of constructing a real
+bot. The flow we exercise — enqueue → dispatcher pop → invoke
+``_run_chime_turn`` — is independent of Discord network code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+# ===========================================================================
+# format_chime_content / ChimeRequest
+# ===========================================================================
+
+
+class TestChimeFormatting:
+    def test_wrapper_includes_schedule_and_fired_at(self):
+        from loom.autonomy.chime import ChimeRequest, format_chime_content
+
+        req = ChimeRequest(
+            schedule_name="morning_greeting",
+            intent="向 Dakai 道早安",
+            fired_at=datetime(2026, 5, 14, 1, 0, tzinfo=timezone.utc),
+        )
+        out = format_chime_content(req)
+
+        assert out.startswith('<system_chime schedule="morning_greeting"')
+        assert 'fired_at="2026-05-14T01:00:00+00:00"' in out
+        assert "向 Dakai 道早安" in out
+        assert out.endswith("</system_chime>")
+
+    def test_intent_is_stripped(self):
+        from loom.autonomy.chime import ChimeRequest, format_chime_content
+
+        req = ChimeRequest(
+            schedule_name="x",
+            intent="\n\n  hello  \n\n",
+            fired_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        assert "hello" in format_chime_content(req)
+        # No leading/trailing whitespace bleeding into the body
+        assert ">\nhello\n<" in format_chime_content(req)
+
+
+# ===========================================================================
+# CronTrigger — mode + target validation
+# ===========================================================================
+
+
+class TestCronTriggerModes:
+    def test_default_mode_is_independent(self):
+        from loom.autonomy.triggers import CronTrigger
+
+        t = CronTrigger(name="x", intent="y", cron="0 9 * * *")
+        assert t.mode == "independent"
+        assert t.target == {}
+
+    def test_chime_mode_keeps_target(self):
+        from loom.autonomy.triggers import CronTrigger
+
+        t = CronTrigger(
+            name="x",
+            intent="y",
+            cron="0 9 * * *",
+            mode="chime",
+            target={"type": "discord_thread", "id": "123"},
+        )
+        assert t.mode == "chime"
+        assert t.target["id"] == "123"
+
+    def test_invalid_mode_raises(self):
+        from loom.autonomy.triggers import CronTrigger
+
+        with pytest.raises(ValueError):
+            CronTrigger(name="x", intent="y", cron="0 9 * * *", mode="bogus")
+
+
+# ===========================================================================
+# SessionRegistry
+# ===========================================================================
+
+
+class TestSessionRegistry:
+    def test_register_lookup_by_label(self):
+        from loom.platform.session_registry import SessionRegistry
+
+        reg = SessionRegistry()
+        sess_a = object()
+        sess_b = object()
+        reg.register("a", sess_a, labels={"discord_thread": "111"})  # type: ignore[arg-type]
+        reg.register("b", sess_b, labels={"discord_thread": "222"})  # type: ignore[arg-type]
+
+        assert reg.find_by_label("discord_thread", "111") == [sess_a]
+        assert reg.find_by_label("discord_thread", "222") == [sess_b]
+        assert reg.find_by_label("discord_thread", "999") == []
+
+    def test_unregister_removes_session(self):
+        from loom.platform.session_registry import SessionRegistry
+
+        reg = SessionRegistry()
+        sess = object()
+        reg.register("a", sess, labels={"discord_thread": "111"})  # type: ignore[arg-type]
+        reg.unregister("a")
+        assert reg.get("a") is None
+        assert reg.find_by_label("discord_thread", "111") == []
+
+    def test_re_register_overwrites_labels(self):
+        from loom.platform.session_registry import SessionRegistry
+
+        reg = SessionRegistry()
+        sess = object()
+        reg.register("a", sess, labels={"discord_thread": "111"})  # type: ignore[arg-type]
+        reg.register("a", sess, labels={"discord_thread": "222"})  # type: ignore[arg-type]
+        assert reg.find_by_label("discord_thread", "111") == []
+        assert reg.find_by_label("discord_thread", "222") == [sess]
+
+
+# ===========================================================================
+# AutonomyDaemon._execute_plan — chime routing
+# ===========================================================================
+
+
+def _make_daemon(*, chime_delivery=None, session=None):
+    from loom.autonomy.daemon import AutonomyDaemon
+    from loom.notify.confirm import ConfirmFlow
+    from loom.notify.router import NotificationRouter
+
+    router = NotificationRouter()
+    flow = ConfirmFlow(send_fn=lambda n: None)
+    return AutonomyDaemon(
+        notify_router=router,
+        confirm_flow=flow,
+        loom_session=session,
+        chime_delivery=chime_delivery,
+    )
+
+
+def _chime_plan(*, target=None, fallback=None):
+    from loom.autonomy.planner import ActionDecision, PlannedAction
+    from loom.core.harness.permissions import TrustLevel
+
+    tgt = dict(target or {"type": "discord_thread", "id": "111"})
+    if fallback is not None:
+        tgt["fallback"] = fallback
+    return PlannedAction(
+        trigger_name="morning_greeting",
+        intent="say hi",
+        prompt="say hi",
+        decision=ActionDecision.EXECUTE,
+        trust_level=TrustLevel.SAFE,
+        context={
+            "mode": "chime",
+            "target": tgt,
+            "trigger_name": "morning_greeting",
+            "intent": "say hi",
+            "allowed_tools": [],
+            "scope_grants": [],
+            "attach_outputs": [],
+            "notify_thread_id": 0,
+            "trust_level": "safe",
+        },
+    )
+
+
+class TestChimeExecution:
+    @pytest.mark.asyncio
+    async def test_chime_routes_to_delivery_callback(self):
+        delivered: list = []
+
+        async def deliver(req):
+            delivered.append(req)
+            return True
+
+        daemon = _make_daemon(chime_delivery=deliver)
+        await daemon._execute_plan(_chime_plan())
+
+        assert len(delivered) == 1
+        assert delivered[0].schedule_name == "morning_greeting"
+        assert delivered[0].target["id"] == "111"
+
+    @pytest.mark.asyncio
+    async def test_chime_with_no_callback_skips(self):
+        # No delivery callback wired + no session ⇒ nothing happens (no crash).
+        daemon = _make_daemon(chime_delivery=None, session=None)
+        await daemon._execute_plan(_chime_plan(fallback="skip"))
+        # If we reach here without exception, the skip branch worked.
+
+    @pytest.mark.asyncio
+    async def test_chime_miss_falls_back_to_independent(self):
+        async def deliver(req):
+            return False  # target session not found
+
+        ran_independent = asyncio.Event()
+
+        async def fake_stream(prompt, **_):
+            ran_independent.set()
+            if False:
+                yield  # pragma: no cover — generator marker
+
+        session = MagicMock()
+        session.stream_turn = fake_stream
+        session.perm.session_authorized = set()
+        session.perm.authorize = MagicMock()
+        session.perm.revoke = MagicMock()
+        session.perm.revoke_matching = MagicMock()
+        session.workspace = "/tmp"
+
+        daemon = _make_daemon(chime_delivery=deliver, session=session)
+        await daemon._execute_plan(_chime_plan(fallback="independent"))
+
+        assert ran_independent.is_set()
+
+    @pytest.mark.asyncio
+    async def test_chime_miss_skips_when_fallback_is_skip(self):
+        async def deliver(req):
+            return False
+
+        called = False
+
+        async def fake_stream(prompt, **_):
+            nonlocal called
+            called = True
+            if False:
+                yield
+
+        session = MagicMock()
+        session.stream_turn = fake_stream
+
+        daemon = _make_daemon(chime_delivery=deliver, session=session)
+        await daemon._execute_plan(_chime_plan(fallback="skip"))
+
+        assert called is False
+
+
+# ===========================================================================
+# daemon.load_config — chime schedule parsing
+# ===========================================================================
+
+
+class TestChimeConfigLoading:
+    def test_loads_chime_schedule(self, tmp_path):
+        toml_content = """
+[autonomy]
+enabled = true
+
+[[autonomy.schedules]]
+name = "morning_greeting"
+cron = "0 1 * * *"
+intent = "say hi"
+trust_level = "safe"
+mode = "chime"
+
+  [autonomy.schedules.target]
+  type = "discord_thread"
+  id = "12345"
+"""
+        cfg = tmp_path / "loom.toml"
+        cfg.write_text(toml_content, encoding="utf-8")
+
+        daemon = _make_daemon()
+        n = daemon.load_config(cfg)
+        assert n == 1
+
+        triggers = list(daemon._evaluator._triggers.values())
+        assert triggers[0].mode == "chime"
+        assert triggers[0].target == {
+            "type": "discord_thread",
+            "id": "12345",
+            "fallback": "skip",
+        }
+
+    def test_chime_without_target_id_is_skipped(self, tmp_path):
+        toml_content = """
+[autonomy]
+enabled = true
+
+[[autonomy.schedules]]
+name = "broken"
+cron = "0 1 * * *"
+intent = "x"
+mode = "chime"
+
+  [autonomy.schedules.target]
+  type = "discord_thread"
+"""
+        cfg = tmp_path / "loom.toml"
+        cfg.write_text(toml_content, encoding="utf-8")
+
+        daemon = _make_daemon()
+        # Missing id ⇒ schedule is dropped with a warning, not a crash.
+        n = daemon.load_config(cfg)
+        assert n == 0
+
+    def test_chime_wrong_target_type_is_skipped(self, tmp_path):
+        toml_content = """
+[autonomy]
+enabled = true
+
+[[autonomy.schedules]]
+name = "broken"
+cron = "0 1 * * *"
+intent = "x"
+mode = "chime"
+
+  [autonomy.schedules.target]
+  type = "cli"
+  id = "whatever"
+"""
+        cfg = tmp_path / "loom.toml"
+        cfg.write_text(toml_content, encoding="utf-8")
+
+        daemon = _make_daemon()
+        n = daemon.load_config(cfg)
+        assert n == 0
+
+    def test_integer_target_id_is_coerced_to_string(self, tmp_path):
+        toml_content = """
+[autonomy]
+enabled = true
+
+[[autonomy.schedules]]
+name = "g"
+cron = "0 1 * * *"
+intent = "x"
+mode = "chime"
+
+  [autonomy.schedules.target]
+  type = "discord_thread"
+  id = 99999
+"""
+        cfg = tmp_path / "loom.toml"
+        cfg.write_text(toml_content, encoding="utf-8")
+
+        daemon = _make_daemon()
+        daemon.load_config(cfg)
+        trig = next(iter(daemon._evaluator._triggers.values()))
+        # Label lookup compares to str(thread_id) so the parsed value must be a str.
+        assert trig.target["id"] == "99999"
+
+
+# ===========================================================================
+# LoomDiscordBot.deliver_chime — dedupe + dispatch
+#
+# We bypass __init__ to avoid constructing a real discord.Client. The chime
+# dispatch path only touches: _sessions, _running_turns, _chime_pending,
+# _chime_dispatcher, _client.get_channel, and session.stream_turn.
+# ===========================================================================
+
+
+def _make_bot_stub():
+    """Build a minimal LoomDiscordBot without going through __init__."""
+    from loom.platform.discord.bot import LoomDiscordBot
+
+    bot = LoomDiscordBot.__new__(LoomDiscordBot)
+    bot._sessions = {}
+    bot._running_turns = {}
+    bot._chime_pending = {}
+    bot._chime_dispatcher = {}
+    bot._client = MagicMock()
+    bot._client.get_channel = MagicMock(return_value=None)
+    return bot
+
+
+class TestDeliverChime:
+    @pytest.mark.asyncio
+    async def test_rejects_non_discord_thread_target(self):
+        from loom.autonomy.chime import ChimeRequest
+
+        bot = _make_bot_stub()
+        req = ChimeRequest(
+            schedule_name="x",
+            intent="y",
+            fired_at=datetime.now(timezone.utc),
+            target={"type": "cli", "id": "1"},
+        )
+        assert await bot.deliver_chime(req) is False
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_session_not_loaded(self):
+        from loom.autonomy.chime import ChimeRequest
+
+        bot = _make_bot_stub()
+        req = ChimeRequest(
+            schedule_name="x",
+            intent="y",
+            fired_at=datetime.now(timezone.utc),
+            target={"type": "discord_thread", "id": "404"},
+        )
+        assert await bot.deliver_chime(req) is False
+
+    @pytest.mark.asyncio
+    async def test_latest_wins_dedupe(self):
+        from loom.autonomy.chime import ChimeRequest
+
+        bot = _make_bot_stub()
+        # Pretend a session exists for this thread but stop the dispatcher
+        # from actually executing by replacing the runner.
+        bot._sessions[111] = MagicMock()
+        bot._run_chime_turn = AsyncMock(return_value=None)
+
+        async def deliver(intent):
+            return await bot.deliver_chime(
+                ChimeRequest(
+                    schedule_name="morning",
+                    intent=intent,
+                    fired_at=datetime.now(timezone.utc),
+                    target={"type": "discord_thread", "id": "111"},
+                )
+            )
+
+        # Fire three chimes for the same schedule before the dispatcher
+        # has a chance to drain (no yields between them).
+        results = await asyncio.gather(deliver("v1"), deliver("v2"), deliver("v3"))
+        assert all(results)
+
+        # Wait for dispatcher to drain.
+        await asyncio.sleep(0)
+        for _ in range(10):
+            if not bot._chime_dispatcher and not bot._chime_pending:
+                break
+            await asyncio.sleep(0)
+
+        # All three enqueues collapsed onto a single dispatch — last intent wins.
+        assert bot._run_chime_turn.await_count == 1
+        delivered_req = bot._run_chime_turn.await_args.args[1]
+        assert delivered_req.intent == "v3"

--- a/tests/test_chime.py
+++ b/tests/test_chime.py
@@ -440,3 +440,203 @@ class TestDeliverChime:
         assert bot._run_chime_turn.await_count == 1
         delivered_req = bot._run_chime_turn.await_args.args[1]
         assert delivered_req.intent == "v3"
+
+
+# ===========================================================================
+# Dispatcher edge cases — regressions from PR #373 review
+# ===========================================================================
+
+
+class TestChimeDispatcherEdgeCases:
+    @pytest.mark.asyncio
+    async def test_chime_survives_user_turn_cancellation(self):
+        """A cancelled in-flight user turn must not silently drop a queued chime.
+
+        Repro of PR #373 review finding #2: ``except Exception`` did not
+        catch ``asyncio.CancelledError`` (Py3.8+ inherits BaseException),
+        so the dispatcher exited after popping the request.
+        """
+        from loom.autonomy.chime import ChimeRequest
+
+        bot = _make_bot_stub()
+        bot._sessions[111] = MagicMock()
+        bot._run_chime_turn = AsyncMock(return_value=None)
+
+        # Stand in for an in-flight user turn that we'll cancel before
+        # the chime dispatcher gets to await it.
+        async def fake_user_turn():
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                raise
+        user_task = asyncio.ensure_future(fake_user_turn())
+        bot._running_turns[111] = user_task
+
+        # Deliver the chime — dispatcher picks the name, then awaits user_task.
+        assert await bot.deliver_chime(
+            ChimeRequest(
+                schedule_name="morning",
+                intent="hello",
+                fired_at=datetime.now(timezone.utc),
+                target={"type": "discord_thread", "id": "111"},
+            )
+        )
+
+        # Give the dispatcher a turn to reach the await.
+        await asyncio.sleep(0)
+        # Now cancel the user turn — this is what `_handle_message`'s
+        # cancel-and-replace path does when a new user message arrives.
+        user_task.cancel()
+        try:
+            await user_task
+        except asyncio.CancelledError:
+            pass
+
+        # Dispatcher should still drain.
+        for _ in range(20):
+            if bot._run_chime_turn.await_count >= 1:
+                break
+            await asyncio.sleep(0)
+
+        assert bot._run_chime_turn.await_count == 1, (
+            "chime was silently dropped when the user turn was cancelled"
+        )
+        assert bot._chime_pending.get(111) is None
+
+    @pytest.mark.asyncio
+    async def test_latest_wins_through_user_turn_wait(self):
+        """A same-name chime arriving while the dispatcher is waiting on
+        an in-flight user turn must still collapse onto the original slot.
+
+        Repro of PR #373 review finding #3: the original code popped the
+        request before waiting, so a late same-name chime created a fresh
+        entry that ran on the next loop iteration — both delivered.
+        """
+        from loom.autonomy.chime import ChimeRequest
+
+        bot = _make_bot_stub()
+        bot._sessions[111] = MagicMock()
+        bot._run_chime_turn = AsyncMock(return_value=None)
+
+        # Long in-flight user turn we control.
+        user_done = asyncio.Event()
+
+        async def fake_user_turn():
+            await user_done.wait()
+        user_task = asyncio.ensure_future(fake_user_turn())
+        bot._running_turns[111] = user_task
+
+        # First chime ("old") — gets queued, dispatcher reaches the wait.
+        assert await bot.deliver_chime(
+            ChimeRequest(
+                schedule_name="morning",
+                intent="old",
+                fired_at=datetime.now(timezone.utc),
+                target={"type": "discord_thread", "id": "111"},
+            )
+        )
+        await asyncio.sleep(0)  # let dispatcher reach `await existing`
+
+        # Second chime ("new") for the same schedule — must overwrite.
+        assert await bot.deliver_chime(
+            ChimeRequest(
+                schedule_name="morning",
+                intent="new",
+                fired_at=datetime.now(timezone.utc),
+                target={"type": "discord_thread", "id": "111"},
+            )
+        )
+
+        # Release the user turn so the dispatcher proceeds.
+        user_done.set()
+        await user_task
+        for _ in range(20):
+            if bot._run_chime_turn.await_count >= 1 and not bot._chime_pending:
+                break
+            await asyncio.sleep(0)
+
+        assert bot._run_chime_turn.await_count == 1, (
+            "same-name chime arriving during user-turn wait was not deduped"
+        )
+        delivered_req = bot._run_chime_turn.await_args.args[1]
+        assert delivered_req.intent == "new"
+
+
+# ===========================================================================
+# Chime permission scoping (PR #373 review finding #1)
+# ===========================================================================
+
+
+class TestChimePermissions:
+    @pytest.mark.asyncio
+    async def test_chime_applies_and_revokes_schedule_grants(self):
+        """allowed_tools / scope_grants on the schedule must be pre-authorized
+        before the chime turn and revoked after — same invariant as
+        ``AutonomyDaemon._run_agent`` for independent runs."""
+        from loom.autonomy.chime import ChimeRequest
+
+        bot = _make_bot_stub()
+
+        # Fake session.perm capturing all permission calls.
+        session = MagicMock()
+        session.perm.session_authorized = set()
+        authorized: list[str] = []
+        revoked: list[str] = []
+        granted: list = []
+        revoke_matching_calls: list = []
+
+        def _authorize(name):
+            authorized.append(name)
+            session.perm.session_authorized.add(name)
+        def _revoke(name):
+            revoked.append(name)
+        def _grant(g):
+            granted.append(g)
+        def _revoke_matching(pred):
+            revoke_matching_calls.append(pred)
+
+        session.perm.authorize = MagicMock(side_effect=_authorize)
+        session.perm.revoke = MagicMock(side_effect=_revoke)
+        session.perm.grant = MagicMock(side_effect=_grant)
+        session.perm.revoke_matching = MagicMock(side_effect=_revoke_matching)
+        bot._sessions[111] = session
+
+        applied_during_turn: dict[str, list[str]] = {}
+
+        async def fake_turn(thread_id, req):
+            # Snapshot the state *during* the turn — should reflect grants.
+            applied_during_turn["authorized"] = list(authorized)
+            applied_during_turn["granted_count"] = len(granted)
+        bot._run_chime_turn = AsyncMock(side_effect=fake_turn)
+
+        req = ChimeRequest(
+            schedule_name="morning",
+            intent="hi",
+            fired_at=datetime.now(timezone.utc),
+            target={"type": "discord_thread", "id": "111"},
+            allowed_tools=("write_file", "memorize"),
+            scope_grants=(
+                {"resource": "path", "action": "write", "selector": "news/*"},
+            ),
+        )
+        assert await bot.deliver_chime(req)
+
+        # Wait for dispatcher to fully complete — including the finally
+        # block where revoke happens. The done_callback that clears
+        # _chime_dispatcher fires after the dispatcher coroutine fully
+        # returns, so it's a safe completion signal.
+        for _ in range(50):
+            if not bot._chime_dispatcher and not bot._chime_pending:
+                break
+            await asyncio.sleep(0)
+
+        # Authorized during the turn, revoked after.
+        assert applied_during_turn["authorized"] == ["write_file", "memorize"]
+        assert applied_during_turn["granted_count"] == 1
+        assert sorted(revoked) == ["memorize", "write_file"]
+        assert len(revoke_matching_calls) == 1
+
+        # The scope_grants ScopeGrant should carry an autonomy:<schedule> source
+        # so revoke_matching's predicate can target it.
+        assert granted[0].source == "autonomy:morning"
+        assert revoke_matching_calls[0](granted[0]) is True


### PR DESCRIPTION
Closes #369 (v1 scope).

## Summary

- Adds **chime mode** to autonomy cron schedules: instead of always spawning an independent session, a schedule can wake an already-active Discord-thread session and let the agent respond in-context.
- The injected turn is wrapped in `<system_chime schedule="…" fired_at="…">…</system_chime>` so the agent can tell scheduled wakes apart from user messages (Agent.md.example updated to teach this).
- Same-process only (`loom discord start --autonomy`); cold threads with no loaded session fall back per `target.fallback`.

## Naming

We picked `chime` over `wake` / `pulse`:
- `pulse` already taken by `loom/core/memory/pulse.py`
- `chime` reads as "scheduled rings, not interrupting" in both English and Chinese, matches the intent of a polite, non-blocking nudge.

## How it wires together

```
cron fires
  → AutonomyDaemon._execute_plan (mode=="chime")
  → chime_delivery callback (bot.deliver_chime)
  → LoomDiscordBot enqueues per (thread_id, schedule_name), dedupe latest-wins
  → _chime_dispatcher_loop awaits any in-flight user turn, then _run_chime_turn
  → session.stream_turn(<system_chime>…</system_chime>, origin="chime")
  → rendered into the Discord thread (marker line + reply)
```

## loom.toml

```toml
[[autonomy.schedules]]
name        = "morning_greeting"
cron        = "0 1 * * *"          # 09:00 Asia/Taipei
intent      = "向 user 道早安，並簡述今天行程"
trust_level = "safe"
mode        = "chime"

  [autonomy.schedules.target]
  type     = "discord_thread"
  id       = "1490024181994225744"
  fallback = "skip"                 # | "independent"
```

## v1 scope (intentionally narrow)

- `target.type` only supports `discord_thread`
- Same process only — the autonomy daemon and Discord bot share an event loop via `loom discord start --autonomy`
- Cold threads (no loaded session) are **not** implicitly resumed
- CLI session targets + cross-process discovery left to a future iteration

## Open behaviours

- **Latest wins per schedule_name** if multiple fires pile up before a previous chime drains (per #369 open question 1)
- Chime waits for any in-flight user turn before chiming — never interrupts user mid-thought
- Chime uses a lightweight renderer (marker line + send-once reply); no envelope-display polish. Future work can promote the full `_run_turn` renderer if desired.

## Test plan

- [x] 19 new tests in `tests/test_chime.py` (format / trigger validation / registry / daemon routing / config loading / bot dedupe)
- [x] Full suite green: 1725 existing + 19 new = 1744 tests passing
- [x] GitNexus impact: LOW on `LoomSession` / `AutonomyDaemon`; LOW (intra-module) on `CronTrigger`
- [x] GitNexus detect_changes: medium risk, but affected processes are line-drift only (`_maybe_start_maintenance`, `_hash_autonomy_section`), no behaviour change
- [ ] Manual smoke: add a `mode = "chime"` schedule with a 1-min cron, start `loom discord start --autonomy --channel <id>`, confirm the marker + reply land in-thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)