### PR TITLE
fix(timezone): #388 — honor user zone across memory tools, Discord, ledger

### DIFF
--- a/loom/core/cognition/reflection.py
+++ b/loom/core/cognition/reflection.py
@@ -9,7 +9,10 @@ Phase 2: query interface over episodic + procedural memory.
 Phase 3: the Autonomy Engine will call this to decide what to do next.
 """
 
+from datetime import UTC
 from typing import TYPE_CHECKING
+
+from loom.core.timezone import user_zone
 
 if TYPE_CHECKING:
     from loom.core.memory.facade import MemoryFacade
@@ -40,11 +43,14 @@ class ReflectionAPI:
         ordered most-recent first.
         """
         entries = await self._episodic.read_session(session_id)
+        zone = user_zone()
         tool_entries = [
             {
                 "content": e.content,
                 "metadata": e.metadata,
-                "timestamp": e.created_at.isoformat(),
+                "timestamp": (
+                    e.created_at if e.created_at.tzinfo else e.created_at.replace(tzinfo=UTC)
+                ).astimezone(zone).isoformat(),
             }
             for e in entries
             if e.event_type == "tool_result"

--- a/loom/core/ledger/recall.py
+++ b/loom/core/ledger/recall.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+
+from loom.core.timezone import user_zone
 from typing import Any, Literal
 
 from loom.core.ledger.schema import LedgerEvent
@@ -109,15 +111,15 @@ def group_events_by_turn(events: list[LedgerEvent]) -> list[TurnSlice]:
 
 
 def _fmt_date(ts: float) -> str:
-    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d")
+    return datetime.fromtimestamp(ts, tz=user_zone()).strftime("%Y-%m-%d")
 
 
 def _fmt_time(ts: float) -> str:
-    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%H:%M")
+    return datetime.fromtimestamp(ts, tz=user_zone()).strftime("%H:%M")
 
 
 def _fmt_full(ts: float) -> str:
-    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime(
+    return datetime.fromtimestamp(ts, tz=user_zone()).strftime(
         "%Y-%m-%d %H:%M:%S"
     )
 

--- a/loom/core/memory/search.py
+++ b/loom/core/memory/search.py
@@ -23,9 +23,11 @@ import logging
 import math
 import re
 from collections import Counter
-from datetime import datetime
+from datetime import UTC, datetime
 from dataclasses import dataclass, field
 from typing import Any, Literal
+
+from loom.core.timezone import user_zone
 
 logger = logging.getLogger(__name__)
 
@@ -102,11 +104,26 @@ class MemorySearchResult:
     updated_at: str = ""    # ISO timestamp of last update (empty if unknown)
 
     def format(self, max_value_len: int = 300) -> str:
-        """Human-readable one-entry summary with timestamp and effective confidence."""
+        """Human-readable one-entry summary with timestamp and effective confidence.
+
+        The stored ``updated_at`` is a UTC ISO string; the date hint is
+        rendered in the user's configured timezone so it matches the
+        same boundary the rest of the agent-facing surface uses
+        (see issue #388). Naked ISO strings are treated as UTC.
+        """
         truncated = self.value[:max_value_len]
         if len(self.value) > max_value_len:
             truncated += "…"
-        date_hint = f" [{self.updated_at[:10]}]" if self.updated_at else ""
+        date_hint = ""
+        if self.updated_at:
+            try:
+                parsed = datetime.fromisoformat(self.updated_at.replace("Z", "+00:00"))
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=UTC)
+                local_date = parsed.astimezone(user_zone()).strftime("%Y-%m-%d")
+                date_hint = f" [{local_date}]"
+            except ValueError:
+                date_hint = f" [{self.updated_at[:10]}]"
         conf = self.metadata.get("effective_confidence") or self.metadata.get("confidence")
         conf_hint = f" conf={conf:.2f}" if conf is not None else ""
         return f"[{self.type}]{date_hint}{conf_hint} {self.key}\n  {truncated}"

--- a/loom/core/timezone.py
+++ b/loom/core/timezone.py
@@ -1,25 +1,53 @@
 """
-Timezone Utilities — Issue #124
+Timezone Utilities — Issues #124, #388
 
-Provides a single source of truth for all user-facing timestamps
-in the Loom framework.
+Single source of truth for user-facing timestamps in the Loom framework.
 
 Architecture
 ------------
 Two clocks:
-  - `utc_now()`     — always UTC; used for logging, DB, cron scheduling
-  - `local_now()`   — user's timezone (from [timezone] config in loom.toml);
-                      used for ALL timestamps that appear in LLM prompts
+  - ``utc_now()``    — always UTC; used for internal logging, DB writes,
+                       cron scheduling
+  - ``local_now()``  — user's configured timezone (from [timezone] config
+                       in loom.toml); used for every timestamp that the
+                       LLM or the user is going to see
+  - ``user_zone()``  — the user's ``ZoneInfo`` itself; use when parsing
+                       agent-supplied date/datetime strings so naked
+                       inputs are interpreted in the same zone the agent
+                       sees in injected prompt timestamps
 
-The [timezone] section in loom.toml:
-  user = "Asia/Taipei"   # user-facing display / LLM context (any IANA tz name)
-  internal = "UTC"        # system timestamps (logging, DB, cron)
+The ``[timezone]`` section in ``loom.toml``::
 
-If ``[timezone].user`` is absent, the framework falls back to UTC — never to
-a hardcoded regional timezone.
+    user     = "Asia/Taipei"   # any IANA tz name; falls back to UTC if absent
+    internal = "UTC"           # system timestamps (logging, DB, cron)
 
-All code that injects timestamps into messages going to the LLM MUST use
-``local_now()`` — never ``datetime.now(UTC)`` directly.
+Boundary cheat sheet
+--------------------
+**User-zone paths** (agent / human visible — always use ``local_now()``
+or ``user_zone()``)::
+
+  - LLM prompt timestamp prefix (``user_timestamp()``)
+  - Memory tool inputs: ``recall`` / ``recall_period`` / ``ledger_recall``
+    parse ``since``/``until`` via ``user_zone()``
+  - Memory tool outputs: ``_format_period_results``, ledger
+    narrative/summary/raw render, ``ReflectionAPI.recent_tool_calls``
+  - Discord chime delivery stamp + daily compaction loop trigger time
+
+**UTC paths** (internal only — keep ``datetime.now(UTC)``)::
+
+  - SQLite memory store columns (``semantic.updated_at``,
+    ``episodic.created_at``, ledger event ``timestamp``); agents read
+    them via the user-zone tools above, never raw
+  - Forensics / dreaming / counter_factual / autonomy audit timestamps
+  - Cron scheduling: ``CronTrigger.should_fire(datetime.now(UTC))``;
+    cron strings in ``loom.toml [[autonomy.schedules]]`` are always
+    written in UTC, the operator hand-converts from local time. The
+    per-schedule ``timezone`` field is currently a no-op — do not rely
+    on it (tracked separately).
+
+When in doubt: if the timestamp is about to enter a tool result, a
+prompt, or chat UI, route through this module. Never inject
+``datetime.now(UTC)`` directly into anything the agent or user reads.
 """
 
 from __future__ import annotations
@@ -113,6 +141,17 @@ def local_now() -> datetime:
 def local_zone_name() -> str:
     """Return the configured user timezone name (e.g. 'Asia/Taipei')."""
     return str(_ensure_user_zone().key)
+
+
+def user_zone() -> zoneinfo.ZoneInfo:
+    """
+    Return the user's configured timezone as a :class:`zoneinfo.ZoneInfo`.
+
+    Use when parsing agent-supplied date/datetime strings — naked inputs
+    should be interpreted in the user's zone, matching what the agent
+    sees in injected prompt timestamps (``user_timestamp()``).
+    """
+    return _ensure_user_zone()
 
 
 def user_timestamp() -> str:

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -35,6 +35,7 @@ import httpx
 from loom.core.harness.middleware import ToolCall, ToolResult, VerifierResult
 from loom.core.harness.permissions import ToolCapability, TrustLevel
 from loom.core.harness.scope import ScopeRequirement, ScopeRequest
+from loom.core.timezone import local_zone_name, user_zone
 from loom.core.security.self_termination_guard import SelfTerminationGuard
 from loom.core.security.command_scanner import CommandScanner
 from loom.core.security.sandbox_runtime import (
@@ -991,21 +992,56 @@ async def _run_bash_job(
 # ------------------------------------------------------------------
 
 def _parse_memory_datetime(value: str | None) -> datetime | None:
-    """Parse a tool-facing date/datetime string into an aware UTC datetime."""
+    """Parse a tool-facing date/datetime string into an aware UTC datetime.
+
+    Naked dates (``YYYY-MM-DD``) and naked datetimes (no offset) are
+    interpreted in the user's configured timezone — matching what the
+    agent sees in injected prompt timestamps. Strings with an explicit
+    offset (``+08:00`` / ``Z``) are honored as written. The return value
+    is always normalised to UTC so callers can compare it against DB
+    timestamps directly. See issue #388.
+    """
     if not value:
         return None
     raw = value.strip()
     if not raw:
         return None
+    zone = user_zone()
     try:
         if len(raw) == 10 and raw[4] == "-" and raw[7] == "-":
-            return datetime.fromisoformat(raw).replace(tzinfo=UTC)
+            return datetime.fromisoformat(raw).replace(tzinfo=zone).astimezone(UTC)
         parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
     except ValueError as exc:
         raise ValueError(f"Invalid datetime {value!r}; use YYYY-MM-DD or ISO datetime") from exc
     if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=UTC)
+        return parsed.replace(tzinfo=zone).astimezone(UTC)
     return parsed.astimezone(UTC)
+
+
+def _format_local_timestamp(
+    value: datetime | str | None, *, date_only: bool = False
+) -> str:
+    """Format a stored UTC datetime (or ISO string) in the user's zone.
+
+    Agent-facing tool output mirrors the same timezone the agent sees in
+    injected prompt timestamps, so since/until inputs and emitted
+    created_at/updated_at lines match. Returns ``""`` for falsy input.
+    See issue #388.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return ""
+        try:
+            value = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except ValueError:
+            return raw[:10] if date_only else raw[:16]
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    local = value.astimezone(user_zone())
+    return local.strftime("%Y-%m-%d" if date_only else "%Y-%m-%d %H:%M")
 
 
 def make_recall_tool(memory: "MemoryFacade") -> ToolDefinition:
@@ -1117,14 +1153,16 @@ def make_recall_tool(memory: "MemoryFacade") -> ToolDefinition:
                     "type": "string",
                     "description": (
                         "Optional lower bound for semantic updated_at "
-                        "(YYYY-MM-DD or ISO datetime)."
+                        "(YYYY-MM-DD or ISO datetime). Naked values are "
+                        "interpreted in your configured timezone."
                     ),
                 },
                 "until": {
                     "type": "string",
                     "description": (
                         "Optional exclusive upper bound for semantic updated_at "
-                        "(YYYY-MM-DD or ISO datetime)."
+                        "(YYYY-MM-DD or ISO datetime). Naked values are "
+                        "interpreted in your configured timezone."
                     ),
                 },
             },
@@ -1137,21 +1175,27 @@ def make_recall_tool(memory: "MemoryFacade") -> ToolDefinition:
 
 
 def _format_period_results(groups: dict[str, list]) -> str:
-    """Format grouped period recall evidence for the agent."""
+    """Format grouped period recall evidence for the agent.
+
+    Timestamps are converted to the user's configured timezone so they
+    match what the agent sees in injected prompt timestamps and what
+    since/until inputs are parsed against.
+    """
     sections: list[str] = []
+    zone_suffix = f" ({local_zone_name()})"
     semantic = groups.get("semantic", [])
     if semantic:
-        lines = ["Semantic facts"]
+        lines = [f"Semantic facts{zone_suffix}"]
         for entry in semantic:
-            stamp = entry.updated_at.isoformat()[:10] if entry.updated_at else ""
+            stamp = _format_local_timestamp(entry.updated_at, date_only=True)
             lines.append(f"- [{stamp}] {entry.key}: {entry.value[:240]}")
         sections.append("\n".join(lines))
 
     episodic = groups.get("episodic", [])
     if episodic:
-        lines = ["Episodic events"]
+        lines = [f"Episodic events{zone_suffix}"]
         for entry in episodic:
-            stamp = entry.created_at.isoformat()[:16] if entry.created_at else ""
+            stamp = _format_local_timestamp(entry.created_at)
             lines.append(
                 f"- [{stamp}] {entry.session_id} {entry.event_type}: "
                 f"{entry.content[:240]}"
@@ -1160,11 +1204,12 @@ def _format_period_results(groups: dict[str, list]) -> str:
 
     sessions = groups.get("sessions", [])
     if sessions:
-        lines = ["Sessions"]
+        lines = [f"Sessions{zone_suffix}"]
         for session in sessions:
             title = session.get("title") or "(untitled)"
+            stamp = _format_local_timestamp(session.get("last_active"))
             lines.append(
-                f"- [{session.get('last_active', '')[:16]}] "
+                f"- [{stamp}] "
                 f"{session.get('session_id')}: {title} "
                 f"({session.get('turn_count', 0)} turns)"
             )
@@ -1172,10 +1217,11 @@ def _format_period_results(groups: dict[str, list]) -> str:
 
     messages = groups.get("messages", [])
     if messages:
-        lines = ["Session messages"]
+        lines = [f"Session messages{zone_suffix}"]
         for message in messages:
+            stamp = _format_local_timestamp(message.get("created_at"))
             lines.append(
-                f"- [{message.get('created_at', '')[:16]}] "
+                f"- [{stamp}] "
                 f"{message.get('session_id')} {message.get('role')}: "
                 f"{str(message.get('content') or '')[:240]}"
             )
@@ -1234,11 +1280,19 @@ def make_recall_period_tool(memory: "MemoryFacade") -> ToolDefinition:
             "properties": {
                 "since": {
                     "type": "string",
-                    "description": "Required lower bound (YYYY-MM-DD or ISO datetime).",
+                    "description": (
+                        "Required lower bound (YYYY-MM-DD or ISO datetime). "
+                        "Naked values are interpreted in your configured "
+                        "timezone (same as the prompt timestamp prefix)."
+                    ),
                 },
                 "until": {
                     "type": "string",
-                    "description": "Optional exclusive upper bound (YYYY-MM-DD or ISO datetime).",
+                    "description": (
+                        "Optional exclusive upper bound (YYYY-MM-DD or ISO "
+                        "datetime). Naked values are interpreted in your "
+                        "configured timezone."
+                    ),
                 },
                 "limit": {
                     "type": "integer",
@@ -2408,11 +2462,18 @@ def make_ledger_recall_tool(
                 },
                 "since": {
                     "type": "string",
-                    "description": "Lower bound (YYYY-MM-DD or ISO datetime).",
+                    "description": (
+                        "Lower bound (YYYY-MM-DD or ISO datetime). Naked "
+                        "values are interpreted in your configured "
+                        "timezone (same as the prompt timestamp prefix)."
+                    ),
                 },
                 "until": {
                     "type": "string",
-                    "description": "Exclusive upper bound.",
+                    "description": (
+                        "Exclusive upper bound. Naked values are "
+                        "interpreted in your configured timezone."
+                    ),
                 },
                 "output": {
                     "type": "string",

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -57,7 +57,7 @@ import logging
 import json
 import os
 import time
-from datetime import datetime, time as datetime_time, timezone
+from datetime import datetime, time as datetime_time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -73,6 +73,7 @@ except ImportError as exc:  # pragma: no cover
     ) from exc
 
 from loom.core.harness.scope import ConfirmDecision
+from loom.core.timezone import user_zone
 from loom.core.events import (
     EnvelopeStarted, EnvelopeUpdated, EnvelopeCompleted,
     ExecutionEnvelopeView,
@@ -282,7 +283,7 @@ class LoomDiscordBot:
         # Turn summary display mode: "off" | "on" | "detail"
         self._summary_mode: str = "on"
 
-        local_tz = datetime.now().astimezone().tzinfo or timezone.utc
+        local_tz = user_zone()
         self._daily_compaction_loop = tasks.loop(
             time=datetime_time(hour=5, minute=0, tzinfo=local_tz),
         )(self._run_daily_compaction)
@@ -788,8 +789,11 @@ class LoomDiscordBot:
             return
 
         # Local-time stamp so the marker is human-readable in chat.
+        # Uses the user's configured zone (loom.toml [timezone].user), not
+        # the bot host's local zone — keeps display consistent regardless
+        # of where the process runs.
         try:
-            local_dt = req.fired_at.astimezone()
+            local_dt = req.fired_at.astimezone(user_zone())
             stamp = local_dt.strftime("%H:%M %Z").strip()
         except Exception:
             stamp = req.fired_at.isoformat()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""
+Test-suite conftest.
+
+Pins the user timezone to UTC so timestamp-formatting assertions are
+deterministic regardless of which ``loom.toml`` the runner discovers.
+Tests that need a different zone should monkeypatch
+``loom.core.timezone._USER_ZONE`` themselves.
+"""
+
+from __future__ import annotations
+
+import zoneinfo
+
+import loom.core.timezone as _tz_module
+
+_tz_module._USER_ZONE = zoneinfo.ZoneInfo("UTC")

--- a/tests/test_memory_datetime_parsing.py
+++ b/tests/test_memory_datetime_parsing.py
@@ -1,0 +1,99 @@
+"""
+Tests for ``_parse_memory_datetime`` — issue #388.
+
+The parser must interpret naked dates / datetimes in the user's
+configured timezone so that ``since``/``until`` arguments line up with
+the timestamp prefix the agent sees in prompts. Strings with an explicit
+offset are honored as written; the return value is always normalised
+to UTC for direct comparison against DB rows.
+"""
+
+from __future__ import annotations
+
+import zoneinfo
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+import loom.core.timezone as _tz_module
+from loom.platform.cli.tools import _parse_memory_datetime
+
+
+@pytest.fixture
+def taipei_zone(monkeypatch):
+    """Pin user zone to Asia/Taipei for a single test."""
+    monkeypatch.setattr(
+        _tz_module, "_USER_ZONE", zoneinfo.ZoneInfo("Asia/Taipei")
+    )
+
+
+def test_empty_input_returns_none():
+    assert _parse_memory_datetime(None) is None
+    assert _parse_memory_datetime("") is None
+    assert _parse_memory_datetime("   ") is None
+
+
+def test_naked_date_uses_user_zone(taipei_zone):
+    # 2026-05-17 00:00 Asia/Taipei == 2026-05-16 16:00 UTC.
+    result = _parse_memory_datetime("2026-05-17")
+    assert result == datetime(2026, 5, 16, 16, 0, tzinfo=UTC)
+
+
+def test_naked_datetime_uses_user_zone(taipei_zone):
+    # 2026-05-17 16:00 Asia/Taipei == 2026-05-17 08:00 UTC.
+    result = _parse_memory_datetime("2026-05-17T16:00:00")
+    assert result == datetime(2026, 5, 17, 8, 0, tzinfo=UTC)
+
+
+def test_explicit_offset_honored(taipei_zone):
+    # Explicit +08:00 must still be respected even when user zone is Taipei.
+    result = _parse_memory_datetime("2026-05-17T16:00:00+08:00")
+    assert result == datetime(2026, 5, 17, 8, 0, tzinfo=UTC)
+
+
+def test_explicit_offset_different_from_user_zone(taipei_zone):
+    # +00:00 wins over Taipei default.
+    result = _parse_memory_datetime("2026-05-17T16:00:00+00:00")
+    assert result == datetime(2026, 5, 17, 16, 0, tzinfo=UTC)
+
+
+def test_z_suffix_treated_as_utc(taipei_zone):
+    result = _parse_memory_datetime("2026-05-17T16:00:00Z")
+    assert result == datetime(2026, 5, 17, 16, 0, tzinfo=UTC)
+
+
+def test_naked_date_with_utc_user_zone():
+    # conftest pins user zone to UTC; naked date stays UTC.
+    result = _parse_memory_datetime("2026-05-17")
+    assert result == datetime(2026, 5, 17, 0, 0, tzinfo=UTC)
+
+
+def test_invalid_string_raises_valueerror():
+    with pytest.raises(ValueError, match="Invalid datetime"):
+        _parse_memory_datetime("not-a-date")
+
+
+def test_naked_datetime_with_microseconds_under_user_zone(taipei_zone):
+    # Microsecond precision survives the zone conversion.
+    result = _parse_memory_datetime("2026-05-17T16:00:00.123456")
+    expected = datetime(2026, 5, 17, 16, 0, 0, 123456, tzinfo=zoneinfo.ZoneInfo("Asia/Taipei")).astimezone(UTC)
+    assert result == expected
+
+
+def test_negative_offset(taipei_zone):
+    # 2026-05-17 16:00 -05:00 == 2026-05-17 21:00 UTC.
+    result = _parse_memory_datetime("2026-05-17T16:00:00-05:00")
+    assert result == datetime(2026, 5, 17, 21, 0, tzinfo=UTC)
+
+
+def test_return_value_is_always_utc(taipei_zone):
+    # Whatever the input zone, the return value's tzinfo is UTC.
+    for raw in [
+        "2026-05-17",
+        "2026-05-17T16:00:00",
+        "2026-05-17T16:00:00+08:00",
+        "2026-05-17T16:00:00-05:00",
+        "2026-05-17T16:00:00Z",
+    ]:
+        result = _parse_memory_datetime(raw)
+        assert result.utcoffset() == timedelta(0), raw

--- a/tests/test_memory_datetime_parsing.py
+++ b/tests/test_memory_datetime_parsing.py
@@ -16,6 +16,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 import loom.core.timezone as _tz_module
+from loom.core.memory.search import MemorySearchResult
 from loom.platform.cli.tools import _parse_memory_datetime
 
 
@@ -97,3 +98,66 @@ def test_return_value_is_always_utc(taipei_zone):
     ]:
         result = _parse_memory_datetime(raw)
         assert result.utcoffset() == timedelta(0), raw
+
+
+# ── MemorySearchResult.format() — agent-facing recall hits ────────────
+
+
+def test_recall_format_date_hint_uses_user_zone(taipei_zone):
+    # Fact stored at 16:30 UTC == 00:30 next day in Asia/Taipei.
+    # PR #391 review case: date hint must reflect the local date.
+    result = MemorySearchResult(
+        type="semantic",
+        key="foo",
+        value="bar",
+        score=1.0,
+        updated_at="2026-05-16T16:30:00+00:00",
+    )
+    out = result.format()
+    assert " [2026-05-17] " in out
+
+
+def test_recall_format_date_hint_under_utc():
+    # conftest pins user zone to UTC; date hint matches stored date.
+    result = MemorySearchResult(
+        type="semantic",
+        key="foo",
+        value="bar",
+        score=1.0,
+        updated_at="2026-05-16T16:30:00+00:00",
+    )
+    out = result.format()
+    assert " [2026-05-16] " in out
+
+
+def test_recall_format_naked_timestamp_treated_as_utc(taipei_zone):
+    # Stored strings without offset (legacy rows) are treated as UTC.
+    result = MemorySearchResult(
+        type="semantic",
+        key="foo",
+        value="bar",
+        score=1.0,
+        updated_at="2026-05-16T16:30:00",
+    )
+    out = result.format()
+    assert " [2026-05-17] " in out
+
+
+def test_recall_format_invalid_timestamp_falls_back_to_slice():
+    result = MemorySearchResult(
+        type="semantic",
+        key="foo",
+        value="bar",
+        score=1.0,
+        updated_at="not-an-iso-string",
+    )
+    out = result.format()
+    assert " [not-an-iso" in out
+
+
+def test_recall_format_empty_timestamp_omits_hint():
+    result = MemorySearchResult(
+        type="semantic", key="foo", value="bar", score=1.0, updated_at=""
+    )
+    out = result.format()
+    assert "[" not in out.split("\n")[0].replace("[semantic]", "")


### PR DESCRIPTION
Closes #388.

## Summary

`[timezone].user` in `loom.toml` was already the single source of truth for LLM-facing timestamps, but several call sites bypassed it — so the agent saw `Asia/Taipei` in injected prompts yet had to talk to tools that secretly assumed UTC. The 8-hour drift surfaced first in `ledger_recall` `since`/`until`, but the pattern repeated across recall outputs, Discord chime display, and the daily compaction loop.

This PR makes every agent-facing or user-facing timestamp path consistently use the configured user zone, while keeping internal DB / audit logs / cron evaluation on UTC.

## Boundary after this PR

**User-zone paths** (agent / human visible):
- LLM prompt timestamp prefix (already correct)
- Memory tool inputs: `recall` / `recall_period` / `ledger_recall` parse `since`/`until` via `user_zone()` — naked values interpreted in user zone, explicit offsets honored
- Memory tool outputs: `_format_period_results`, ledger narrative / summary / raw, `ReflectionAPI.recent_tool_calls`
- Discord chime delivery stamp + daily compaction loop trigger time

**UTC paths** (internal, unchanged):
- SQLite memory store columns
- Forensics / dreaming / counter_factual / autonomy audit timestamps
- `CronTrigger.should_fire(datetime.now(UTC))` — `loom.toml [[autonomy.schedules]]` cron strings remain UTC (operator hand-converts)

Documented as a cheat sheet in the `loom/core/timezone.py` module docstring so future code knows which path to pick.

## Changes

- `loom/core/timezone.py` — expose `user_zone()` public getter; expanded docstring with the boundary cheat sheet
- `loom/platform/cli/tools.py` — `_parse_memory_datetime` defaults naked input to user zone; new `_format_local_timestamp` helper; `_format_period_results` emits local-zone timestamps with zone-suffix section headers; updated `since`/`until` schema descriptions on three tools
- `loom/core/cognition/reflection.py` — `recent_tool_calls` converts timestamps to user zone
- `loom/core/ledger/recall.py` — `_fmt_date` / `_fmt_time` / `_fmt_full` use user zone for narrative / summary / raw rendering
- `loom/platform/discord/bot.py` — daily compaction loop and chime stamp use `user_zone()` instead of host machine zone
- `tests/conftest.py` — pin user zone to UTC for deterministic timestamp assertions
- `tests/test_memory_datetime_parsing.py` — 11 cases covering naked datetime / date-only / explicit offset / Z suffix / microseconds / negative offset

## Follow-up surfaced (not in this PR)

`CronTrigger.timezone` field (`loom/autonomy/triggers.py:96`) is declared and read from `loom.toml`, but `should_fire()` never consults it — currently a silent no-op. Tracking separately; making it real requires migrating all existing schedule strings.

## Test plan

- [x] `pytest tests/ -x` — 1917 passed
- [x] New tests cover naked datetime, naked date, explicit `+08:00`, `+00:00`, `Z` suffix, microseconds, negative offset, invalid strings, return-value-is-always-UTC invariant
- [x] `gitnexus_detect_changes` confirms scope matches intent (3 affected processes, all expected)
- [ ] Manual: `ledger_recall(since="2026-05-17T16:00:00")` no longer drifts 8 hours when `[timezone].user = "Asia/Taipei"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)