### PR TITLE
fix(skill_review): cross-turn activation window + inferred unload boundary

### DIFF
--- a/loom/core/skill_review/query.py
+++ b/loom/core/skill_review/query.py
@@ -7,12 +7,20 @@ score. The consumer reasons about the evidence.
 Shape choices:
 
 - An *episode* is one load_skill activation. It carries the raw events
-  that followed in the same turn (tool_lifecycle, memory_op, judge_verdict,
-  turn_end), capped to keep payloads bounded.
-- Activation window per turn: from the load_skill END event up to either
-  the matching unload_skill in the same turn or the turn_end, whichever
-  comes first. Most turns have at most one activation; multiple loads
-  in the same turn produce overlapping episodes (no de-dup).
+  that followed (tool_lifecycle, memory_op, judge_verdict, turn_end),
+  capped to keep payloads bounded.
+- Activation window:
+    start = load_skill END timestamp
+    end   = earliest of (explicit unload_skill END for same skill,
+            next load_skill END for same skill = implicit re-activation
+            boundary, query window's until_ts when neither exists)
+  The window spans turns deliberately: agents routinely keep a skill
+  loaded across many turns. Per-turn scoping silently lost cross-turn
+  usage and miscounted feedback density.
+- ``unload_inferred`` flags episodes whose window was closed by
+  heuristic (re-load) or remained open (no unload before until_ts);
+  ``unload_inferred_reason`` distinguishes the two. Surfacing these
+  lets reviewers see when the agent's load/unload bookend habit fails.
 - Distinct sessions are surfaced for cross-session reasoning ("this skill
   has been active in 3 different sessions this week").
 - No "health score". doc/54 §1 rules out process-signal grading.
@@ -37,16 +45,21 @@ _DEFAULT_MAX_EPISODES = 100
 
 @dataclass(frozen=True)
 class SkillEpisode:
-    """One load_skill activation and the same-turn events that followed."""
+    """One load_skill activation and the events that followed it."""
 
     load_event_id: str
     session_id: str
-    turn_id: str
+    turn_id: str                          # turn that issued load_skill
     loaded_at: float
-    unloaded_at: float | None
-    turn_outcome: str | None              # from turn_end payload, if present
+    unloaded_at: float | None             # window-end ts, None when still open at until_ts
+    turn_outcome: str | None              # outcome of the loading turn, if it ended
     events_after_load: list[LedgerEvent] = field(default_factory=list)
     truncated: bool = False               # True if events_after_load was capped
+    unload_inferred: bool = False         # True when window closed by heuristic
+    unload_inferred_reason: str | None = None
+    # One of: None (explicit unload), "reloaded_without_unload" (next
+    # load_skill END for same skill closed the window),
+    # "no_unload_in_window" (no boundary found before until_ts).
 
 
 @dataclass(frozen=True)
@@ -120,36 +133,77 @@ async def query_skill_ledger(
     episodes_truncated = load_count > max_episodes
     load_ends_for_episodes = load_ends[-max_episodes:] if episodes_truncated else load_ends
 
-    # Build one episode per load. Same-turn events: fetched by turn_id and
-    # filtered to the activation window. We accept the per-turn fetch cost
-    # because turns are short and the alternative (one giant query then
-    # in-memory bucket) is messier with no payoff at Phase 1 scale.
+    # Build one episode per load. Activation windows span turns: an agent
+    # may load a skill in turn N and only unload it in turn N+k, with
+    # plenty of in-between work to attribute. Closing the window at the
+    # loading turn's end (the old behaviour) silently dropped all that
+    # evidence and made feedback density look zero.
     episodes: list[SkillEpisode] = []
-    for load in load_ends_for_episodes:
+    for load_idx, load in enumerate(load_ends_for_episodes):
         loaded_at = load.timestamp
 
-        # Find unload_skill END for the same skill in the same turn, if any.
-        turn_unload_ts: float | None = None
-        for un in unload_ends:
-            if un.turn_id == load.turn_id and un.timestamp > loaded_at:
-                turn_unload_ts = un.timestamp
-                break
+        # Earliest explicit unload for this skill after loaded_at (any turn).
+        # unload_ends came from a timestamp-ordered fetch, so the first
+        # hit is the earliest.
+        explicit_unload_ts: float | None = next(
+            (un.timestamp for un in unload_ends if un.timestamp > loaded_at),
+            None,
+        )
 
-        turn_events = await ledger.events.where(turn_id=load.turn_id).order_by("timestamp").all()
+        # Earliest subsequent reload of the same skill. Reloading is
+        # treated as an implicit boundary: the prior activation is over
+        # as soon as the agent declares a new one.
+        next_reload_ts: float | None = next(
+            (la.timestamp for la in load_ends if la.timestamp > loaded_at),
+            None,
+        )
 
-        # Window: (loaded_at, unload_ts or +inf]. Strict > on loaded_at so
-        # we don't re-include the load event itself.
-        window_end = turn_unload_ts if turn_unload_ts is not None else float("inf")
+        # Pick the earliest of the two candidates. Each carries whether
+        # it represents an inferred boundary.
+        boundary_ts: float | None = None
+        unload_inferred = False
+        unload_inferred_reason: str | None = None
+        candidates: list[tuple[float, bool, str | None]] = []
+        if explicit_unload_ts is not None:
+            candidates.append((explicit_unload_ts, False, None))
+        if next_reload_ts is not None:
+            candidates.append((next_reload_ts, True, "reloaded_without_unload"))
+        if candidates:
+            boundary_ts, unload_inferred, unload_inferred_reason = min(
+                candidates, key=lambda c: c[0]
+            )
+        else:
+            # No boundary in the query window — episode stays open through until_ts.
+            unload_inferred = True
+            unload_inferred_reason = "no_unload_in_window"
+
+        window_end = boundary_ts if boundary_ts is not None else until_ts
+
+        # Fetch by time range (cross-turn). The cap keeps the in-memory
+        # working set bounded for long-open windows; we apply it after
+        # filtering so the cap reflects the kept events, not raw fetch
+        # size.
+        events_in_window = await (
+            ledger.events
+            .since(loaded_at)
+            .until(window_end)
+            .order_by("timestamp")
+            .all()
+        )
         in_window = [
-            e for e in turn_events
+            e for e in events_in_window
             if loaded_at < e.timestamp <= window_end
             and e.event_id != load.event_id
         ]
 
-        # turn_outcome from the turn's own turn_end, regardless of window
-        # (a turn either ends or it doesn't).
+        # turn_outcome stays bound to the loading turn (semantic anchor:
+        # "the turn that activated this skill"). For cross-turn windows,
+        # other turn_ends will appear inside events_after_load.
+        load_turn_events = await (
+            ledger.events.where(turn_id=load.turn_id).order_by("timestamp").all()
+        )
         turn_outcome: str | None = None
-        for e in turn_events:
+        for e in load_turn_events:
             if e.event_type == "turn_end":
                 turn_outcome = e.payload.get("outcome")
                 break
@@ -162,10 +216,12 @@ async def query_skill_ledger(
             session_id=load.session_id,
             turn_id=load.turn_id,
             loaded_at=loaded_at,
-            unloaded_at=turn_unload_ts,
+            unloaded_at=boundary_ts,
             turn_outcome=turn_outcome,
             events_after_load=events_kept,
             truncated=truncated,
+            unload_inferred=unload_inferred,
+            unload_inferred_reason=unload_inferred_reason,
         ))
 
     return SkillUsageDigest(

--- a/loom/core/skill_review/query.py
+++ b/loom/core/skill_review/query.py
@@ -11,12 +11,15 @@ Shape choices:
   capped to keep payloads bounded.
 - Activation window:
     start = load_skill END timestamp
-    end   = earliest of (explicit unload_skill END for same skill,
-            next load_skill END for same skill = implicit re-activation
-            boundary, query window's until_ts when neither exists)
+    end   = earliest of (explicit unload_skill END for same skill in
+            the same session, next load_skill END for same skill in
+            the same session = implicit re-activation boundary,
+            query window's until_ts when neither exists)
   The window spans turns deliberately: agents routinely keep a skill
   loaded across many turns. Per-turn scoping silently lost cross-turn
-  usage and miscounted feedback density.
+  usage and miscounted feedback density. It does NOT span sessions:
+  an unload in a different session must not close this episode and
+  another session's events must not be attributed here.
 - ``unload_inferred`` flags episodes whose window was closed by
   heuristic (re-load) or remained open (no unload before until_ts);
   ``unload_inferred_reason`` distinguishes the two. Surfacing these
@@ -133,28 +136,42 @@ async def query_skill_ledger(
     episodes_truncated = load_count > max_episodes
     load_ends_for_episodes = load_ends[-max_episodes:] if episodes_truncated else load_ends
 
-    # Build one episode per load. Activation windows span turns: an agent
-    # may load a skill in turn N and only unload it in turn N+k, with
-    # plenty of in-between work to attribute. Closing the window at the
-    # loading turn's end (the old behaviour) silently dropped all that
-    # evidence and made feedback density look zero.
+    # Build one episode per load. Activation windows span turns within
+    # the loading session: an agent may load a skill in turn N and only
+    # unload it in turn N+k, with plenty of in-between work to attribute.
+    # Closing the window at the loading turn's end (the original
+    # behaviour) silently dropped all that evidence and made feedback
+    # density look zero. Crossing *session* boundaries, however, is
+    # never correct — a load in session A must not be closed by an
+    # unload in session B, and B's events must not appear in A's
+    # episode (see PR #393 review).
     episodes: list[SkillEpisode] = []
     for load_idx, load in enumerate(load_ends_for_episodes):
         loaded_at = load.timestamp
+        load_session_id = load.session_id
 
-        # Earliest explicit unload for this skill after loaded_at (any turn).
-        # unload_ends came from a timestamp-ordered fetch, so the first
-        # hit is the earliest.
+        # Earliest explicit unload for this skill in the same session
+        # after loaded_at. unload_ends came from a timestamp-ordered
+        # fetch, so the first session-matching hit is the earliest.
         explicit_unload_ts: float | None = next(
-            (un.timestamp for un in unload_ends if un.timestamp > loaded_at),
+            (
+                un.timestamp
+                for un in unload_ends
+                if un.session_id == load_session_id and un.timestamp > loaded_at
+            ),
             None,
         )
 
-        # Earliest subsequent reload of the same skill. Reloading is
-        # treated as an implicit boundary: the prior activation is over
-        # as soon as the agent declares a new one.
+        # Earliest subsequent reload of the same skill in the same
+        # session. Reloading is treated as an implicit boundary: the
+        # prior activation is over as soon as the agent declares a new
+        # one in the same session.
         next_reload_ts: float | None = next(
-            (la.timestamp for la in load_ends if la.timestamp > loaded_at),
+            (
+                la.timestamp
+                for la in load_ends
+                if la.session_id == load_session_id and la.timestamp > loaded_at
+            ),
             None,
         )
 
@@ -179,12 +196,15 @@ async def query_skill_ledger(
 
         window_end = boundary_ts if boundary_ts is not None else until_ts
 
-        # Fetch by time range (cross-turn). The cap keeps the in-memory
-        # working set bounded for long-open windows; we apply it after
-        # filtering so the cap reflects the kept events, not raw fetch
-        # size.
+        # Fetch by time range, scoped to the loading session (cross-turn
+        # within session is the intended span; cross-session would
+        # mis-attribute evidence — see PR #393 review). The cap keeps
+        # the in-memory working set bounded for long-open windows; we
+        # apply it after filtering so the cap reflects the kept events,
+        # not raw fetch size.
         events_in_window = await (
             ledger.events
+            .where(session_id=load_session_id)
             .since(loaded_at)
             .until(window_end)
             .order_by("timestamp")
@@ -197,10 +217,14 @@ async def query_skill_ledger(
         ]
 
         # turn_outcome stays bound to the loading turn (semantic anchor:
-        # "the turn that activated this skill"). For cross-turn windows,
-        # other turn_ends will appear inside events_after_load.
+        # "the turn that activated this skill"). Scope by session_id
+        # too — turn_id is not guaranteed globally unique across
+        # sessions (see PR #393 review).
         load_turn_events = await (
-            ledger.events.where(turn_id=load.turn_id).order_by("timestamp").all()
+            ledger.events
+            .where(turn_id=load.turn_id, session_id=load_session_id)
+            .order_by("timestamp")
+            .all()
         )
         turn_outcome: str | None = None
         for e in load_turn_events:

--- a/loom/core/skill_review/render.py
+++ b/loom/core/skill_review/render.py
@@ -5,25 +5,29 @@ the ``skill_review`` tool; the weekly worker can reuse or replace as
 needed for richer markdown.
 
 Format choices:
-- ISO-ish timestamps (UTC) — readable, sortable, no timezone surprises
+- Timestamps in the user's configured timezone (matches the rest of the
+  agent-facing surface; see issue #388 boundary)
 - Per-episode block — agent quotes/cites blocks back during discussion
 - Compact event lines — no syntactic clutter; one event per line
+- Inferred-boundary tag on episodes that lack an explicit unload, so
+  reviewers notice the load/unload bookend gap
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime
 
 from loom.core.skill_review.query import SkillUsageDigest, SkillEpisode
+from loom.core.timezone import user_zone
 
 
 def _fmt_ts(ts: float) -> str:
-    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    return datetime.fromtimestamp(ts, tz=user_zone()).strftime("%Y-%m-%d %H:%M:%S")
 
 
 def _fmt_event_line(e) -> str:
     """One-line summary of a single LedgerEvent."""
-    ts = datetime.fromtimestamp(e.timestamp, tz=timezone.utc).strftime("%H:%M:%S")
+    ts = datetime.fromtimestamp(e.timestamp, tz=user_zone()).strftime("%H:%M:%S")
     et = e.event_type
     p = e.payload
 
@@ -61,10 +65,18 @@ def _fmt_event_line(e) -> str:
 
 
 def _render_episode(ep: SkillEpisode, idx: int) -> str:
+    if ep.unloaded_at is None:
+        unload_line = "<no explicit unload>"
+        if ep.unload_inferred:
+            unload_line += f" (inferred: {ep.unload_inferred_reason})"
+    elif ep.unload_inferred:
+        unload_line = f"{_fmt_ts(ep.unloaded_at)} (inferred: {ep.unload_inferred_reason})"
+    else:
+        unload_line = _fmt_ts(ep.unloaded_at)
     lines = [
         f"## Episode {idx} — {ep.session_id} / {ep.turn_id} — {_fmt_ts(ep.loaded_at)}",
         f"loaded_at:   {_fmt_ts(ep.loaded_at)}",
-        f"unloaded_at: {_fmt_ts(ep.unloaded_at) if ep.unloaded_at else '<no explicit unload>'}",
+        f"unloaded_at: {unload_line}",
         f"turn_outcome: {ep.turn_outcome or '<no turn_end>'}",
     ]
     suffix = " (truncated)" if ep.truncated else ""

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -2001,7 +2001,10 @@ def make_load_skill_tool(
         description=(
             "Load a skill's full instructions into context. Call this when a task "
             "matches a skill listed in <available_skills>. The skill's workflow, "
-            "principles, and output format will be returned for you to follow."
+            "principles, and output format will be returned for you to follow. "
+            "When you finish using a skill, call `unload_skill` so the activation "
+            "window closes cleanly — `skill_review` and the weekly report use "
+            "that bookend to attribute tool usage and feedback to the right skill."
         ),
         trust_level=TrustLevel.SAFE,
         input_schema={
@@ -2069,7 +2072,12 @@ def make_unload_skill_tool(
     return ToolDefinition(
         name="unload_skill",
         description=(
-            "Remove a skill's precondition checks from the tool pipeline. "
+            "Close out a previously loaded skill. Call this once you're done "
+            "using a skill — it removes the skill's precondition checks AND "
+            "bookends the activation in the ledger so `skill_review` can "
+            "attribute the in-between tool calls and feedback to the right "
+            "skill. Skipping this leaves the window open until the next "
+            "re-load or the query end, which makes usage analytics unreliable. "
             "Call with no name to list skills with mounted checks."
         ),
         trust_level=TrustLevel.SAFE,

--- a/tests/test_skill_review_query.py
+++ b/tests/test_skill_review_query.py
@@ -240,3 +240,158 @@ async def test_sessions_distinct_and_sorted(
     digest = await query_skill_ledger(ledger, "code_weaver")
     assert digest.load_count == 2
     assert digest.sessions == ("sess_a", "sess_b")
+
+
+# ── Cross-turn / orphan-load scenarios — agent commonly forgets unload ──
+
+
+async def test_unload_in_later_turn_captures_cross_turn_window(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    """Skill loaded in turn A and unloaded in turn C must surface all
+    intermediate evidence — agents routinely span turns mid-task."""
+    async with async_turn_scope("turn_A"), async_correlation_scope("c_A"):
+        await _emit_load(emitter, skill="code_weaver", suffix="1")
+    async with async_turn_scope("turn_B"), async_correlation_scope("c_B"):
+        # In-between work that the old per-turn query silently lost.
+        await emitter.emit_tool_lifecycle(
+            payload=ToolLifecyclePayload(
+                phase="END",
+                tool_name="write_file",
+                tool_call_id="call_w_B",
+                args_digest="sha256:wB",
+                result_digest="sha256:rwB",
+            ),
+            event_id="evt_w_end_B",
+        )
+        await emitter.emit_memory_op(
+            payload=MemoryOpPayload(
+                operation="write",
+                memory_id="mem_feedback_B",
+                trust_tier="user_explicit",
+            ),
+        )
+    async with async_turn_scope("turn_C"), async_correlation_scope("c_C"):
+        await _emit_unload(emitter, skill="code_weaver", suffix="1")
+
+    digest = await query_skill_ledger(ledger, "code_weaver")
+    assert digest.load_count == 1
+    assert digest.unload_count == 1
+    assert len(digest.episodes) == 1
+    ep = digest.episodes[0]
+    assert ep.unload_inferred is False
+    assert ep.unload_inferred_reason is None
+    assert ep.unloaded_at is not None and ep.unloaded_at > ep.loaded_at
+    tool_names = [
+        e.payload.get("tool_name") for e in ep.events_after_load
+        if e.event_type == "tool_lifecycle"
+    ]
+    assert "write_file" in tool_names
+    types = [e.event_type for e in ep.events_after_load]
+    assert "memory_op" in types
+
+
+async def test_load_without_unload_marks_inferred_no_boundary(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    """Loaded but never unloaded within the query window — episode stays
+    open and flags ``no_unload_in_window``. This is the common agent
+    bookend-failure case."""
+    async with async_turn_scope("turn_A"), async_correlation_scope("c_A"):
+        await _emit_load(emitter, skill="code_weaver", suffix="1")
+        await emitter.emit_tool_lifecycle(
+            payload=ToolLifecyclePayload(
+                phase="END",
+                tool_name="write_file",
+                tool_call_id="call_w_A",
+                args_digest="sha256:wA",
+                result_digest="sha256:rwA",
+            ),
+            event_id="evt_w_end_A",
+        )
+
+    digest = await query_skill_ledger(ledger, "code_weaver")
+    assert digest.load_count == 1
+    assert digest.unload_count == 0
+    ep = digest.episodes[0]
+    assert ep.unload_inferred is True
+    assert ep.unload_inferred_reason == "no_unload_in_window"
+    assert ep.unloaded_at is None
+    # Despite the open window, in-window evidence is still captured.
+    tool_names = [
+        e.payload.get("tool_name") for e in ep.events_after_load
+        if e.event_type == "tool_lifecycle"
+    ]
+    assert "write_file" in tool_names
+
+
+async def test_reload_without_unload_closes_previous_episode(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    """Re-loading the same skill before unloading the prior activation
+    is treated as an implicit boundary — the prior episode closes at
+    the re-load timestamp and is flagged ``reloaded_without_unload``."""
+    async with async_turn_scope("turn_A"), async_correlation_scope("c_A"):
+        await _emit_load(emitter, skill="code_weaver", suffix="1")
+        await emitter.emit_tool_lifecycle(
+            payload=ToolLifecyclePayload(
+                phase="END",
+                tool_name="write_file",
+                tool_call_id="call_w_A",
+                args_digest="sha256:wA",
+                result_digest="sha256:rwA",
+            ),
+            event_id="evt_w_end_A",
+        )
+    async with async_turn_scope("turn_B"), async_correlation_scope("c_B"):
+        await _emit_load(emitter, skill="code_weaver", suffix="2")
+        await _emit_unload(emitter, skill="code_weaver", suffix="2")
+
+    digest = await query_skill_ledger(ledger, "code_weaver")
+    assert digest.load_count == 2
+    assert digest.unload_count == 1
+    assert len(digest.episodes) == 2
+
+    first, second = digest.episodes
+    assert first.unload_inferred is True
+    assert first.unload_inferred_reason == "reloaded_without_unload"
+    assert first.unloaded_at is not None  # set to the reload timestamp
+    # In-window evidence between first load and the reload boundary.
+    tool_names = [
+        e.payload.get("tool_name") for e in first.events_after_load
+        if e.event_type == "tool_lifecycle"
+    ]
+    assert "write_file" in tool_names
+
+    assert second.unload_inferred is False
+    assert second.unload_inferred_reason is None
+
+
+async def test_nested_skills_each_get_own_window(
+    ledger: LedgerStore, emitter: LedgerEmitter
+) -> None:
+    """Loading skill B while skill A is still active is fine — A's
+    activation persists until A is itself unloaded; B's load/unload
+    events naturally appear inside A's events_after_load as evidence."""
+    async with async_turn_scope("turn_A"), async_correlation_scope("c_A"):
+        await _emit_load(emitter, skill="code_weaver", suffix="A1")
+        await _emit_load(emitter, skill="news_aggregator", suffix="B1")
+        await _emit_unload(emitter, skill="news_aggregator", suffix="B1")
+        await _emit_unload(emitter, skill="code_weaver", suffix="A1")
+
+    digest_a = await query_skill_ledger(ledger, "code_weaver")
+    digest_b = await query_skill_ledger(ledger, "news_aggregator")
+
+    assert digest_a.load_count == 1
+    assert digest_a.episodes[0].unload_inferred is False
+    # Inner skill's lifecycle events should appear in A's evidence —
+    # this is what lets a reviewer notice the nesting pattern.
+    inner_tools = {
+        e.payload.get("tool_name") for e in digest_a.episodes[0].events_after_load
+        if e.event_type == "tool_lifecycle"
+        and e.payload.get("skill_id") == "news_aggregator"
+    }
+    assert {"load_skill", "unload_skill"} <= inner_tools
+
+    assert digest_b.load_count == 1
+    assert digest_b.episodes[0].unload_inferred is False

--- a/tests/test_skill_review_query.py
+++ b/tests/test_skill_review_query.py
@@ -367,6 +367,80 @@ async def test_reload_without_unload_closes_previous_episode(
     assert second.unload_inferred_reason is None
 
 
+async def test_cross_session_unload_does_not_close_other_sessions_episode(
+    ledger: LedgerStore,
+) -> None:
+    """Activation windows must stay within the loading session.
+
+    PR #393 review case: sess_A loads code_weaver and never unloads;
+    sess_B later runs unrelated work and unloads code_weaver. The
+    sess_A episode must remain open (inferred boundary) and must NOT
+    pull sess_B's events into events_after_load.
+    """
+    e_a = LedgerEmitter(ledger, session_id="sess_A")
+    e_b = LedgerEmitter(ledger, session_id="sess_B")
+
+    async with async_turn_scope("turn_A1"), async_correlation_scope("c_A1"):
+        await _emit_load(e_a, skill="code_weaver", suffix="A1")
+    async with async_turn_scope("turn_B1"), async_correlation_scope("c_B1"):
+        await e_b.emit_tool_lifecycle(
+            payload=ToolLifecyclePayload(
+                phase="END",
+                tool_name="write_file",
+                tool_call_id="call_w_B",
+                args_digest="sha256:wB",
+                result_digest="sha256:rwB",
+            ),
+            event_id="evt_w_end_B",
+        )
+        await _emit_unload(e_b, skill="code_weaver", suffix="B1")
+
+    digest = await query_skill_ledger(ledger, "code_weaver")
+    assert digest.load_count == 1
+    assert digest.unload_count == 1  # the sess_B unload is still counted globally
+    assert digest.sessions == ("sess_A", "sess_B")
+    assert len(digest.episodes) == 1
+
+    ep = digest.episodes[0]
+    assert ep.session_id == "sess_A"
+    # sess_B's unload must NOT close sess_A's episode.
+    assert ep.unload_inferred is True
+    assert ep.unload_inferred_reason == "no_unload_in_window"
+    assert ep.unloaded_at is None
+    # sess_B's write_file must NOT appear in sess_A's evidence.
+    foreign_session_event_ids = {
+        e.event_id for e in ep.events_after_load if e.session_id != "sess_A"
+    }
+    assert foreign_session_event_ids == set()
+
+
+async def test_cross_session_reload_does_not_close_other_sessions_episode(
+    ledger: LedgerStore,
+) -> None:
+    """A re-load of the same skill in a different session is not an
+    implicit boundary for an open episode in another session."""
+    e_a = LedgerEmitter(ledger, session_id="sess_A")
+    e_b = LedgerEmitter(ledger, session_id="sess_B")
+
+    async with async_turn_scope("turn_A1"), async_correlation_scope("c_A1"):
+        await _emit_load(e_a, skill="code_weaver", suffix="A1")
+    async with async_turn_scope("turn_B1"), async_correlation_scope("c_B1"):
+        await _emit_load(e_b, skill="code_weaver", suffix="B1")
+        await _emit_unload(e_b, skill="code_weaver", suffix="B1")
+
+    digest = await query_skill_ledger(ledger, "code_weaver")
+    assert digest.load_count == 2
+    assert len(digest.episodes) == 2
+
+    sess_a_ep = next(ep for ep in digest.episodes if ep.session_id == "sess_A")
+    assert sess_a_ep.unload_inferred is True
+    assert sess_a_ep.unload_inferred_reason == "no_unload_in_window"
+    assert sess_a_ep.unloaded_at is None
+
+    sess_b_ep = next(ep for ep in digest.episodes if ep.session_id == "sess_B")
+    assert sess_b_ep.unload_inferred is False
+
+
 async def test_nested_skills_each_get_own_window(
     ledger: LedgerStore, emitter: LedgerEmitter
 ) -> None:

--- a/tests/test_skill_review_tool.py
+++ b/tests/test_skill_review_tool.py
@@ -106,3 +106,27 @@ async def test_trust_level_safe(ledger: LedgerStore) -> None:
     """Read-only tool must be SAFE — no confirmation prompts."""
     tool = make_skill_review_tool(ledger)
     assert tool.trust_level == TrustLevel.SAFE
+
+
+async def test_render_surfaces_inferred_unload_reason(
+    ledger: LedgerStore,
+) -> None:
+    """When the agent forgets to unload, the rendered output must flag
+    the boundary as inferred so reviewers spot the bookend gap."""
+    emitter = LedgerEmitter(ledger, session_id="sess_test")
+    async with async_turn_scope("turn_A"), async_correlation_scope("c_A"):
+        await emitter.emit_tool_lifecycle(
+            payload=ToolLifecyclePayload(
+                phase="END",
+                tool_name="load_skill",
+                tool_call_id="call_1",
+                args_digest="sha256:1",
+                skill_id="code_weaver",
+            ),
+            event_id="evt_load_end_orphan",
+        )
+
+    tool = make_skill_review_tool(ledger)
+    result = await tool.executor(_call({"skill_id": "code_weaver"}))
+    assert result.success is True
+    assert "inferred: no_unload_in_window" in result.output


### PR DESCRIPTION
Partially addresses #364. Unblocks #366.

## Why

You noticed the agent often forgets to call `unload_skill`. The original `query_skill_ledger` (doc/54 §4.3 / §5 P0-4) scoped each episode strictly to the loading turn:

- `unload_skill` was only matched if its `turn_id` equaled the load's `turn_id`
- `events_after_load` was fetched via `where(turn_id=load.turn_id).all()`

Real usage routinely spans turns (a single task lives across many turns) and nests skills (load A → load B → unload B → unload A). The old per-turn scoping silently dropped all cross-turn evidence and made feedback density look zero — exactly what the 2026-05-16 weekly report showed: `code_weaver` 5 loads, every one tagged `muffled_run`, despite real interactive feedback in those turns.

## What changes

**Activation window now spans turns** (`loom/core/skill_review/query.py`):

`effective_unload_ts` is the earliest of three candidates:

1. **Explicit unload** for this skill after `loaded_at` (any turn) → `unload_inferred=False`
2. **Next re-load** of the same skill → `unload_inferred=True`, `reason=\"reloaded_without_unload\"` (re-loading conceptually restarts the activation)
3. **Neither** → window stays open through `until_ts`; `unload_inferred=True`, `reason=\"no_unload_in_window\"`

Events are fetched by time range, not `turn_id`, so cross-turn tool calls, memory_op feedback, and intermediate `turn_end` events all land in `events_after_load`. `turn_outcome` still anchors to the loading turn (\"the turn that activated this skill\").

**`SkillEpisode` gains two fields** so reviewers can see the bookend gap:

- `unload_inferred: bool`
- `unload_inferred_reason: str | None` — `\"reloaded_without_unload\"` / `\"no_unload_in_window\"` / `None`

**Render surfaces the inferred tag** (`loom/core/skill_review/render.py`):

```
unloaded_at: 2026-05-18 22:35:00 (inferred: reloaded_without_unload)
unloaded_at: <no explicit unload> (inferred: no_unload_in_window)
```

Bonus: render now uses the user's configured zone for all timestamps, closing the last agent-facing surface missed in PR #391 / issue #388.

**Tool descriptions strengthen the bookend reminder** (`loom/platform/cli/tools.py`):

- `load_skill`: append \"When you finish using a skill, call `unload_skill` so the activation window closes cleanly — `skill_review` and the weekly report use that bookend to attribute tool usage and feedback to the right skill.\"
- `unload_skill`: explicit framing on bookend semantics and what skipping it costs.

## Why not auto-unload (deliberate non-change)

Original brainstorm considered framework-level auto-unload on `turn_end` or on next `load_skill`. Rejected because real Loom usage:

- **frequently spans turns** — a single task can occupy 10+ turns with the same skill loaded
- **nests skills** — load A, load B inside A, unload B, keep using A

Auto-unload would silently kill legitimate long-form work. Heuristic + reminder is the right layer for this.

## Test plan

- [x] 4 new query tests: cross-turn unload, never-unload, reload-without-unload, nested skills
- [x] 1 new tool render test: inferred-tag surfacing in tool output
- [x] All 23 existing skill_review tests pass unchanged (same-turn semantics preserved)
- [x] Full suite: 1927 passed
- [x] `gitnexus_detect_changes` confirms scope matches intent (4 affected processes, all expected)
- [ ] Manual: next weekly report (or ad-hoc `skill_review code_weaver`) shows real feedback density instead of universal `muffled_run`

## What this unblocks

- **#364**: provides one concrete tuning result (inferred-boundary surfacing) and corrects the data the watch issue is collecting
- **#366**: meta-skill-engineer renovation needs reliable usage patterns; this PR makes the data reliable

🤖 Generated with [Claude Code](https://claude.com/claude-code)