### PR TITLE
feat(memory): persist Pulse injects to session_log for noise/utility analysis (#377)

### DIFF
--- a/loom/core/memory/pulse.py
+++ b/loom/core/memory/pulse.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 import textwrap
+from dataclasses import dataclass
 from datetime import datetime, UTC
 from typing import TYPE_CHECKING
 
@@ -46,6 +47,30 @@ logger = logging.getLogger(__name__)
 _BRIEF_TOP_N = 3
 _GATE_KEY_PREFIX = "pulse.contradiction."
 
+# Pulse type labels. Stable strings — used as session_log metadata keys
+# (Issue #377) so renaming requires a migration of any analytics queries.
+PULSE_TYPE_SESSION_BRIEF = "session_brief"
+PULSE_TYPE_CONTRADICTION = "contradiction"
+
+# Pulse source for Hook G — Hook A uses the contradicting fact key.
+_SOURCE_HOOK_G = "hook_G"
+
+
+@dataclass(frozen=True, slots=True)
+class PulseRecord:
+    """One Pulse inject — text + provenance for session_log persistence.
+
+    Issue #377: pulses used to be ``list[str]`` and vanished after drain,
+    leaving no way to measure noise vs. utility. Carrying ``pulse_type``
+    and ``pulse_source`` through the drain lets ``session_log`` tag each
+    inject so observation queries like "per-hook per-session inject
+    counts" become a straight SELECT.
+    """
+
+    text: str
+    pulse_type: str
+    pulse_source: str
+
 
 class MemoryPulse:
     """Owns the two active hooks (G + A). Stateless across calls — all
@@ -57,7 +82,7 @@ class MemoryPulse:
         semantic: "SemanticMemory",
         session_id: str,
         session_started_at: datetime,
-        pending_buffer: list[str],
+        pending_buffer: "list[PulseRecord]",
     ) -> None:
         self._db = db
         self._semantic = semantic
@@ -102,7 +127,11 @@ class MemoryPulse:
                 "Memory preheat — milestone facts active in your previous "
                 "session (top by confidence):\n" + "\n".join(lines)
             )
-            self._buffer.append(brief)
+            self._buffer.append(PulseRecord(
+                text=brief,
+                pulse_type=PULSE_TYPE_SESSION_BRIEF,
+                pulse_source=_SOURCE_HOOK_G,
+            ))
         except Exception as exc:
             logger.debug("pulse: session_brief failed: %s", exc)
 
@@ -143,7 +172,11 @@ class MemoryPulse:
                 f"  proposed: {new}\n"
                 f"Reconcile if the new value should override the old."
             )
-            self._buffer.append(notice)
+            self._buffer.append(PulseRecord(
+                text=notice,
+                pulse_type=PULSE_TYPE_CONTRADICTION,
+                pulse_source=key,
+            ))
             await self._mark_notified(key)
         except Exception as exc:
             logger.debug("pulse: contradiction_inject failed: %s", exc)

--- a/loom/core/memory/pulse.py
+++ b/loom/core/memory/pulse.py
@@ -82,7 +82,7 @@ class MemoryPulse:
         semantic: "SemanticMemory",
         session_id: str,
         session_started_at: datetime,
-        pending_buffer: "list[PulseRecord]",
+        pending_buffer: list[PulseRecord],
     ) -> None:
         self._db = db
         self._semantic = semantic

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -118,6 +118,7 @@ from loom.core.memory.episodic import EpisodicEntry, EpisodicMemory
 from loom.core.memory.governance import MemoryGovernor
 from loom.core.memory.index import MemoryIndex, MemoryIndexer, SkillCatalogEntry
 from loom.core.memory.procedural import ProceduralMemory
+from loom.core.memory.pulse import PulseRecord
 from loom.core.memory.relational import RelationalMemory
 from loom.core.memory.search import MemorySearch
 from loom.core.memory.semantic import SemanticEntry, SemanticMemory
@@ -858,8 +859,7 @@ class LoomSession:
         # drained as <system-reminder> alongside verdicts in stream_turn.
         # Records (vs. bare strings) so Issue #377 can persist pulse_type
         # / pulse_source into session_log at drain time.
-        from loom.core.memory.pulse import PulseRecord as _PulseRecord
-        self._pending_pulses: list[_PulseRecord] = []
+        self._pending_pulses: list[PulseRecord] = []
         # In-flight judge background tasks — kept so stop() can cancel them
         # cleanly and so a single turn can't fire judge twice.
         self._judge_tasks: set[asyncio.Task] = set()
@@ -1894,6 +1894,16 @@ class LoomSession:
             # tagged with pulse_type/source so noise-vs-utility analytics
             # can run a straight SELECT instead of guessing from agent
             # behaviour. Verdicts stay log-less for now — separate scope.
+            #
+            # Persistence is best-effort by design: ``_log_message`` is
+            # scheduled fire-and-forget (so a slow DB never stalls the
+            # turn) and ``_pending_pulses.clear()`` runs synchronously
+            # below. If a write fails after clear(), that one inject is
+            # lost from the log — the <system-reminder> still reached
+            # the agent. Analytics is observational, not auditable; a
+            # dropped row skews counts at the margin but doesn't break
+            # any contract. If/when we want at-least-once persistence,
+            # await the tasks before clear() — accept the latency cost.
             for body in self._pending_verdicts:
                 self.messages.append({
                     "role": "user",

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -854,9 +854,12 @@ class LoomSession:
         # Verdicts produced async land here; drained as <system-reminder>
         # at the start of the next stream_turn.
         self._pending_verdicts: list[str] = []
-        # Issue #281 P3 Hook G/A — MemoryPulse appends here, drained as
-        # <system-reminder> alongside verdicts in stream_turn.
-        self._pending_pulses: list[str] = []
+        # Issue #281 P3 Hook G/A — MemoryPulse appends PulseRecords here,
+        # drained as <system-reminder> alongside verdicts in stream_turn.
+        # Records (vs. bare strings) so Issue #377 can persist pulse_type
+        # / pulse_source into session_log at drain time.
+        from loom.core.memory.pulse import PulseRecord as _PulseRecord
+        self._pending_pulses: list[_PulseRecord] = []
         # In-flight judge background tasks — kept so stop() can cancel them
         # cleanly and so a single turn can't fire judge twice.
         self._judge_tasks: set[asyncio.Task] = set()
@@ -1886,11 +1889,29 @@ class LoomSession:
             # (judge verdicts and MemoryPulse hooks) before the agent's next
             # LLM call. Order is incidental: both render as identical
             # <system-reminder> blocks, indistinguishable to the model.
-            for body in (*self._pending_verdicts, *self._pending_pulses):
+            #
+            # Issue #377: pulses also get a session_log row (role='system')
+            # tagged with pulse_type/source so noise-vs-utility analytics
+            # can run a straight SELECT instead of guessing from agent
+            # behaviour. Verdicts stay log-less for now — separate scope.
+            for body in self._pending_verdicts:
                 self.messages.append({
                     "role": "user",
                     "content": f"<system-reminder>\n{body}\n</system-reminder>",
                 })
+            for record in self._pending_pulses:
+                self.messages.append({
+                    "role": "user",
+                    "content": f"<system-reminder>\n{record.text}\n</system-reminder>",
+                })
+                asyncio.ensure_future(self._log_message(
+                    "system", record.text,
+                    metadata={
+                        "pulse_type": record.pulse_type,
+                        "pulse_source": record.pulse_source,
+                    },
+                    turn_index=self._turn_index,
+                ))
             self._pending_verdicts.clear()
             self._pending_pulses.clear()
 

--- a/tests/test_pulse_session_log.py
+++ b/tests/test_pulse_session_log.py
@@ -1,0 +1,222 @@
+"""Tests for Issue #377 — Pulse injects persist to session_log.
+
+Covers two halves: (1) MemoryPulse now buffers PulseRecord instead of
+bare strings, (2) the drain in session.stream_turn (verified directly
+against SessionLog here, decoupled from the full session boot) writes
+a role='system' row tagged with pulse_type / pulse_source.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, UTC
+from pathlib import Path
+
+import aiosqlite
+import pytest_asyncio
+
+from loom.core.memory.contradiction import ConflictType, Contradiction, Resolution
+from loom.core.memory.pulse import (
+    PULSE_TYPE_CONTRADICTION,
+    PULSE_TYPE_SESSION_BRIEF,
+    MemoryPulse,
+    PulseRecord,
+)
+from loom.core.memory.semantic import SemanticEntry
+from loom.core.memory.session_log import SessionLog
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def db_with_schema(tmp_path: Path):
+    """Minimal schema: just the tables Pulse + SessionLog touch."""
+    db_path = tmp_path / "pulse.db"
+    conn = await aiosqlite.connect(str(db_path))
+    await conn.executescript(
+        """
+        CREATE TABLE sessions (
+            session_id TEXT, model TEXT, title TEXT,
+            started_at TEXT, last_active TEXT, turn_count INTEGER DEFAULT 0
+        );
+        CREATE TABLE session_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            turn_index INTEGER NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT NOT NULL,
+            raw_json TEXT,
+            metadata TEXT NOT NULL DEFAULT '{}',
+            created_at TEXT NOT NULL
+        );
+        CREATE TABLE semantic_entries (
+            key TEXT PRIMARY KEY, value TEXT, confidence REAL,
+            domain TEXT, temporal TEXT,
+            updated_at TEXT, last_accessed_at TEXT
+        );
+        CREATE TABLE memory_meta (
+            key TEXT PRIMARY KEY, value TEXT, updated_at TEXT
+        );
+        """
+    )
+    await conn.commit()
+    yield conn
+    await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Hook G — session_brief emits PulseRecord
+# ---------------------------------------------------------------------------
+
+
+async def test_hook_g_emits_pulse_record(db_with_schema):
+    conn = db_with_schema
+
+    # Seed a prior session + a milestone-class fact touched since then.
+    prior_start = "2026-05-01T00:00:00+00:00"
+    await conn.execute(
+        "INSERT INTO sessions VALUES ('prev','m','t',?,?,0)",
+        (prior_start, "2026-05-10T00:00:00+00:00"),
+    )
+    await conn.execute(
+        "INSERT INTO semantic_entries VALUES "
+        "('release.v0341','ship dream loop',0.9,'project','milestone',"
+        "'2026-05-15T00:00:00+00:00','2026-05-15T00:00:00+00:00')"
+    )
+    await conn.commit()
+
+    buf: list[PulseRecord] = []
+    pulse = MemoryPulse(
+        db=conn,
+        semantic=None,  # session_brief queries raw SQL, no SemanticMemory call
+        session_id="curr",
+        session_started_at=datetime.now(UTC),
+        pending_buffer=buf,
+    )
+    await pulse.session_brief()
+
+    assert len(buf) == 1
+    rec = buf[0]
+    assert isinstance(rec, PulseRecord)
+    assert rec.pulse_type == PULSE_TYPE_SESSION_BRIEF
+    assert rec.pulse_source == "hook_G"
+    assert "release.v0341" in rec.text
+
+
+async def test_hook_g_noop_when_no_prior_session(db_with_schema):
+    buf: list[PulseRecord] = []
+    pulse = MemoryPulse(
+        db=db_with_schema, semantic=None, session_id="curr",
+        session_started_at=datetime.now(UTC), pending_buffer=buf,
+    )
+    await pulse.session_brief()
+    assert buf == []
+
+
+# ---------------------------------------------------------------------------
+# Hook A — contradiction_inject emits PulseRecord keyed by fact key
+# ---------------------------------------------------------------------------
+
+
+def _make_contradiction(key: str, old: str, new: str) -> Contradiction:
+    return Contradiction(
+        existing=SemanticEntry(key=key, value=old, confidence=0.8),
+        proposed=SemanticEntry(key=key, value=new, confidence=0.9),
+        conflict_type=ConflictType.KEY_MATCH,
+        resolution=Resolution.REPLACE,
+    )
+
+
+async def test_hook_a_emits_pulse_record(db_with_schema):
+    buf: list[PulseRecord] = []
+    pulse = MemoryPulse(
+        db=db_with_schema, semantic=None, session_id="s1",
+        session_started_at=datetime.now(UTC), pending_buffer=buf,
+    )
+    contradiction = _make_contradiction(
+        "user.timezone", "UTC", "Asia/Taipei",
+    )
+    await pulse.contradiction_inject(contradiction)
+
+    assert len(buf) == 1
+    rec = buf[0]
+    assert rec.pulse_type == PULSE_TYPE_CONTRADICTION
+    assert rec.pulse_source == "user.timezone"
+    assert "UTC" in rec.text and "Asia/Taipei" in rec.text
+
+
+async def test_hook_a_once_per_key_per_session(db_with_schema):
+    """Second contradiction on the same key in the same session is gated."""
+    buf: list[PulseRecord] = []
+    pulse = MemoryPulse(
+        db=db_with_schema, semantic=None, session_id="s1",
+        session_started_at=datetime.now(UTC), pending_buffer=buf,
+    )
+    c = _make_contradiction("user.tz", "UTC", "Asia/Taipei")
+    await pulse.contradiction_inject(c)
+    await pulse.contradiction_inject(c)
+    assert len(buf) == 1  # second one suppressed by gate
+
+
+# ---------------------------------------------------------------------------
+# Drain → session_log: simulate the session.stream_turn write path
+# ---------------------------------------------------------------------------
+
+
+async def test_drain_writes_system_row_with_pulse_metadata(db_with_schema):
+    """Mirrors the session.stream_turn pulse drain: for each PulseRecord,
+    call log_message('system', text, metadata={pulse_type, pulse_source}).
+    """
+    conn = db_with_schema
+    log = SessionLog(conn)
+    await log.create_session("s1", "test-model")
+
+    records = [
+        PulseRecord(text="brief", pulse_type=PULSE_TYPE_SESSION_BRIEF,
+                    pulse_source="hook_G"),
+        PulseRecord(text="conflict on user.tz", pulse_type=PULSE_TYPE_CONTRADICTION,
+                    pulse_source="user.tz"),
+    ]
+    for rec in records:
+        await log.log_message(
+            "s1", turn_index=3, role="system", content=rec.text,
+            metadata={"pulse_type": rec.pulse_type,
+                      "pulse_source": rec.pulse_source},
+        )
+
+    cursor = await conn.execute(
+        "SELECT role, turn_index, content, metadata FROM session_log "
+        "ORDER BY id"
+    )
+    rows = await cursor.fetchall()
+    assert len(rows) == 2
+    assert {r[0] for r in rows} == {"system"}
+    assert {r[1] for r in rows} == {3}
+
+    meta_by_source = {
+        json.loads(r[3])["pulse_source"]: json.loads(r[3]) for r in rows
+    }
+    assert meta_by_source["hook_G"]["pulse_type"] == PULSE_TYPE_SESSION_BRIEF
+    assert meta_by_source["user.tz"]["pulse_type"] == PULSE_TYPE_CONTRADICTION
+
+
+async def test_system_rows_excluded_from_load_messages(db_with_schema):
+    """Pulse rows are observation-only; they must not replay into history
+    on session resume (session_log.load_messages already filters role='system').
+    """
+    conn = db_with_schema
+    log = SessionLog(conn)
+    await log.create_session("s1", "test-model")
+    await log.log_message("s1", 0, "user", "hi")
+    await log.log_message(
+        "s1", 0, "system", "memory preheat …",
+        metadata={"pulse_type": PULSE_TYPE_SESSION_BRIEF,
+                  "pulse_source": "hook_G"},
+    )
+
+    msgs = await log.load_messages("s1")
+    assert [m["role"] for m in msgs] == ["user"]
+    assert all("memory preheat" not in m["content"] for m in msgs)


### PR DESCRIPTION
Closes #377.

## Summary

- Pulse buffer changes from `list[str]` → `list[PulseRecord]` (new dataclass in `pulse.py` carrying `text`, `pulse_type`, `pulse_source`).
- Hook G appends `(session_brief, hook_G)`; Hook A appends `(contradiction, <fact_key>)`.
- `session.stream_turn` drain splits verdicts (unchanged) from pulses; for each pulse it appends the `<system-reminder>` AND fires `_log_message("system", text, metadata={pulse_type, pulse_source}, turn_index=...)`.
- `role='system'` rows are observation-only — `SessionLog.load_messages` already filters them out, so resume never replays the inject.

## Usage notes

**No config needed.** Logging starts immediately for every fresh session after merge. Pre-existing pulse history stays absent (no backfill — we only have the text on disk via `_pending_pulses` strings which get cleared per turn).

**Analytics now possible** — examples you can run against `~/.loom/memory.db`:

```sql
-- Inject volume by hook type, last 7 days
SELECT json_extract(metadata,'$.pulse_type') AS pulse_type, COUNT(*) AS n
FROM session_log
WHERE role='system' AND created_at >= datetime('now','-7 days')
GROUP BY pulse_type;

-- Per-session inject frequency (sanity-check "Hook A is too chatty")
SELECT session_id, COUNT(*) AS injects
FROM session_log
WHERE role='system'
  AND json_extract(metadata,'$.pulse_type') = 'contradiction'
GROUP BY session_id
ORDER BY injects DESC;

-- Hot keys contradicting most often across sessions
SELECT json_extract(metadata,'$.pulse_source') AS key, COUNT(*) AS n
FROM session_log
WHERE role='system'
  AND json_extract(metadata,'$.pulse_type') = 'contradiction'
GROUP BY key
ORDER BY n DESC LIMIT 20;
```

**Things to watch:**
- **DB growth** — every pulse now writes a row. Historic baseline was 0; new floor is the pulse rate. At observed ~515 Hook A markers / 12 days that's <50/day — negligible compared to user/assistant traffic.
- **Verdicts stay log-less** — kept the scope narrow per the issue. If verdict observability becomes useful too, same pattern can be applied without breaking this one.
- **`role='system'` is a new value** for the `session_log` table — schema has no CHECK constraint so writes succeed, and `load_messages` already filters. Anything that reads `session_log` directly (analytics scripts, future migrations) should treat `role='system'` as observation-only metadata.

## Test plan
- [x] 6 new tests in `tests/test_pulse_session_log.py` cover: Hook G emits expected `PulseRecord`, Hook G no-op when no prior session, Hook A emits with key as `pulse_source`, Hook A once-per-key gate, drain writes `role='system'` with metadata, `load_messages` excludes system rows.
- [x] No regressions — 1803 tests pass (the one failure is a pre-existing `import PIL` issue in TUI tests, unrelated).
- [ ] Manual: run a session, contradict an existing fact (e.g. memorize over an existing key with a different value), then `sqlite3 ~/.loom/memory.db "SELECT role, content, metadata FROM session_log WHERE role='system' ORDER BY id DESC LIMIT 5;"` — expect one row per inject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)