### PR TITLE
fix(memory): fold session-compression contradictions into single Pulse (#378)

### DIFF
--- a/loom/core/memory/pulse.py
+++ b/loom/core/memory/pulse.py
@@ -29,7 +29,7 @@ import logging
 import textwrap
 from dataclasses import dataclass
 from datetime import datetime, UTC
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from loom.core.memory.ontology import (
     DOMAIN_PROJECT,
@@ -55,6 +55,24 @@ PULSE_TYPE_CONTRADICTION = "contradiction"
 # Pulse source for Hook G — Hook A uses the contradicting fact key.
 _SOURCE_HOOK_G = "hook_G"
 
+# Issue #378 — fold-display constraints. Folded form caps bullets so a
+# pathological compression batch (50+ contradictions) doesn't blow up the
+# system-reminder. Truncated entries are still individually queryable in
+# session_log (folding only affects the agent-visible inject, not the
+# analytics rows).
+_FOLD_MAX_LINES = 20
+_FOLD_VALUE_LIMIT = 60
+
+
+def _truncate(value: str, limit: int = 160) -> str:
+    """Whitespace-aware shorten so CJK / mixed-script values don't slice
+    mid-grapheme. Used by both Hook A's per-record render and the
+    Issue #378 fold helper."""
+    v = value.strip().replace("\n", " ")
+    if len(v) <= limit:
+        return v
+    return textwrap.shorten(v, width=limit, placeholder="…")
+
 
 @dataclass(frozen=True, slots=True)
 class PulseRecord:
@@ -65,11 +83,54 @@ class PulseRecord:
     and ``pulse_source`` through the drain lets ``session_log`` tag each
     inject so observation queries like "per-hook per-session inject
     counts" become a straight SELECT.
+
+    Issue #378: ``details`` carries structured per-record data (e.g.
+    contradiction key/existing/proposed) so the drain-side fold helper
+    can render a compact bullet form. ``None`` for hooks that don't
+    need structured access (Hook G / session_brief).
     """
 
     text: str
     pulse_type: str
     pulse_source: str
+    details: dict[str, Any] | None = None
+
+
+def fold_contradiction_pulses(records: list[PulseRecord]) -> str:
+    """Render a list of contradiction PulseRecords as one consolidated
+    ``<system-reminder>`` body (Issue #378).
+
+    Callers should only invoke this when ``len(records) >= 2`` — for a
+    single record use ``record.text`` so the original verbose form
+    (multi-line with "Reconcile if…") is preserved. session_log is
+    written separately by the drain caller, so every record here still
+    contributes one row regardless of folding.
+    """
+    if not records:
+        return ""
+    n = len(records)
+    lines = [
+        f"Memory contradictions — {n} stored facts conflict with "
+        f"newly-written values (folded from a single drain):"
+    ]
+    shown = records[:_FOLD_MAX_LINES]
+    for r in shown:
+        d = r.details or {}
+        key = d.get("key", r.pulse_source)
+        resolution = d.get("resolution", "pending")
+        old = _truncate(str(d.get("existing", "?")), limit=_FOLD_VALUE_LIMIT)
+        new = _truncate(str(d.get("proposed", "?")), limit=_FOLD_VALUE_LIMIT)
+        lines.append(
+            f'  - {key} ({resolution}): existing "{old}" → proposed "{new}"'
+        )
+    overflow = n - len(shown)
+    if overflow > 0:
+        lines.append(
+            f"  … +{overflow} more (see session_log role='system' rows "
+            "for the full list)"
+        )
+    lines.append("Reconcile if the new values should override the old.")
+    return "\n".join(lines)
 
 
 class MemoryPulse:
@@ -122,7 +183,7 @@ class MemoryPulse:
             if not rows:
                 return
 
-            lines = [f"- {row[0]}: {self._truncate(row[1])}" for row in rows]
+            lines = [f"- {row[0]}: {_truncate(row[1])}" for row in rows]
             brief = (
                 "Memory preheat — milestone facts active in your previous "
                 "session (top by confidence):\n" + "\n".join(lines)
@@ -163,11 +224,15 @@ class MemoryPulse:
             if await self._already_notified_this_session(key):
                 return
 
-            old = self._truncate(contradiction.existing.value)
-            new = self._truncate(contradiction.proposed.value)
+            old = _truncate(contradiction.existing.value)
+            new = _truncate(contradiction.proposed.value)
+            resolution = (
+                contradiction.resolution.value
+                if contradiction.resolution else "pending"
+            )
             notice = (
                 f"Memory contradiction on key={key!r} (resolution: "
-                f"{contradiction.resolution.value if contradiction.resolution else 'pending'}):\n"
+                f"{resolution}):\n"
                 f"  existing: {old}\n"
                 f"  proposed: {new}\n"
                 f"Reconcile if the new value should override the old."
@@ -176,6 +241,16 @@ class MemoryPulse:
                 text=notice,
                 pulse_type=PULSE_TYPE_CONTRADICTION,
                 pulse_source=key,
+                # Issue #378: structured fields let the drain fold helper
+                # render a compact one-line-per-key form when multiple
+                # contradictions land in the same drain. ``text`` above
+                # stays as the standalone-friendly long form.
+                details={
+                    "key": key,
+                    "existing": old,
+                    "proposed": new,
+                    "resolution": resolution,
+                },
             ))
             await self._mark_notified(key)
         except Exception as exc:
@@ -210,16 +285,3 @@ class MemoryPulse:
         # at this point — do not introduce any before this hook fires.
         await self._db.commit()
 
-    # ------------------------------------------------------------------
-    # helpers
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def _truncate(value: str, limit: int = 160) -> str:
-        # textwrap.shorten is whitespace-aware so CJK / mixed-script values
-        # don't get sliced mid-grapheme on the byte boundary. Falls back to
-        # raw value if already short, since shorten() collapses whitespace.
-        v = value.strip().replace("\n", " ")
-        if len(v) <= limit:
-            return v
-        return textwrap.shorten(v, width=limit, placeholder="…")

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -118,7 +118,11 @@ from loom.core.memory.episodic import EpisodicEntry, EpisodicMemory
 from loom.core.memory.governance import MemoryGovernor
 from loom.core.memory.index import MemoryIndex, MemoryIndexer, SkillCatalogEntry
 from loom.core.memory.procedural import ProceduralMemory
-from loom.core.memory.pulse import PulseRecord
+from loom.core.memory.pulse import (
+    PULSE_TYPE_CONTRADICTION,
+    PulseRecord,
+    fold_contradiction_pulses,
+)
 from loom.core.memory.relational import RelationalMemory
 from loom.core.memory.search import MemorySearch
 from loom.core.memory.semantic import SemanticEntry, SemanticMemory
@@ -1909,11 +1913,29 @@ class LoomSession:
                     "role": "user",
                     "content": f"<system-reminder>\n{body}\n</system-reminder>",
                 })
-            for record in self._pending_pulses:
+
+            # Issue #378: a single session-compression batch can fire
+            # several Hook A contradictions back-to-back (98% of historical
+            # injects, peak 6-in-a-batch). Fold them into one inject so the
+            # agent sees one bullet list instead of N stacked reminders.
+            # session_log keeps one row per record — folding is agent-side
+            # noise reduction only, the analytics granularity is preserved.
+            contradictions = [
+                r for r in self._pending_pulses
+                if r.pulse_type == PULSE_TYPE_CONTRADICTION
+            ]
+            others = [
+                r for r in self._pending_pulses
+                if r.pulse_type != PULSE_TYPE_CONTRADICTION
+            ]
+
+            def _emit_reminder(body: str) -> None:
                 self.messages.append({
                     "role": "user",
-                    "content": f"<system-reminder>\n{record.text}\n</system-reminder>",
+                    "content": f"<system-reminder>\n{body}\n</system-reminder>",
                 })
+
+            def _log_record(record: PulseRecord) -> None:
                 asyncio.ensure_future(self._log_message(
                     "system", record.text,
                     metadata={
@@ -1922,6 +1944,19 @@ class LoomSession:
                     },
                     turn_index=self._turn_index,
                 ))
+
+            for record in others:
+                _emit_reminder(record.text)
+                _log_record(record)
+
+            if len(contradictions) >= 2:
+                _emit_reminder(fold_contradiction_pulses(contradictions))
+                for record in contradictions:
+                    _log_record(record)
+            else:
+                for record in contradictions:
+                    _emit_reminder(record.text)
+                    _log_record(record)
             self._pending_verdicts.clear()
             self._pending_pulses.clear()
 

--- a/tests/test_pulse_session_log.py
+++ b/tests/test_pulse_session_log.py
@@ -380,3 +380,77 @@ def test_drain_passes_through_non_contradiction_pulses_unchanged():
     )
     reminders = _simulate_drain([brief])
     assert reminders == [brief.text]
+
+
+def _simulate_full_drain(
+    verdicts: list[str], pulses: list[PulseRecord]
+) -> list[str]:
+    """Mirror the full session.stream_turn drain — verdicts AND pulses.
+
+    Mirrors the source order:
+      1. verdicts (each as own reminder)
+      2. non-contradiction pulses (each as own reminder)
+      3. contradiction pulses (folded into one reminder when N≥2,
+         else each as own reminder)
+    """
+    contradictions = [r for r in pulses
+                       if r.pulse_type == PULSE_TYPE_CONTRADICTION]
+    others = [r for r in pulses
+              if r.pulse_type != PULSE_TYPE_CONTRADICTION]
+    out: list[str] = []
+    out.extend(verdicts)
+    out.extend(r.text for r in others)
+    if len(contradictions) >= 2:
+        out.append(fold_contradiction_pulses(contradictions))
+    else:
+        out.extend(r.text for r in contradictions)
+    return out
+
+
+def test_drain_ordering_verdicts_first_then_others_then_contradictions():
+    """Issue #378 changed the drain shape from "verdicts then pulses (insertion
+    order)" to "verdicts → non-contradiction pulses → contradictions (folded)".
+    Pin the ordering so a future refactor that interleaves these three
+    classes again will trip a test rather than silently change what the
+    agent sees first."""
+    verdict_a = "verdict alpha"
+    verdict_b = "verdict beta"
+    brief = PulseRecord(
+        text="brief preheat", pulse_type=PULSE_TYPE_SESSION_BRIEF,
+        pulse_source="hook_G",
+    )
+    c1 = _make_contradiction_record("k1", "old1", "new1")
+    c2 = _make_contradiction_record("k2", "old2", "new2")
+
+    reminders = _simulate_full_drain(
+        verdicts=[verdict_a, verdict_b], pulses=[c1, brief, c2],
+    )
+
+    # Expect: 2 verdicts → 1 brief → 1 folded contradiction reminder = 4
+    assert len(reminders) == 4
+    assert reminders[0] == verdict_a
+    assert reminders[1] == verdict_b
+    assert reminders[2] == brief.text
+    assert reminders[3].startswith("Memory contradictions —")
+    # Folded reminder carries both contradiction keys.
+    for key in ("k1", "k2"):
+        assert f"- {key}" in reminders[3]
+
+
+def test_drain_ordering_holds_when_only_one_contradiction_unfolded():
+    """N=1 contradiction stays as its own verbose reminder but still lands
+    after verdicts + non-contradiction pulses — ordering invariant must
+    hold whether or not folding kicks in."""
+    brief = PulseRecord(
+        text="brief", pulse_type=PULSE_TYPE_SESSION_BRIEF,
+        pulse_source="hook_G",
+    )
+    c1 = _make_contradiction_record("solo.key", "x", "y")
+
+    reminders = _simulate_full_drain(
+        verdicts=["v1"], pulses=[c1, brief],
+    )
+
+    assert reminders[0] == "v1"
+    assert reminders[1] == brief.text
+    assert reminders[2] == c1.text  # unfolded singular form

--- a/tests/test_pulse_session_log.py
+++ b/tests/test_pulse_session_log.py
@@ -21,6 +21,7 @@ from loom.core.memory.pulse import (
     PULSE_TYPE_SESSION_BRIEF,
     MemoryPulse,
     PulseRecord,
+    fold_contradiction_pulses,
 )
 from loom.core.memory.semantic import SemanticEntry
 from loom.core.memory.session_log import SessionLog
@@ -220,3 +221,162 @@ async def test_system_rows_excluded_from_load_messages(db_with_schema):
     msgs = await log.load_messages("s1")
     assert [m["role"] for m in msgs] == ["user"]
     assert all("memory preheat" not in m["content"] for m in msgs)
+
+
+# ---------------------------------------------------------------------------
+# Issue #378 — fold_contradiction_pulses: drain-side noise reduction
+# ---------------------------------------------------------------------------
+
+
+def _make_contradiction_record(key: str, old: str, new: str,
+                                resolution: str = "replace") -> PulseRecord:
+    text = (
+        f"Memory contradiction on key={key!r} (resolution: {resolution}):\n"
+        f"  existing: {old}\n"
+        f"  proposed: {new}\n"
+        f"Reconcile if the new value should override the old."
+    )
+    return PulseRecord(
+        text=text,
+        pulse_type=PULSE_TYPE_CONTRADICTION,
+        pulse_source=key,
+        details={"key": key, "existing": old, "proposed": new,
+                 "resolution": resolution},
+    )
+
+
+def test_fold_renders_header_bullets_and_footer():
+    records = [
+        _make_contradiction_record("user.tz", "UTC", "Asia/Taipei"),
+        _make_contradiction_record("user.lang", "en", "zh-TW"),
+        _make_contradiction_record("project.codename", "Loom", "Loom v0.4"),
+    ]
+    body = fold_contradiction_pulses(records)
+
+    # Header announces the count.
+    assert "3 stored facts conflict" in body
+    # Every key appears in its own bullet.
+    for key in ("user.tz", "user.lang", "project.codename"):
+        assert f"- {key}" in body
+    # Old + new values surface inline.
+    assert '"UTC" → proposed "Asia/Taipei"' in body
+    # Footer instructs the agent to reconcile.
+    assert body.rstrip().endswith("Reconcile if the new values should override the old.")
+    # No overflow marker for a small batch.
+    assert "more (see session_log" not in body
+
+
+def test_fold_truncates_pathological_batch():
+    """A compression batch with >20 contradictions still produces a single
+    inject; the bulleted list is capped and an overflow line tells the
+    agent where to find the rest."""
+    records = [
+        _make_contradiction_record(f"fact:{i}", f"old{i}", f"new{i}")
+        for i in range(25)
+    ]
+    body = fold_contradiction_pulses(records)
+
+    assert "25 stored facts conflict" in body
+    # Only the first 20 bullets are rendered.
+    assert "- fact:19" in body
+    assert "- fact:20" not in body
+    # Overflow marker mentions remaining count.
+    assert "+5 more (see session_log" in body
+
+
+def test_fold_uses_pulse_source_when_details_missing():
+    """A PulseRecord without details (e.g. from an older code path) still
+    folds — falls back to pulse_source and 'pending' / '?' placeholders
+    instead of crashing."""
+    bare = PulseRecord(
+        text="legacy text", pulse_type=PULSE_TYPE_CONTRADICTION,
+        pulse_source="legacy.key", details=None,
+    )
+    body = fold_contradiction_pulses([bare, bare])
+    assert "- legacy.key (pending)" in body
+    assert 'existing "?"' in body
+
+
+def test_fold_empty_returns_empty_string():
+    assert fold_contradiction_pulses([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# Drain simulation — mirror session.stream_turn's branching against the
+# real SessionLog. End-to-end would need a full session boot, so we
+# reproduce the drain loop here and assert the observable contract:
+#   • messages list grows by exactly the expected number of reminders
+#   • session_log gets one row per PulseRecord regardless of folding
+# ---------------------------------------------------------------------------
+
+
+def _simulate_drain(pulses: list[PulseRecord]) -> list[str]:
+    """Pure-Python mirror of the session.py drain branching for
+    contradictions. Returns the list of reminder bodies that would be
+    appended to ``self.messages``."""
+    contradictions = [r for r in pulses if r.pulse_type == PULSE_TYPE_CONTRADICTION]
+    others = [r for r in pulses if r.pulse_type != PULSE_TYPE_CONTRADICTION]
+    out = [r.text for r in others]
+    if len(contradictions) >= 2:
+        out.append(fold_contradiction_pulses(contradictions))
+    else:
+        out.extend(r.text for r in contradictions)
+    return out
+
+
+async def test_drain_folds_multiple_contradictions_into_single_reminder(db_with_schema):
+    conn = db_with_schema
+    log = SessionLog(conn)
+    await log.create_session("s1", "test-model")
+
+    pulses = [
+        _make_contradiction_record("k1", "old1", "new1"),
+        _make_contradiction_record("k2", "old2", "new2"),
+        _make_contradiction_record("k3", "old3", "new3"),
+        PulseRecord(text="preheat", pulse_type=PULSE_TYPE_SESSION_BRIEF,
+                    pulse_source="hook_G"),
+    ]
+
+    reminders = _simulate_drain(pulses)
+    # 1 brief + 1 folded contradiction reminder — NOT 4.
+    assert len(reminders) == 2
+    folded = next(r for r in reminders if r.startswith("Memory contradictions —"))
+    for key in ("k1", "k2", "k3"):
+        assert f"- {key}" in folded
+
+    # session_log still records every individual pulse — analytics
+    # granularity is unchanged by folding.
+    for record in pulses:
+        await log.log_message(
+            "s1", turn_index=7, role="system", content=record.text,
+            metadata={"pulse_type": record.pulse_type,
+                      "pulse_source": record.pulse_source},
+        )
+    cursor = await conn.execute(
+        "SELECT COUNT(*), "
+        "SUM(CASE WHEN json_extract(metadata,'$.pulse_type')='contradiction' "
+        "         THEN 1 ELSE 0 END) "
+        "FROM session_log WHERE role='system'"
+    )
+    total, contradictions_logged = await cursor.fetchone()
+    assert total == 4
+    assert contradictions_logged == 3
+
+
+def test_drain_single_contradiction_uses_original_text():
+    """N=1 should NOT fold — agent sees the original verbose multi-line
+    notice (preserves the standalone-friendly form Hook A wrote)."""
+    rec = _make_contradiction_record("user.tz", "UTC", "Asia/Taipei")
+    reminders = _simulate_drain([rec])
+    assert reminders == [rec.text]
+    assert "Memory contradictions —" not in reminders[0]  # fold header absent
+    assert "Memory contradiction on key=" in reminders[0]  # original singular form
+
+
+def test_drain_passes_through_non_contradiction_pulses_unchanged():
+    brief = PulseRecord(
+        text="preheat lines …",
+        pulse_type=PULSE_TYPE_SESSION_BRIEF, pulse_source="hook_G",
+    )
+    reminders = _simulate_drain([brief])
+    assert reminders == [brief.text]


### PR DESCRIPTION
Closes #378. Stacks on #377 (PulseRecord schema), which is already on master.

## Summary

A single session-compression batch can flag 6 contradictions in 3 ms — all of which used to surface as 6 stacked `<system-reminder>` blocks at the next turn. Fold them in the drain so the agent sees **one** bullet list, while session_log keeps **N rows** for analytics.

| Layer | Change |
|-------|--------|
| `pulse.py` | `PulseRecord.details` (optional dict); `fold_contradiction_pulses()` helper; module-level `_truncate` lifted out of `MemoryPulse` |
| `pulse.py · Hook A` | populates `details={key, existing, proposed, resolution}` |
| `session.py · drain` | splits contradictions from others; folds when N≥2; non-contradiction pulses + verdicts untouched |
| `session_log` | unchanged — one row per record regardless of folding |

## Usage notes

**Zero config.** Takes effect on every fresh drain after merge.

**What the agent sees now**:

Before (6 separate reminders, 6 turns of clutter):
```
<system-reminder>Memory contradiction on key='loom.fact:1' ...</system-reminder>
<system-reminder>Memory contradiction on key='loom.fact:2' ...</system-reminder>
... (×4 more)
```

After (one consolidated reminder):
```
<system-reminder>
Memory contradictions — 6 stored facts conflict with newly-written values (folded from a single drain):
  - loom.fact:1 (replace): existing "v1" → proposed "v2"
  - loom.fact:2 (replace): existing "..." → proposed "..."
  ...
Reconcile if the new values should override the old.
</system-reminder>
```

**N=1 still uses the original verbose form** — single-contradiction events are clearer with the standalone "Reconcile if the new value should override the old." wording than a degenerate 1-bullet list.

**Pathological batches are capped at 20 bullets** with a "+M more (see session_log role='system' rows for the full list)" pointer. Truncated entries are still individually queryable.

**Analytics queries unchanged**:
```sql
-- Hot keys (each row is still one fact contradiction)
SELECT json_extract(metadata,'$.pulse_source') AS key, COUNT(*)
FROM session_log
WHERE role='system' AND json_extract(metadata,'$.pulse_type')='contradiction'
GROUP BY key ORDER BY 2 DESC;

-- "How many rows did each fold cover?" (new — derivable from grouping)
SELECT session_id, turn_index, COUNT(*) AS folded_into_one_inject
FROM session_log
WHERE role='system' AND json_extract(metadata,'$.pulse_type')='contradiction'
GROUP BY session_id, turn_index
HAVING folded_into_one_inject >= 2;
```

**Things to watch**:
- **Mid-turn ordering**: the drain order is now `verdicts → non-contradiction pulses → (folded or unfolded) contradictions`. Previously verdicts came first, then ALL pulses interleaved by insertion order. If anything in the codebase relied on contradiction reminders appearing in their original insertion position relative to session_brief, that ordering has shifted — none found in grep, and the new `test_drain_ordering_*` tests pin this so future refactors won't drift silently.
- **Fire-and-forget loss now amplified by fold size**: the `_log_message` calls remain fire-and-forget (per the comment added in #377), so a write failure can drop a row from `session_log`. Before this PR, each Hook A pulse was its own asyncio task — losing one dropped one row. Now N contradictions from a single drain are scheduled in a tight loop and the buffer clears synchronously after; if the event loop crashes between schedule and write, you can lose **all N rows** of that batch in one go (rather than one). The agent still received the (folded) `<system-reminder>` — only the analytics row is at risk. Same trade-off as #377, just with a larger blast radius per failure. If/when at-least-once persistence becomes a requirement, await the tasks before `clear()` (drain-block comment in session.py spells out the path).
- **PulseRecord schema change is back-compat**: `details` defaults to `None`. Callers that built records without it (none in tree) keep working; `fold_contradiction_pulses` falls back to `pulse_source` and "?" placeholders.

## Test plan
- [x] 9 new tests in `tests/test_pulse_session_log.py` (total now 15): fold shape, overflow truncation, missing-details fallback, empty input, full drain simulation (1 reminder + N log rows), N=1 unfolded, non-contradiction passthrough, drain ordering with verdicts + non-contradiction pulses + folded contradictions, ordering invariant when N=1 unfolded.
- [x] All 6 #377 tests still pass — schema change is back-compat.
- [x] 1792 tests pass (the pre-existing PIL ModuleNotFoundError tests are skipped, same baseline as #377).
- [ ] Manual: trigger a session compaction that contradicts ≥2 existing facts; check that the next turn's history shows ONE `<system-reminder>` with N bullets, and `SELECT COUNT(*) FROM session_log WHERE role='system' AND json_extract(metadata,'$.pulse_type')='contradiction'` increments by N (not 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
