### PR TITLE
feat(memory): wire dream_cycle into autonomy as DreamLoop (#376)

### DIFF
--- a/loom.toml.example
+++ b/loom.toml.example
@@ -485,6 +485,14 @@ enabled  = false           # set true to activate daemon
 # dream_cycle is a SAFE tool — no allowed_tools needed for it.
 # But relate (writing relational triples) is GUARDED.
 #
+# OVERLAP WARNING: ``[memory.dream]`` above already schedules a themed
+# dream every ``interval_hours`` directly inside the daemon (no LLM
+# intent layer). Use *this* schedule only when you want a *free* dream
+# (themed=false, cross-domain) on top of the themed loop, or when you
+# disable ``[memory.dream]`` and want to drive the whole cadence via
+# the LLM-routed trigger pipeline. Otherwise prefer ``[memory.dream]``
+# — same effect, no token cost on the intent.
+#
 # [[autonomy.schedules]]
 # name          = "offline_dreaming"
 # cron          = "0 3 * * *"        # 03:00 UTC = 11:00 Asia/Taipei

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -185,6 +185,20 @@ threshold       = 0.1    # overrides [memory.governance].semantic_decay_threshol
 # "knowledge.milestone" = 365
 
 # ─────────────────────────────────────────────
+# Dream loop (Issue #376) — Themed background synthesis
+# ─────────────────────────────────────────────
+# Runs ``dream_cycle(themed=True)`` on a fixed cadence inside the autonomy
+# daemon, parallel to ``[memory.lifecycle]``. Theme rotation state
+# (self → user → project → knowledge) lives in ``memory_meta`` so it
+# survives restarts. The free-form / single-domain modes remain available
+# via the ``dream_cycle`` tool — this loop only owns the themed schedule.
+
+[memory.dream]
+enabled        = true   # set false to disable scheduled dreams entirely
+interval_hours = 12     # cadence (first dream ~5min after daemon start)
+sample_size    = 15     # facts sampled per cycle (matches tool default)
+
+# ─────────────────────────────────────────────
 # Reflection (Issue #120 PR1) — Skill diagnostic layer
 # ─────────────────────────────────────────────
 # When a skill is activated via ``load_skill`` and the turn completes,

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -192,6 +192,14 @@ threshold       = 0.1    # overrides [memory.governance].semantic_decay_threshol
 # (self → user → project → knowledge) lives in ``memory_meta`` so it
 # survives restarts. The free-form / single-domain modes remain available
 # via the ``dream_cycle`` tool — this loop only owns the themed schedule.
+#
+# Recommended pairing (the "B plan"):
+#   • Keep ``[memory.dream]`` on — themed rotation runs cheaply (no LLM
+#     intent layer, just direct python call).
+#   • Add an ``[[autonomy.schedules]]`` block for *free* dreams only
+#     (themed=false, cross-domain) — see the dreaming example near the
+#     bottom of this file.
+#   • Do NOT add a second schedule for themed dreams — it would double-fire.
 
 [memory.dream]
 enabled        = true   # set false to disable scheduled dreams entirely
@@ -481,28 +489,29 @@ enabled  = false           # set true to activate daemon
 #   { resource = "exec", action = "execute", selector = "workspace" },
 # ]
 
-# ── Example: offline dreaming (background knowledge synthesis) ─────────────────
-# dream_cycle is a SAFE tool — no allowed_tools needed for it.
-# But relate (writing relational triples) is GUARDED.
+# ── Example: free-dream supplement (pair with [memory.dream]) ──────────────────
+# Themed rotation is owned by ``[memory.dream]`` (daemon-level, no LLM
+# intent). This schedule is the recommended complement: a single daily
+# *free* dream (themed=false) that samples cross-domain instead of
+# pinning one ontology bucket. Together they give you ~2 themed +
+# 1 free dream per day.
 #
-# OVERLAP WARNING: ``[memory.dream]`` above already schedules a themed
-# dream every ``interval_hours`` directly inside the daemon (no LLM
-# intent layer). Use *this* schedule only when you want a *free* dream
-# (themed=false, cross-domain) on top of the themed loop, or when you
-# disable ``[memory.dream]`` and want to drive the whole cadence via
-# the LLM-routed trigger pipeline. Otherwise prefer ``[memory.dream]``
-# — same effect, no token cost on the intent.
+# Do NOT add a second schedule that calls ``dream_cycle`` with themed=true
+# — that would double-fire against ``[memory.dream]``. If you prefer
+# full LLM-routed control (e.g. dynamic sample_size from intent), set
+# ``[memory.dream].enabled = false`` and use schedules exclusively.
 #
 # [[autonomy.schedules]]
-# name          = "offline_dreaming"
-# cron          = "0 3 * * *"        # 03:00 UTC = 11:00 Asia/Taipei
-# intent        = """Run dream_cycle to synthesise insights from semantic memory.
-#                    Call the dream_cycle tool with default settings and report
-#                    how many new relational insights were written."""
+# name          = "offline_dreaming_free"
+# cron          = "0 19 * * *"       # 19:00 UTC = 03:00 Asia/Taipei
+# intent        = """Run a free cross-domain dream. Call dream_cycle with
+#                    themed=false (the default) so the sample spans all
+#                    four ontology domains at random. Report how many
+#                    new relational insights were written."""
 # trust_level   = "safe"
 # notify        = false
 # notify_thread = 0
-# allowed_tools = ["memorize", "relate"]
+# allowed_tools = ["dream_cycle", "memorize"]
 
 # ── Example: weekly memory housekeeping ──────────────────────────────────────────
 # memory_prune is a SAFE tool — no allowed_tools needed.

--- a/loom/autonomy/daemon.py
+++ b/loom/autonomy/daemon.py
@@ -25,7 +25,7 @@ from typing import Awaitable, Callable
 from loom.autonomy.chime import ChimeRequest
 from loom.autonomy.evaluator import TriggerEvaluator
 from loom.autonomy.history import TriggerHistory
-from loom.autonomy.maintenance import MaintenanceLoop
+from loom.autonomy.maintenance import DreamLoop, MaintenanceLoop
 from loom.autonomy.planner import ActionPlanner, PlannedAction, ActionDecision
 from loom.autonomy.triggers import CronTrigger, EventTrigger, ConditionTrigger
 from loom.core.infra import AbortController, wait_aborted
@@ -473,6 +473,9 @@ class AutonomyDaemon:
         maint_task = self._maybe_start_maintenance()
         if maint_task is not None:
             wait_set.append(maint_task)
+        dream_task = self._maybe_start_dream_loop()
+        if dream_task is not None:
+            wait_set.append(dream_task)
 
         done, pending = await asyncio.wait(
             wait_set, return_when=asyncio.FIRST_COMPLETED
@@ -513,6 +516,62 @@ class AutonomyDaemon:
             "[autonomy] memory maintenance loop started "
             "(interval=%.1fh, throttle=%.1fmin)",
             loop._interval_seconds / 3600.0, loop._min_gap_minutes,
+        )
+        return asyncio.ensure_future(loop.run_forever())
+
+    def _maybe_start_dream_loop(self) -> asyncio.Task | None:
+        """Read [memory.dream] and launch DreamLoop if enabled.
+
+        Issue #376: ``dream_cycle`` only ran when the agent remembered to
+        call its tool form. This loop gives it a deterministic cadence so
+        themed rotation actually fires every day.
+        """
+        session = self._session
+        db = getattr(session, "_db", None) if session else None
+        if session is None or db is None:
+            return None
+        memory = getattr(session, "_memory", None)
+        if memory is None:
+            return None
+        try:
+            from loom.core.session import _load_loom_config  # local import: lazy
+            cfg = _load_loom_config().get("memory", {}).get("dream", {})
+        except Exception as exc:
+            logger.debug("[autonomy] dream config load failed: %s", exc)
+            return None
+        if not cfg.get("enabled", True):
+            return None
+
+        sample_size = int(cfg.get("sample_size", 15))
+        router = session.router
+        model = session.model
+
+        async def _dream_once() -> dict:
+            from loom.core.cognition.dreaming import dream_cycle
+
+            async def _llm_fn(messages: list[dict]) -> str:
+                response = await router.chat(
+                    model=model, messages=messages, max_tokens=2048,
+                )
+                return response.text or ""
+
+            return await dream_cycle(
+                semantic=memory.semantic,
+                relational=memory.relational,
+                llm_fn=_llm_fn,
+                sample_size=sample_size,
+                themed=True,
+                db=db,
+            )
+
+        loop = DreamLoop(
+            dream_fn=_dream_once,
+            abort=self._abort,
+            interval_hours=float(cfg.get("interval_hours", 12.0)),
+        )
+        logger.info(
+            "[autonomy] dream loop started (interval=%.1fh, sample=%d)",
+            loop._interval_seconds / 3600.0, sample_size,
         )
         return asyncio.ensure_future(loop.run_forever())
 

--- a/loom/autonomy/maintenance.py
+++ b/loom/autonomy/maintenance.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import Any, Awaitable, Callable, TYPE_CHECKING
 
 from loom.core.infra import AbortController, wait_aborted
 from loom.core.memory.lifecycle import MemoryLifecycle
@@ -91,3 +91,61 @@ class MaintenanceLoop:
                     )
             except Exception as exc:  # never let maintenance crash the daemon
                 logger.warning("[maintenance] cycle failed: %s", exc)
+
+
+class DreamLoop:
+    """Drives ``dream_cycle(themed=True)`` on a fixed interval until aborted.
+
+    Issue #376: ``dream_cycle`` shipped as a first-class tool in #149 but had
+    no deterministic trigger — it only ran when the agent remembered to call
+    it, leaving empty days. This loop owns the cadence; theme rotation state
+    lives in ``memory_meta`` (``dream.last_theme``) and survives restarts.
+    """
+
+    # Same rationale as MaintenanceLoop._FIRST_SWEEP_DELAY_SECONDS — defer
+    # the first dream so startup doesn't compete with session bring-up.
+    _FIRST_SWEEP_DELAY_SECONDS = 300.0
+
+    def __init__(
+        self,
+        dream_fn: Callable[[], Awaitable[dict[str, Any]]],
+        abort: AbortController,
+        interval_hours: float = 12.0,
+    ) -> None:
+        self._dream_fn = dream_fn
+        self._abort = abort
+        self._interval_seconds = max(60.0, interval_hours * 3600.0)
+
+    async def run_forever(self) -> None:
+        """Run a dream cycle ``_FIRST_SWEEP_DELAY_SECONDS`` after start, then
+        every ``interval_hours``. Returns when the abort signal fires."""
+        first_iter = True
+        while not self._abort.signal.is_set():
+            timeout = (
+                self._FIRST_SWEEP_DELAY_SECONDS if first_iter
+                else self._interval_seconds
+            )
+            first_iter = False
+            try:
+                await asyncio.wait_for(
+                    wait_aborted(self._abort.signal),
+                    timeout=timeout,
+                )
+                return  # abort signalled
+            except asyncio.TimeoutError:
+                pass  # interval elapsed, run a cycle
+
+            try:
+                result = await self._dream_fn()
+                logger.info(
+                    "[dream] cycle domain=%s sampled=%d found=%d written=%d",
+                    result.get("domain") or "free",
+                    result.get("facts_sampled", 0),
+                    result.get("triples_found", 0),
+                    result.get("triples_written", 0),
+                )
+                errors = result.get("errors") or []
+                if errors:
+                    logger.warning("[dream] warnings: %s", "; ".join(errors))
+            except Exception as exc:  # never let dreaming crash the daemon
+                logger.warning("[dream] cycle failed: %s", exc)

--- a/tests/test_dream_loop.py
+++ b/tests/test_dream_loop.py
@@ -1,0 +1,153 @@
+"""Tests for DreamLoop (Issue #376) — autonomy-driven dream cadence."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from loom.autonomy.maintenance import DreamLoop
+from loom.core.infra import AbortController
+
+
+@pytest.fixture(autouse=True)
+def _fast_first_sweep(monkeypatch):
+    """Shorten the first-sweep delay so tests don't wait 5 minutes."""
+    monkeypatch.setattr(DreamLoop, "_FIRST_SWEEP_DELAY_SECONDS", 0.05)
+
+
+async def test_dream_loop_calls_dream_fn_then_aborts():
+    calls: list[dict] = []
+
+    async def dream_fn():
+        result = {
+            "domain": "self",
+            "facts_sampled": 5,
+            "triples_found": 3,
+            "triples_written": 2,
+            "errors": [],
+        }
+        calls.append(result)
+        return result
+
+    abort = AbortController()
+    loop = DreamLoop(dream_fn=dream_fn, abort=abort, interval_hours=24.0)
+
+    task = asyncio.create_task(loop.run_forever())
+    # Wait long enough for the first sweep to fire, but well under the
+    # 24h interval so the second one cannot.
+    await asyncio.sleep(0.2)
+    abort.abort()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert len(calls) == 1
+
+
+async def test_dream_loop_returns_immediately_when_pre_aborted():
+    async def dream_fn():
+        raise AssertionError("should not run when pre-aborted")
+
+    abort = AbortController()
+    abort.abort()
+    loop = DreamLoop(dream_fn=dream_fn, abort=abort, interval_hours=24.0)
+
+    await asyncio.wait_for(loop.run_forever(), timeout=0.5)
+
+
+async def test_dream_loop_swallows_dream_fn_failure(caplog):
+    calls = 0
+
+    async def dream_fn():
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("boom")
+
+    abort = AbortController()
+    loop = DreamLoop(dream_fn=dream_fn, abort=abort, interval_hours=24.0)
+
+    with caplog.at_level(logging.WARNING, logger="loom.autonomy.maintenance"):
+        task = asyncio.create_task(loop.run_forever())
+        await asyncio.sleep(0.2)
+        abort.abort()
+        await asyncio.wait_for(task, timeout=1.0)
+
+    assert calls == 1
+    assert any("dream] cycle failed" in r.message for r in caplog.records)
+
+
+async def test_dream_loop_min_interval_clamp():
+    """interval_hours that would be < 60s gets clamped, so the loop is
+    never set to a degenerate zero-sleep busy-poll."""
+    loop = DreamLoop(
+        dream_fn=lambda: asyncio.sleep(0),  # never invoked
+        abort=AbortController(),
+        interval_hours=0.0,
+    )
+    assert loop._interval_seconds >= 60.0
+
+
+# ---------------------------------------------------------------------------
+# Daemon wiring (_maybe_start_dream_loop) — exercises config gating + the
+# closure construction. Stops short of running an actual dream cycle.
+# ---------------------------------------------------------------------------
+
+
+class _StubMemory:
+    def __init__(self):
+        self.semantic = object()
+        self.relational = object()
+
+
+class _StubSession:
+    def __init__(self, *, with_memory=True, with_db=True):
+        self._memory = _StubMemory() if with_memory else None
+        self._db = object() if with_db else None
+        self.router = object()
+        self.model = "stub-model"
+
+
+def _make_daemon(session):
+    from loom.autonomy.daemon import AutonomyDaemon
+
+    return AutonomyDaemon(
+        notify_router=None,
+        confirm_flow=None,
+        loom_session=session,
+    )
+
+
+def test_maybe_start_dream_loop_skipped_when_disabled(monkeypatch):
+    monkeypatch.setattr(
+        "loom.core.session._load_loom_config",
+        lambda: {"memory": {"dream": {"enabled": False}}},
+    )
+    daemon = _make_daemon(_StubSession())
+    assert daemon._maybe_start_dream_loop() is None
+
+
+def test_maybe_start_dream_loop_skipped_without_session(monkeypatch):
+    daemon = _make_daemon(None)
+    assert daemon._maybe_start_dream_loop() is None
+
+
+def test_maybe_start_dream_loop_skipped_without_db(monkeypatch):
+    monkeypatch.setattr(
+        "loom.core.session._load_loom_config",
+        lambda: {"memory": {"dream": {"enabled": True}}},
+    )
+    daemon = _make_daemon(_StubSession(with_db=False))
+    assert daemon._maybe_start_dream_loop() is None
+
+
+async def test_maybe_start_dream_loop_launches_and_cancels(monkeypatch):
+    monkeypatch.setattr(DreamLoop, "_FIRST_SWEEP_DELAY_SECONDS", 60.0)
+    monkeypatch.setattr(
+        "loom.core.session._load_loom_config",
+        lambda: {"memory": {"dream": {"enabled": True, "interval_hours": 12}}},
+    )
+    daemon = _make_daemon(_StubSession())
+    task = daemon._maybe_start_dream_loop()
+    assert task is not None
+    daemon._abort.abort()
+    await asyncio.wait_for(task, timeout=1.0)


### PR DESCRIPTION
Closes #376.

## Summary

- Adds `DreamLoop` in `loom/autonomy/maintenance.py`, parallel to `MaintenanceLoop` (same abort signal, same first-sweep delay, same never-crash logging).
- Adds `AutonomyDaemon._maybe_start_dream_loop()` that builds the `dream_cycle(themed=True)` closure from the session's `router`/`model`/`_memory`/`_db` and appends it to `start()`'s `wait_set`.
- Adds `[memory.dream]` to `loom.toml.example` (`enabled=true`, `interval_hours=12`, `sample_size=15`).
- Theme rotation state (`dream.last_theme`) keeps living in `memory_meta` — survives restarts; the existing `dream_cycle` tool remains untouched.

## Usage notes

**To turn on:** nothing — defaults to enabled. Daemon will fire the first themed dream ~5min after startup and then every 12h. Cycle hits `self → user → project → knowledge` in round-robin, picking up wherever the previous run left off (state in `memory_meta.dream.last_theme`).

**To turn off / tune:** add to `loom.toml`:
```toml
[memory.dream]
enabled        = false   # silence the schedule entirely (tool form still works)
interval_hours = 24      # halve the cadence to one dream/day
sample_size    = 30      # bigger sample = denser triples but higher LLM cost
```

**Things to watch:**
- **LLM cost** — every cycle calls the configured chat model (`max_tokens=2048`). At default 12h × `sample_size=15`, that's two ~2k-token calls/day. If you run on a paid endpoint and don't want this, set `enabled=false`.
- **Two writers, one DB** — both this loop and `MaintenanceLoop` write to `~/.loom/memory.db`. `dream_cycle` writes `relational` triples; lifecycle writes decay state. No overlap, but if you previously relied on dreams only firing when you (or 絲絲) explicitly invoked the tool, expect a steady stream of `source='dreaming'` rows now.
- **First sweep timing** — the 5-minute first-sweep delay means a fresh `loom autonomy start` does NOT immediately dream. If you want to verify it's wired, either watch logs (`[autonomy] dream loop started ...` at boot, `[dream] cycle domain=... sampled=... ...` per cycle) or temporarily drop the interval.
- **Themed rotation only** — this loop always passes `themed=True`. Free dreams (`domain=None, themed=False`) and pinned-domain dreams remain available only through the agent-facing `dream_cycle` tool — by design (Hook D / inject-on-discovery is deferred per the issue).
- **Failures swallowed** — if the LLM call or DB write throws, the loop logs a warning and waits for the next interval. It won't crash the daemon, but it also won't retry sooner.

## Test plan
- [x] 8 new tests in `tests/test_dream_loop.py` cover: first-sweep fires, pre-abort returns, `dream_fn` failure is swallowed, `interval_hours` clamped, daemon skip when `enabled=false`, skip when no session, skip when no db, launch + cancel happy path.
- [x] `tests/test_autonomy.py` + `tests/test_memory_maintenance.py` 79/79 pass (no regression).
- [ ] Manual: start `loom autonomy start`, confirm `[autonomy] dream loop started` in logs and a `[dream] cycle ...` line within 5 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)