### PR TITLE
feat(image): make OpenAI generation configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,10 +386,12 @@ Model routing works by prefix — `gpt-*` and `openai/<model>` use
 `codex login`. Other prefixes include `claude-*`, `ollama/<name>`,
 `lmstudio/<name>`, and `MiniMax-*`. Switch mid-session with `/model`.
 
-Image generation includes `openai__text_to_image`, which calls `gpt-image-2`
-and writes a PNG/WebP/JPEG under the workspace. With Codex OAuth it uses the
-Codex Responses backend and supports workspace image `subject_reference`
-anchors; with `OPENAI_API_KEY` it uses the OpenAI Images API.
+Image generation is opt-in via `[tools.image]` in `loom.toml`. When configured
+with `default_provider = "openai"`, Loom exposes the canonical
+`image_generate` tool backed by `gpt-image-2` and writes a PNG/WebP/JPEG under
+the workspace. With Codex OAuth it uses the Codex Responses backend and
+supports workspace image `subject_reference` anchors; with `OPENAI_API_KEY` it
+uses the OpenAI Images API.
 
 ---
 

--- a/doc/33-CLI-命令.md
+++ b/doc/33-CLI-命令.md
@@ -69,10 +69,12 @@ loom auth openai --skip-codex-login
 聊天模型路由刻意分開：`gpt-*` / `openai/<model>` 走 `OPENAI_API_KEY`，
 `codex/<model>`（例如 `codex/gpt-5.5`）才走 Codex OAuth backend。
 
-### `openai__text_to_image`
+### `image_generate`
 
-Agent 可用工具，生成圖片並寫入 workspace。`auth_mode=codex` 走 Codex Responses backend；
-`auth_mode=api_key` 走 OpenAI Images API：
+Agent 可用工具，生成圖片並寫入 workspace。這個工具預設不註冊；在 `loom.toml`
+設定 `[tools.image].enabled = true` 且 `default_provider = "openai"` 後，Loom 會註冊
+canonical `image_generate`，目前背後使用 OpenAI GPT Image。`auth_mode=codex`
+走 Codex Responses backend；`auth_mode=api_key` 走 OpenAI Images API：
 
 ```json
 {

--- a/doc/53-AgentLedger-設計.md
+++ b/doc/53-AgentLedger-設計.md
@@ -891,7 +891,7 @@ Step 6. 測試全綠 → merge → 切換 Loom Agent 啟新版開新 session
 | `thought` | ✅ emit（#334） | §3.3 signal accumulator：judge fail/uncertain、outcome abandoned/error、artifact >10KB 任一觸發 commit；inline ≤50KB / blob > 50KB |
 | `model_event` | ✅ emit（#334） | stream_turn 主 loop、`run_judge`（sync + async）、subagent 三條 router 路徑都 emit；`_turn_token_usage` 餵 turn_end |
 | `judge_verdict` | ✅ emit（#334） | `_maybe_run_judge` / `_run_judge_async` 兩條路徑；判定 pass/fail/uncertain → PASS/FAIL/CONCERN，`error` 設值 → ERROR |
-| `artifact_emit` | ✅ emit（#334） | LifecycleMiddleware END 後檢查 `_ARTIFACT_PRODUCERS={write_file, openai__text_to_image}`；rolled_back 或 failed 不 emit |
+| `artifact_emit` | ✅ emit（#334） | LifecycleMiddleware END 後檢查 artifact extractor registry（如 `write_file`, `image_generate`）；rolled_back 或 failed 不 emit |
 
 `三類 exception 自開新 correlation_id`（§4.2）：
 - `env_observation` ✅ 實作（PR #330 commit 4）

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -111,9 +111,24 @@ reminder_after_turns = 10
 # base_url      = "https://chatgpt.com/backend-api/codex/responses"
 # default_model = "gpt-5.5"            # bare model name — no "codex/" prefix here
 #
-# OpenAI image generation uses the openai__text_to_image tool.
-# It defaults to gpt-image-2. Codex OAuth uses the Codex Responses backend;
-# OPENAI_API_KEY uses the OpenAI Images API.
+# ─────────────────────────────────────────────
+# Image generation
+# ─────────────────────────────────────────────
+# Disabled by default so agent profiles can choose their preferred drawing
+# provider explicitly. Enable this block to expose the canonical
+# image_generate tool backed by OpenAI GPT Image.
+#
+# [tools.image]
+# enabled = true
+# default_provider = "openai"
+#
+# [tools.image.openai]
+# enabled   = true
+# model     = "gpt-image-2"
+# auth_mode = "auto"  # auto | codex | api_key
+#
+# Codex OAuth uses the Codex Responses backend; OPENAI_API_KEY uses the
+# OpenAI Images API.
 
 # ─────────────────────────────────────────────
 # Memory

--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -146,7 +146,7 @@ def _extract_write_file_artifact(call: "ToolCall", result: "ToolResult") -> dict
     }
 
 
-def _extract_openai_image_artifact(
+def _extract_image_generate_artifact(
     call: "ToolCall", result: "ToolResult"
 ) -> dict | None:
     import hashlib
@@ -190,7 +190,8 @@ def _extract_pursuit_write_artifact(
 
 _ARTIFACT_EXTRACTORS: dict[str, Callable[["ToolCall", "ToolResult"], dict | None]] = {
     "write_file": _extract_write_file_artifact,
-    "openai__text_to_image": _extract_openai_image_artifact,
+    "image_generate": _extract_image_generate_artifact,
+    "openai__text_to_image": _extract_image_generate_artifact,
     "pursuit_write": _extract_pursuit_write_artifact,
 }
 

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1388,6 +1388,11 @@ class LoomSession:
                     ).strip() or "auto",
                 )
             )
+        elif _image_enabled and _image_provider and _image_provider != "openai":
+            logger.warning(
+                "[tools.image] provider %r is not supported; skipping image_generate.",
+                _image_provider,
+            )
 
         # Register sub-agent tool (Phase 5E)
         self.registry.register(make_spawn_agent_tool(self))

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1371,7 +1371,23 @@ class LoomSession:
         brave_key = env.get("brave_search_key") or env.get("BRAVE_SEARCH_KEY", "")
         if brave_key:
             self.registry.register(make_web_search_tool(brave_key))
-        self.registry.register(make_openai_image_generation_tool(self.workspace))
+        _image_cfg = (_load_loom_config().get("tools", {}).get("image", {}) or {})
+        _image_enabled = bool(_image_cfg.get("enabled", False))
+        _image_provider = str(_image_cfg.get("default_provider", "")).strip().lower()
+        _openai_image_cfg = (_image_cfg.get("openai", {}) or {})
+        _openai_image_enabled = bool(_openai_image_cfg.get("enabled", True))
+        if _image_enabled and _image_provider == "openai" and _openai_image_enabled:
+            self.registry.register(
+                make_openai_image_generation_tool(
+                    self.workspace,
+                    default_model=str(
+                        _openai_image_cfg.get("model", "gpt-image-2")
+                    ).strip() or "gpt-image-2",
+                    default_auth_mode=str(
+                        _openai_image_cfg.get("auth_mode", "auto")
+                    ).strip() or "auto",
+                )
+            )
 
         # Register sub-agent tool (Phase 5E)
         self.registry.register(make_spawn_agent_tool(self))

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -163,7 +163,7 @@ def _resolve_workspace_path(raw: str, workspace: Path) -> Path:
 
 
 def _make_openai_image_scope_resolver(workspace: Path):
-    """Scope resolver for the OpenAI image tool."""
+    """Scope resolver for the OpenAI-backed image generation tool."""
     import os.path
 
     _workspace_resolved = workspace.resolve()
@@ -2610,8 +2610,14 @@ def _detect_image_mime_type(image_bytes: bytes) -> str | None:
     return None
 
 
-def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
-    """Build an OpenAI GPT Image generation tool."""
+def make_openai_image_generation_tool(
+    workspace: Path,
+    *,
+    tool_name: str = "image_generate",
+    default_model: str = "gpt-image-2",
+    default_auth_mode: str = "auto",
+) -> ToolDefinition:
+    """Build the canonical image_generate tool backed by OpenAI GPT Image."""
 
     from loom.core.session import _load_env
     from loom.core.cognition.openai_auth import resolve_openai_credential
@@ -2626,7 +2632,7 @@ def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
                 error="Missing required argument: prompt",
             )
 
-        auth_mode = str(call.args.get("auth_mode", "auto")).strip().lower()
+        auth_mode = str(call.args.get("auth_mode", default_auth_mode)).strip().lower()
         if auth_mode not in {"auto", "codex", "api_key"}:
             return ToolResult(
                 call_id=call.id,
@@ -2666,7 +2672,7 @@ def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
             output_path = output_path.with_suffix(".png")
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        image_model = str(call.args.get("model", "gpt-image-2")).strip() or "gpt-image-2"
+        image_model = str(call.args.get("model", default_model)).strip() or default_model
         image_options: dict[str, Any] = {
             "model": image_model,
             "n": int(call.args.get("n", 1) or 1),
@@ -2840,10 +2846,11 @@ def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
         )
 
     return ToolDefinition(
-        name="openai__text_to_image",
+        name=tool_name,
         description=(
-            "Generate an image with OpenAI GPT Image and save it to a workspace file. "
-            "Uses Codex OAuth first when available, with OPENAI_API_KEY fallback."
+            "Generate an image with the configured default image provider and "
+            "save it to a workspace file. This installation routes the request "
+            "through OpenAI GPT Image."
         ),
         trust_level=TrustLevel.GUARDED,
         capabilities=ToolCapability.NETWORK | ToolCapability.MUTATES,
@@ -2858,7 +2865,7 @@ def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
                 "model": {
                     "type": "string",
                     "description": "OpenAI image model.",
-                    "default": "gpt-image-2",
+                    "default": default_model,
                 },
                 "size": {
                     "type": "string",
@@ -2873,7 +2880,7 @@ def make_openai_image_generation_tool(workspace: Path) -> ToolDefinition:
                 "auth_mode": {
                     "type": "string",
                     "enum": ["auto", "codex", "api_key"],
-                    "default": "auto",
+                    "default": default_auth_mode,
                     "description": "auto prefers Codex OAuth and falls back to OPENAI_API_KEY.",
                 },
                 "subject_reference": {

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -2850,7 +2850,7 @@ def make_openai_image_generation_tool(
         description=(
             "Generate an image with the configured default image provider and "
             "save it to a workspace file. This installation routes the request "
-            "through OpenAI GPT Image."
+            f"through OpenAI GPT Image model {default_model}."
         ),
         trust_level=TrustLevel.GUARDED,
         capabilities=ToolCapability.NETWORK | ToolCapability.MUTATES,

--- a/tests/test_ledger_deferred_events.py
+++ b/tests/test_ledger_deferred_events.py
@@ -368,12 +368,12 @@ async def test_artifact_emit_for_write_file(
     assert p["digest"].startswith("sha256:")
 
 
-async def test_artifact_emit_for_openai_text_to_image(
+async def test_artifact_emit_for_image_generate(
     ledger: LedgerStore, emitter: LedgerEmitter
 ) -> None:
     import json
     reg = _producer_registry(
-        "openai__text_to_image",
+        "image_generate",
         json.dumps({
             "path": "img/out.png", "model": "gpt-image-2",
             "credential_source": "env", "bytes": 4096,
@@ -383,10 +383,10 @@ async def test_artifact_emit_for_openai_text_to_image(
         [LifecycleMiddleware(registry=reg, ledger_emitter=emitter)]
     )
     call = _make_call(
-        "openai__text_to_image", {"prompt": "a cat", "output_path": "img/out.png"},
+        "image_generate", {"prompt": "a cat", "output_path": "img/out.png"},
     )
     async with async_turn_scope("turn_ai"), async_correlation_scope("c1"):
-        await pipeline.execute(call, reg.get("openai__text_to_image").executor)
+        await pipeline.execute(call, reg.get("image_generate").executor)
 
     rows = [r for r in await ledger.fetch_by_turn("turn_ai")
             if r.event_type == "artifact_emit"]

--- a/tests/test_openai_image_tool.py
+++ b/tests/test_openai_image_tool.py
@@ -318,10 +318,13 @@ def test_openai_image_tool_schema_and_scope_include_subject_reference(tmp_path):
 
 
 def test_openai_image_tool_registers_as_canonical_image_generate(tmp_path):
-    tool = make_openai_image_generation_tool(tmp_path)
+    tool = make_openai_image_generation_tool(
+        tmp_path, default_model="gpt-image-custom"
+    )
 
     assert tool.name == "image_generate"
     assert tool.tags == ["image", "openai"]
+    assert "gpt-image-custom" in tool.description
 
 
 @pytest.mark.asyncio

--- a/tests/test_openai_image_tool.py
+++ b/tests/test_openai_image_tool.py
@@ -317,6 +317,13 @@ def test_openai_image_tool_schema_and_scope_include_subject_reference(tmp_path):
     )
 
 
+def test_openai_image_tool_registers_as_canonical_image_generate(tmp_path):
+    tool = make_openai_image_generation_tool(tmp_path)
+
+    assert tool.name == "image_generate"
+    assert tool.tags == ["image", "openai"]
+
+
 @pytest.mark.asyncio
 async def test_openai_image_tool_auto_falls_back_when_codex_token_rejected(
     tmp_path,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -196,6 +196,50 @@ async def session_plugin_tool(call):
 
         await session.stop()
 
+    async def test_start_warns_when_configured_image_provider_is_unsupported(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path,
+        session_module,
+        caplog,
+    ) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(session_module, "build_router", lambda *a, **k: MagicMock())
+        monkeypatch.setattr(session_module, "_load_loom_config", lambda: {
+            "tools": {
+                "image": {
+                    "enabled": True,
+                    "default_provider": "comfyui-local",
+                },
+            },
+        })
+        monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {})
+        monkeypatch.setattr(session_module, "build_embedding_provider", lambda env, cfg: None)
+        from rich.prompt import Confirm
+        monkeypatch.setattr(Confirm, "ask", lambda *args, **kwargs: True)
+
+        from loom.core.session import LoomSession
+
+        session = LoomSession(
+            model="gpt-test",
+            db_path=str(tmp_path / "loom.db"),
+            workspace=workspace,
+        )
+        with caplog.at_level("WARNING", logger="loom.core.session"):
+            await session.start()
+
+        assert session.registry.get("image_generate") is None
+        assert any(
+            "[tools.image] provider 'comfyui-local' is not supported" in r.message
+            for r in caplog.records
+        )
+
+        await session.stop()
+
     async def test_start_loads_mcp_servers_into_session(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -146,10 +146,55 @@ async def session_plugin_tool(call):
         assert session._pipeline is not None
         assert session._mcp_clients == []
         assert session.registry.get("session_plugin_tool") is not None
-        assert session.registry.get("openai__text_to_image") is not None
+        assert session.registry.get("image_generate") is None
+        assert session.registry.get("openai__text_to_image") is None
 
         await session.stop()
         assert session._db is None
+
+    async def test_start_registers_configured_openai_image_generate_tool(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path,
+        session_module,
+    ) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(session_module, "build_router", lambda *a, **k: MagicMock())
+        monkeypatch.setattr(session_module, "_load_loom_config", lambda: {
+            "tools": {
+                "image": {
+                    "enabled": True,
+                    "default_provider": "openai",
+                    "openai": {
+                        "enabled": True,
+                        "model": "gpt-image-2",
+                        "auth_mode": "auto",
+                    },
+                },
+            },
+        })
+        monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {})
+        monkeypatch.setattr(session_module, "build_embedding_provider", lambda env, cfg: None)
+        from rich.prompt import Confirm
+        monkeypatch.setattr(Confirm, "ask", lambda *args, **kwargs: True)
+
+        from loom.core.session import LoomSession
+
+        session = LoomSession(
+            model="gpt-test",
+            db_path=str(tmp_path / "loom.db"),
+            workspace=workspace,
+        )
+        await session.start()
+
+        assert session.registry.get("image_generate") is not None
+        assert session.registry.get("openai__text_to_image") is None
+
+        await session.stop()
 
     async def test_start_loads_mcp_servers_into_session(
         self,


### PR DESCRIPTION
## Summary
- expose OpenAI image generation through canonical `image_generate` when `[tools.image]` opts into `default_provider = "openai"`
- stop registering the old OpenAI-specific image tool by default so non-OpenAI drawing agents do not accidentally pick it
- move artifact emission to the canonical image tool name and refresh config/docs examples

## Verification
- `pytest -q tests` — 1795 passed, 68 warnings
- `python -m py_compile loom/platform/cli/tools.py loom/core/session.py loom/core/harness/middleware.py`
- `git diff --check`
- `npx gitnexus detect-changes --scope staged` — risk low, affected processes 0