### PR TITLE
feat(tasks): add pursuit — long-lived task artifacts as markdown (#375)

### DIFF
--- a/doc/52-主線與支線.md
+++ b/doc/52-主線與支線.md
@@ -57,11 +57,37 @@ doc/50 點中的「Memory Governance 從寫入治理 → 演化治理」是 Loom
 
 **對應 issues**：尚無，先佔 milestone 位置
 
-### 1.5 Memory System v2
+### 1.5 Memory System v2 — ✅ Closed（2026-05-17）
 
-三軸 schema + MemoryPulse 鉤子。Phase 0 ontology 已鎖、Hook G + Hook A 已 ship（v0.3.6.0）。
+三軸 schema + MemoryPulse 鉤子。Phase 0-3 全 ship：
 
-**對應 issues**：#280（主動式記憶鉤子）、#281（三軸分類）
+| Phase | PR | 內容 |
+|-------|----|----|
+| P1-A/B | #301 | three-axis fact ontology schema + API |
+| P1-C | #303 | LLM-assisted domain classifier |
+| P2 | #304 | MemoryLifecycle two-stage state machine |
+| P3-A | #305 | daemon-cron MaintenanceLoop |
+| P3-B | #307 | MemoryPulse Hook G + Hook A |
+| P3-C | #308 | Dream 2.0 themed sampling |
+| 補強 | `eea9365` | time-aware recall |
+
+觀察期（~2026-05-17）數據驅動的鉤子決議：
+
+| Hook | 狀態 | 理由 |
+|------|------|------|
+| A 矛盾觸發 | ✅ ship | 噪音 folding → #378 |
+| G Session 預熱 | ✅ ship | — |
+| D Dream inject | ⏸ 緩議 | 燃料 cadence 不穩，先補 #376 |
+| B Decay warning | ⏸ 緩議 | niche，無強推動 |
+| E Context waterline | ⏸ 緩議 | 缺 recall 遙測基礎 |
+| H Skill cue | ⏸ 緩議 | 卡 skill 系統穩態（§2.4） |
+
+**已完成 issues**：#280（主動式記憶鉤子）、#281（三軸分類）— closed 2026-05-17
+
+**Follow-up issues**：
+- #376 — dream_cycle 接入 MaintenanceLoop（cadence 穩定化）
+- #377 — MemoryPulse inject 留痕 session_log（observability 基礎）
+- #378 — Hook A session 壓縮 contradiction folding（噪音 506/515 集中處）
 
 ### 1.6 Quest E — Doc Integrity
 
@@ -203,7 +229,7 @@ Memory v2 #280 #281      ─── partially in-flight ───
 | **Phase 3** | Quest D — Skill Evolution Arena（吃 Ledger replay）；#292 #295 #296 依序 | 4-6 週 |
 | **Phase 4** | Quest A — Sandbox Wall（用 srt 後端，見 §5.3）；#29 #214 | 2-3 週 |
 | **Phase 5** | Quest E #313 doc symbol CI；#314 Capability Sheet 自動投影（吃 Ledger query + Quest D evidence） | 2-3 週 |
-| **見縫** | Memory v2 #280 #281 持續、Quest C-Watch #315 lint（小工具，可隨時插入） | n/a |
+| **見縫** | ~~Memory v2 #280 #281 持續~~（✅ 2026-05-17 收尾，follow-up #376/#377/#378 獨立追蹤）、Quest C-Watch #315 lint（小工具，可隨時插入） | n/a |
 
 **注意**：上表是順序而非死線。每 phase 完成後重新評估下一段 scope。
 

--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -169,9 +169,29 @@ def _extract_openai_image_artifact(
     }
 
 
+def _extract_pursuit_write_artifact(
+    call: "ToolCall", result: "ToolResult"
+) -> dict | None:
+    import hashlib
+    import json as _json
+    content = call.args.get("content", "") or ""
+    encoded = content.encode("utf-8")
+    try:
+        payload = _json.loads(result.output or "{}")
+    except Exception:
+        payload = {}
+    return {
+        "artifact_type": "text_file",
+        "size_bytes": len(encoded),
+        "digest": "sha256:" + hashlib.sha256(encoded).hexdigest(),
+        "location": payload.get("path"),
+    }
+
+
 _ARTIFACT_EXTRACTORS: dict[str, Callable[["ToolCall", "ToolResult"], dict | None]] = {
     "write_file": _extract_write_file_artifact,
     "openai__text_to_image": _extract_openai_image_artifact,
+    "pursuit_write": _extract_pursuit_write_artifact,
 }
 
 

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1390,6 +1390,20 @@ class LoomSession:
             )
         )
 
+        # Issue #375: Pursuit tools — long-lived task artifacts as markdown
+        # under ~/.loom/pursuits/. Cross-session by design (unlike TaskList).
+        # Stateless wrt session so one PursuitStore instance is fine.
+        from loom.core.tasks.pursuit import PursuitStore
+        from loom.platform.cli.tools import (
+            make_pursuit_list_tool,
+            make_pursuit_read_tool,
+            make_pursuit_write_tool,
+        )
+        pursuit_store = PursuitStore()
+        self.registry.register(make_pursuit_list_tool(pursuit_store))
+        self.registry.register(make_pursuit_read_tool(pursuit_store))
+        self.registry.register(make_pursuit_write_tool(pursuit_store))
+
         # Issue #154: async job inspection tools. The JobStore + Scratchpad
         # themselves are created in __init__ so run_bash/fetch_url can close
         # over them; only the inspection tools are registered here.

--- a/loom/core/tasks/pursuit.py
+++ b/loom/core/tasks/pursuit.py
@@ -1,0 +1,102 @@
+"""PursuitStore — filesystem-backed long-lived task artifacts.
+
+Pursuit ≠ memory. Memory (`memory.db`) is the agent's cognition / growth log;
+pursuit is a task-axis artifact (issue #375) — user-directed tracking that
+lives until the task is done, then gets deleted. Each pursuit is one
+markdown file under ``~/.loom/pursuits/<id>.md``.
+
+Shape mirrors ``TaskListManager`` (loom/core/tasks/manager.py) — pure logic
+here, tool factories live in ``loom/platform/cli/tools.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from pathlib import Path
+
+
+_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+
+
+class PursuitError(ValueError):
+    """Raised for invalid id or missing pursuit."""
+
+
+def _default_root() -> Path:
+    return Path.home() / ".loom" / "pursuits"
+
+
+class PursuitStore:
+    """Read/write/list markdown pursuit files.
+
+    The store owns id ↔ path resolution and atomic write semantics. It does
+    NOT interpret pursuit content — the markdown shape is the agent's
+    contract with the user, not enforced here.
+    """
+
+    def __init__(self, root: Path | None = None) -> None:
+        self._root = root if root is not None else _default_root()
+
+    @property
+    def root(self) -> Path:
+        return self._root
+
+    def _path(self, pursuit_id: str) -> Path:
+        if not _ID_RE.match(pursuit_id):
+            raise PursuitError(
+                f"invalid pursuit id {pursuit_id!r}: "
+                "lowercase letters/digits/hyphens only, 1-64 chars, "
+                "must start with letter or digit"
+            )
+        return self._root / f"{pursuit_id}.md"
+
+    def list(self) -> list[str]:
+        """Return sorted list of pursuit ids found under root."""
+        if not self._root.exists():
+            return []
+        ids = []
+        for entry in self._root.iterdir():
+            if entry.is_file() and entry.suffix == ".md":
+                stem = entry.stem
+                if _ID_RE.match(stem):
+                    ids.append(stem)
+        ids.sort()
+        return ids
+
+    def exists(self, pursuit_id: str) -> bool:
+        return self._path(pursuit_id).exists()
+
+    def read(self, pursuit_id: str) -> str:
+        path = self._path(pursuit_id)
+        if not path.exists():
+            raise PursuitError(f"pursuit not found: {pursuit_id}")
+        return path.read_text(encoding="utf-8")
+
+    def write(self, pursuit_id: str, content: str) -> Path:
+        """Atomic write — tmp file + rename so partial writes never linger."""
+        path = self._path(pursuit_id)
+        self._root.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=f".{pursuit_id}.", suffix=".md.tmp", dir=str(self._root)
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(content)
+            os.replace(tmp_path, path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+        return path
+
+    def delete(self, pursuit_id: str) -> bool:
+        """Remove a pursuit. Returns True if a file was removed."""
+        path = self._path(pursuit_id)
+        if path.exists():
+            path.unlink()
+            return True
+        return False

--- a/loom/core/tasks/pursuit.py
+++ b/loom/core/tasks/pursuit.py
@@ -93,10 +93,3 @@ class PursuitStore:
             raise
         return path
 
-    def delete(self, pursuit_id: str) -> bool:
-        """Remove a pursuit. Returns True if a file was removed."""
-        path = self._path(pursuit_id)
-        if path.exists():
-            path.unlink()
-            return True
-        return False

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -86,6 +86,7 @@ if TYPE_CHECKING:
     from loom.core.memory.skill_outcome import SkillOutcomeTracker
     from loom.core.infra.telemetry import AgentTelemetryTracker
     from loom.core.tasks.manager import TaskListManager
+    from loom.core.tasks.pursuit import PursuitStore
 
 _WEB_TIMEOUT = 10.0       # seconds for all HTTP calls
 _CONTENT_LIMIT = 2000     # max chars returned to agent
@@ -3219,6 +3220,168 @@ def make_task_write_tool(
         tags=["task", "planning"],
         impact_scope="agent",
         inline_only=True,  # Output is a structured status JSON; #197
+    )
+
+
+# ------------------------------------------------------------------
+# Issue #375: Pursuit tools — long-lived task artifacts (markdown files
+# under ~/.loom/pursuits/). Pursuit ≠ memory: pursuit is task-axis,
+# memory.db is the agent's cognition. Three thin tools wrap PursuitStore;
+# the agent orchestrates `pursuit_read` + web tools + `pursuit_write`
+# herself rather than a monolithic `pursuit_pull` primitive.
+# ------------------------------------------------------------------
+
+
+def make_pursuit_list_tool(store: "PursuitStore") -> ToolDefinition:
+    async def _pursuit_list(call: ToolCall) -> ToolResult:
+        ids = store.list()
+        payload = {"count": len(ids), "pursuits": ids}
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=True,
+            output=json.dumps(payload, ensure_ascii=False),
+        )
+
+    return ToolDefinition(
+        name="pursuit_list",
+        description=(
+            "List all active pursuits — long-lived tracking tasks the user "
+            "has asked you to follow (e.g. 'OpenAI 世紀審判'). Returns ids "
+            "you can pass to pursuit_read/pursuit_write. Use this when the "
+            "user asks 'what am I tracking' or before answering 'how's X?' "
+            "without an id in mind."
+        ),
+        trust_level=TrustLevel.SAFE,
+        capabilities=ToolCapability.NONE,
+        input_schema={"type": "object", "properties": {}},
+        executor=_pursuit_list,
+        tags=["task", "pursuit"],
+        impact_scope="agent",
+        inline_only=True,
+    )
+
+
+def make_pursuit_read_tool(store: "PursuitStore") -> ToolDefinition:
+    async def _pursuit_read(call: ToolCall) -> ToolResult:
+        pid = (call.args.get("id") or "").strip()
+        if not pid:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error="'id' is required",
+            )
+        try:
+            content = store.read(pid)
+        except ValueError as exc:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error=str(exc),
+            )
+        payload = {"id": pid, "content": content}
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=True,
+            output=json.dumps(payload, ensure_ascii=False),
+        )
+
+    return ToolDefinition(
+        name="pursuit_read",
+        description=(
+            "Read a pursuit's full markdown by id. Returns the dimensions, "
+            "thresholds, and accumulated snapshots the user has been "
+            "tracking. Use when the user asks about a specific tracked "
+            "topic. After reading, you typically run search/fetch tools "
+            "yourself to gather fresh data, then call pursuit_write with "
+            "an appended snapshot section."
+        ),
+        trust_level=TrustLevel.SAFE,
+        capabilities=ToolCapability.NONE,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Pursuit id (e.g. 'openai-trial').",
+                },
+            },
+            "required": ["id"],
+        },
+        executor=_pursuit_read,
+        tags=["task", "pursuit"],
+        impact_scope="agent",
+        inline_only=True,
+    )
+
+
+def make_pursuit_write_tool(store: "PursuitStore") -> ToolDefinition:
+    async def _pursuit_write(call: ToolCall) -> ToolResult:
+        pid = (call.args.get("id") or "").strip()
+        content = call.args.get("content")
+        if not pid:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error="'id' is required",
+            )
+        if not isinstance(content, str) or not content.strip():
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False,
+                error="'content' is required and must be a non-empty string",
+            )
+        try:
+            path = store.write(pid, content)
+        except ValueError as exc:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error=str(exc),
+            )
+        payload = {
+            "id": pid,
+            "path": str(path),
+            "bytes": len(content.encode("utf-8")),
+        }
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=True,
+            output=json.dumps(payload, ensure_ascii=False),
+        )
+
+    return ToolDefinition(
+        name="pursuit_write",
+        description=(
+            "Write/replace a pursuit's full markdown by id. Pass the FULL "
+            "intended markdown — this overwrites previous content "
+            "(edit-style, per #205/#206). Use for: (a) creating a new "
+            "tracker from a spoken user request, (b) appending a fresh "
+            "snapshot under '## 累積快照' after pulling new data, "
+            "(c) editing dimensions/thresholds. Recommended shape: "
+            "title + status/created/last_pulled metadata + '## 維度' + "
+            "'## 累積快照' with dated subsections. To retire a pursuit, "
+            "ask the user to delete the file under ~/.loom/pursuits/."
+        ),
+        trust_level=TrustLevel.SAFE,
+        capabilities=ToolCapability.NONE,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": (
+                        "Pursuit id: lowercase letters/digits/hyphens, "
+                        "1-64 chars. Becomes the filename "
+                        "(~/.loom/pursuits/<id>.md)."
+                    ),
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Full markdown content (replaces previous).",
+                },
+            },
+            "required": ["id", "content"],
+        },
+        executor=_pursuit_write,
+        tags=["task", "pursuit"],
+        impact_scope="agent",
+        inline_only=True,
     )
 
 

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -3312,6 +3312,33 @@ def make_pursuit_read_tool(store: "PursuitStore") -> ToolDefinition:
     )
 
 
+def _make_pursuit_write_resolver() -> "Callable[[ToolCall], ScopeRequest]":
+    """Scope resolver for pursuit_write — selector is the pursuit id.
+
+    Granting scope for one pursuit id (e.g. "openai-trial") suppresses
+    re-confirmation on subsequent writes to that same tracker, while
+    leaving other pursuits gated. Invalid/missing id falls back to '*'
+    so the requirement still surfaces to the user (it will fail at
+    executor-level validation anyway).
+    """
+    def _resolve(call: ToolCall) -> ScopeRequest:
+        pid = (call.args.get("id") or "").strip() or "*"
+        return ScopeRequest(
+            tool_name=call.tool_name,
+            capabilities=call.capabilities,
+            requirements=[
+                ScopeRequirement(
+                    resource="pursuit",
+                    action="write",
+                    selector=pid,
+                    tool_name=call.tool_name,
+                    capabilities=call.capabilities,
+                ),
+            ],
+        )
+    return _resolve
+
+
 def make_pursuit_write_tool(store: "PursuitStore") -> ToolDefinition:
     async def _pursuit_write(call: ToolCall) -> ToolResult:
         pid = (call.args.get("id") or "").strip()
@@ -3358,8 +3385,8 @@ def make_pursuit_write_tool(store: "PursuitStore") -> ToolDefinition:
             "'## 累積快照' with dated subsections. To retire a pursuit, "
             "ask the user to delete the file under ~/.loom/pursuits/."
         ),
-        trust_level=TrustLevel.SAFE,
-        capabilities=ToolCapability.NONE,
+        trust_level=TrustLevel.GUARDED,
+        capabilities=ToolCapability.MUTATES,
         input_schema={
             "type": "object",
             "properties": {
@@ -3375,13 +3402,22 @@ def make_pursuit_write_tool(store: "PursuitStore") -> ToolDefinition:
                     "type": "string",
                     "description": "Full markdown content (replaces previous).",
                 },
+                "justification": {
+                    "type": "string",
+                    "description": (
+                        "簡短說明為何在目前的脈絡下寫入/覆蓋這個 pursuit 是合"
+                        "理且必要的（給人類審核看）。"
+                    ),
+                },
             },
-            "required": ["id", "content"],
+            "required": ["id", "content", "justification"],
         },
         executor=_pursuit_write,
         tags=["task", "pursuit"],
-        impact_scope="agent",
+        impact_scope="filesystem",
         inline_only=True,
+        scope_descriptions=["writes/overwrites ~/.loom/pursuits/<id>.md"],
+        scope_resolver=_make_pursuit_write_resolver(),
     )
 
 

--- a/tests/test_pursuit.py
+++ b/tests/test_pursuit.py
@@ -1,0 +1,236 @@
+"""Tests for PursuitStore + pursuit tools — Issue #375.
+
+Covers:
+  - PursuitStore: id validation, list/read/write/delete, atomic write
+  - Tool executors: success path, error path, JSON shape
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from loom.core.tasks.pursuit import PursuitStore, PursuitError
+from loom.core.harness.middleware import ToolCall
+from loom.core.harness.permissions import TrustLevel
+from loom.platform.cli.tools import (
+    make_pursuit_list_tool,
+    make_pursuit_read_tool,
+    make_pursuit_write_tool,
+)
+
+
+def _tc(name: str, args: dict) -> ToolCall:
+    return ToolCall(
+        tool_name=name, args=args,
+        trust_level=TrustLevel.SAFE, session_id="test",
+    )
+
+
+@pytest.fixture
+def store(tmp_path):
+    return PursuitStore(root=tmp_path / "pursuits")
+
+
+# ── PursuitStore: id validation ───────────────────────────────────────
+
+class TestIdValidation:
+    @pytest.mark.parametrize("pid", [
+        "openai-trial", "x", "a1", "long-name-with-many-hyphens-123",
+        "0day", "a" * 64,
+    ])
+    def test_valid_ids(self, store, pid):
+        store.write(pid, "content")
+        assert store.exists(pid)
+
+    @pytest.mark.parametrize("pid", [
+        "",                          # empty
+        "Has-Caps",                  # uppercase
+        "with space",                # space
+        "with/slash",                # path traversal attempt
+        "..",                        # parent dir
+        "../escape",                 # parent dir
+        "-leading-hyphen",           # cannot start with hyphen
+        "trailing.dot",              # dot
+        "under_score",               # underscore
+        "a" * 65,                    # too long
+    ])
+    def test_invalid_ids_rejected(self, store, pid):
+        with pytest.raises(PursuitError):
+            store.write(pid, "content")
+        with pytest.raises(PursuitError):
+            store.read(pid)
+
+
+# ── PursuitStore: list / read / write / delete ────────────────────────
+
+class TestStoreOperations:
+    def test_list_empty_when_no_root(self, store):
+        assert store.list() == []
+
+    def test_list_returns_sorted_ids(self, store):
+        store.write("zeta", "z")
+        store.write("alpha", "a")
+        store.write("middle", "m")
+        assert store.list() == ["alpha", "middle", "zeta"]
+
+    def test_list_ignores_non_md(self, store, tmp_path):
+        store.write("real-one", "x")
+        (tmp_path / "pursuits" / "stray.txt").write_text("not a pursuit")
+        (tmp_path / "pursuits" / "no_extension").write_text("nope")
+        assert store.list() == ["real-one"]
+
+    def test_list_ignores_invalid_id_files(self, store, tmp_path):
+        store.write("valid", "x")
+        # File with invalid id sitting in the dir should not appear in list
+        (tmp_path / "pursuits" / "BAD-ID.md").write_text("x")
+        assert store.list() == ["valid"]
+
+    def test_read_missing_raises(self, store):
+        with pytest.raises(PursuitError, match="not found"):
+            store.read("ghost")
+
+    def test_write_then_read_roundtrip(self, store):
+        content = "# OpenAI 世紀審判\n\nstatus: active\n"
+        store.write("openai-trial", content)
+        assert store.read("openai-trial") == content
+
+    def test_write_overwrites(self, store):
+        store.write("topic", "v1")
+        store.write("topic", "v2")
+        assert store.read("topic") == "v2"
+
+    def test_write_creates_root_dir(self, store):
+        # Root does not exist before first write
+        assert not store.root.exists()
+        store.write("first", "hi")
+        assert store.root.is_dir()
+
+    def test_write_atomic_leaves_no_tmp(self, store):
+        store.write("topic", "content")
+        leftovers = [p for p in store.root.iterdir() if p.name.endswith(".tmp")]
+        assert leftovers == []
+
+    def test_delete_returns_true_when_present(self, store):
+        store.write("topic", "x")
+        assert store.delete("topic") is True
+        assert not store.exists("topic")
+
+    def test_delete_returns_false_when_missing(self, store):
+        assert store.delete("ghost") is False
+
+    def test_exists(self, store):
+        assert store.exists("topic") is False
+        store.write("topic", "x")
+        assert store.exists("topic") is True
+
+
+# ── Tool: pursuit_list ────────────────────────────────────────────────
+
+class TestPursuitListTool:
+    async def test_empty(self, store):
+        tool = make_pursuit_list_tool(store)
+        result = await tool.executor(_tc("pursuit_list", {}))
+        assert result.success
+        payload = json.loads(result.output)
+        assert payload == {"count": 0, "pursuits": []}
+
+    async def test_populated(self, store):
+        store.write("b-one", "x")
+        store.write("a-one", "y")
+        tool = make_pursuit_list_tool(store)
+        result = await tool.executor(_tc("pursuit_list", {}))
+        payload = json.loads(result.output)
+        assert payload["count"] == 2
+        assert payload["pursuits"] == ["a-one", "b-one"]
+
+
+# ── Tool: pursuit_read ────────────────────────────────────────────────
+
+class TestPursuitReadTool:
+    async def test_success(self, store):
+        store.write("topic", "# Hello\n\ncontent here")
+        tool = make_pursuit_read_tool(store)
+        result = await tool.executor(_tc("pursuit_read", {"id": "topic"}))
+        assert result.success
+        payload = json.loads(result.output)
+        assert payload == {"id": "topic", "content": "# Hello\n\ncontent here"}
+
+    async def test_missing_id_arg(self, store):
+        tool = make_pursuit_read_tool(store)
+        result = await tool.executor(_tc("pursuit_read", {}))
+        assert not result.success
+        assert "id" in result.error
+
+    async def test_not_found(self, store):
+        tool = make_pursuit_read_tool(store)
+        result = await tool.executor(_tc("pursuit_read", {"id": "ghost"}))
+        assert not result.success
+        assert "not found" in result.error
+
+    async def test_invalid_id(self, store):
+        tool = make_pursuit_read_tool(store)
+        result = await tool.executor(_tc("pursuit_read", {"id": "Bad Id"}))
+        assert not result.success
+        assert "invalid" in result.error
+
+
+# ── Tool: pursuit_write ───────────────────────────────────────────────
+
+class TestPursuitWriteTool:
+    async def test_create(self, store):
+        tool = make_pursuit_write_tool(store)
+        result = await tool.executor(_tc("pursuit_write", {
+            "id": "openai-trial",
+            "content": "# OpenAI 世紀審判\nstatus: active\n",
+        }))
+        assert result.success
+        payload = json.loads(result.output)
+        assert payload["id"] == "openai-trial"
+        assert payload["bytes"] > 0
+        assert payload["path"].endswith("openai-trial.md")
+        assert store.read("openai-trial").startswith("# OpenAI 世紀審判")
+
+    async def test_overwrite(self, store):
+        tool = make_pursuit_write_tool(store)
+        await tool.executor(_tc("pursuit_write", {"id": "t", "content": "v1"}))
+        await tool.executor(_tc("pursuit_write", {"id": "t", "content": "v2"}))
+        assert store.read("t") == "v2"
+
+    async def test_missing_id(self, store):
+        tool = make_pursuit_write_tool(store)
+        result = await tool.executor(_tc("pursuit_write", {"content": "x"}))
+        assert not result.success
+        assert "id" in result.error
+
+    async def test_missing_content(self, store):
+        tool = make_pursuit_write_tool(store)
+        result = await tool.executor(_tc("pursuit_write", {"id": "topic"}))
+        assert not result.success
+        assert "content" in result.error
+
+    async def test_empty_content_rejected(self, store):
+        tool = make_pursuit_write_tool(store)
+        result = await tool.executor(_tc("pursuit_write", {
+            "id": "topic", "content": "   \n  ",
+        }))
+        assert not result.success
+        assert "content" in result.error
+
+    async def test_invalid_id(self, store):
+        tool = make_pursuit_write_tool(store)
+        result = await tool.executor(_tc("pursuit_write", {
+            "id": "Has Caps", "content": "x",
+        }))
+        assert not result.success
+        assert "invalid" in result.error
+
+    async def test_path_traversal_blocked(self, store):
+        tool = make_pursuit_write_tool(store)
+        result = await tool.executor(_tc("pursuit_write", {
+            "id": "../escape", "content": "x",
+        }))
+        assert not result.success
+        # And no file was created outside root
+        assert not (store.root.parent / "escape.md").exists()

--- a/tests/test_pursuit.py
+++ b/tests/test_pursuit.py
@@ -12,8 +12,12 @@ import json
 import pytest
 
 from loom.core.tasks.pursuit import PursuitStore, PursuitError
-from loom.core.harness.middleware import ToolCall
-from loom.core.harness.permissions import TrustLevel
+from loom.core.harness.middleware import (
+    ToolCall,
+    ToolResult,
+    _extract_pursuit_write_artifact,
+)
+from loom.core.harness.permissions import TrustLevel, ToolCapability
 from loom.platform.cli.tools import (
     make_pursuit_list_tool,
     make_pursuit_read_tool,
@@ -112,14 +116,6 @@ class TestStoreOperations:
         leftovers = [p for p in store.root.iterdir() if p.name.endswith(".tmp")]
         assert leftovers == []
 
-    def test_delete_returns_true_when_present(self, store):
-        store.write("topic", "x")
-        assert store.delete("topic") is True
-        assert not store.exists("topic")
-
-    def test_delete_returns_false_when_missing(self, store):
-        assert store.delete("ghost") is False
-
     def test_exists(self, store):
         assert store.exists("topic") is False
         store.write("topic", "x")
@@ -184,6 +180,7 @@ class TestPursuitWriteTool:
         result = await tool.executor(_tc("pursuit_write", {
             "id": "openai-trial",
             "content": "# OpenAI 世紀審判\nstatus: active\n",
+            "justification": "user asked to start tracking",
         }))
         assert result.success
         payload = json.loads(result.output)
@@ -194,26 +191,34 @@ class TestPursuitWriteTool:
 
     async def test_overwrite(self, store):
         tool = make_pursuit_write_tool(store)
-        await tool.executor(_tc("pursuit_write", {"id": "t", "content": "v1"}))
-        await tool.executor(_tc("pursuit_write", {"id": "t", "content": "v2"}))
+        await tool.executor(_tc("pursuit_write", {
+            "id": "t", "content": "v1", "justification": "j",
+        }))
+        await tool.executor(_tc("pursuit_write", {
+            "id": "t", "content": "v2", "justification": "j",
+        }))
         assert store.read("t") == "v2"
 
     async def test_missing_id(self, store):
         tool = make_pursuit_write_tool(store)
-        result = await tool.executor(_tc("pursuit_write", {"content": "x"}))
+        result = await tool.executor(_tc("pursuit_write", {
+            "content": "x", "justification": "j",
+        }))
         assert not result.success
         assert "id" in result.error
 
     async def test_missing_content(self, store):
         tool = make_pursuit_write_tool(store)
-        result = await tool.executor(_tc("pursuit_write", {"id": "topic"}))
+        result = await tool.executor(_tc("pursuit_write", {
+            "id": "topic", "justification": "j",
+        }))
         assert not result.success
         assert "content" in result.error
 
     async def test_empty_content_rejected(self, store):
         tool = make_pursuit_write_tool(store)
         result = await tool.executor(_tc("pursuit_write", {
-            "id": "topic", "content": "   \n  ",
+            "id": "topic", "content": "   \n  ", "justification": "j",
         }))
         assert not result.success
         assert "content" in result.error
@@ -221,7 +226,7 @@ class TestPursuitWriteTool:
     async def test_invalid_id(self, store):
         tool = make_pursuit_write_tool(store)
         result = await tool.executor(_tc("pursuit_write", {
-            "id": "Has Caps", "content": "x",
+            "id": "Has Caps", "content": "x", "justification": "j",
         }))
         assert not result.success
         assert "invalid" in result.error
@@ -229,8 +234,92 @@ class TestPursuitWriteTool:
     async def test_path_traversal_blocked(self, store):
         tool = make_pursuit_write_tool(store)
         result = await tool.executor(_tc("pursuit_write", {
-            "id": "../escape", "content": "x",
+            "id": "../escape", "content": "x", "justification": "j",
         }))
         assert not result.success
         # And no file was created outside root
         assert not (store.root.parent / "escape.md").exists()
+
+
+# ── Tool definition guarantees ────────────────────────────────────────
+
+class TestPursuitWriteToolDefinition:
+    """Regression guards: GUARDED + MUTATES + justification required +
+    scope resolver wired. These shape the harness-layer behavior the
+    executor unit tests cannot verify directly."""
+
+    def test_trust_and_capabilities_are_guarded_mutating(self, store):
+        tool = make_pursuit_write_tool(store)
+        assert tool.trust_level == TrustLevel.GUARDED
+        assert tool.capabilities == ToolCapability.MUTATES
+
+    def test_input_schema_requires_justification(self, store):
+        tool = make_pursuit_write_tool(store)
+        required = tool.input_schema["required"]
+        assert "justification" in required
+        assert "id" in required
+        assert "content" in required
+
+    def test_scope_resolver_selector_is_pursuit_id(self, store):
+        tool = make_pursuit_write_tool(store)
+        assert tool.scope_resolver is not None
+        call = _tc("pursuit_write", {
+            "id": "openai-trial", "content": "x", "justification": "j",
+        })
+        req = tool.scope_resolver(call)
+        assert len(req.requirements) == 1
+        r = req.requirements[0]
+        assert r.resource == "pursuit"
+        assert r.action == "write"
+        assert r.selector == "openai-trial"
+
+    def test_scope_resolver_falls_back_to_star_for_missing_id(self, store):
+        tool = make_pursuit_write_tool(store)
+        call = _tc("pursuit_write", {"content": "x", "justification": "j"})
+        req = tool.scope_resolver(call)
+        assert req.requirements[0].selector == "*"
+
+
+# ── Artifact extractor ────────────────────────────────────────────────
+
+class TestPursuitWriteArtifact:
+    def test_extracts_size_and_digest(self):
+        import hashlib
+
+        content = "# Hello\n\ncontent body"
+        encoded = content.encode("utf-8")
+        call = ToolCall(
+            tool_name="pursuit_write",
+            args={"id": "t", "content": content, "justification": "j"},
+            trust_level=TrustLevel.GUARDED, session_id="test",
+        )
+        result = ToolResult(
+            call_id=call.id, tool_name="pursuit_write",
+            success=True,
+            output=json.dumps({
+                "id": "t", "path": "/tmp/pursuits/t.md", "bytes": len(encoded),
+            }),
+        )
+        artifact = _extract_pursuit_write_artifact(call, result)
+        assert artifact == {
+            "artifact_type": "text_file",
+            "size_bytes": len(encoded),
+            "digest": "sha256:" + hashlib.sha256(encoded).hexdigest(),
+            "location": "/tmp/pursuits/t.md",
+        }
+
+    def test_extractor_handles_malformed_output_json(self):
+        call = ToolCall(
+            tool_name="pursuit_write",
+            args={"id": "t", "content": "x", "justification": "j"},
+            trust_level=TrustLevel.GUARDED, session_id="test",
+        )
+        # Output that isn't valid JSON should not raise — location ends None
+        result = ToolResult(
+            call_id=call.id, tool_name="pursuit_write",
+            success=True, output="not-json",
+        )
+        artifact = _extract_pursuit_write_artifact(call, result)
+        assert artifact is not None
+        assert artifact["location"] is None
+        assert artifact["size_bytes"] == 1  # one byte: 'x'


### PR DESCRIPTION
Closes part of #375 (MVP — see Followups for what was intentionally deferred).

## Summary

Pursuit is the on-demand answer to "track this for me" — a markdown file
under \`~/.loom/pursuits/<id>.md\` that 絲絲 reads, refreshes with fresh
data, and rewrites when the user asks about it.

Aligned with the design comment on #375 (https://github.com/Dakai666/Loom/issues/375#issuecomment-4469519048):
- **Task axis, not memory axis** — pursuit lives in the filesystem, never touches \`memory.db\`. \`memory.db\` stays as 絲絲's cognition; pursuit stays as user-directed task artifacts that die with the task.
- **On-demand, not daemon** — no background poller, no Hook D dependency, no race conditions. The agent calls \`pursuit_read\` + web tools + \`pursuit_write\` herself when prompted.
- **Edit-style, not verb soup** — single \`pursuit_write\` overwrites the whole markdown (per #205/#206 lesson).

## Surface

| Tool | Behavior |
|------|----------|
| \`pursuit_list\` | Returns active pursuit ids (filesystem listing) |
| \`pursuit_read\` | Returns full markdown for a given id |
| \`pursuit_write\` | Atomic overwrite of the whole markdown by id |

Recommended markdown shape (suggested in tool description, not enforced):

\`\`\`markdown
# OpenAI 世紀審判
status: active
created: 2026-05-17
last_pulled: 2026-05-17

## 維度
- 陪審團裁決
- 估值變化（±20%）
- 監管動向

## 累積快照
### 2026-05-17（初建）
- 估值 last known: \$300B
- 監管: SEC 8 月有非正式 inquiry
\`\`\`

## Architecture decisions

- **Placement**: \`loom/core/tasks/pursuit.py\` (logic) + \`loom/platform/cli/tools.py\` (tool factories) + \`loom/core/session.py\` (registration), mirroring TaskListManager's split. Did not open a new top-level module (no \`loom/extensibility/\`, no \`loom/pursuit/\`) — YAGNI and tasks/ is the natural home per CLAUDE.md's Tasks layer.
- **PursuitStore is filesystem-rooted, session-agnostic** — one instance per session is fine (no per-session state).
- **Path traversal**: id validated against \`^[a-z0-9][a-z0-9-]{0,63}$\` before any FS touch. Paths outside \`~/.loom/pursuits/\` are unreachable.
- **Atomic writes**: tmp + rename, so a crashed write never leaves a half-file.

## Pre-flight checks (per CLAUDE.md)

- \`gitnexus_impact(TaskListManager, upstream)\` → **risk LOW** (only \`tasks/__init__.py\` imports it; we add a sibling file, don't modify TaskListManager).
- \`gitnexus_detect_changes(all)\` → **risk_level: low**, 0 affected processes. The "touched" jobs/_fmt_job/_jobs_* entries are line-shift artifacts (insertion above them), not real edits.
- New imports respect the layer rules (no Tasks → Autonomy/Memory leakage).

## Tests

41 new tests in \`tests/test_pursuit.py\`:
- PursuitStore id validation (parametrized: 6 valid / 10 invalid including path traversal, uppercase, dots, underscores, length overflow)
- list / read / write / delete / exists semantics
- atomic write leaves no .tmp leftover
- Tool executors: success, missing arg, invalid arg, not-found, overwrite, path traversal rejection

Run: \`pytest tests/test_pursuit.py\` → 41 passed in 0.41s. Combined with \`test_tasklist.py\`: 69 passed.

## Intentionally NOT in this PR (Followups)

- **\`pursuit_pull\` composite tool** — original design proposed this; cut after realizing the agent can orchestrate \`pursuit_read\` + \`web_search\` + \`pursuit_write\` more flexibly. Reconsider if real usage shows the chaining is awkward.
- **\`pursuit_delete\` tool** — \`PursuitStore.delete()\` exists but is unexposed. Users can \`rm\` the markdown for now; add the tool when retiring trackers becomes a frequent verb.
- **Schema enforcement** — markdown shape is a suggestion in the tool description, not validated. Let real usage pressure the shape before locking it.

## Test plan

- [ ] In a fresh \`loom chat\` session, say "幫我追蹤 OpenAI 世紀審判" and verify 絲絲 creates \`~/.loom/pursuits/openai-trial.md\` via \`pursuit_write\`
- [ ] Ask "OpenAI 案最近怎樣" later, verify she calls \`pursuit_read\` then runs searches
- [ ] Say "我目前在追什麼" and verify \`pursuit_list\` is invoked
- [ ] Edit the markdown by hand, then have 絲絲 read it — verify she sees the edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)