### PR TITLE
docs: clear doc integrity ignore-block debt

### DIFF
--- a/doc/12b-Memory-Health.md
+++ b/doc/12b-Memory-Health.md
@@ -150,13 +150,19 @@ class OperationHealth:
 
 Agent 可透過 `memory_health` 工具主動查詢健康狀態：
 
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
 ```python
-# loom/core/cognition/memory_health.py 中的 memory_health tool
-# （實為 MemoryHealthTracker 的 wrapper tool）
+# loom/core/memory/health.py
+report = tracker.snapshot()
+summary = report.render_summary()
+agent_context = report.render_agent_context()
+```
 
-result = await memory_health_tool(call)
-# 回傳 HealthReport.render_summary() 的字串
+tool 註冊不是獨立的 `memory_health.py` 模組；`MemoryGovernor` 建立 `MemoryHealthTracker`，`LoomSession.start()` 把相關 memory maintenance tools 註冊進 session registry。工具回傳的是 tracker 產生的健康摘要字串。
+
+```python
+# loom/core/memory/maintenance.py
+def make_memory_health_tool(governor: "MemoryGovernor") -> ToolDefinition:
+    ...
 ```
 
 平台在 session 啟動時注入 `render_agent_context()` 的內容（如果有 prior issues）。

--- a/doc/12b-Memory-Health.md
+++ b/doc/12b-Memory-Health.md
@@ -192,7 +192,3 @@ def make_memory_health_tool(governor: "MemoryGovernor") -> ToolDefinition:
 [memory]
 health.enabled = true   # 預設 true，關閉 = false
 ```
-
----
-
-*文件草稿 | 2026-04-26 03:21 Asia/Taipei*

--- a/doc/19-Autonomy-概述.md
+++ b/doc/19-Autonomy-概述.md
@@ -50,86 +50,34 @@ Loom 的 Autonomy Engine 讓它「主動」——在滿足特定條件時自動�
 
 ---
 
-## Decision Pipeline
+## 決策與執行路徑
 
-### 決策流程
+### 現行流程
 
-當觸發器觸發時，Decision Pipeline 決定「是否要行動」以及「如何行動」：
+舊版設計把決策拆成 `DecisionPipeline`；現行實作沒有獨立的 core autonomy decision 模組。觸發器 fired 後，流程集中在 `AutonomyDaemon`、`TriggerEvaluator`、`ActionPlanner`：
 
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
 ```python
-# loom/core/autonomy/decision.py
-class DecisionPipeline:
-    """決策管道"""
-    
-    def __init__(
-        self,
-        trust_level: TrustLevel,
-        memory: MemoryStore,
-        notification_router: NotificationRouter,
-    ):
-        self.trust_level = trust_level
-        self.memory = memory
-        self.notification_router = notification_router
-    
-    async def decide(
-        self,
-        trigger: Trigger,
-        context: dict,
-    ) -> Decision:
-        """
-        根據觸發器和上下文做出決策
-        
-        Returns:
-            Decision: APPROVE / DENY / CONFIRM / DEFER
-        """
-        
-        # 1. 評估信任級別
-        trust_decision = await self._evaluate_trust(trigger, context)
-        
-        if trust_decision == TrustDecision.BLOCK:
-            return Decision.DENY
-        
-        # 2. 評估風險
-        risk = await self._evaluate_risk(trigger, context)
-        
-        if risk > self._risk_threshold:
-            return Decision.CONFIRM  # 需要確認
-        
-        # 3. 評估時機
-        if not await self._is_appropriate_time(trigger):
-            return Decision.DEFER  # 推遲
-        
-        # 4. 做出決定
-        return Decision.APPROVE
+# loom/autonomy/daemon.py
+async def _on_trigger_fire(self, trigger, context):
+    plan = await self._planner.handle(trigger, context)
+    await self._execute_plan(plan)
 ```
+
+`ActionPlanner` 依 trigger 的 `trust_level` 和 context 回傳 `PlannedAction`。daemon 再根據 decision 選擇：
+
+| Decision | daemon 行為 |
+|----------|-------------|
+| `EXECUTE` | 直接執行 agent turn；chime mode 先嘗試投遞到既有 session |
+| `NOTIFY` / `HOLD` | 透過 `ConfirmFlow` 發確認通知 |
+| `SKIP` | 不執行 |
 
 ### Trust Level 映射
 
-```python
-def _evaluate_trust(
-    self,
-    trigger: Trigger,
-    context: dict,
-) -> TrustDecision:
-    """根據 Trust Level 決定是否允許"""
-    
-    if self.trust_level == TrustLevel.SAFE:
-        # SAFE: 只允許純讀取操作
-        if trigger.requires_write:
-            return TrustDecision.BLOCK
-        return TrustDecision.ALLOW
-    
-    elif self.trust_level == TrustLevel.GUARDED:
-        # GUARDED: 允許讀取 + 安全的寫入
-        if trigger.risk_level > RiskLevel.LOW:
-            return TrustDecision.BLOCK
-        return TrustDecision.ALLOW
-    
-    elif self.trust_level == TrustLevel.CRITICAL:
-        # CRITICAL: 允許所有操作（由用戶監督）
-        return TrustDecision.ALLOW
-```
+| Trust level | 語意 |
+|-------------|------|
+| `safe` | 預期只做低風險任務 |
+| `guarded` | 需要通知或確認，並可搭配 `allowed_tools` / `scope_grants` |
+| `critical` | 高影響任務，規劃層會更保守處理 |
 
 詳見 [21-Action-Planner.md](21-Action-Planner.md)。
 

--- a/doc/20-觸發器詳解.md
+++ b/doc/20-觸發器詳解.md
@@ -1,518 +1,231 @@
 # 觸發器詳解
 
-Autonomy Engine 支援三種觸發器：CronTrigger、EventTrigger、ConditionTrigger。本篇詳細說明各觸發器的設計與實現。
+Autonomy Engine 目前支援三種觸發器：`CronTrigger`、`EventTrigger`、`ConditionTrigger`。三者都定義在 `loom/autonomy/triggers.py`，由 `loom/autonomy/evaluator.py` 的 `TriggerEvaluator` 註冊、輪詢與發火。
 
 ---
 
-## Trigger 抽象
+## 真實模組分工
 
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
+| 模組 | 職責 |
+|------|------|
+| `loom/autonomy/triggers.py` | 觸發器資料結構與 cron 驗證 |
+| `loom/autonomy/evaluator.py` | 觸發器註冊、事件送入、定期輪詢 |
+| `loom/autonomy/daemon.py` | 從 `loom.toml` 載入設定，並把 fired trigger 交給 planner 執行 |
+| `loom/autonomy/planner.py` | 根據 trust level 與 intent 產生行動計畫 |
+
+Loom 沒有 `loom/core/autonomy/triggers/` 子目錄，也沒有獨立的 `TriggerRegistry` 或 `EventBus` 模組。registry 行為就在 `TriggerEvaluator` 內部，event trigger 透過 `TriggerEvaluator.emit()` 收到事件。
+
+---
+
+## TriggerDefinition
+
+所有觸發器都繼承 `TriggerDefinition`。它不是抽象 `should_fire()` 介面，而是一個 dataclass，負責攜帶 autonomy 執行需要的共同欄位。
+
 ```python
-# loom/core/autonomy/triggers/base.py
-class Trigger(ABC):
-    """觸發器抽象基類"""
-    
-    @abstractmethod
-    async def should_fire(self) -> bool:
-        """是否應該觸發"""
-        pass
-    
-    @abstractmethod
-    async def get_context(self) -> dict:
-        """獲取觸發時的上下文"""
-        pass
-    
+# loom/autonomy/triggers.py
+@dataclass
+class TriggerDefinition:
+    name: str
+    intent: str
+    trust_level: str = "guarded"
+    notify: bool = True
+    enabled: bool = True
+    notify_thread_id: int = 0
+    allowed_tools: list[str] = field(default_factory=list)
+    scope_grants: list[dict[str, Any]] = field(default_factory=list)
+    attach_outputs: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
     @property
-    @abstractmethod
-    def id(self) -> str:
-        """觸發器唯一標識"""
-        pass
-    
-    @property
-    def risk_level(self) -> RiskLevel:
-        """觸發器的風險等級"""
-        return RiskLevel.LOW
-    
-    @property
-    def requires_write(self) -> bool:
-        """是否需要寫入操作"""
-        return False
+    def kind(self) -> TriggerKind:
+        raise NotImplementedError
 ```
+
+共同欄位的含義：
+
+| 欄位 | 說明 |
+|------|------|
+| `name` | trigger 的穩定名稱，也是註冊 key |
+| `intent` | 觸發後 agent 要完成的自然語言任務描述 |
+| `trust_level` | `safe` / `guarded` / `critical` |
+| `notify` | 執行前或執行後是否發通知 |
+| `allowed_tools` | 此 trigger 可臨時預授權的 GUARDED tools |
+| `scope_grants` | 此 trigger 執行期間注入的 scope-aware grants |
+| `attach_outputs` | 執行後要附到通知的 workspace glob |
 
 ---
 
 ## CronTrigger
 
-### 用途
+`CronTrigger` 使用 5 欄 cron 表達式：minute、hour、day-of-month、month、day-of-week。它有自己的輕量 validator 與 matcher，沒有依賴 `croniter`。
 
-定時執行任務，如「每天早上 9 點發送天氣預報」。
+```python
+# loom/autonomy/triggers.py
+@dataclass
+class CronTrigger(TriggerDefinition):
+    cron: str = "0 9 * * *"
+    timezone: str = "UTC"
+    mode: str = "independent"
+    target: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self):
+        _validate_cron(self.cron)
+        if self.mode not in ("independent", "chime"):
+            raise ValueError(...)
+
+    @property
+    def kind(self) -> TriggerKind:
+        return TriggerKind.CRON
+
+    def should_fire(self, dt: datetime) -> bool:
+        minute, hour, dom, month, dow = self.cron.strip().split()
+        ...
+```
 
 ### Cron 表達式
-
-Loom 使用標準的 5 位 cron 表達式：
 
 ```
 ┌───────────── 分鐘 (0-59)
 │ ┌─────────── 小時 (0-23)
 │ │ ┌───────── 日 (1-31)
 │ │ │ ┌─────── 月 (1-12)
-│ │ │ │ ┌───── 星期 (0-6, 0 = 星期日)
+│ │ │ │ ┌───── 星期 (0-7, 0/7 = 星期日)
 │ │ │ │ │
 * * * * *
 ```
 
 | 表達式 | 意義 |
 |--------|------|
-| `0 9 * * *` | 每天早上 9:00 |
+| `0 9 * * *` | 每天 09:00 |
 | `*/15 * * * *` | 每 15 分鐘 |
-| `0 9 * * 1-5` | 每個工作日早上 9:00 |
-| `0 9 1 * *` | 每月 1 日早上 9:00 |
+| `0 9 * * 1-5` | 每個工作日 09:00 |
+| `0 9 1 * *` | 每月 1 日 09:00 |
 
-### 實現
-
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
-```python
-# loom/core/autonomy/triggers/cron.py
-import croniter
-from datetime import datetime
-
-class CronTrigger(Trigger):
-    """定時觸發器"""
-    
-    def __init__(
-        self,
-        id: str,
-        cron_expr: str,
-        action: str,
-        enabled: bool = True,
-        timezone: str = "UTC",
-    ):
-        self.id = id
-        self.cron_expr = cron_expr
-        self.action = action
-        self.enabled = enabled
-        self.timezone = timezone
-        
-        self._cron = croniter.croniter(cron_expr, datetime.now())
-        self._last_fire_time: datetime | None = None
-        self._next_fire_time: datetime | None = None
-    
-    async def should_fire(self) -> bool:
-        """檢查是否應該觸發"""
-        if not self.enabled:
-            return False
-        
-        now = datetime.now()
-        
-        # 計算下次觸發時間
-        if self._next_fire_time is None:
-            self._next_fire_time = self._cron.get_next(datetime)
-        
-        # 檢查是否到達觸發時間
-        if now >= self._next_fire_time:
-            self._last_fire_time = self._next_fire_time
-            self._next_fire_time = self._cron.get_next(datetime)
-            return True
-        
-        return False
-    
-    async def get_context(self) -> dict:
-        return {
-            "trigger_type": "cron",
-            "trigger_id": self.id,
-            "action": self.action,
-            "last_fire_time": self._last_fire_time,
-            "next_fire_time": self._next_fire_time,
-            "cron_expr": self.cron_expr,
-        }
-```
-
-### 使用範例
+### 設定範例
 
 ```toml
-[[autonomy.triggers.cron]]
-id = "morning_weather"
-cron = "0 8 * * *"
-action = "fetch_weather_and_notify"
-enabled = true
+[[autonomy.schedules]]
+name        = "memory_housekeeping"
+cron        = "0 19 * * 0"
+intent      = "Run memory housekeeping and report retained/pruned counts."
+trust_level = "safe"
+notify      = false
+```
+
+`mode = "chime"` 時，cron 不會開新 autonomy session，而是把 chime 投遞到既有 Discord thread session：
+
+```toml
+[[autonomy.schedules]]
+name        = "morning_greeting"
+cron        = "0 1 * * *"
+intent      = "向 user 主動道早安，提一兩件今天值得留意的事"
+trust_level = "safe"
+mode        = "chime"
+
+  [autonomy.schedules.target]
+  type     = "discord_thread"
+  id       = "1490024181994225744"
+  fallback = "skip"
 ```
 
 ---
 
 ## EventTrigger
 
-### 用途
+`EventTrigger` 只保存要監聽的 event name。事件送入與匹配由 `TriggerEvaluator.emit()` 做。
 
-當特定事件發生時觸發，如「檔案變更」、「Git push」、「用戶上線」。
-
-### 事件類型
-
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
 ```python
-# loom/core/autonomy/triggers/events.py
-class EventType(Enum):
-    # 檔案系統事件
-    FILE_CREATED = "file_created"
-    FILE_MODIFIED = "file_modified"
-    FILE_DELETED = "file_deleted"
-    FILE_ACCESSED = "file_accessed"
-    
-    # Git 事件
-    GIT_PUSH = "git_push"
-    GIT_PR_OPENED = "git_pr_opened"
-    GIT_PR_MERGED = "git_pr_merged"
-    
-    # 用戶事件
-    USER_ONLINE = "user_online"
-    USER_OFFLINE = "user_offline"
-    USER_MESSAGE = "user_message"
-    
-    # 系統事件
-    SYSTEM_STARTUP = "system_startup"
-    SYSTEM_SHUTDOWN = "system_shutdown"
-    ERROR_OCCURRED = "error_occurred"
+# loom/autonomy/triggers.py
+@dataclass
+class EventTrigger(TriggerDefinition):
+    event_name: str = ""
+
+    @property
+    def kind(self) -> TriggerKind:
+        return TriggerKind.EVENT
 ```
 
-### 實現
-
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
-```python
-# loom/core/autonomy/triggers/event.py
-class EventTrigger(Trigger):
-    """事件觸發器"""
-    
-    def __init__(
-        self,
-        id: str,
-        event_type: EventType,
-        action: str,
-        filter: str | None = None,  # 可選的過濾條件
-        enabled: bool = True,
-    ):
-        self.id = id
-        self.event_type = event_type
-        self.action = action
-        self.filter = filter
-        self.enabled = enabled
-        
-        self._last_event: dict | None = None
-    
-    async def should_fire(self) -> bool:
-        """檢查是否有新事件"""
-        if not self.enabled:
-            return False
-        
-        # 從事件佇列取最新事件
-        event = await self._poll_event()
-        
-        if event is None:
-            return False
-        
-        # 應用過濾器
-        if self.filter and not self._matches_filter(event):
-            return False
-        
-        self._last_event = event
-        return True
-    
-    def _matches_filter(self, event: dict) -> bool:
-        """檢查事件是否匹配過濾器"""
-        if not self.filter:
-            return True
-        
-        # 簡單的 glob 匹配
-        if self.filter.startswith("*.py"):
-            path = event.get("path", "")
-            return path.endswith(".py")
-        
-        # 可以擴展更多過濾類型
-        return True
-    
-    async def get_context(self) -> dict:
-        return {
-            "trigger_type": "event",
-            "trigger_id": self.id,
-            "event_type": self.event_type.value,
-            "action": self.action,
-            "event_data": self._last_event,
-        }
-```
-
-### 事件監聽
-
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
-```python
-# loom/core/autonomy/events.py
-class EventBus:
-    """全域事件匯流排"""
-    
-    _instance: "EventBus | None" = None
-    
-    def __init__(self):
-        self._handlers: dict[EventType, list[Callable]] = defaultdict(list)
-    
-    @classmethod
-    def get_instance(cls) -> "EventBus":
-        if cls._instance is None:
-            cls._instance = EventBus()
-        return cls._instance
-    
-    def subscribe(self, event_type: EventType, handler: Callable):
-        """訂閱事件"""
-        self._handlers[event_type].append(handler)
-    
-    async def publish(self, event_type: EventType, data: dict):
-        """發布事件"""
-        for handler in self._handlers[event_type]:
-            await handler(data)
-```
-
-### 使用範例
+設定檔中的 event trigger 使用 `[[autonomy.triggers]]`：
 
 ```toml
-[[autonomy.triggers.event]]
-id = "test_on_change"
-event = "file_modified"
-filter = "*.py"
-action = "run_unit_tests"
-enabled = true
-
-[[autonomy.triggers.event]]
-id = "deploy_on_push"
-event = "git_push"
-action = "deploy_to_staging"
-enabled = false
+[[autonomy.triggers]]
+name        = "on_deploy"
+event       = "deploy_done"
+intent      = "Run deployment smoke checks and report failures."
+trust_level = "guarded"
+notify      = true
 ```
+
+runtime 端呼叫：
+
+```python
+# loom/autonomy/evaluator.py
+await evaluator.emit("deploy_done", {"sha": "abc123"})
+```
+
+沒有全域 `EventBus`；需要發事件的 runtime 持有 evaluator 或透過 daemon 暴露的入口呼叫。
 
 ---
 
 ## ConditionTrigger
 
-### 用途
+`ConditionTrigger` 是最小的 callable wrapper。它保存 `condition_fn`，輪詢時呼叫，例外會被吞掉並視為 `False`。
 
-當特定條件滿足時觸發，如「磁碟空間低於 10%」、「用戶連續 3 次請求失敗」。
-
-### 條件類型
-
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
 ```python
-# loom/core/autonomy/triggers/condition.py
-class ConditionType(Enum):
-    # 系統監控
-    CPU_HIGH = "cpu_high"
-    MEMORY_LOW = "memory_low"
-    DISK_FULL = "disk_full"
-    
-    # 應用監控
-    ERROR_RATE_HIGH = "error_rate_high"
-    LATENCY_HIGH = "latency_high"
-    USER_LOGIN_FAILED = "user_login_failed"
-    
-    # 時間條件
-    TIME_OF_DAY = "time_of_day"
-    DAY_OF_WEEK = "day_of_week"
-    
-    # 自訂條件
-    CUSTOM = "custom"
-```
-
-### 實現
-
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
-```python
-# loom/core/autonomy/triggers/condition.py
+# loom/autonomy/triggers.py
 @dataclass
-class Condition:
-    """單一條件"""
-    type: ConditionType
-    threshold: float | None = None  # 閾值
-    operator: str = ">"             # 比較運算符
-    
-@dataclass
-class ConditionConfig:
-    """條件配置"""
-    conditions: list[Condition]
-    logic: str = "AND"  # AND / OR
-    
-class ConditionTrigger(Trigger):
-    """條件觸發器"""
-    
-    def __init__(
-        self,
-        id: str,
-        config: ConditionConfig,
-        action: str,
-        check_interval: float = 60.0,  # 檢查間隔（秒）
-        enabled: bool = True,
-    ):
-        self.id = id
-        self.config = config
-        self.action = action
-        self.check_interval = check_interval
-        self.enabled = enabled
-        
-        self._last_check: datetime | None = None
-        self._triggered: bool = False  # 避免重複觸發
-    
-    async def should_fire(self) -> bool:
-        """檢查條件是否滿足"""
-        if not self.enabled:
+class ConditionTrigger(TriggerDefinition):
+    condition_fn: Callable[[], bool] | None = None
+
+    @property
+    def kind(self) -> TriggerKind:
+        return TriggerKind.CONDITION
+
+    def evaluate(self) -> bool:
+        if self.condition_fn is None:
             return False
-        
-        # 檢查間隔
-        now = datetime.now()
-        if self._last_check and (now - self._last_check).total_seconds() < self.check_interval:
+        try:
+            return bool(self.condition_fn())
+        except Exception:
             return False
-        
-        self._last_check = now
-        
-        # 評估條件
-        results = await self._evaluate_conditions()
-        
-        if self.config.logic == "AND":
-            satisfied = all(results)
-        else:  # OR
-            satisfied = any(results)
-        
-        # 避免重複觸發
-        if satisfied and not self._triggered:
-            self._triggered = True
-            return True
-        elif not satisfied:
-            self._triggered = False
-        
-        return False
-    
-    async def _evaluate_conditions(self) -> list[bool]:
-        """評估所有條件"""
-        results = []
-        
-        for condition in self.config.conditions:
-            current_value = await self._get_current_value(condition.type)
-            
-            if condition.threshold is None:
-                results.append(bool(current_value))
-            else:
-                results.append(self._compare(current_value, condition.operator, condition.threshold))
-        
-        return results
-    
-    async def _get_current_value(self, condition_type: ConditionType) -> float:
-        """獲取條件的當前值"""
-        if condition_type == ConditionType.CPU_HIGH:
-            return await self._get_cpu_usage()
-        elif condition_type == ConditionType.MEMORY_LOW:
-            return await self._get_memory_available()
-        elif condition_type == ConditionType.DISK_FULL:
-            return await self._get_disk_usage()
-        # ... 其他條件
-        return 0.0
-    
-    def _compare(self, value: float, operator: str, threshold: float) -> bool:
-        """比較值"""
-        if operator == ">":
-            return value > threshold
-        elif operator == ">=":
-            return value >= threshold
-        elif operator == "<":
-            return value < threshold
-        elif operator == "<=":
-            return value <= threshold
-        elif operator == "==":
-            return value == threshold
-        return False
-    
-    async def get_context(self) -> dict:
-        return {
-            "trigger_type": "condition",
-            "trigger_id": self.id,
-            "action": self.action,
-            "conditions": [
-                {"type": c.type.value, "threshold": c.threshold}
-                for c in self.config.conditions
-            ],
-        }
 ```
 
-### 使用範例
-
-```toml
-[[autonomy.triggers.condition]]
-id = "disk_space_warning"
-conditions = [
-    { type = "disk_full", threshold = 90, operator = ">" }
-]
-logic = "AND"
-action = "notify_disk_warning"
-check_interval = 300
-enabled = true
-
-[[autonomy.triggers.condition]]
-id = "high_error_rate"
-conditions = [
-    { type = "error_rate_high", threshold = 5, operator = ">" },
-    { type = "latency_high", threshold = 1000, operator = ">" }
-]
-logic = "OR"
-action = "notify_error_alert"
-enabled = true
-```
+目前 `loom.toml` loader 只會載入 `schedules` 與 event `triggers`；condition trigger 主要是程式內註冊使用。
 
 ---
 
-## Trigger 管理
+## TriggerEvaluator 管理
 
-### Trigger Registry
+`TriggerEvaluator` 是實際的 registry。它用 trigger name 當 key，提供 register / unregister / enabled_triggers，並負責把 fired trigger 交給 planner。
 
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
 ```python
-# loom/core/autonomy/trigger_registry.py
-class TriggerRegistry:
-    """觸發器註冊表"""
-    
-    def __init__(self):
-        self._triggers: dict[str, Trigger] = {}
-    
-    def register(self, trigger: Trigger):
-        """註冊觸發器"""
-        self._triggers[trigger.id] = trigger
-    
-    def unregister(self, trigger_id: str):
-        """取消註冊"""
-        if trigger_id in self._triggers:
-            del self._triggers[trigger_id]
-    
-    def get(self, trigger_id: str) -> Trigger | None:
-        return self._triggers.get(trigger_id)
-    
-    def list_enabled(self) -> list[Trigger]:
+# loom/autonomy/evaluator.py
+class TriggerEvaluator:
+    def __init__(self, on_fire=None, history=None):
+        self._triggers: dict[str, TriggerDefinition] = {}
+        self._on_fire = on_fire
+        self._history = history
+
+    def register(self, trigger: TriggerDefinition) -> None:
+        self._triggers[trigger.name] = trigger
+
+    def unregister(self, name: str) -> None:
+        self._triggers.pop(name, None)
+
+    def enabled_triggers(self) -> list[TriggerDefinition]:
         return [t for t in self._triggers.values() if t.enabled]
-    
-    def load_from_config(self, config: list[dict]):
-        """從配置載入"""
-        for item in config:
-            trigger_type = item.pop("type")
-            
-            if trigger_type == "cron":
-                trigger = CronTrigger(**item)
-            elif trigger_type == "event":
-                trigger = EventTrigger(**item)
-            elif trigger_type == "condition":
-                trigger = ConditionTrigger(**item)
-            else:
-                raise ValueError(f"Unknown trigger type: {trigger_type}")
-            
-            self.register(trigger)
 ```
+
+Cron 和 condition trigger 由 evaluator 的 polling loop 檢查；event trigger 由 `emit()` 觸發。若 trigger fired，daemon 會把 trigger + context 交給 `ActionPlanner`，再依 trust level 決定 execute / notify / hold / skip。
 
 ---
 
 ## 總結
 
-| 觸發器 | 觸發方式 | 適用場景 |
-|--------|----------|----------|
-| CronTrigger | 時間表達式 | 定期任務：天氣預報、每日報告 |
-| EventTrigger | 事件監聽 | 響應事件：檔案變更、Git push |
-| ConditionTrigger | 條件判斷 | 監控告警：磁碟空間、錯誤率 |
+| 觸發器 | 實作位置 | 觸發方式 | 目前設定入口 |
+|--------|----------|----------|--------------|
+| `CronTrigger` | `loom/autonomy/triggers.py` | cron 時間匹配 | `[[autonomy.schedules]]` |
+| `EventTrigger` | `loom/autonomy/triggers.py` | `TriggerEvaluator.emit()` | `[[autonomy.triggers]]` |
+| `ConditionTrigger` | `loom/autonomy/triggers.py` | callable 回傳 true | 程式內註冊 |
 
-三種觸發器可以組合使用，實現複雜的自動化場景。
+觸發器本身只描述「何時醒來」與「醒來要做什麼」。實際行動、確認、通知、permission grants 都在 daemon / planner / session runtime 內處理。

--- a/doc/23-Notification-概述.md
+++ b/doc/23-Notification-概述.md
@@ -34,16 +34,15 @@ Notification Layer 提供統一的介面來發送這些通知。
 │   └──────┬──────┘                                         │
 │          │                                                 │
 │          ▼                                                 │
-│   ┌─────────────┐     ┌─────────────┐                     │
-│   │  Routable   │────▶│  Notifier   │                     │
-│   │             │     │  Registry   │                     │
-│   └─────────────┘     └──────┬──────┘                     │
-│                               │                             │
+│   ┌─────────────┐                                         │
+│   │ BaseNotifier│  router 內部以 channel 註冊              │
+│   └──────┬──────┘                                         │
+│          │                                                 │
 │        ┌──────────┬──────────┬──────────┬──────────┐       │
 │        ▼          ▼          ▼          ▼          ▼       │
-│   ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐  │
-│   │   CLI  │ │ Webhook│ │ Telegram│ │Discord │ │  ...  │  │
-│   └────────┘ └────────┘ └────────┘ └────────┘ └────────┘  │
+│   ┌────────┐ ┌────────┐ ┌────────┐ ┌────────────┐         │
+│   │   CLI  │ │ Webhook│ │Discord │ │Discord Bot │         │
+│   └────────┘ └────────┘ └────────┘ └────────────┘         │
 │                                                             │
 └─────────────────────────────────────────────────────────────┘
 ```
@@ -57,47 +56,32 @@ Notification Layer 提供統一的介面來發送這些通知。
 class NotificationType(Enum):
     """通知類型"""
     
-    # 資訊
-    INFO = "info"              # 一般資訊
-    SUCCESS = "success"         # 成功訊息
-    
-    # 警告
-    WARNING = "warning"         # 警告（需要關注）
-    ERROR = "error"             # 錯誤（需要處理）
-    
-    # 確認
-    CONFIRM = "confirm"         # 需要用戶確認
+    INFO    = "info"     # 一般資訊，無需回覆
+    CONFIRM = "confirm"  # yes/no 確認
+    INPUT   = "input"    # 需要自由文字輸入
+    ALERT   = "alert"    # 急迫警示
+    REPORT  = "report"   # 週期性摘要
 ```
 
 ---
 
 ## Notification 結構
 
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
 ```python
-# loom/core/notification/models.py
+# loom/notify/types.py
 @dataclass
 class Notification:
-    """通知"""
-    
-    type: NotificationType      # 通知類型
-    title: str                 # 標題
-    message: str               # 內容
-    
-    # 來源
-    source: str                # 來源模組（如 "autonomy.daemon"）
-    source_id: str | None      # 來源 ID（如觸發器 ID）
-    
-    # 選項
-    channel: str = "default"   # 發送頻道
-    metadata: dict = field(default_factory=dict)  # 額外資料
-    
-    # 時間
-    created_at: datetime = field(default_factory=datetime.now)
-    
-    # 狀態（用於 CONFIRM 類型）
-    status: NotificationStatus = NotificationStatus.PENDING
-    response: ConfirmResult | None = None
+    type: NotificationType
+    title: str
+    body: str
+    trigger_name: str = ""
+    timeout_seconds: int = 60
+    thread_id: int = 0
+    attachments: list[Path] = field(default_factory=list)
+    inline_image: Path | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    id: str = field(default_factory=lambda: str(uuid.uuid4())[:8])
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 ```
 
 ---
@@ -110,56 +94,25 @@ class Notification:
 # loom/notify/router.py
 class NotificationRouter:
     """通知路由器"""
-    
-    def __init__(
-        self,
-        notifier_registry: NotifierRegistry,
-        confirm_flow_factory: Callable[[], ConfirmFlow],
-    ):
-        self.notifier_registry = notifier_registry
-        self.confirm_flow_factory = confirm_flow_factory
-        self._queue: asyncio.Queue = asyncio.Queue()
-    
-    async def send(
-        self,
-        notification_type: NotificationType,
-        message: str,
-        title: str | None = None,
-        channel: str = "default",
-        **kwargs,
-    ) -> Notification:
-        """
-        發送通知的統一介面
-        """
-        
-        notification = Notification(
-            type=notification_type,
-            title=title or self._default_title(notification_type),
-            message=message,
-            source=kwargs.get("source", "unknown"),
-            source_id=kwargs.get("source_id"),
-            channel=channel,
-            metadata=kwargs,
-        )
-        
-        # CONFIRM 類型需要特殊處理
-        if notification_type == NotificationType.CONFIRM:
-            return await self._send_confirm(notification)
-        
-        # 一般通知加入佇列
-        await self._queue.put(notification)
-        
-        # 異步處理佇列
-        asyncio.create_task(self._process_queue())
-        
-        return notification
-    
-    async def _process_queue(self):
-        """處理通知佇列"""
-        while not self._queue.empty():
-            notification = await self._queue.get()
-            await self._deliver(notification)
-            self._queue.task_done()
+
+    def __init__(self) -> None:
+        self._notifiers: dict[str, BaseNotifier] = {}
+
+    def register(self, notifier: BaseNotifier) -> "NotificationRouter":
+        self._notifiers[notifier.channel] = notifier
+        return self
+
+    async def send(self, notification: Notification) -> dict[str, bool]:
+        """投遞到所有已註冊 notifier，回傳各 channel 成敗。"""
+        tasks = {
+            channel: notifier.send(notification)
+            for channel, notifier in self._notifiers.items()
+        }
+        outcomes = await asyncio.gather(*tasks.values(), return_exceptions=True)
+        return {
+            channel: not isinstance(outcome, Exception)
+            for channel, outcome in zip(tasks.keys(), outcomes)
+        }
 ```
 
 ### 發送到 Notifier
@@ -168,71 +121,20 @@ class NotificationRouter:
 async def _deliver(self, notification: Notification):
     """將通知投遞到所有訂閱的 Notifier"""
     
-    # 根據 channel 找到訂閱的 notifier
-    notifiers = self.notifier_registry.get_for_channel(notification.channel)
-    
-    for notifier in notifiers:
-        try:
-            await notifier.send(notification)
-        except Exception as e:
-            logger.error(f"Failed to send notification via {notifier.name}: {e}")
+    await self.send(notification)
 ```
 
 ---
 
-## NotifierRegistry
+## Notifier 註冊
 
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
+Loom 沒有獨立 `NotifierRegistry`。`NotificationRouter` 自己保存 `{channel: notifier}`，每個 adapter 透過 `channel` 欄位決定註冊名稱。
+
 ```python
-# loom/core/notification/registry.py
-class NotifierRegistry:
-    """Notifier 註冊表"""
-    
-    def __init__(self):
-        self._notifiers: dict[str, Notifier] = {}
-        self._channel_map: dict[str, list[str]] = defaultdict(list)  # channel -> [notifier_id, ...]
-    
-    def register(self, notifier: Notifier, channels: list[str] | None = None):
-        """註冊 Notifier"""
-        self._notifiers[notifier.name] = notifier
-        
-        # 預設發到所有 channel
-        if channels is None:
-            channels = ["default"]
-        
-        for channel in channels:
-            self._channel_map[channel].append(notifier.name)
-    
-    def unregister(self, notifier_name: str):
-        """取消註冊"""
-        if notifier_name in self._notifiers:
-            del self._notifiers[notifier_name]
-        
-        # 從 channel_map 中移除
-        for channel, names in self._channel_map.items():
-            if notifier_name in names:
-                names.remove(notifier_name)
-    
-    def get(self, name: str) -> Notifier | None:
-        return self._notifiers.get(name)
-    
-    def get_for_channel(self, channel: str) -> list[Notifier]:
-        """根據 channel 獲取 notifier 列表"""
-        notifier_names = self._channel_map.get(channel, ["default"])
-        
-        result = []
-        for name in notifier_names:
-            if name in self._notifiers:
-                result.append(self._notifiers[name])
-        
-        # 如果沒有找到，返回 default
-        if not result and "default" in self._notifiers:
-            result.append(self._notifiers["default"])
-        
-        return result
-    
-    def list_all(self) -> list[Notifier]:
-        return list(self._notifiers.values())
+# loom/notify/router.py
+router = NotificationRouter()
+router.register(CLINotifier(console))
+router.register(WebhookNotifier(url="https://..."))
 ```
 
 ---
@@ -242,30 +144,15 @@ class NotifierRegistry:
 ### 發送確認請求
 
 ```python
-async def _send_confirm(self, notification: Notification) -> Notification:
-    """發送需要確認的通知"""
-    
-    # 創建 ConfirmFlow
-    flow = self.confirm_flow_factory()
-    
-    # 執行確認流程
-    result = await flow.run(
-        prompt=notification.message,
-        timeout=notification.metadata.get("timeout", 300),
-    )
-    
-    # 更新 notification 狀態
-    notification.status = NotificationStatus.RESOLVED
-    notification.response = result
-    
-    # 根據結果回調
-    if notification.metadata.get("on_approve"):
-        await self._handle_callback(
-            notification.metadata["on_approve"],
-            result == ConfirmResult.APPROVED
-        )
-    
-    return notification
+# loom/notify/confirm.py
+flow = ConfirmFlow(send_fn=router.send, wait_fn=cli_notifier.wait_reply)
+result = await flow.ask(Notification(
+    type=NotificationType.CONFIRM,
+    title="Loom autonomy: cleanup_task",
+    body="Do you want to delete all test data?",
+    trigger_name="cleanup_task",
+    timeout_seconds=300,
+))
 ```
 
 詳見 [25-ConfirmFlow.md](25-ConfirmFlow.md)。
@@ -278,70 +165,37 @@ async def _send_confirm(self, notification: Notification) -> Notification:
 
 ```python
 # 簡單通知
-await notification_router.send(
-    NotificationType.INFO,
-    "Task completed successfully",
-    source="task.scheduler"
-)
+await notification_router.send(Notification(
+    type=NotificationType.INFO,
+    title="Task completed",
+    body="Task completed successfully",
+))
 
-# 錯誤通知
-await notification_router.send(
-    NotificationType.ERROR,
-    f"Tool '{tool_name}' execution failed: {error}",
-    source="harness.executor"
-)
+# 警示通知
+await notification_router.send(Notification(
+    type=NotificationType.ALERT,
+    title="Tool failed",
+    body=f"Tool '{tool_name}' execution failed: {error}",
+))
 
 # 需要確認
-await notification_router.send(
-    NotificationType.CONFIRM,
-    "Do you want to delete all test data?",
-    source="autonomy.action_planner",
-    source_id="cleanup_task",
-    timeout=600,
-    on_approve="execute_delete",
-    on_deny="abort"
-)
+result = await confirm_flow.ask(Notification(
+    type=NotificationType.CONFIRM,
+    title="Cleanup task",
+    body="Do you want to delete all test data?",
+    trigger_name="cleanup_task",
+    timeout_seconds=600,
+))
 ```
 
 ### loom.toml 配置
 
 ```toml
-[notification]
-
-# 預設 channel
+[notify]
 default_channel = "cli"
-
-# 佇列設定
-queue_size = 100
-process_interval = 1  # 秒
-
-# 通知設定
-[notification.channels]
-
-# CLI 通知（總是啟用）
-[notification.channels.cli]
-enabled = true
-type = "cli"
-
-# Webhook 通知
-[notification.channels.webhook]
-enabled = true
-type = "webhook"
-url = "https://hooks.example.com/notify"
-
-# Telegram 通知
-[notification.channels.telegram]
-enabled = false
-type = "telegram"
-bot_token = "${TELEGRAM_BOT_TOKEN}"
-chat_id = "${TELEGRAM_CHAT_ID}"
-
-# Discord 通知
-[notification.channels.discord]
-enabled = false
-type = "discord"
-webhook_url = "${DISCORD_WEBHOOK_URL}"
 ```
+
+`default_channel` 目前是 informational；實際 fan-out 由 runtime 註冊了哪些 notifiers 決定（CLI、Webhook、DiscordBotNotifier 等）。
 
 ---
 
@@ -351,10 +205,9 @@ Notification Layer 提供：
 
 | 元件 | 職責 |
 |------|------|
-| NotificationType | 五種通知類型（INFO/SUCCESS/WARNING/ERROR/CONFIRM） |
+| NotificationType | 五種通知類型（INFO/CONFIRM/INPUT/ALERT/REPORT） |
 | Notification | 統一的通知資料結構 |
 | NotificationRouter | 統一的通知入口和路由 |
-| NotifierRegistry | 管理多個 Notifier 適配器 |
 | ConfirmFlow | 確認請求的特殊處理 |
 
-透過 Notification Layer，Loom 的各個模組可以統一地發送通知，而不需要關心底層的發送方式（CLI、Webhook、Telegram 等）。
+透過 Notification Layer，Loom 的各個模組可以統一地發送通知，而不需要關心底層的發送方式（CLI、Webhook、Discord 等）。

--- a/doc/24-Notifier-適配器.md
+++ b/doc/24-Notifier-適配器.md
@@ -188,15 +188,13 @@ Bot 接收用戶上傳的檔案時自動處理：
 
 ## Phase X：Telegram Notifier
 
-> **尚未實作**（Phase X 規劃）。以下為說明性代碼。
+> **尚未實作**（Phase X 規劃）。目前 repo 沒有 Telegram adapter；如需實作，建議以自訂 plugin 提供一個 `BaseNotifier` 子類，而不是假設核心已有檔案。
 
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
 ```python
-# loom/notify/adapters/telegram.py  （Phase X，尚未實作）
 class TelegramNotifier(BaseNotifier):
     """Telegram Bot 通知器（Phase X）"""
 
-    name = "telegram"
+    channel = "telegram"
 
     def __init__(
         self,
@@ -211,7 +209,7 @@ class TelegramNotifier(BaseNotifier):
         ...
 ```
 
-loom.toml 中的 `[notification.channels.telegram]` 設定亦屬 Phase X。
+Telegram 的 loom.toml 設定格式屬 Phase X，尚未支援。
 
 ---
 
@@ -245,19 +243,8 @@ class EmailNotifier(BaseNotifier):
 ## 實際已實作的 loom.toml 配置
 
 ```toml
-[notification]
+[notify]
 default_channel = "cli"
-
-[notification.channels.webhook]
-enabled = true
-url = "https://hooks.example.com/notify"
-headers = { Authorization = "Bearer ${WEBHOOK_TOKEN}" }
-timeout = 10.0
-
-[notification.channels.discord]
-enabled = true
-webhook_url = "${DISCORD_WEBHOOK_URL}"
-username = "Loom Bot"
 ```
 
 > Telegram、Email 的 loom.toml 設定格式屬 Phase X 規劃，尚未支援。

--- a/doc/27-SOUL-設計.md
+++ b/doc/27-SOUL-設計.md
@@ -239,17 +239,19 @@ You do...
 
 ### 如何更新 SOUL？
 
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
 ```bash
-# 編輯 SOUL 文件
-vim loom/core/soul/SOUL.md
+# 編輯 repo 或使用者設定中的 SOUL 文件
+vim SOUL.md
 
-# 測試變更
-loom chat --test-soul
+# 以一般 chat 啟動，PromptStack 會依 loom.toml 的 [identity] 載入
+loom chat
 
-# 驗證語法
-loom validate --soul
+# 若使用自訂位置，設定 loom.toml：
+# [identity]
+# soul = "SOUL.md"
 ```
+
+SOUL 不是核心 package 裡的內建檔；`PromptStack.from_config()` 會從 `loom.toml` 的 `[identity]` 區段解析 `soul` 路徑，預設是目前工作目錄下的 `SOUL.md`。
 
 ---
 

--- a/doc/28-Personalities.md
+++ b/doc/28-Personalities.md
@@ -22,64 +22,22 @@ Loom 預設提供 6 種人格：
 ## Personalities 目錄結構
 
 ```
-loom/
-└── core/
-    └── personalities/
-        ├── archetypes.json      # 人格元資料
-        ├── adversarial.md       # 詳細人格定義
-        ├── architect.md
-        ├── barista.md
-        ├── minimalist.md
-        ├── operator.md
-        └── researcher.md
+personalities/
+├── adversarial.md
+├── architect.md
+├── barista.md
+├── minimalist.md
+├── operator.md
+└── researcher.md
 ```
+
+現行實作沒有 `archetypes.json` registry。人格是普通 Markdown 檔，`PromptStack` 透過 `[identity].personality` 或 runtime `switch_personality()` 載入。
 
 ---
 
 ## 人格格式
 
-### archetypes.json
-
-```json
-{
-  "adversarial": {
-    "name": "Adversarial",
-    "description": "喜歡質疑和挑戰的批判性思維者",
-    "strengths": ["安全性", "發現漏洞", "壓力測試"],
-    "tone": "挑戰性、直接、不留情面"
-  },
-  "architect": {
-    "name": "Architect",
-    "description": "結構化思維的系統設計師",
-    "strengths": ["架構設計", "簡潔表達", "邏輯清晰"],
-    "tone": "精準、專業、層次分明"
-  },
-  "barista": {
-    "name": "Barista",
-    "description": "友善輕鬆的咖啡師風格",
-    "strengths": ["日常對話", "情緒支持", "輕鬆氛圍"],
-    "tone": "溫暖、友善、休閒"
-  },
-  "minimalist": {
-    "name": "Minimalist",
-    "description": "極簡主義者，只說必要的",
-    "strengths": ["效率", "不浪費時間", "直接"],
-    "tone": "極簡、直接、零廢話"
-  },
-  "operator": {
-    "name": "Operator",
-    "description": "執行導向的任務執行者",
-    "strengths": ["任務完成", "步驟執行", "可靠性"],
-    "tone": "實用、清晰、面向行動"
-  },
-  "researcher": {
-    "name": "Researcher",
-    "description": "深入分析的研究者",
-    "strengths": ["分析", "評估", "全面性"],
-    "tone": "謹慎、詳細、客觀"
-  }
-}
-```
+每個 Markdown 檔本身就是完整人格定義；檔名 stem 就是 runtime 切換時使用的名稱，例如 `personalities/architect.md` 對應 `architect`。
 
 ---
 
@@ -346,7 +304,7 @@ Let me know if you need anything else! 😊
 
 ```bash
 # 在對話中用命令切換
-/set personality architect
+/personality architect
 
 # 查看當前人格
 /personality
@@ -400,22 +358,16 @@ response = await loom.chat(
 ...
 ```
 
-### 註冊新人格
+### 載入與切換新人格
 
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
 ```python
-# loom/core/personalities/registry.py
-class PersonalityRegistry:
-    def register(self, personality: Personality):
-        """註冊新人格"""
-        self._personalities[personality.id] = personality
-    
-    def load(self, personality_id: str) -> Personality:
-        """載入人格"""
-        if personality_id not in self._personalities:
-            raise ValueError(f"Unknown personality: {personality_id}")
-        return self._personalities[personality_id]
+# loom/core/cognition/prompt_stack.py
+stack.available_personalities()      # 掃描 personalities_dir 下的 *.md
+stack.switch_personality("analyst")  # 讀取 personalities/analyst.md
+stack.clear_personality()
 ```
+
+沒有獨立 registry class；新增人格就是新增 `.md` 檔，或在 `loom.toml` 的 `[identity]` 指向特定 personality 檔。
 
 ---
 

--- a/doc/29-Extensibility-概述.md
+++ b/doc/29-Extensibility-概述.md
@@ -137,45 +137,24 @@ Model Context Protocol（MCP）提供完整的雙向整合：
 
 ## 擴充載入時機
 
-> 以下 `ExtensionLoader` 是設計示意，實際載入路徑見 `loom/extensibility/{adapter,plugin}.py` + `LoomSession.start()`。
+實際載入路徑見 `loom/extensibility/adapter.py`、`loom/extensibility/plugin.py` 與 `LoomSession.start()`。沒有獨立 `ExtensionLoader` 類別。
 
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
 ```python
-# loom/core/extensibility/loader.py
-class ExtensionLoader:
-    """擴充載入器"""
-    
-    async def load_all(self):
-        """載入所有擴充"""
-        
-        # 1. 載入 Plugins
-        await self._load_plugins()
-        
-        # 2. 載入 Lenses
-        await self._load_lenses()
-        
-        # 3. 載入 Skills
-        await self._load_skills()
-        
-        # 4. 載入 Personalities
-        await self._load_personalities()
-    
-    async def _load_plugins(self):
-        """載入 plugins"""
-        plugin_dirs = self._discover_plugins()
-        
-        for plugin_dir in plugin_dirs:
-            plugin = await self._load_plugin(plugin_dir)
-            self.plugin_registry.register(plugin)
-    
-    async def _load_lenses(self):
-        """載入 lenses"""
-        lens_configs = self.config.get("lenses", [])
-        
-        for config in lens_configs:
-            lens = self._create_lens(config)
-            self.lens_registry.register(lens)
+# loom/extensibility/plugin.py
+class PluginRegistry:
+    def register(self, plugin: LoomPlugin) -> None: ...
+
+    def install_into(self, session: object) -> dict[str, int]:
+        for plugin in self._plugins:
+            for tool_def in plugin.tools():
+                session.registry.register(tool_def)
+            for notifier in plugin.notifiers():
+                router = getattr(session, "_notifier_router", None)
+                if router is not None:
+                    router.register(notifier)
 ```
+
+`LoomSession.start()` 會建立 live session 所需的 registry、pipeline、notification router 等物件，再安裝內建或外部擴充貢獻的 tools / middleware / notifiers。
 
 ---
 

--- a/doc/34-TUI-使用指南.md
+++ b/doc/34-TUI-使用指南.md
@@ -72,9 +72,8 @@ ToolBlock 與 Header 同步顯示 agent 當前動作：
 
 顯示本 session 所有 `write_file` 產出的檔案：
 
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
 ```
-✚ loom/core/tasks/scheduler.py    created    2m ago
+✚ loom/core/tasks/manager.py      created    2m ago
 ~ loom/core/harness/middleware.py  modified   5m ago
 ```
 

--- a/doc/35-Session-管理.md
+++ b/doc/35-Session-管理.md
@@ -1,380 +1,203 @@
 # Session 管理
 
-Session 是 Loom 的對話上下文容器。每次聊天都是在一個 Session 中進行的。
+Session 是 Loom 的對話 runtime。實作上沒有 `loom/core/session/` package；權威入口是單檔 `loom/core/session.py` 的 `LoomSession`，持久化歷史則由 `loom/core/memory/session_log.py` 的 `SessionLog` 負責。
 
 ---
 
-## Session 結構
+## 真實模組分工
 
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
-```python
-# loom/core/session/models.py
-@dataclass
-class Session:
-    """Session 模型"""
-    
-    id: str                           # 唯一 ID
-    created_at: datetime              # 建立時間
-    updated_at: datetime              # 最後更新時間
-    
-    # 配置
-    personality: str                  # 使用的人格
-    model: str | None                 # 使用的模型
-    trust_level: TrustLevel           # 信任級別
-    
-    # 歷史
-    messages: list[Message]           # 訊息歷史
-    
-    # 統計
-    message_count: int                # 訊息數量
-    token_usage: int                  # Token 使用量
-    
-    # 狀態
-    status: SessionStatus             # 狀態
-    metadata: dict                    # 額外資料
-```
+| 模組 | 職責 |
+|------|------|
+| `loom/core/session.py` | `LoomSession` runtime、工具註冊、turn loop、pause/resume/cancel/stop |
+| `loom/core/memory/session_log.py` | SQLite `sessions` / `session_log` 兩張表的讀寫 |
+| `loom/platform/cli/main.py` | `loom chat`、`loom sessions` CLI 與 slash commands |
+| `loom/platform/session_registry.py` | 進程內 active session registry，供 chime / Discord runtime 查找 |
+
+Session 的 runtime 狀態與持久化資料沒有拆成 `models.py`、`manager.py`、`store.py`；這些舊路徑不存在。
 
 ---
 
-## Session 狀態
+## LoomSession
 
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
+`LoomSession` 是 live agent runtime。它擁有主要 agent loop、permission context、tool registry、memory facade、prompt stack、ledger emitter、notification router 等 session-scoped 物件。
+
 ```python
-# loom/core/session/models.py
-class SessionStatus(Enum):
-    """Session 狀態"""
-    ACTIVE = "active"       # 進行中
-    PAUSED = "paused"       # 暫停
-    COMPLETED = "completed"  # 已完成
-    ARCHIVED = "archived"   # 已歸檔
+# loom/core/session.py
+class LoomSession:
+    def __init__(
+        self,
+        model: str | None = None,
+        db_path: str | None = None,
+        resume_session_id: str | None = None,
+        ...
+    ):
+        self.session_id = resume_session_id or str(uuid.uuid4())[:8]
+        self._resume = resume_session_id is not None
+        self.perm = PermissionContext(session_id=self.session_id)
+        self.registry = ToolRegistry()
 ```
+
+主要生命週期：
+
+| 方法 | 說明 |
+|------|------|
+| `start()` | 載入 config、prompt stack、memory、tools、plugins、ledger、session log |
+| `stream_turn(user_input)` | 執行一輪對話並串流事件 |
+| `pause()` / `resume()` / `resume_with()` / `cancel()` | HITL pause boundary 控制 |
+| `stop()` | flush memory health、compact、更新 session metadata、關閉資源 |
+
+---
+
+## SessionLog
+
+`SessionLog` 是持久化 session metadata 與完整對話歷史的 SQLite gateway。
+
+```python
+# loom/core/memory/session_log.py
+class SessionLog:
+    async def create_session(
+        self, session_id: str, model: str, title: str | None = None
+    ) -> None: ...
+
+    async def log_message(
+        self,
+        session_id: str,
+        turn_index: int,
+        role: str,
+        content: str,
+        metadata: dict[str, Any] | None = None,
+        raw_json: str | None = None,
+    ) -> None: ...
+
+    async def list_sessions(self, limit: int = 20) -> list[dict[str, Any]]: ...
+    async def get_session(self, session_id: str) -> dict[str, Any] | None: ...
+    async def load_messages(self, session_id: str) -> list[dict[str, Any]]: ...
+    async def delete_session(self, session_id: str) -> None: ...
+```
+
+兩張資料表：
+
+| 表 | 用途 |
+|----|------|
+| `sessions` | `session_id`、model、title、started_at、last_active、turn_count |
+| `session_log` | 每個 user / assistant / tool 訊息，包含 raw assistant JSON 以支援 resume |
+
+`create_session()` 使用 `INSERT OR IGNORE`，所以 resume 已存在 session 時不會覆蓋 metadata。`log_message()` 在 hot path 會吞掉例外並記錄 warning，避免 DB 問題阻塞 agent turn。
 
 ---
 
 ## Session 生命週期
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                  Session 生命週期                            │
-├─────────────────────────────────────────────────────────────┤
-│                                                             │
-│   create ──▶ active ──▶ complete                           │
-│                │      │                                     │
-│                │      └──▶ archive                          │
-│                │                                            │
-│                └──▶ pause ──▶ resume ──▶ active            │
-│                                                             │
-└─────────────────────────────────────────────────────────────┘
+new LoomSession
+      │
+      ▼
+start()
+      │
+      ├─ new session: SessionLog.create_session()
+      └─ resume: SessionLog.load_messages() + restore turn_index
+      │
+      ▼
+stream_turn()
+      │
+      ├─ tool batch boundary 可 pause/resume/cancel
+      ├─ 訊息寫入 SessionLog
+      └─ turn metadata 更新
+      │
+      ▼
+stop()
+      ├─ memory health flush
+      ├─ optional compaction
+      └─ SessionLog.update_session()
 ```
 
-### 建立 Session
-
-```bash
-# 建立新 session（chat 命令自動建立）
-loom chat
-
-# 指定 session ID 建立新 session
-loom chat --session new_session_id
-
-# 從範本建立
-loom chat --session new_id --template research
-```
-
-### 恢復 Session
-
-```bash
-# 恢復上次 session
-loom chat --resume
-
-# 恢復特定 session
-loom chat --session abc123
-```
-
-### 完成 Session
-
-```bash
-# 手動標記完成
-loom sessions complete abc123
-
-# 或直接退出 chat（會自動標記）
-```
+Loom 目前沒有 enum 型 `ACTIVE / PAUSED / COMPLETED / ARCHIVED` session status 欄位。CLI 顯示的 session 清單主要依 `last_active` 排序，並用目前載入的 `session_id` 標示 active。
 
 ---
 
-## Session 命令
+## CLI 操作
 
-### `loom sessions list`
-
-列出所有 sessions。
+### 建立或恢復 chat session
 
 ```bash
-loom sessions list [options]
+# 建立新 session
+loom chat
 
-# 選項
---status       按狀態過濾（active/paused/completed/archived）
---limit        最大數量（預設: 20）
---format       輸出格式（text/table/json）
+# 恢復最近 session
+loom chat --resume
+
+# 恢復指定 session
+loom chat --session <session_id>
+
+# 啟動時設定或覆蓋 title
+loom chat --name "Research run"
 ```
 
-**輸出範例**
-
-```
-$ loom sessions list
-
- Sessions
- ─────────────────────────────────────────────────────────
- ID          Status     Messages  Updated            Personality
- ─────────────────────────────────────────────────────────
- abc123      active     12       2 minutes ago     architect
- def456      completed  45       2 days ago        minimalist
- ghi789      archived   23       1 week ago        barista
- ─────────────────────────────────────────────────────────
-```
-
-### `loom sessions show`
-
-查看 Session 詳情。
+TUI 模式在未指定 session 時會自動恢復最近一次 session：
 
 ```bash
-loom sessions show <session_id> [options]
-
-# 選項
---messages      顯示訊息歷史
---stats         顯示統計
---metadata      顯示元資料
+loom chat --tui
+loom chat --tui --session <session_id>
 ```
 
-**輸出範例**
-
-```
-$ loom sessions show abc123
-
- Session: abc123
- ─────────────────────────────────────────────────────────
- Status:       active
- Personality:  architect
- Model:        gpt-4o
- Trust Level:  GUARDED
- ─────────────────────────────────────────────────────────
- Created:      2024-01-15 10:00:00
- Updated:      2024-01-15 10:30:00
- ─────────────────────────────────────────────────────────
- Messages:     12
- Token Usage:  8,234
- ─────────────────────────────────────────────────────────
-```
-
-### `loom sessions resume`
-
-恢復 Session。
+### 管理已保存 sessions
 
 ```bash
-loom sessions resume <session_id>
-loom sessions resume  # 恢復最近一個
+# 列出最近 sessions
+loom sessions list --limit 20
+
+# 顯示完整對話 replay
+loom sessions show <session_id>
+
+# 刪除 session metadata 與訊息
+loom sessions rm <session_id>
 ```
 
-### `loom sessions delete`
-
-刪除 Session。
-
-```bash
-loom sessions delete <session_id> [options]
-
-# 選項
---force         跳過確認
-```
-
-### `loom sessions export`
-
-匯出 Session。
-
-```bash
-loom sessions export <session_id> [options]
-
-# 選項
---format        格式（json/markdown/text）
---output, -o    輸出檔案
---include       包含內容（messages/memory/stats/all）
-```
-
-**範例**
-
-```bash
-# 匯出為 JSON
-loom sessions export abc123 -o session.json
-
-# 匯出為 Markdown
-loom sessions export abc123 --format markdown -o session.md
-```
-
-### `loom sessions archive`
-
-歸檔 Session。
-
-```bash
-loom sessions archive <session_id>
-```
+目前沒有 `sessions complete`、`sessions archive` 或 `sessions export` CLI 子命令；需要匯出時通常從 `SessionLog.load_messages()` 或 DB 查詢層讀出。
 
 ---
 
 ## 程式化操作
 
-### Python API
+建立 runtime session：
 
 ```python
-from loom.core.session.manager import SessionManager
+from loom.core.session import LoomSession
 
-manager = SessionManager()
-
-# 建立新 session
-session = await manager.create(
-    personality="architect",
-    model="gpt-4o",
-    trust_level=TrustLevel.GUARDED,
-)
-
-# 列出 sessions
-sessions = await manager.list(status=SessionStatus.ACTIVE)
-
-# 獲取 session
-session = await manager.get("abc123")
-
-# 更新 session
-await manager.update("abc123", personality="minimalist")
-
-# 刪除 session
-await manager.delete("abc123")
-
-# 匯出 session
-exported = await manager.export("abc123", format="json")
+session = LoomSession(model="claude-sonnet-4-6")
+await session.start()
+async for event in session.stream_turn("幫我整理今天的任務"):
+    ...
+await session.stop()
 ```
 
-### Session Manager
+讀取已保存 session：
 
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
 ```python
-# loom/core/session/manager.py
-class SessionManager:
-    """Session 管理器"""
-    
-    def __init__(self, store: SessionStore):
-        self.store = store
-    
-    async def create(self, **kwargs) -> Session:
-        """建立新 session"""
-        session = Session(
-            id=self._generate_id(),
-            created_at=datetime.now(),
-            updated_at=datetime.now(),
-            **kwargs
-        )
-        await self.store.save(session)
-        return session
-    
-    async def list(
-        self,
-        status: SessionStatus | None = None,
-        limit: int = 20,
-    ) -> list[Session]:
-        """列出 sessions"""
-        return await self.store.list(status=status, limit=limit)
-    
-    async def get(self, session_id: str) -> Session | None:
-        """獲取 session"""
-        return await self.store.get(session_id)
-    
-    async def update(self, session_id: str, **updates) -> Session:
-        """更新 session"""
-        session = await self.get(session_id)
-        
-        for key, value in updates.items():
-            setattr(session, key, value)
-        
-        session.updated_at = datetime.now()
-        await self.store.save(session)
-        
-        return session
-    
-    async def delete(self, session_id: str):
-        """刪除 session"""
-        await self.store.delete(session_id)
-    
-    async def archive(self, session_id: str):
-        """歸檔 session"""
-        await self.update(session_id, status=SessionStatus.ARCHIVED)
+import aiosqlite
+from loom.core.memory.session_log import SessionLog
+
+async with aiosqlite.connect("~/.loom/memory.db") as conn:
+    log = SessionLog(conn)
+    recent = await log.list_sessions(limit=20)
+    messages = await log.load_messages(recent[0]["session_id"])
 ```
 
 ---
 
-## Session 儲存
+## 與 active registry 的關係
 
-### SQLite 後端
-
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
-```python
-# loom/core/session/store.py
-class SQLiteSessionStore:
-    """SQLite Session 儲存"""
-    
-    def __init__(self, db_path: str):
-        self.db = aiosqlite.connect(db_path)
-        await self._init_tables()
-    
-    async def _init_tables(self):
-        """初始化資料表"""
-        await self.db.execute("""
-            CREATE TABLE IF NOT EXISTS sessions (
-                id TEXT PRIMARY KEY,
-                created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL,
-                personality TEXT NOT NULL,
-                model TEXT,
-                trust_level TEXT NOT NULL,
-                message_count INTEGER DEFAULT 0,
-                token_usage INTEGER DEFAULT 0,
-                status TEXT NOT NULL,
-                metadata TEXT
-            )
-        """)
-```
-
-### 自動清理
-
-```toml
-[session]
-
-# 自動歸檔設定
-[session.auto_archive]
-enabled = true
-after_days = 30      # 30 天後自動歸檔
-max_active = 10      # 最多 10 個 active sessions
-
-# 自動刪除
-[session.auto_delete]
-enabled = false
-after_days = 90       # 90 天後自動刪除已歸檔的 sessions
-```
+`SessionLog` 保存歷史；`loom/platform/session_registry.py` 只保存目前進程內活著的 `LoomSession` 物件。Discord chime 模式會用 registry 找指定 thread 對應的 active session，找不到時依 trigger 的 `target.fallback` 決定 skip 或開獨立 session。
 
 ---
 
 ## 總結
 
-Session 管理命令：
-
-| 命令 | 功能 |
-|------|------|
-| `loom sessions list` | 列出 sessions |
-| `loom sessions show` | 查看詳情 |
-| `loom sessions resume` | 恢復 session |
-| `loom sessions delete` | 刪除 session |
-| `loom sessions export` | 匯出 session |
-| `loom sessions archive` | 歸檔 session |
-
-Session 狀態：
-
-| 狀態 | 意義 |
-|------|------|
-| ACTIVE | 進行中 |
-| PAUSED | 暫停 |
-| COMPLETED | 已完成 |
-| ARCHIVED | 已歸檔 |
+| 概念 | 現行實作 |
+|------|----------|
+| Live runtime | `LoomSession` |
+| Persistent history | `SessionLog` |
+| Session metadata | SQLite `sessions` table |
+| Message replay | SQLite `session_log` table |
+| CLI list/show/delete | `loom sessions list/show/rm` |
+| In-process lookup | `SessionRegistry` |

--- a/doc/40-新增Notifier.md
+++ b/doc/40-新增Notifier.md
@@ -6,52 +6,46 @@
 
 ## Notifier 結構
 
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
 ```python
-# loom/core/notification/adapters/base.py
-class Notifier(ABC):
-    """Notifier 抽象基類"""
-    
-    @property
-    @abstractmethod
-    def name(self) -> str:
-        """Notifier 名稱"""
-        pass
-    
-    @abstractmethod
-    async def send(self, notification: Notification) -> bool:
-        """發送通知"""
-        pass
+# loom/notify/router.py
+class BaseNotifier:
+    """Abstract base for all notification adapters."""
+    channel: str
+
+    async def send(self, notification: Notification) -> None:
+        raise NotImplementedError
 ```
 
 ---
 
 ## 步驟 1：創建 Notifier 類
 
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
-```python
-# loom/core/notification/adapters/slack.py
-from dataclasses import dataclass
-from loom.core.notification.adapters.base import Notifier
-from loom.core.notification.models import Notification, NotificationType
+以下 Slack 範例是自訂 plugin 內的 adapter，不是核心 repo 內建檔案。
 
-class SlackNotifier(Notifier):
+```python
+import aiohttp
+
+from loom.notify.router import BaseNotifier
+from loom.notify.types import Notification, NotificationType
+
+class SlackNotifier(BaseNotifier):
     """Slack 通知器"""
+
+    channel = "slack"
     
     def __init__(
         self,
         webhook_url: str,
-        channel: str | None = None,
+        slack_channel: str | None = None,
         username: str = "Loom Bot",
         icon_emoji: str = ":robot_face:",
     ):
-        self.name = "slack"
         self.webhook_url = webhook_url
-        self.channel = channel
+        self.slack_channel = slack_channel
         self.username = username
         self.icon_emoji = icon_emoji
     
-    async def send(self, notification: Notification) -> bool:
+    async def send(self, notification: Notification) -> None:
         """發送 Slack 通知"""
         
         payload = self._build_payload(notification)
@@ -61,7 +55,7 @@ class SlackNotifier(Notifier):
                 self.webhook_url,
                 json=payload,
             ) as response:
-                return response.status == 200
+                response.raise_for_status()
     
     def _build_payload(self, notification: Notification) -> dict:
         """構建 Slack payload"""
@@ -82,7 +76,7 @@ class SlackNotifier(Notifier):
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": notification.message
+                    "text": notification.body
                 }
             }
         ]
@@ -93,8 +87,8 @@ class SlackNotifier(Notifier):
             "blocks": blocks,
         }
         
-        if self.channel:
-            payload["channel"] = self.channel
+        if self.slack_channel:
+            payload["channel"] = self.slack_channel
         
         if color:
             payload["attachments"] = [{
@@ -108,10 +102,10 @@ class SlackNotifier(Notifier):
         """根據類型獲取顏色"""
         return {
             NotificationType.INFO: "#36a5db",
-            NotificationType.SUCCESS: "#2ecc71",
-            NotificationType.WARNING: "#f39c12",
-            NotificationType.ERROR: "#e74c3c",
             NotificationType.CONFIRM: "#9b59b6",
+            NotificationType.INPUT: "#9b59b6",
+            NotificationType.ALERT: "#e74c3c",
+            NotificationType.REPORT: "#2ecc71",
         }.get(notification_type, "#95a5a6")
 ```
 
@@ -122,63 +116,55 @@ class SlackNotifier(Notifier):
 ### 程式化註冊
 
 ```python
-from loom.core.notification.registry import NotifierRegistry
+from loom.notify.router import NotificationRouter
 
 # 創建 Notifier
 slack = SlackNotifier(
     webhook_url="https://hooks.slack.com/services/xxx",
-    channel="#alerts"
+    slack_channel="#alerts"
 )
 
 # 註冊
-registry = NotifierRegistry.get_instance()
-registry.register(slack, channels=["critical", "default"])
+router = NotificationRouter()
+router.register(slack)
 ```
 
 ### loom.toml 配置
 
 ```toml
-[notification.channels]
-
-# Slack
-[notification.channels.slack]
-enabled = true
-type = "slack"
-webhook_url = "${SLACK_WEBHOOK_URL}"
-channel = "#alerts"
-username = "Loom Bot"
-icon_emoji = ":robot_face:"
+[notify]
+default_channel = "cli"
 ```
+
+核心設定目前只定義通知預設 channel。自訂 Slack token、channel 等設定通常由 plugin 自己讀取環境變數或自己的 config 區段。
 
 ---
 
 ## 步驟 3：測試 Notifier
 
-```bash
-# 測試通知發送
-loom notify test --notifier slack --message "Test message"
-```
+目前沒有通用 `loom notify test` CLI。測試自訂 notifier 時，建議在 plugin 單元測試中建立 `Notification` 並呼叫 `send()`，或把 notifier 註冊到 `NotificationRouter` 後用 `router.send(notification)` 做整合測試。
 
 ---
 
 ## 完整範例：Line Notify
 
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
+以下同樣是自訂 adapter 範例；核心 repo 尚未內建 Line Notify。
+
 ```python
-# loom/core/notification/adapters/line.py
-class LineNotifyNotifier(Notifier):
+class LineNotifyNotifier(BaseNotifier):
     """Line Notify 通知器"""
+
+    channel = "line_notify"
     
     def __init__(self, token: str):
-        self.name = "line_notify"
         self.token = token
         self.api_url = "https://notify-api.line.me/api/notify"
     
-    async def send(self, notification: Notification) -> bool:
+    async def send(self, notification: Notification) -> None:
         """發送 Line Notify"""
         
         payload = {
-            "message": f"\n{notification.title}\n{notification.message}"
+            "message": f"\n{notification.title}\n{notification.body}"
         }
         
         headers = {
@@ -191,8 +177,7 @@ class LineNotifyNotifier(Notifier):
                 data=payload,
                 headers=headers,
             ) as response:
-                data = await response.json()
-                return data.get("status") == 200
+                response.raise_for_status()
 ```
 
 ---
@@ -202,7 +187,7 @@ class LineNotifyNotifier(Notifier):
 新增 Notifier 的步驟：
 
 1. 創建 Notifier 子類
-2. 實現 `name` 屬性和 `send()` 方法
+2. 實現 `channel` 屬性和 `send()` 方法
 3. 構建通知 payload
-4. 註冊到 NotifierRegistry
-5. 在 loom.toml 配置或測試
+4. 註冊到 `NotificationRouter`，通常由 plugin 的 `notifiers()` 貢獻
+5. 在 plugin/config 中保存必要 token 或 webhook URL

--- a/doc/41-新增人格.md
+++ b/doc/41-新增人格.md
@@ -6,7 +6,7 @@
 
 ## 人格結構
 
-每個人格是一個 Markdown 檔案，定義在 `loom/core/personalities/` 目錄下。
+每個人格是一個 Markdown 檔案。預設目錄是 repo / workspace 下的 `personalities/`；也可以在 `loom.toml` 的 `[identity].personalities_dir` 改成其他位置。
 
 ---
 
@@ -46,22 +46,26 @@
 ### 程式化註冊
 
 ```python
-from loom.core.personalities.loader import PersonalityLoader
+from loom.core.cognition.prompt_stack import PromptStack
 
-# 創建並註冊
-loader = PersonalityLoader()
-await loader.load("my_custom_personality")
+stack = PromptStack(personalities_dir="personalities")
+stack.switch_personality("my_custom_personality")
 ```
 
 ### 自動發現
 
 將人格檔案放入以下目錄，Loom 會自動發現：
 
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
 ```bash
-loom/core/personalities/my_custom_personality.md
-~/.loom/personalities/my_custom_personality.md
-./loom/personalities/my_custom_personality.md
+personalities/my_custom_personality.md
+```
+
+如果要使用別的目錄：
+
+```toml
+[identity]
+personalities_dir = "personalities"
+personality = "personalities/my_custom_personality.md"
 ```
 
 ---
@@ -110,5 +114,5 @@ loom/core/personalities/my_custom_personality.md
 
 1. 創建 `.md` 檔案
 2. 定義核心特質、回答風格、語氣
-3. 放入 personalities 目錄
-4. 選擇使用（`/set personality my_custom`）
+3. 放入 `[identity].personalities_dir` 指向的目錄
+4. 選擇使用（`/personality my_custom_personality`）

--- a/doc/49a-PR-C-實作草稿.md
+++ b/doc/49a-PR-C-實作草稿.md
@@ -78,32 +78,24 @@ Loom Agent 的訊息走 `_run_streaming_turn` 既有路徑（TextChunk / Markdow
 
 ---
 
-## 4. 新抽象：`FooterController`（PR-D 完整版的前哨）
+## 4. Footer 現況（PR-D 已落地到 TUI app）
 
-PR-D 才會做完整的 1 行 live footer。但 PR-C 的「綠燈閃光」、「token budget 浮出」、「grant TTL 倒數」需要一個最小可用的 footer，才能把分流落地。
+舊版草稿曾規劃新增獨立 footer controller；現行實作沒有獨立 footer 檔。footer state 與 rendering 已集中在 persistent CLI/TUI application。
 
-<!-- doc-integrity:ignore-block — code-block 中的 `# loom/...` path comment 為示意，與目前實際模組結構不同（待整章重寫）。 -->
 ```python
-# loom/platform/cli/footer.py（新檔）
+# loom/platform/cli/app.py
+@dataclass
+class FooterState:
+    token_pct: float = 0.0
+    thinking: bool = False
+    active_tools: dict[str, ToolEnvelope] = field(default_factory=dict)
+    compaction: bool = False
+    grant_hint: str | None = None
+    transient_hint: _TransientHint | None = None
 
-class FooterController:
-    """1 行 status footer 的最小實作。
-
-    PR-C 階段：用 Rich Live 在 main_loop 底層維護一行可變狀態。
-    PR-D 階段：合併進 persistent Application 的固定 bottom Window。
-    """
-
-    def __init__(self, console: Console):
-        self._console = console
-        self._status: dict[str, str] = {}
-        self._flash_message: str | None = None
-        self._live: Live | None = None
-
-    async def start(self) -> None: ...
-    async def stop(self) -> None: ...
-    def set_status(self, key: str, value: str | None) -> None: ...
-    def flash(self, msg: str, duration: float) -> None: ...
-    def _render(self) -> Text: ...
+class LoomApp:
+    def _render_footer(self) -> FormattedText:
+        ...
 ```
 
 **status 欄位順序**（從左到右）：
@@ -268,4 +260,3 @@ PR-C 收斂為 C1-C4。C5 移到 PR-D。
 - Tracking issue：#236
 - 已 merge：PR-A (#237) PR-B (#242)
 - 後續：PR-D (Linear stream + Live Footer)、PR-E (TaskList)
-


### PR DESCRIPTION
## Summary
- rewrite the stale trigger and session management chapters around the current single-file runtime architecture
- refresh notification, notifier, SOUL, personality, extensibility, TUI, and PR-C draft docs to point at implemented modules and supported commands
- remove all issue #390 `doc-integrity:ignore-block` markers without adding new ignores

## Verification
- `pytest -q tests/test_doc_integrity.py` — 2 passed
- `git diff --check`
- `rg -n "doc-integrity:ignore-block" doc` — no matches
- `npx gitnexus detect-changes --scope staged` — No changes detected

Closes #390