### PR TITLE
feat(ledger): #385 — ledger_recall narrative recall over AgentLedger

### DIFF
--- a/loom/core/ledger/recall.py
+++ b/loom/core/ledger/recall.py
@@ -1,0 +1,380 @@
+"""Ledger recall — human-readable rendering over EventQuery results.
+
+doc/53 Pull API (`LedgerStore.events`) covers the structured query layer.
+This module is the rendering layer the agent uses when it wants to
+"recall" past activity in story form, not as a SQL result set.
+
+Three output formats:
+
+- ``narrative`` — per-turn paragraph story. Header + user intent + agent
+  action chain. Default for queries scoped to ``session_id`` /
+  ``correlation_id`` (i.e. "rebuild what happened in this slice").
+- ``summary``  — aggregate stats over the result set (tool counts,
+  success/failure ratio, turn outcomes). Default for queries scoped to
+  ``skill_id`` / ``tool_name`` / time range.
+- ``raw``      — one-line-per-event timeline. Escape hatch when the agent
+  wants to inspect events directly.
+
+Cross-database join (events in ``ledger.db`` + user messages in
+``memory.db.session_log``) happens in the tool layer; the renderer takes
+``messages_by_turn`` as a plain dict so it stays pure-data and trivially
+testable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from loom.core.ledger.schema import LedgerEvent
+
+
+OutputFormat = Literal["narrative", "summary", "raw"]
+
+_USER_TEXT_CAP = 120        # user message preview length
+_ERR_TEXT_CAP = 60          # error text length in action chain
+_COMPACT_TOOL_THRESHOLD = 8  # actions per turn before we condense
+_RAW_DEFAULT_MAX = 100
+
+
+# ── Turn grouping ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class TurnSlice:
+    """One turn's window: bookends + events in between.
+
+    ``started_at`` / ``ended_at`` come from ``turn_start`` / ``turn_end``
+    when present; missing bookends fall back to the first/last event
+    timestamp in the slice.
+    """
+
+    turn_id: str
+    session_id: str
+    started_at: float
+    ended_at: float | None
+    outcome: str | None
+    events: list[LedgerEvent] = field(default_factory=list)
+
+
+def group_events_by_turn(events: list[LedgerEvent]) -> list[TurnSlice]:
+    """Split an event list into per-turn slices, preserving turn order.
+
+    Order is determined by the first event seen per ``turn_id``. The
+    caller is responsible for sorting ``events`` by timestamp ASC if
+    chronological ordering matters.
+    """
+    by_turn: dict[str, list[LedgerEvent]] = {}
+    order: list[str] = []
+    for e in events:
+        if e.turn_id not in by_turn:
+            by_turn[e.turn_id] = []
+            order.append(e.turn_id)
+        by_turn[e.turn_id].append(e)
+
+    slices: list[TurnSlice] = []
+    for turn_id in order:
+        turn_events = by_turn[turn_id]
+        start_ts: float | None = None
+        end_ts: float | None = None
+        outcome: str | None = None
+        for e in turn_events:
+            if e.event_type == "turn_start":
+                start_ts = e.timestamp
+            elif e.event_type == "turn_end":
+                end_ts = e.timestamp
+                outcome = e.payload.get("outcome")
+        if start_ts is None:
+            start_ts = turn_events[0].timestamp
+        slices.append(
+            TurnSlice(
+                turn_id=turn_id,
+                session_id=turn_events[0].session_id,
+                started_at=start_ts,
+                ended_at=end_ts,
+                outcome=outcome,
+                events=turn_events,
+            )
+        )
+    return slices
+
+
+# ── Time formatting ───────────────────────────────────────────────────
+
+
+def _fmt_date(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d")
+
+
+def _fmt_time(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%H:%M")
+
+
+def _fmt_full(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
+
+
+# ── Narrative renderer ────────────────────────────────────────────────
+
+
+def render_narrative(
+    slices: list[TurnSlice],
+    messages_by_turn: dict[str, list[dict[str, Any]]],
+    *,
+    verbose: bool = False,
+) -> str:
+    """Per-turn paragraph narrative.
+
+    Each turn renders as a three-line block: header (round + HH:MM),
+    user intent (first user message preview, or fallback), and an agent
+    action chain summarising the tool calls.
+
+    ``messages_by_turn`` is keyed by ``turn_id`` and holds session_log
+    rows shaped like :meth:`SessionLog.messages_between` output.
+    """
+    if not slices:
+        return _empty_window()
+
+    sessions_seen: list[str] = []
+    for sl in slices:
+        if sl.session_id not in sessions_seen:
+            sessions_seen.append(sl.session_id)
+
+    parts: list[str] = []
+    for sid in sessions_seen:
+        sid_slices = [sl for sl in slices if sl.session_id == sid]
+        first_ts = sid_slices[0].started_at
+        parts.append(f"## session {sid} — {_fmt_date(first_ts)}")
+        parts.append("")
+        for idx, sl in enumerate(sid_slices, start=1):
+            parts.append(
+                _render_turn(
+                    sl, idx,
+                    messages_by_turn.get(sl.turn_id, []),
+                    verbose=verbose,
+                )
+            )
+            parts.append("")
+    return "\n".join(parts).rstrip()
+
+
+def _render_turn(
+    sl: TurnSlice,
+    idx: int,
+    messages: list[dict[str, Any]],
+    *,
+    verbose: bool,
+) -> str:
+    header = f"第 {idx} 輪 ({_fmt_time(sl.started_at)})"
+    user_line = _render_user_line(messages)
+    action_line = _render_actions(sl.events, verbose=verbose)
+    if sl.outcome and sl.outcome not in {"clean", None}:
+        action_line += f"  ← turn 結局 {sl.outcome}"
+    return f"{header}\n{user_line}\n{action_line}"
+
+
+def _render_user_line(messages: list[dict[str, Any]]) -> str:
+    for m in messages:
+        if m.get("role") != "user":
+            continue
+        text = (m.get("content") or "").strip()
+        if not text:
+            continue
+        if len(text) > _USER_TEXT_CAP:
+            text = text[:_USER_TEXT_CAP] + "…"
+        return f"你說：{text}"
+    return "（沒有捕捉到你的訊息）"
+
+
+def _render_actions(events: list[LedgerEvent], *, verbose: bool) -> str:
+    ends = [
+        e for e in events
+        if e.event_type == "tool_lifecycle"
+        and e.payload.get("phase") == "END"
+    ]
+    if not ends:
+        return "我這回合沒有動工具。"
+
+    parts: list[str] = []
+    successes = 0
+    failures = 0
+    rolled = 0
+    for e in ends:
+        p = e.payload
+        tool = p.get("tool_name", "?")
+        if p.get("rolled_back"):
+            parts.append(f"{tool}（rollback）")
+            rolled += 1
+        elif p.get("error"):
+            err = (p.get("error") or "")[:_ERR_TEXT_CAP]
+            parts.append(f"{tool}（失敗：{err}）")
+            failures += 1
+        else:
+            parts.append(tool)
+            successes += 1
+
+    total = len(ends)
+    duration_s = ends[-1].timestamp - ends[0].timestamp if total >= 2 else 0
+    summary_bits = [f"{total} events"]
+    if duration_s > 0:
+        summary_bits.append(f"{duration_s:.1f}s")
+    if failures or rolled:
+        outcome_bits = f"{successes}成 {failures}敗"
+        if rolled:
+            outcome_bits += f" {rolled}回滾"
+        summary_bits.append(outcome_bits)
+    suffix = f"（{', '.join(summary_bits)}）"
+
+    if not verbose and total > _COMPACT_TOOL_THRESHOLD:
+        unique_tools: list[str] = []
+        for e in ends:
+            t = e.payload.get("tool_name", "?")
+            if t not in unique_tools:
+                unique_tools.append(t)
+        body = f"我做了 {total} 件事，主要用 " + "、".join(unique_tools[:5])
+    else:
+        body = "我做了：" + " → ".join(parts)
+    return f"{body}{suffix}"
+
+
+# ── Summary renderer ──────────────────────────────────────────────────
+
+
+def render_summary(events: list[LedgerEvent]) -> str:
+    """Aggregate stats: window, sessions, per-tool success/failure, turn outcomes."""
+    if not events:
+        return _empty_window()
+
+    start_ts = min(e.timestamp for e in events)
+    end_ts = max(e.timestamp for e in events)
+
+    by_tool: dict[str, dict[str, int]] = {}
+    sessions: set[str] = set()
+    turn_outcomes: dict[str, int] = {}
+
+    for e in events:
+        sessions.add(e.session_id)
+        if (
+            e.event_type == "tool_lifecycle"
+            and e.payload.get("phase") == "END"
+        ):
+            t = e.payload.get("tool_name", "?")
+            slot = by_tool.setdefault(t, {"ok": 0, "err": 0})
+            if e.payload.get("error") or e.payload.get("rolled_back"):
+                slot["err"] += 1
+            else:
+                slot["ok"] += 1
+        elif e.event_type == "turn_end":
+            o = e.payload.get("outcome", "?")
+            turn_outcomes[o] = turn_outcomes.get(o, 0) + 1
+
+    sessions_sorted = sorted(sessions)
+    sessions_preview = ", ".join(sessions_sorted[:5])
+    if len(sessions_sorted) > 5:
+        sessions_preview += "…"
+
+    lines = [
+        f"## 摘要：{_fmt_full(start_ts)} ~ {_fmt_full(end_ts)}",
+        f"session 數：{len(sessions_sorted)}（{sessions_preview}）",
+        f"事件總數：{len(events)}",
+    ]
+
+    if by_tool:
+        lines.append("")
+        lines.append("工具使用：")
+        for tool, stats in sorted(
+            by_tool.items(),
+            key=lambda kv: -(kv[1]["ok"] + kv[1]["err"]),
+        ):
+            total = stats["ok"] + stats["err"]
+            rate = (stats["ok"] / total * 100) if total else 0
+            lines.append(
+                f"  - {tool}: {total} 次"
+                f"（成功 {stats['ok']}, 失敗 {stats['err']}, {rate:.0f}%）"
+            )
+
+    if turn_outcomes:
+        lines.append("")
+        lines.append("turn 結局：")
+        for outcome, n in sorted(
+            turn_outcomes.items(), key=lambda kv: -kv[1]
+        ):
+            lines.append(f"  - {outcome}: {n}")
+
+    return "\n".join(lines)
+
+
+# ── Raw renderer (escape hatch) ───────────────────────────────────────
+
+
+def render_raw(
+    events: list[LedgerEvent], *, max_events: int = _RAW_DEFAULT_MAX
+) -> str:
+    """One-line-per-event timeline. Truncates beyond ``max_events``."""
+    if not events:
+        return _empty_window()
+
+    truncated = len(events) > max_events
+    header = f"## Raw events ({len(events)} total"
+    if truncated:
+        header += f", showing first {max_events}"
+    header += ")"
+
+    lines = [header]
+    for e in events[:max_events]:
+        lines.append(_render_raw_line(e))
+    return "\n".join(lines)
+
+
+def _render_raw_line(e: LedgerEvent) -> str:
+    p = e.payload
+    extras: list[str] = []
+    if "tool_name" in p:
+        extras.append(f"tool={p['tool_name']}")
+    if p.get("phase"):
+        extras.append(f"phase={p['phase']}")
+    if p.get("verdict"):
+        extras.append(f"verdict={p['verdict']}")
+    if p.get("outcome"):
+        extras.append(f"outcome={p['outcome']}")
+    if p.get("error"):
+        extras.append(f"err={(p['error'] or '')[:40]}")
+    extras_s = (" " + " ".join(extras)) if extras else ""
+    return f"  {_fmt_full(e.timestamp)}  [{e.event_type}]{extras_s}"
+
+
+# ── Output format inference ───────────────────────────────────────────
+
+
+def infer_output_format(
+    *,
+    session_id: str | None = None,
+    correlation_id: str | None = None,
+    skill_id: str | None = None,
+    tool_name: str | None = None,
+    verdict: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    explicit: str | None = None,
+) -> OutputFormat:
+    """Pick the renderer from the query dimensions the agent supplied.
+
+    Explicit override wins. Otherwise: scoped-slice queries
+    (``session_id`` / ``correlation_id``) get narrative; the rest fall
+    through to summary.
+    """
+    if explicit in ("narrative", "summary", "raw"):
+        return explicit  # type: ignore[return-value]
+    if session_id or correlation_id:
+        return "narrative"
+    return "summary"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _empty_window() -> str:
+    return "(這段時間沒有可回憶的事件)"

--- a/loom/core/ledger/recall.py
+++ b/loom/core/ledger/recall.py
@@ -37,6 +37,11 @@ _ERR_TEXT_CAP = 60          # error text length in action chain
 _COMPACT_TOOL_THRESHOLD = 8  # actions per turn before we condense
 _RAW_DEFAULT_MAX = 100
 
+_TRUNCATION_WARNING = (
+    "[!] 結果觸及 ledger 查詢上限；以下內容可能不完整，"
+    "請收窄 filter（時間範圍 / session_id / correlation_id）取得完整結果。"
+)
+
 
 # ── Turn grouping ─────────────────────────────────────────────────────
 
@@ -125,6 +130,7 @@ def render_narrative(
     messages_by_turn: dict[str, list[dict[str, Any]]],
     *,
     verbose: bool = False,
+    truncated: bool = False,
 ) -> str:
     """Per-turn paragraph narrative.
 
@@ -134,9 +140,12 @@ def render_narrative(
 
     ``messages_by_turn`` is keyed by ``turn_id`` and holds session_log
     rows shaped like :meth:`SessionLog.messages_between` output.
+
+    ``truncated=True`` prepends a warning so the agent knows the
+    underlying ledger fetch hit the per-query cap.
     """
     if not slices:
-        return _empty_window()
+        return _maybe_prepend_warning(_empty_window(), truncated)
 
     sessions_seen: list[str] = []
     for sl in slices:
@@ -158,7 +167,7 @@ def render_narrative(
                 )
             )
             parts.append("")
-    return "\n".join(parts).rstrip()
+    return _maybe_prepend_warning("\n".join(parts).rstrip(), truncated)
 
 
 def _render_turn(
@@ -243,10 +252,16 @@ def _render_actions(events: list[LedgerEvent], *, verbose: bool) -> str:
 # ── Summary renderer ──────────────────────────────────────────────────
 
 
-def render_summary(events: list[LedgerEvent]) -> str:
-    """Aggregate stats: window, sessions, per-tool success/failure, turn outcomes."""
+def render_summary(
+    events: list[LedgerEvent], *, truncated: bool = False,
+) -> str:
+    """Aggregate stats: window, sessions, per-tool success/failure, turn outcomes.
+
+    ``truncated=True`` prepends a warning so the agent doesn't quote
+    success rates / totals as if they cover the full population.
+    """
     if not events:
-        return _empty_window()
+        return _maybe_prepend_warning(_empty_window(), truncated)
 
     start_ts = min(e.timestamp for e in events)
     end_ts = max(e.timestamp for e in events)
@@ -304,29 +319,37 @@ def render_summary(events: list[LedgerEvent]) -> str:
         ):
             lines.append(f"  - {outcome}: {n}")
 
-    return "\n".join(lines)
+    return _maybe_prepend_warning("\n".join(lines), truncated)
 
 
 # ── Raw renderer (escape hatch) ───────────────────────────────────────
 
 
 def render_raw(
-    events: list[LedgerEvent], *, max_events: int = _RAW_DEFAULT_MAX
+    events: list[LedgerEvent],
+    *,
+    max_events: int = _RAW_DEFAULT_MAX,
+    truncated: bool = False,
 ) -> str:
-    """One-line-per-event timeline. Truncates beyond ``max_events``."""
-    if not events:
-        return _empty_window()
+    """One-line-per-event timeline. Truncates beyond ``max_events``.
 
-    truncated = len(events) > max_events
+    ``truncated=True`` (the fetch-level cap was hit) is distinct from
+    ``max_events`` (the render-level cap shown in the header); both can
+    apply simultaneously and the warning makes the distinction explicit.
+    """
+    if not events:
+        return _maybe_prepend_warning(_empty_window(), truncated)
+
+    cap_hit = len(events) > max_events
     header = f"## Raw events ({len(events)} total"
-    if truncated:
+    if cap_hit:
         header += f", showing first {max_events}"
     header += ")"
 
     lines = [header]
     for e in events[:max_events]:
         lines.append(_render_raw_line(e))
-    return "\n".join(lines)
+    return _maybe_prepend_warning("\n".join(lines), truncated)
 
 
 def _render_raw_line(e: LedgerEvent) -> str:
@@ -378,3 +401,9 @@ def infer_output_format(
 
 def _empty_window() -> str:
     return "(這段時間沒有可回憶的事件)"
+
+
+def _maybe_prepend_warning(body: str, truncated: bool) -> str:
+    if not truncated:
+        return body
+    return f"{_TRUNCATION_WARNING}\n\n{body}"

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1368,6 +1368,13 @@ class LoomSession:
         from loom.platform.cli.tools import make_skill_review_tool
         self.registry.register(make_skill_review_tool(self._ledger_store))
 
+        # Issue #385: ledger_recall — story-form recall over the ledger,
+        # joined with session_log so each turn quotes the user's message.
+        from loom.platform.cli.tools import make_ledger_recall_tool
+        self.registry.register(
+            make_ledger_recall_tool(self._ledger_store, self._memory)
+        )
+
 
         # Register web tools (Phase 5D)
         self.registry.register(make_fetch_url_tool(

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -2226,31 +2226,47 @@ def make_ledger_recall_tool(
             # (skill_id / tool_name / verdict) sit on top of a scope
             # filter, the initial fetch returns only matching events —
             # turn_start / turn_end / preceding user message get filtered
-            # out, breaking the story. Re-pull events for the matched
-            # turn_ids using scope filters only.
+            # out, breaking the story.
+            #
+            # Hydrate by turn_id directly rather than re-querying scope:
+            # the narrow query already pinpointed the turns we care about,
+            # and `idx_turn` makes per-turn lookups cheap. Re-querying
+            # scope risks losing matched turns whose timestamps fall
+            # outside the broad fetch's _LEDGER_RECALL_EVENT_CAP window
+            # (e.g. matched turn at event #1500 of a long session) — see
+            # PR #386 review.
             has_narrowing = bool(skill_id or tool_name or verdict)
             has_scope = bool(
                 session_id or correlation_id
                 or since_dt is not None or until_dt is not None
             )
             if has_narrowing and has_scope:
-                matching_turn_ids = {e.turn_id for e in events}
-                if matching_turn_ids:
-                    broad_query = _build_query(
-                        ledger_store,
-                        session_id=session_id,
-                        correlation_id=correlation_id,
-                        since_dt=since_dt,
-                        until_dt=until_dt,
+                # Preserve first-seen turn order from the initial query so
+                # `limit` selects the chronologically earliest matches.
+                ordered_turn_ids: list[str] = []
+                seen_turn_ids: set[str] = set()
+                for e in events:
+                    if e.turn_id not in seen_turn_ids:
+                        seen_turn_ids.add(e.turn_id)
+                        ordered_turn_ids.append(e.turn_id)
+                ordered_turn_ids = ordered_turn_ids[:limit]
+
+                hydrated: list = []
+                for tid in ordered_turn_ids:
+                    turn_q = (
+                        ledger_store.events
+                        .where(turn_id=tid)
+                        .order_by("timestamp")
+                        .limit(_LEDGER_RECALL_EVENT_CAP + 1)
                     )
-                    broad_events = await broad_query.all()
-                    if len(broad_events) > _LEDGER_RECALL_EVENT_CAP:
+                    turn_events = await turn_q.all()
+                    if len(turn_events) > _LEDGER_RECALL_EVENT_CAP:
                         truncated = True
-                        broad_events = broad_events[:_LEDGER_RECALL_EVENT_CAP]
-                    events = [
-                        e for e in broad_events
-                        if e.turn_id in matching_turn_ids
-                    ]
+                        turn_events = turn_events[
+                            :_LEDGER_RECALL_EVENT_CAP
+                        ]
+                    hydrated.extend(turn_events)
+                events = hydrated
 
             slices = group_events_by_turn(events)[:limit]
             messages_by_turn = await _fetch_user_messages_per_turn(

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -2105,6 +2105,237 @@ def make_skill_review_tool(
 
 
 # ------------------------------------------------------------------
+# ledger_recall tool (Issue #385) — narrative recall over AgentLedger
+# ------------------------------------------------------------------
+
+
+_LEDGER_RECALL_EVENT_CAP = 1000
+"""Hard cap on events pulled per ledger_recall call. Renderers truncate
+further per their own semantics (narrative trims to N turn slices, raw
+trims to N events). Prevents runaway queries from drowning the agent."""
+
+
+def make_ledger_recall_tool(
+    ledger_store: "LedgerStore | None",
+    memory: "MemoryFacade | None",
+) -> ToolDefinition:
+    """Create a SAFE ``ledger_recall`` tool — story-form recall over the ledger.
+
+    Wraps the doc/53 §6.2 Pull API (``LedgerStore.events``) and joins
+    against ``memory.session_log`` so each turn's narrative paragraph can
+    quote the user's actual message. Issue #385 design summary:
+    https://github.com/Dakai666/Loom/issues/385#issuecomment-4471257209.
+    """
+    from datetime import datetime, timezone
+
+    from loom.core.ledger.recall import (
+        group_events_by_turn,
+        infer_output_format,
+        render_narrative,
+        render_raw,
+        render_summary,
+    )
+
+    _DIMENSION_KEYS = (
+        "session_id", "correlation_id", "skill_id",
+        "tool_name", "verdict", "since", "until",
+    )
+
+    async def _ledger_recall(call: ToolCall) -> ToolResult:
+        if ledger_store is None:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False,
+                error="Ledger is not available in this session; cannot recall.",
+            )
+
+        args = call.args or {}
+        session_id = (args.get("session_id") or "").strip() or None
+        correlation_id = (args.get("correlation_id") or "").strip() or None
+        skill_id = (args.get("skill_id") or "").strip() or None
+        tool_name = (args.get("tool_name") or "").strip() or None
+        verdict = (args.get("verdict") or "").strip() or None
+        explicit_output = (args.get("output") or "").strip() or None
+        verbose = bool(args.get("verbose", False))
+
+        try:
+            limit = int(args.get("limit", 20))
+        except (TypeError, ValueError):
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error="'limit' must be an integer",
+            )
+        limit = max(1, min(limit, 100))
+
+        try:
+            since_dt = _parse_memory_datetime(args.get("since"))
+            until_dt = _parse_memory_datetime(args.get("until"))
+        except ValueError as exc:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error=str(exc),
+            )
+
+        # Require at least one dimension — refuses unbounded ledger scans.
+        if not any([
+            session_id, correlation_id, skill_id,
+            tool_name, verdict, since_dt, until_dt,
+        ]):
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False,
+                error=(
+                    "ledger_recall requires at least one dimension: "
+                    + ", ".join(_DIMENSION_KEYS)
+                ),
+            )
+
+        # Build the EventQuery chain.
+        query = ledger_store.events
+        if session_id:
+            query = query.where(session_id=session_id)
+        if correlation_id:
+            query = query.where(correlation_id=correlation_id)
+        if skill_id:
+            query = query.where(skill_id=skill_id)
+        if tool_name:
+            query = query.where(tool_name=tool_name)
+        if verdict:
+            query = query.where(verdict=verdict)
+        if since_dt is not None:
+            query = query.since(since_dt)
+        if until_dt is not None:
+            query = query.until(until_dt)
+        query = query.order_by("timestamp").limit(_LEDGER_RECALL_EVENT_CAP)
+
+        events = await query.all()
+
+        output_format = infer_output_format(
+            session_id=session_id,
+            correlation_id=correlation_id,
+            skill_id=skill_id,
+            tool_name=tool_name,
+            verdict=verdict,
+            since=args.get("since"),
+            until=args.get("until"),
+            explicit=explicit_output,
+        )
+
+        if output_format == "narrative":
+            slices = group_events_by_turn(events)[:limit]
+            messages_by_turn = await _fetch_user_messages_per_turn(
+                memory, slices,
+            )
+            text = render_narrative(
+                slices, messages_by_turn, verbose=verbose,
+            )
+        elif output_format == "raw":
+            text = render_raw(events, max_events=limit)
+        else:
+            text = render_summary(events)
+
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name,
+            success=True, output=text,
+        )
+
+    async def _fetch_user_messages_per_turn(
+        memory: "MemoryFacade | None",
+        slices: list,
+    ) -> dict[str, list[dict]]:
+        """Pull user messages from session_log for each turn's time window.
+
+        Per-turn query rather than a single bulk pull: ledger ``turn_id``
+        and session_log ``turn_index`` are different keys, so we map via
+        the turn's [started_at, ended_at] window. Bounded by the renderer's
+        turn limit (≤100), so per-call query count is small.
+        """
+        if memory is None or memory.session_log is None:
+            return {}
+        out: dict[str, list[dict]] = {}
+        for sl in slices:
+            start_dt = datetime.fromtimestamp(sl.started_at, tz=timezone.utc)
+            # If turn never ended in the result set, take the last event's ts
+            # as a generous upper bound (events are already sorted ASC).
+            end_ts = sl.ended_at if sl.ended_at is not None else (
+                sl.events[-1].timestamp if sl.events else sl.started_at
+            )
+            # +1s slack so an end-aligned message isn't excluded.
+            end_dt = datetime.fromtimestamp(end_ts + 1.0, tz=timezone.utc)
+            try:
+                rows = await memory.session_log.messages_between(
+                    start_dt, end_dt,
+                    session_id=sl.session_id, limit=10,
+                )
+            except Exception:
+                rows = []
+            out[sl.turn_id] = rows
+        return out
+
+    return ToolDefinition(
+        name="ledger_recall",
+        description=(
+            "Recall past activity from the event ledger as story-form "
+            "narrative. Use when you want to remember 'what happened "
+            "in session X' or 'what did I do with skill Y this week'. "
+            "Defaults to per-turn narrative for session/correlation "
+            "queries; aggregate summary for skill/tool/time-range queries. "
+            "Read-only."
+        ),
+        trust_level=TrustLevel.SAFE,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "session_id": {"type": "string"},
+                "correlation_id": {"type": "string"},
+                "skill_id": {"type": "string"},
+                "tool_name": {"type": "string"},
+                "verdict": {
+                    "type": "string",
+                    "description": "e.g. 'success' / 'error' (from JudgeVerdict).",
+                },
+                "since": {
+                    "type": "string",
+                    "description": "Lower bound (YYYY-MM-DD or ISO datetime).",
+                },
+                "until": {
+                    "type": "string",
+                    "description": "Exclusive upper bound.",
+                },
+                "output": {
+                    "type": "string",
+                    "enum": ["narrative", "summary", "raw"],
+                    "description": (
+                        "Override the auto-inferred format. Default: "
+                        "narrative for session/correlation; summary otherwise."
+                    ),
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": (
+                        "For narrative: max turns. For raw: max events. "
+                        "Ignored for summary. 1–100, default 20."
+                    ),
+                    "default": 20,
+                },
+                "verbose": {
+                    "type": "boolean",
+                    "description": (
+                        "Narrative only — list every tool call instead of "
+                        "compacting when a turn has many actions."
+                    ),
+                    "default": False,
+                },
+            },
+            "required": [],
+        },
+        executor=_ledger_recall,
+        tags=["memory", "recall", "ledger", "read-only"],
+        impact_scope="read-only",
+    )
+
+
+# ------------------------------------------------------------------
 # Skill lifecycle tools (Issue #120 PR 3)
 # ------------------------------------------------------------------
 

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -2190,25 +2190,24 @@ def make_ledger_recall_tool(
                 ),
             )
 
-        # Build the EventQuery chain.
-        query = ledger_store.events
-        if session_id:
-            query = query.where(session_id=session_id)
-        if correlation_id:
-            query = query.where(correlation_id=correlation_id)
-        if skill_id:
-            query = query.where(skill_id=skill_id)
-        if tool_name:
-            query = query.where(tool_name=tool_name)
-        if verdict:
-            query = query.where(verdict=verdict)
-        if since_dt is not None:
-            query = query.since(since_dt)
-        if until_dt is not None:
-            query = query.until(until_dt)
-        query = query.order_by("timestamp").limit(_LEDGER_RECALL_EVENT_CAP)
-
+        # Build the EventQuery chain with all user-supplied filters.
+        # Fetch cap+1 so we can detect truncation atomically (no separate
+        # COUNT query) — anything beyond _LEDGER_RECALL_EVENT_CAP is a
+        # signal that aggregates / chronology may be incomplete.
+        query = _build_query(
+            ledger_store,
+            session_id=session_id,
+            correlation_id=correlation_id,
+            skill_id=skill_id,
+            tool_name=tool_name,
+            verdict=verdict,
+            since_dt=since_dt,
+            until_dt=until_dt,
+        )
         events = await query.all()
+        truncated = len(events) > _LEDGER_RECALL_EVENT_CAP
+        if truncated:
+            events = events[:_LEDGER_RECALL_EVENT_CAP]
 
         output_format = infer_output_format(
             session_id=session_id,
@@ -2222,22 +2221,84 @@ def make_ledger_recall_tool(
         )
 
         if output_format == "narrative":
+            # Narrative needs full turn context (turn_start, user message
+            # window, every tool, turn_end). When narrowing filters
+            # (skill_id / tool_name / verdict) sit on top of a scope
+            # filter, the initial fetch returns only matching events —
+            # turn_start / turn_end / preceding user message get filtered
+            # out, breaking the story. Re-pull events for the matched
+            # turn_ids using scope filters only.
+            has_narrowing = bool(skill_id or tool_name or verdict)
+            has_scope = bool(
+                session_id or correlation_id
+                or since_dt is not None or until_dt is not None
+            )
+            if has_narrowing and has_scope:
+                matching_turn_ids = {e.turn_id for e in events}
+                if matching_turn_ids:
+                    broad_query = _build_query(
+                        ledger_store,
+                        session_id=session_id,
+                        correlation_id=correlation_id,
+                        since_dt=since_dt,
+                        until_dt=until_dt,
+                    )
+                    broad_events = await broad_query.all()
+                    if len(broad_events) > _LEDGER_RECALL_EVENT_CAP:
+                        truncated = True
+                        broad_events = broad_events[:_LEDGER_RECALL_EVENT_CAP]
+                    events = [
+                        e for e in broad_events
+                        if e.turn_id in matching_turn_ids
+                    ]
+
             slices = group_events_by_turn(events)[:limit]
             messages_by_turn = await _fetch_user_messages_per_turn(
                 memory, slices,
             )
             text = render_narrative(
-                slices, messages_by_turn, verbose=verbose,
+                slices, messages_by_turn,
+                verbose=verbose, truncated=truncated,
             )
         elif output_format == "raw":
-            text = render_raw(events, max_events=limit)
+            text = render_raw(
+                events, max_events=limit, truncated=truncated,
+            )
         else:
-            text = render_summary(events)
+            text = render_summary(events, truncated=truncated)
 
         return ToolResult(
             call_id=call.id, tool_name=call.tool_name,
             success=True, output=text,
         )
+
+    def _build_query(
+        store: "LedgerStore",
+        *,
+        session_id: str | None = None,
+        correlation_id: str | None = None,
+        skill_id: str | None = None,
+        tool_name: str | None = None,
+        verdict: str | None = None,
+        since_dt=None,
+        until_dt=None,
+    ):
+        q = store.events
+        if session_id:
+            q = q.where(session_id=session_id)
+        if correlation_id:
+            q = q.where(correlation_id=correlation_id)
+        if skill_id:
+            q = q.where(skill_id=skill_id)
+        if tool_name:
+            q = q.where(tool_name=tool_name)
+        if verdict:
+            q = q.where(verdict=verdict)
+        if since_dt is not None:
+            q = q.since(since_dt)
+        if until_dt is not None:
+            q = q.until(until_dt)
+        return q.order_by("timestamp").limit(_LEDGER_RECALL_EVENT_CAP + 1)
 
     async def _fetch_user_messages_per_turn(
         memory: "MemoryFacade | None",

--- a/tests/test_ledger_recall.py
+++ b/tests/test_ledger_recall.py
@@ -358,3 +358,42 @@ def test_infer_other_dimensions_pick_summary():
 
 def test_infer_ignores_invalid_explicit_value():
     assert infer_output_format(session_id="s", explicit="garbage") == "narrative"
+
+
+# ── truncation warning (PR #386 review fix) ───────────────────────────
+
+
+def test_narrative_prepends_truncation_warning():
+    events = [_tool_end("c1", "tool_a", ts_offset=0.5)]
+    slices = group_events_by_turn(events)
+    out = render_narrative(slices, {}, truncated=True)
+    assert out.startswith("[!]")
+    assert "ledger 查詢上限" in out
+    assert "## session" in out  # body still present
+
+
+def test_narrative_no_warning_when_not_truncated():
+    events = [_tool_end("c1", "tool_a", ts_offset=0.5)]
+    slices = group_events_by_turn(events)
+    out = render_narrative(slices, {})
+    assert not out.startswith("[!]")
+
+
+def test_summary_prepends_truncation_warning():
+    events = [_tool_end("c1", "tool_a", ts_offset=0.5)]
+    out = render_summary(events, truncated=True)
+    assert out.startswith("[!]")
+    assert "## 摘要" in out
+
+
+def test_raw_prepends_truncation_warning():
+    events = [_tool_end("c1", "tool_a", ts_offset=0.5)]
+    out = render_raw(events, truncated=True)
+    assert out.startswith("[!]")
+    assert "Raw events" in out
+
+
+def test_empty_window_still_shows_warning_when_truncated():
+    """Edge case: zero events fetched after truncation slice off cap+1 leftover."""
+    out = render_summary([], truncated=True)
+    assert out.startswith("[!]")

--- a/tests/test_ledger_recall.py
+++ b/tests/test_ledger_recall.py
@@ -1,0 +1,360 @@
+"""Tests for loom.core.ledger.recall — pure renderer functions.
+
+Issue #385 Phase 1: ledger_recall narrative / summary / raw rendering.
+
+The renderers operate on plain LedgerEvent + dict inputs, so these tests
+construct events directly without spinning up a LedgerStore. The tool-
+layer cross-database join is covered separately by the tool wiring tests.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from loom.core.ledger.recall import (
+    TurnSlice,
+    group_events_by_turn,
+    infer_output_format,
+    render_narrative,
+    render_raw,
+    render_summary,
+)
+from loom.core.ledger.schema import LedgerEvent
+
+
+# ── Fixture helpers ───────────────────────────────────────────────────
+
+
+_BASE_TS = datetime(2026, 5, 18, 14, 30, 0, tzinfo=timezone.utc).timestamp()
+
+
+def _ev(
+    *,
+    et: str,
+    ts_offset: float,
+    turn_id: str = "turn_a",
+    session_id: str = "sess_1",
+    payload: dict | None = None,
+    event_id: str | None = None,
+) -> LedgerEvent:
+    """Build a LedgerEvent at base + offset seconds. Payload defaults to {}."""
+    return LedgerEvent(
+        event_id=event_id or f"evt_{et}_{ts_offset:.3f}",
+        session_id=session_id,
+        turn_id=turn_id,
+        correlation_id="corr_x",
+        event_type=et,
+        timestamp=_BASE_TS + ts_offset,
+        payload=payload or {},
+    )
+
+
+def _tool_begin(call_id: str, tool: str, *, turn_id="turn_a", ts_offset=0.0) -> LedgerEvent:
+    return _ev(
+        et="tool_lifecycle", ts_offset=ts_offset, turn_id=turn_id,
+        payload={
+            "phase": "BEGIN",
+            "tool_name": tool,
+            "tool_call_id": call_id,
+            "args_digest": "sha256:x",
+        },
+    )
+
+
+def _tool_end(
+    call_id: str, tool: str, *,
+    turn_id="turn_a", ts_offset=1.0,
+    error: str | None = None, rolled_back: bool = False,
+) -> LedgerEvent:
+    payload = {
+        "phase": "END",
+        "tool_name": tool,
+        "tool_call_id": call_id,
+        "args_digest": "sha256:x",
+    }
+    if error:
+        payload["error"] = error
+    if rolled_back:
+        payload["rolled_back"] = True
+    return _ev(
+        et="tool_lifecycle", ts_offset=ts_offset, turn_id=turn_id,
+        payload=payload,
+    )
+
+
+# ── group_events_by_turn ──────────────────────────────────────────────
+
+
+def test_group_empty_returns_empty():
+    assert group_events_by_turn([]) == []
+
+
+def test_group_single_turn_with_bookends():
+    events = [
+        _ev(et="turn_start", ts_offset=0.0, payload={
+            "prompt_stack_hash": "x", "prompt_stack_components": {},
+        }),
+        _tool_begin("c1", "run_bash", ts_offset=0.5),
+        _tool_end("c1", "run_bash", ts_offset=1.2),
+        _ev(et="turn_end", ts_offset=2.0, payload={
+            "outcome": "clean", "duration_ms": 2000, "token_usage": {},
+        }),
+    ]
+    slices = group_events_by_turn(events)
+    assert len(slices) == 1
+    sl = slices[0]
+    assert sl.turn_id == "turn_a"
+    assert sl.started_at == _BASE_TS
+    assert sl.ended_at == _BASE_TS + 2.0
+    assert sl.outcome == "clean"
+    assert len(sl.events) == 4
+
+
+def test_group_without_turn_start_falls_back_to_first_event_ts():
+    events = [
+        _tool_begin("c1", "tool_x", ts_offset=5.0),
+        _tool_end("c1", "tool_x", ts_offset=6.0),
+    ]
+    slices = group_events_by_turn(events)
+    assert len(slices) == 1
+    assert slices[0].started_at == _BASE_TS + 5.0
+    assert slices[0].ended_at is None
+    assert slices[0].outcome is None
+
+
+def test_group_multiple_turns_preserve_first_seen_order():
+    events = [
+        _tool_begin("c1", "a", turn_id="turn_x", ts_offset=0.0),
+        _tool_begin("c2", "b", turn_id="turn_y", ts_offset=1.0),
+        _tool_end("c1", "a", turn_id="turn_x", ts_offset=2.0),
+    ]
+    slices = group_events_by_turn(events)
+    assert [sl.turn_id for sl in slices] == ["turn_x", "turn_y"]
+
+
+# ── render_narrative ──────────────────────────────────────────────────
+
+
+def test_narrative_empty_window():
+    assert "沒有可回憶" in render_narrative([], {})
+
+
+def test_narrative_single_turn_with_user_message():
+    events = [
+        _ev(et="turn_start", ts_offset=0.0, payload={
+            "prompt_stack_hash": "x", "prompt_stack_components": {},
+        }),
+        _tool_begin("c1", "run_bash", ts_offset=0.1),
+        _tool_end("c1", "run_bash", ts_offset=1.4),
+    ]
+    slices = group_events_by_turn(events)
+    msgs = {"turn_a": [{"role": "user", "content": "幫我跑一下 ls"}]}
+    out = render_narrative(slices, msgs)
+    assert "## session sess_1" in out
+    assert "2026-05-18" in out
+    assert "第 1 輪" in out
+    assert "14:30" in out
+    assert "你說：幫我跑一下 ls" in out
+    assert "run_bash" in out
+    assert "1 events" in out
+
+
+def test_narrative_user_message_truncated_at_cap():
+    events = [_tool_end("c1", "tool_x", ts_offset=0.5)]
+    slices = group_events_by_turn(events)
+    long_text = "我" * 200
+    msgs = {"turn_a": [{"role": "user", "content": long_text}]}
+    out = render_narrative(slices, msgs)
+    assert "…" in out
+    # The original 200-char message should NOT appear intact.
+    assert long_text not in out
+
+
+def test_narrative_fallback_when_no_user_message():
+    events = [_tool_end("c1", "tool_x", ts_offset=0.5)]
+    slices = group_events_by_turn(events)
+    out = render_narrative(slices, {})
+    assert "沒有捕捉到你的訊息" in out
+
+
+def test_narrative_tool_failure_shown_in_chain():
+    events = [
+        _tool_end("c1", "tool_a", ts_offset=0.5),
+        _tool_end("c2", "tool_b", ts_offset=1.5, error="target index not found"),
+    ]
+    slices = group_events_by_turn(events)
+    out = render_narrative(slices, {})
+    assert "tool_a" in out
+    assert "tool_b（失敗：target index not found）" in out
+    assert "1成 1敗" in out
+
+
+def test_narrative_rollback_counted_separately():
+    events = [
+        _tool_end("c1", "tool_a", ts_offset=0.5),
+        _tool_end("c2", "tool_b", ts_offset=1.5, rolled_back=True),
+    ]
+    slices = group_events_by_turn(events)
+    out = render_narrative(slices, {})
+    assert "tool_b（rollback）" in out
+    assert "1回滾" in out
+
+
+def test_narrative_compacts_when_many_tools_and_not_verbose():
+    events = [
+        _tool_end(f"c{i}", f"tool_{i % 3}", ts_offset=i * 0.1)
+        for i in range(12)
+    ]
+    slices = group_events_by_turn(events)
+    out_compact = render_narrative(slices, {}, verbose=False)
+    assert "12 件事" in out_compact
+    out_verbose = render_narrative(slices, {}, verbose=True)
+    assert "12 件事" not in out_verbose
+    assert " → " in out_verbose
+
+
+def test_narrative_groups_by_session():
+    events = [
+        _tool_end("c1", "tool_a", turn_id="turn_x",
+                  ts_offset=0.5),
+        _ev(et="tool_lifecycle", ts_offset=10.0,
+            turn_id="turn_y", session_id="sess_2",
+            payload={"phase": "END", "tool_name": "tool_b",
+                     "tool_call_id": "c2", "args_digest": "sha256:y"}),
+    ]
+    slices = group_events_by_turn(events)
+    out = render_narrative(slices, {})
+    assert "## session sess_1" in out
+    assert "## session sess_2" in out
+
+
+def test_narrative_appends_non_clean_outcome():
+    events = [
+        _ev(et="turn_start", ts_offset=0.0, payload={
+            "prompt_stack_hash": "x", "prompt_stack_components": {},
+        }),
+        _tool_end("c1", "tool_a", ts_offset=0.5),
+        _ev(et="turn_end", ts_offset=1.0, payload={
+            "outcome": "abandoned", "duration_ms": 1000, "token_usage": {},
+        }),
+    ]
+    slices = group_events_by_turn(events)
+    out = render_narrative(slices, {})
+    assert "turn 結局 abandoned" in out
+
+
+def test_narrative_turn_with_no_tools():
+    events = [
+        _ev(et="turn_start", ts_offset=0.0, payload={
+            "prompt_stack_hash": "x", "prompt_stack_components": {},
+        }),
+        _ev(et="turn_end", ts_offset=1.0, payload={
+            "outcome": "clean", "duration_ms": 1000, "token_usage": {},
+        }),
+    ]
+    slices = group_events_by_turn(events)
+    out = render_narrative(slices, {})
+    assert "沒有動工具" in out
+
+
+# ── render_summary ────────────────────────────────────────────────────
+
+
+def test_summary_empty_window():
+    assert "沒有可回憶" in render_summary([])
+
+
+def test_summary_aggregates_tools_and_outcomes():
+    events = [
+        _tool_end("c1", "run_bash", ts_offset=0.5),
+        _tool_end("c2", "run_bash", ts_offset=1.0, error="boom"),
+        _tool_end("c3", "read_file", ts_offset=1.5),
+        _ev(et="turn_end", ts_offset=2.0, payload={
+            "outcome": "clean", "duration_ms": 2000, "token_usage": {},
+        }),
+        _ev(et="turn_end", ts_offset=3.0, turn_id="turn_b", payload={
+            "outcome": "retry", "duration_ms": 1000, "token_usage": {},
+        }),
+    ]
+    out = render_summary(events)
+    assert "事件總數：5" in out
+    assert "run_bash: 2 次（成功 1, 失敗 1, 50%）" in out
+    assert "read_file: 1 次（成功 1, 失敗 0, 100%）" in out
+    assert "clean: 1" in out
+    assert "retry: 1" in out
+
+
+def test_summary_counts_rollback_as_failure():
+    events = [
+        _tool_end("c1", "tool_a", ts_offset=0.5, rolled_back=True),
+        _tool_end("c2", "tool_a", ts_offset=1.0),
+    ]
+    out = render_summary(events)
+    assert "tool_a: 2 次（成功 1, 失敗 1, 50%）" in out
+
+
+def test_summary_shows_window_bounds():
+    events = [
+        _tool_end("c1", "tool_a", ts_offset=0.0),
+        _tool_end("c2", "tool_b", ts_offset=60.0),
+    ]
+    out = render_summary(events)
+    assert "2026-05-18 14:30:00" in out
+    assert "2026-05-18 14:31:00" in out
+
+
+# ── render_raw ────────────────────────────────────────────────────────
+
+
+def test_raw_empty_window():
+    assert "沒有可回憶" in render_raw([])
+
+
+def test_raw_one_line_per_event():
+    events = [
+        _tool_begin("c1", "tool_a", ts_offset=0.0),
+        _tool_end("c1", "tool_a", ts_offset=1.0, error="boom"),
+    ]
+    out = render_raw(events)
+    assert "Raw events (2 total)" in out
+    assert "tool=tool_a phase=BEGIN" in out
+    assert "phase=END" in out
+    assert "err=boom" in out
+
+
+def test_raw_truncates_to_max_events():
+    events = [
+        _tool_end(f"c{i}", "tool_x", ts_offset=i * 0.1)
+        for i in range(10)
+    ]
+    out = render_raw(events, max_events=3)
+    assert "10 total" in out
+    assert "showing first 3" in out
+    # Only 1 header line + 3 event lines
+    assert len(out.splitlines()) == 4
+
+
+# ── infer_output_format ───────────────────────────────────────────────
+
+
+def test_infer_explicit_override_wins():
+    assert infer_output_format(session_id="s", explicit="raw") == "raw"
+    assert infer_output_format(skill_id="x", explicit="narrative") == "narrative"
+
+
+def test_infer_session_or_correlation_picks_narrative():
+    assert infer_output_format(session_id="s") == "narrative"
+    assert infer_output_format(correlation_id="c") == "narrative"
+
+
+def test_infer_other_dimensions_pick_summary():
+    assert infer_output_format(skill_id="opencli") == "summary"
+    assert infer_output_format(tool_name="run_bash") == "summary"
+    assert infer_output_format(since="2026-05-01") == "summary"
+    assert infer_output_format() == "summary"
+
+
+def test_infer_ignores_invalid_explicit_value():
+    assert infer_output_format(session_id="s", explicit="garbage") == "narrative"

--- a/tests/test_ledger_recall_tool.py
+++ b/tests/test_ledger_recall_tool.py
@@ -1,0 +1,358 @@
+"""Tests for the ledger_recall tool factory (Issue #385).
+
+Covers:
+- input validation (no ledger, missing dimensions, bad limit/dates)
+- EventQuery wiring (session_id / skill_id / verdict / time range filters)
+- output format inference (narrative for session/correlation, summary
+  for skill/tool/time, explicit override)
+- session_log cross-database join (user messages quoted in narrative)
+- raw escape hatch with truncation
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from loom.core.harness.middleware import ToolCall
+from loom.core.harness.permissions import TrustLevel
+from loom.core.ledger import (
+    LedgerEmitter,
+    LedgerStore,
+    ToolLifecyclePayload,
+    TurnEndPayload,
+    TurnStartPayload,
+)
+from loom.platform.cli.tools import make_ledger_recall_tool
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def ledger(tmp_path: Path):
+    s = LedgerStore(
+        db_path=tmp_path / "ledger.db", blob_dir=tmp_path / "blobs"
+    )
+    await s.open()
+    try:
+        yield s
+    finally:
+        await s.close()
+
+
+class FakeSessionLog:
+    """In-memory stand-in for MemoryFacade.session_log used by the tool.
+
+    Only needs to satisfy ``messages_between(since, until, *, session_id,
+    limit)`` returning the same row shape as the real implementation.
+    """
+
+    def __init__(self, rows: list[dict]) -> None:
+        self._rows = rows
+
+    async def messages_between(
+        self, since, until=None, *, session_id=None, limit=100,
+    ):
+        out = []
+        for r in self._rows:
+            if session_id and r["session_id"] != session_id:
+                continue
+            created = datetime.fromisoformat(r["created_at"])
+            if created < since:
+                continue
+            if until is not None and created >= until:
+                continue
+            out.append(r)
+            if len(out) >= limit:
+                break
+        return out
+
+
+class FakeMemory:
+    def __init__(self, session_log=None) -> None:
+        self.session_log = session_log
+
+
+def _call(args: dict) -> ToolCall:
+    return ToolCall(
+        tool_name="ledger_recall",
+        args=args,
+        trust_level=TrustLevel.SAFE,
+        session_id="sess_x",
+    )
+
+
+async def _seed_turn(
+    emitter: LedgerEmitter,
+    *,
+    turn_id: str,
+    base_ts: float,
+    tools: list[tuple[str, str | None]],
+    outcome: str = "clean",
+    skill_id: str | None = None,
+) -> None:
+    """Seed one turn: turn_start → tool ENDs → turn_end."""
+    await emitter.emit(
+        "turn_start",
+        TurnStartPayload(
+            prompt_stack_hash=f"hash_{turn_id}",
+            prompt_stack_components={},
+        ),
+        turn_id=turn_id,
+        event_id=f"evt_ts_{turn_id}",
+        timestamp=base_ts,
+    )
+    for i, (tname, err) in enumerate(tools):
+        await emitter.emit_tool_lifecycle(
+            payload=ToolLifecyclePayload(
+                phase="END",
+                tool_name=tname,
+                tool_call_id=f"call_{turn_id}_{i}",
+                args_digest=f"sha256:{turn_id}{i}",
+                error=err,
+                skill_id=skill_id if tname == "load_skill" else None,
+            ),
+            event_id=f"evt_tool_{turn_id}_{i}",
+            timestamp=base_ts + 0.5 + i * 0.5,
+            turn_id=turn_id,
+        )
+    await emitter.emit(
+        "turn_end",
+        TurnEndPayload(
+            outcome=outcome,
+            duration_ms=int(2000 + len(tools) * 500),
+            token_usage={},
+        ),
+        turn_id=turn_id,
+        event_id=f"evt_te_{turn_id}",
+        timestamp=base_ts + 2.0 + len(tools) * 0.5,
+    )
+
+
+# ── Input validation ──────────────────────────────────────────────────
+
+
+async def test_no_ledger_returns_error():
+    tool = make_ledger_recall_tool(None, None)
+    result = await tool.executor(_call({"session_id": "x"}))
+    assert result.success is False
+    assert "Ledger is not available" in (result.error or "")
+
+
+async def test_no_dimension_rejected(ledger: LedgerStore):
+    tool = make_ledger_recall_tool(ledger, FakeMemory())
+    result = await tool.executor(_call({}))
+    assert result.success is False
+    assert "at least one dimension" in (result.error or "")
+
+
+async def test_bad_limit_rejected(ledger: LedgerStore):
+    tool = make_ledger_recall_tool(ledger, FakeMemory())
+    result = await tool.executor(
+        _call({"session_id": "s", "limit": "not_an_int"})
+    )
+    assert result.success is False
+    assert "limit" in (result.error or "").lower()
+
+
+async def test_bad_date_rejected(ledger: LedgerStore):
+    tool = make_ledger_recall_tool(ledger, FakeMemory())
+    result = await tool.executor(_call({"since": "not-a-date"}))
+    assert result.success is False
+    assert "datetime" in (result.error or "").lower()
+
+
+async def test_trust_level_safe():
+    tool = make_ledger_recall_tool(None, None)
+    assert tool.trust_level == TrustLevel.SAFE
+
+
+# ── Empty window ──────────────────────────────────────────────────────
+
+
+async def test_empty_session_renders_fallback(ledger: LedgerStore):
+    tool = make_ledger_recall_tool(ledger, FakeMemory())
+    result = await tool.executor(_call({"session_id": "no_such_session"}))
+    assert result.success is True
+    assert "沒有可回憶" in result.output
+
+
+# ── Narrative path (session_id) ───────────────────────────────────────
+
+
+async def test_narrative_includes_user_messages_via_session_log(
+    ledger: LedgerStore,
+):
+    base = time.time()
+    emitter = LedgerEmitter(ledger, session_id="sess_narrative")
+    await _seed_turn(
+        emitter,
+        turn_id="turn_one",
+        base_ts=base,
+        tools=[("run_bash", None), ("read_file", None)],
+    )
+
+    user_ts = datetime.fromtimestamp(
+        base + 0.2, tz=timezone.utc,
+    ).isoformat()
+    fake_log = FakeSessionLog([
+        {
+            "session_id": "sess_narrative",
+            "turn_index": 0,
+            "role": "user",
+            "content": "幫我跑一下測試然後讀 README",
+            "raw_json": None,
+            "metadata": {},
+            "created_at": user_ts,
+        },
+    ])
+    tool = make_ledger_recall_tool(ledger, FakeMemory(fake_log))
+    result = await tool.executor(_call({"session_id": "sess_narrative"}))
+
+    assert result.success is True
+    assert "session sess_narrative" in result.output
+    assert "第 1 輪" in result.output
+    assert "你說：幫我跑一下測試然後讀 README" in result.output
+    assert "run_bash" in result.output
+    assert "read_file" in result.output
+
+
+async def test_narrative_works_without_session_log(ledger: LedgerStore):
+    base = time.time()
+    emitter = LedgerEmitter(ledger, session_id="sess_no_log")
+    await _seed_turn(
+        emitter,
+        turn_id="turn_nolog",
+        base_ts=base,
+        tools=[("run_bash", None)],
+    )
+
+    tool = make_ledger_recall_tool(ledger, None)  # no memory facade
+    result = await tool.executor(_call({"session_id": "sess_no_log"}))
+    assert result.success is True
+    assert "沒有捕捉到你的訊息" in result.output
+    assert "run_bash" in result.output
+
+
+async def test_narrative_failure_surfaced(ledger: LedgerStore):
+    base = time.time()
+    emitter = LedgerEmitter(ledger, session_id="sess_fail")
+    await _seed_turn(
+        emitter,
+        turn_id="turn_f",
+        base_ts=base,
+        tools=[("opencli", "target index not found")],
+        outcome="retry",
+    )
+
+    tool = make_ledger_recall_tool(ledger, FakeMemory())
+    result = await tool.executor(_call({"session_id": "sess_fail"}))
+    assert result.success is True
+    assert "失敗：target index not found" in result.output
+    assert "turn 結局 retry" in result.output
+
+
+# ── Summary path (skill_id / tool_name / time range) ──────────────────
+
+
+async def test_summary_default_for_tool_name(ledger: LedgerStore):
+    base = time.time()
+    emitter = LedgerEmitter(ledger, session_id="sess_sum")
+    await _seed_turn(
+        emitter, turn_id="turn_s1", base_ts=base,
+        tools=[("run_bash", None), ("run_bash", "boom")],
+    )
+    await _seed_turn(
+        emitter, turn_id="turn_s2", base_ts=base + 100,
+        tools=[("run_bash", None)],
+    )
+
+    tool = make_ledger_recall_tool(ledger, FakeMemory())
+    result = await tool.executor(_call({"tool_name": "run_bash"}))
+    assert result.success is True
+    assert "## 摘要" in result.output
+    assert "run_bash" in result.output
+    assert "成功 2" in result.output
+    assert "失敗 1" in result.output
+
+
+async def test_summary_for_skill_id(ledger: LedgerStore):
+    base = time.time()
+    emitter = LedgerEmitter(ledger, session_id="sess_skill")
+    await _seed_turn(
+        emitter, turn_id="turn_sk", base_ts=base,
+        tools=[("load_skill", None)], skill_id="my_skill",
+    )
+
+    tool = make_ledger_recall_tool(ledger, FakeMemory())
+    result = await tool.executor(_call({"skill_id": "my_skill"}))
+    assert result.success is True
+    assert "## 摘要" in result.output
+
+
+# ── Output format override ────────────────────────────────────────────
+
+
+async def test_explicit_narrative_overrides_summary_default(
+    ledger: LedgerStore,
+):
+    base = time.time()
+    emitter = LedgerEmitter(ledger, session_id="sess_ovr")
+    await _seed_turn(
+        emitter, turn_id="turn_ov", base_ts=base,
+        tools=[("run_bash", None)],
+    )
+    tool = make_ledger_recall_tool(ledger, FakeMemory())
+    # tool_name alone would auto-pick summary; explicit narrative wins
+    result = await tool.executor(
+        _call({"tool_name": "run_bash", "output": "narrative"})
+    )
+    assert result.success is True
+    assert "## session" in result.output
+    assert "第 1 輪" in result.output
+
+
+async def test_raw_output_truncates(ledger: LedgerStore):
+    base = time.time()
+    emitter = LedgerEmitter(ledger, session_id="sess_raw")
+    # 5 turns × 3 tools each = lots of events
+    for i in range(5):
+        await _seed_turn(
+            emitter, turn_id=f"turn_r{i}", base_ts=base + i * 10,
+            tools=[("tool_a", None), ("tool_b", None), ("tool_c", None)],
+        )
+
+    tool = make_ledger_recall_tool(ledger, FakeMemory())
+    result = await tool.executor(
+        _call({"session_id": "sess_raw", "output": "raw", "limit": 3})
+    )
+    assert result.success is True
+    assert "Raw events" in result.output
+    assert "showing first 3" in result.output
+
+
+async def test_verdict_filter_narrows_results(ledger: LedgerStore):
+    """Sanity check that EventQuery.where(verdict=...) is wired through."""
+    base = time.time()
+    emitter = LedgerEmitter(ledger, session_id="sess_verdict")
+    # Seed two turns; only one has a turn_end with non-clean outcome.
+    await _seed_turn(
+        emitter, turn_id="turn_clean", base_ts=base,
+        tools=[("a", None)], outcome="clean",
+    )
+    await _seed_turn(
+        emitter, turn_id="turn_retry", base_ts=base + 50,
+        tools=[("b", None)], outcome="retry",
+    )
+
+    # verdict isn't populated by these payloads (TurnEnd uses 'outcome'),
+    # so this proves the filter is applied even when zero events match.
+    tool = make_ledger_recall_tool(ledger, FakeMemory())
+    result = await tool.executor(_call({"verdict": "PASS"}))
+    assert result.success is True
+    assert "沒有可回憶" in result.output

--- a/tests/test_ledger_recall_tool.py
+++ b/tests/test_ledger_recall_tool.py
@@ -473,3 +473,74 @@ async def test_no_truncation_warning_when_under_cap(ledger: LedgerStore):
     result = await tool.executor(_call({"tool_name": "run_bash"}))
     assert result.success is True
     assert not result.output.startswith("[!]")
+
+
+async def test_narrative_hydrates_matched_turn_past_scope_cap(
+    ledger: LedgerStore, monkeypatch,
+):
+    """PR #386 re-review [P2]: even after the narrowing-filter fix,
+    narrative could lose matched turns when the broad scope re-query
+    hit the cap before reaching them.
+
+    Example: ``ledger_recall(session_id='x', tool_name='rare_tool')``
+    where the matching turn sits after 1000 earlier non-matching
+    events — the narrow query finds the turn_id, but the broad scope
+    re-query only returns the first cap events of the session and
+    the in-memory turn_id filter then drops the match entirely.
+
+    Fix: hydrate by ``turn_id`` directly (the narrow query already
+    pinpointed the matched turns; ``idx_turn`` makes per-turn lookups
+    cheap), rather than scanning the broad scope and filtering.
+    """
+    import loom.platform.cli.tools as tools_mod
+    monkeypatch.setattr(tools_mod, "_LEDGER_RECALL_EVENT_CAP", 5)
+
+    base = time.time()
+    emitter = LedgerEmitter(ledger, session_id="sess_late")
+
+    # 8 earlier turns × 2 tools each = 32 events that would saturate any
+    # broad-scope cap of 5 long before reaching the matched turn.
+    for i in range(8):
+        await _seed_turn(
+            emitter, turn_id=f"turn_early_{i}", base_ts=base + i * 10,
+            tools=[("filler_a", None), ("filler_b", None)],
+        )
+
+    # The matched turn lives well beyond the cap window.
+    late_ts = base + 1000
+    await _seed_turn(
+        emitter, turn_id="turn_late", base_ts=late_ts,
+        tools=[("write_file", None), ("rare_tool", None)],
+        outcome="retry",
+    )
+
+    user_ts = datetime.fromtimestamp(
+        late_ts + 0.1, tz=timezone.utc,
+    ).isoformat()
+    fake_log = FakeSessionLog([{
+        "session_id": "sess_late",
+        "turn_index": 8,
+        "role": "user",
+        "content": "找到那個 rare tool 的事",
+        "raw_json": None,
+        "metadata": {},
+        "created_at": user_ts,
+    }])
+
+    tool = make_ledger_recall_tool(ledger, FakeMemory(fake_log))
+    result = await tool.executor(_call({
+        "session_id": "sess_late",
+        "tool_name": "rare_tool",
+    }))
+
+    assert result.success is True
+    # The matched turn must fully hydrate despite living past the cap.
+    assert "你說：找到那個 rare tool 的事" in result.output
+    assert "turn 結局 retry" in result.output
+    # Non-matching tool in the SAME turn must surface (full turn context).
+    assert "write_file" in result.output
+    assert "rare_tool" in result.output
+    # Earlier non-matching turns must NOT pollute the narrative.
+    assert "turn_early" not in result.output
+    assert "filler_a" not in result.output
+    assert "filler_b" not in result.output

--- a/tests/test_ledger_recall_tool.py
+++ b/tests/test_ledger_recall_tool.py
@@ -356,3 +356,120 @@ async def test_verdict_filter_narrows_results(ledger: LedgerStore):
     result = await tool.executor(_call({"verdict": "PASS"}))
     assert result.success is True
     assert "沒有可回憶" in result.output
+
+
+# ── PR #386 review fixes ──────────────────────────────────────────────
+
+
+async def test_narrative_rehydrates_full_turn_when_narrowing_filter_applied(
+    ledger: LedgerStore,
+):
+    """Bug: session_id + tool_name=X filtered out turn_start / turn_end /
+    user message preceding the first matching tool, leaving narrative
+    without user intent or outcome.
+
+    Fix: when narrative + narrowing + scope, re-pull full turn context
+    for the matching turn_ids using scope filters only.
+    """
+    base = time.time()
+    emitter = LedgerEmitter(ledger, session_id="sess_hydrate")
+    # Turn with: turn_start, two tools (one matched, one not), turn_end
+    # with non-clean outcome.
+    await _seed_turn(
+        emitter,
+        turn_id="turn_h",
+        base_ts=base,
+        tools=[("write_file", None), ("run_bash", None)],
+        outcome="retry",
+    )
+    # A second turn with NO run_bash — must not appear in narrative.
+    await _seed_turn(
+        emitter,
+        turn_id="turn_skip",
+        base_ts=base + 50,
+        tools=[("read_file", None)],
+    )
+
+    # User message is at base + 0.1 — BEFORE the first run_bash tool (at
+    # base + 1.0 in this seed pattern). Without the re-query, narrative
+    # would search session_log from base+1.0 onward and miss the message.
+    user_ts = datetime.fromtimestamp(base + 0.1, tz=timezone.utc).isoformat()
+    fake_log = FakeSessionLog([{
+        "session_id": "sess_hydrate",
+        "turn_index": 0,
+        "role": "user",
+        "content": "請幫我跑測試",
+        "raw_json": None,
+        "metadata": {},
+        "created_at": user_ts,
+    }])
+
+    tool = make_ledger_recall_tool(ledger, FakeMemory(fake_log))
+    result = await tool.executor(_call({
+        "session_id": "sess_hydrate",
+        "tool_name": "run_bash",
+    }))
+
+    assert result.success is True
+    # User message must surface (this is the regression we're fixing).
+    assert "你說：請幫我跑測試" in result.output
+    # Turn outcome must surface.
+    assert "turn 結局 retry" in result.output
+    # The other (non-matching) tool from the same turn becomes visible
+    # because narrative shows full turn context.
+    assert "write_file" in result.output
+    assert "run_bash" in result.output
+    # The non-matching turn must not appear.
+    assert "turn_skip" not in result.output
+    assert "read_file" not in result.output
+
+
+async def test_truncation_warning_in_summary(
+    ledger: LedgerStore, monkeypatch,
+):
+    """When ledger fetch hits the per-query cap, summary prepends a
+    warning so the agent doesn't cite partial totals as authoritative.
+
+    Monkeypatched cap rather than seeding 1000+ real events — same code
+    path, faster test.
+    """
+    import loom.platform.cli.tools as tools_mod
+    monkeypatch.setattr(tools_mod, "_LEDGER_RECALL_EVENT_CAP", 3)
+
+    base = time.time()
+    emitter = LedgerEmitter(ledger, session_id="sess_trunc")
+    # 5 tool ENDs > cap of 3
+    for i in range(5):
+        await emitter.emit_tool_lifecycle(
+            turn_id=f"turn_t{i}",
+            payload=ToolLifecyclePayload(
+                phase="END",
+                tool_name="run_bash",
+                tool_call_id=f"call_{i}",
+                args_digest=f"sha256:{i}",
+            ),
+            event_id=f"evt_{i}",
+            timestamp=base + i * 0.5,
+        )
+
+    tool = make_ledger_recall_tool(ledger, FakeMemory())
+    result = await tool.executor(_call({"tool_name": "run_bash"}))
+    assert result.success is True
+    assert result.output.startswith("[!]")
+    assert "ledger 查詢上限" in result.output
+    # Still renders the summary body
+    assert "## 摘要" in result.output
+
+
+async def test_no_truncation_warning_when_under_cap(ledger: LedgerStore):
+    """Sanity: with comfortable headroom, warning must NOT appear."""
+    base = time.time()
+    emitter = LedgerEmitter(ledger, session_id="sess_ok")
+    await _seed_turn(
+        emitter, turn_id="turn_ok", base_ts=base,
+        tools=[("run_bash", None)],
+    )
+    tool = make_ledger_recall_tool(ledger, FakeMemory())
+    result = await tool.executor(_call({"tool_name": "run_bash"}))
+    assert result.success is True
+    assert not result.output.startswith("[!]")


### PR DESCRIPTION
Closes #385.

## Summary

- New SAFE read-only tool ``ledger_recall`` lets the agent recall past activity from ``ledger.db`` as **story-form narrative**, not as a SQL result set. Wraps the doc/53 Pull API (``LedgerStore.events``) and joins with ``memory.session_log`` per-turn so each turn's paragraph quotes the user's actual message.
- Three output formats — ``narrative`` (per-turn paragraph story, default for ``session_id`` / ``correlation_id``), ``summary`` (aggregate stats, default for ``skill_id`` / ``tool_name`` / time range), ``raw`` (one-line-per-event timeline, escape hatch). Auto-inferred from query dimensions; explicit ``output`` arg overrides.
- Refuses queries with **zero dimensions** to prevent unbounded ledger scans. Internal hard cap of 1000 events per query; user-facing ``limit`` controls output unit count (turns for narrative, events for raw).

## Design alignment

Implementation matches the design summary on issue #385 (https://github.com/Dakai666/Loom/issues/385#issuecomment-4471257209):

- ✅ Scope: P1 + P2 only (renderer + wiring + registration). P3/P4 (dynamic dimensions, pattern clustering) deferred to dream cycle / scheduled review territory.
- ✅ Narrative default, per-turn paragraphs, absolute time (UTC).
- ✅ Cross-DB approach **A** — Python-side per-turn time-window query, no SQLite ATTACH, no schema change.
- ✅ ``turn_id`` (ledger) and ``turn_index`` (session_log) are different keys — joined via the turn's [started_at, ended_at] window.
- ✅ No write-back to memory.db (agent calls ``memorize`` itself when warranted).
- ✅ No separate design doc — treated as a thin wrapper over doc/53.
- ✅ ``skill_review`` preserved — serves the doc/54 SKILL.md optimization loop; ``ledger_recall`` is the general agent-facing recall.

## Files

| File | Change |
|------|--------|
| ``loom/core/ledger/recall.py`` | **new** — renderers (narrative / summary / raw) + ``group_events_by_turn`` + ``infer_output_format`` |
| ``loom/platform/cli/tools.py`` | ``make_ledger_recall_tool`` factory beside ``make_skill_review_tool`` |
| ``loom/core/session.py`` | Register tool beside ``skill_review`` registration |
| ``tests/test_ledger_recall.py`` | **new** — 25 pure renderer tests |
| ``tests/test_ledger_recall_tool.py`` | **new** — 14 tool wiring + validation + cross-DB join tests |

## Smoke test on real ledger

Ran ``ledger_recall(session_id='460ebdf4')`` against a real ``~/.loom/ledger.db`` session:

```
## session 460ebdf4 — 2026-05-18

第 1 輪 (06:32)
你說：[[2026-05-18 14:32 Asia/Taipei]]
絲絲要不要來玩網頁遊戲 這很有趣 https://wikigacha.com/
我做了：fetch_url（失敗：HTML body is only 30 chars...） → load_skill → run_bash → run_bash → run_bash（5 events, 35.9s, 4成 1敗）

第 4 輪 (06:37)
你說：[[2026-05-18 14:37 Asia/Taipei]]
對啦 第三張! SSR
我做了：run_bash → run_bash → run_bash（3 events, 25.1s）  ← turn 結局 abandoned
```

User messages, tool chains, success/failure tallies, and non-clean turn outcomes (``abandoned``) all surface correctly.

## Test plan

- [x] ``pytest tests/test_ledger_recall.py`` — 25/25 pass
- [x] ``pytest tests/test_ledger_recall_tool.py`` — 14/14 pass
- [x] ``pytest tests/ -k "session or ledger or skill_review or recall"`` — 292/292 pass (no neighbouring regressions)
- [x] Smoke test against real ``~/.loom/ledger.db`` — narrative renders cleanly
- [x] ``gitnexus detect_changes`` — LOW risk, 0 affected execution flows (purely additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)