### PR TITLE
feat(sandbox): add authorized CLI profiles

### DIFF
--- a/doc/37-loom-toml-參考.md
+++ b/doc/37-loom-toml-參考.md
@@ -232,6 +232,12 @@ backend         = "srt"           # "none" | "srt"
 allow_write     = [".", "/private/tmp"]
 deny_read       = ["~/.ssh", "~/.aws", "~/.gnupg", ".env"]
 allowed_domains = ["pypi.org", "files.pythonhosted.org", "api.github.com"]
+
+[security.sandbox.profiles.github]
+match_commands  = ["gh"]
+allow_read      = ["~/.config/gh", "~/.gitconfig"]
+allow_write     = [".", "/private/tmp", "~/.cache/gh"]
+allowed_domains = ["api.github.com", "github.com"]
 ```
 
 | 欄位 | 類型 | 預設值 | 說明 |
@@ -244,10 +250,14 @@ allowed_domains = ["pypi.org", "files.pythonhosted.org", "api.github.com"]
 | `allowed_domains` | list[str] | `[]` | 網路 allowlist，空陣列 = 全擋 |
 | `denied_domains` | list[str] | `[]` | 額外網路黑名單 |
 | `allowed_sockets` / `denied_sockets` | list[str] | `[]` | Unix socket 控制（macOS 上罕用） |
+| `profiles.<name>.match_commands` | list[str] | `[]` | 依 command root 自動選 profile，例如 `gh pr view` 選到 `github` |
+| `profiles.<name>.allow_read` / `allow_write` / `allowed_domains` / `allowed_sockets` | list[str] | `[]` | profile 的 additive overlay，只在該次 `run_bash` 經授權後合併進 srt 設定 |
 
 **路徑語意**：`~` 展開為家目錄；`.` 錨定在 session workspace。
 **macOS 特別注意**：`/tmp` 是 `/private/tmp` 的 symlink，要寫 temp file 請列 `/private/tmp`。
 **Fail-closed**：`backend = "srt"` 但找不到 binary 時 session 啟動會失敗並提示安裝指令，避免 silent downgrade。
+
+**CLI profiles**：profile 只是描述可要求的額外沙箱能力，不是永久授權。`run_bash` 可用 command root 自動選擇，或在參數中傳 `sandbox_profile = "github"` 明確指定；實際使用時仍走現有 permission prompt，可選本次 / 30 分鐘 lease / 本 session / deny，重開 session 後需要重新授權。
 
 ---
 

--- a/doc/55-Sandbox-Runtime.md
+++ b/doc/55-Sandbox-Runtime.md
@@ -45,6 +45,12 @@ backend         = "srt"           # "none" | "srt"
 allow_write     = [".", "/private/tmp"]
 deny_read       = ["~/.ssh", "~/.aws", "~/.gnupg", ".env"]
 allowed_domains = ["pypi.org", "files.pythonhosted.org", "api.github.com"]
+
+[security.sandbox.profiles.github]
+match_commands  = ["gh"]
+allow_read      = ["~/.config/gh", "~/.gitconfig"]
+allow_write     = [".", "/private/tmp", "~/.cache/gh"]
+allowed_domains = ["api.github.com", "github.com"]
 ```
 
 預設 `backend = "none"` — 不裝 srt、不改設定，行為與舊版完全一致。
@@ -91,6 +97,18 @@ hi
 
 `srt` 內部跑 HTTP proxy + SOCKS5 proxy，sandbox 內所有 TCP 都被導向 proxy；不在 allowlist 內會回 403 / Connection blocked。
 
+## CLI profiles
+
+有些 CLI 需要固定的家目錄設定、cache、socket 或 domain，例如 `gh` 需要 `~/.config/gh` 與 `api.github.com`。把這些能力直接塞進全域 `[security.sandbox]` 會讓每個 `run_bash` 都變寬，所以 Loom 支援 named profile：
+
+- `match_commands = ["gh"]` 會讓 `gh pr view 387` 自動要求 `github` profile。
+- `run_bash` 也可明確傳 `sandbox_profile = "github"`，適合 wrapper 或 command root 不易判斷的 CLI。
+- profile 只是一份 additive overlay；它不會自己授權。
+- 實際使用仍走 scope-aware permission prompt：本次 / 30 分鐘 lease / 本 session / deny。
+- 授權只存在 runtime。重開 session 或重啟後，要重新授權。
+
+Profile 被授權後，該次 `run_bash` 會用 base sandbox settings 加上 profile overlay 產生有效 srt 設定；未授權就 fail closed，不會偷用 profile 的額外路徑或 domain。
+
 ## 層次分工
 
 ```
@@ -128,8 +146,10 @@ SandboxSettings.from_config()     ← loom/core/security/sandbox_runtime.py
 make_run_bash_tool(sandbox=...)   ← loom/platform/cli/tools.py
         │
         ├─ srt_available() check → 缺失就 raise RuntimeError
+        ├─ scope_resolver()       → 需要時加入 sandbox_profile requirement
+        ├─ permission prompt      → once / lease / session / deny
         │
-        ├─ write_settings_file()  → 寫一份 JSON 到 $TMPDIR/loom-srt-<hash>.json
+        ├─ write_settings_file()  → base 或 profile-merged JSON 到 $TMPDIR
         │
         └─ _maybe_wrap(cmd)
               │
@@ -137,7 +157,7 @@ make_run_bash_tool(sandbox=...)   ← loom/platform/cli/tools.py
        "srt -s <settings> -c <cmd>"  → asyncio.create_subprocess_shell
 ```
 
-設定檔以 (workspace, pid) hash 為檔名，**session 內穩定**——不會每 call 散落新 tmp file。
+設定檔以內容 hash 為檔名，base sandbox 與同一個 profile overlay 在 session 內穩定；不會每 call 散落新 tmp file。
 
 ## 不在本期 scope
 

--- a/docs/superpowers/plans/2026-05-19-sandbox-profile-scope-grants.md
+++ b/docs/superpowers/plans/2026-05-19-sandbox-profile-scope-grants.md
@@ -1,0 +1,1217 @@
+# Sandbox Profile Scope Grants Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `run_bash` use named srt sandbox profiles for CLIs such as `gh` only after the user approves the profile through the existing once / 30-minute / session / deny permission flow.
+
+**Architecture:** Extend `SandboxSettings` with named `SandboxProfile` entries, detect or explicitly select a profile per `run_bash` call, emit a `sandbox_profile:use:<name>` scope requirement, and merge the approved profile into the per-call srt settings. The sandbox stays enabled for execution; authorization lives in `PermissionContext` only and disappears when the session ends.
+
+**Tech Stack:** Python dataclasses, existing `PermissionContext` / `ScopeGrant` / `BlastRadiusMiddleware`, existing `run_bash` tool factory, pytest.
+
+---
+
+## File Structure
+
+- Modify `loom/core/security/sandbox_runtime.py`
+  - Owns `SandboxProfile`, profile parsing, command-root detection, profile selection, and sandbox settings merge.
+- Modify `loom/platform/cli/tools.py`
+  - Adds `sandbox_profile` input arg, wires profile-aware `run_bash` scope resolution, checks authorization metadata before applying a profile, and renders per-call srt settings.
+- Modify `loom/core/harness/middleware.py`
+  - Corrects scope-aware `ConfirmDecision.ONCE` semantics so "once" does not add a reusable grant.
+- Modify `loom/core/harness/scope.py`
+  - Adds a named exact matcher entry for `sandbox_profile` so the resource type is explicit.
+- Modify `loom/core/session.py`
+  - Passes profile-aware sandbox settings into the profile-aware run_bash resolver through the existing tool factory.
+- Modify `loom.toml.example`, `doc/37-loom-toml-參考.md`, `doc/55-Sandbox-Runtime.md`
+  - Documents profile config and runtime-only grant behavior.
+- Modify `tests/test_sandbox_runtime.py`
+  - Tests profile parsing, strict validation, command detection, and merge behavior.
+- Modify `tests/test_scope_phase_b.py`
+  - Tests `sandbox_profile` scope requirements and once/lease/session authorization behavior.
+- Create `tests/test_run_bash_sandbox_profiles.py`
+  - Tests foreground and async `run_bash` use merged per-call settings without invoking real srt.
+
+---
+
+### Task 1: Sandbox Profile Data Model and Merge
+
+**Files:**
+- Modify: `loom/core/security/sandbox_runtime.py`
+- Test: `tests/test_sandbox_runtime.py`
+
+- [ ] **Step 1: Run GitNexus impact analysis before editing symbols**
+
+Run:
+
+```bash
+npx gitnexus impact SandboxSettings --direction upstream
+```
+
+Expected: report direct callers and risk. If risk is HIGH or CRITICAL, stop and warn the user before editing.
+
+- [ ] **Step 2: Write failing tests for profile parsing and validation**
+
+Add to `tests/test_sandbox_runtime.py`:
+
+```python
+class TestProfileConfig:
+    def test_profiles_parse_from_config(self):
+        s = SandboxSettings.from_config({
+            "backend": "srt",
+            "allow_write": ["."],
+            "profiles": {
+                "github": {
+                    "match_commands": ["gh", "git"],
+                    "allow_read": ["~/.config/gh", "~/.gitconfig"],
+                    "allow_write": [".", "/private/tmp", "~/.cache/gh"],
+                    "allowed_domains": ["api.github.com", "github.com"],
+                },
+            },
+        })
+
+        assert "github" in s.profiles
+        profile = s.profiles["github"]
+        assert profile.match_commands == ["gh", "git"]
+        assert profile.allowed_domains == ["api.github.com", "github.com"]
+
+    def test_profile_list_fields_reject_scalar_strings(self):
+        with pytest.raises(ValueError, match="profiles.github.allow_write"):
+            SandboxSettings.from_config({
+                "backend": "srt",
+                "profiles": {
+                    "github": {"match_commands": ["gh"], "allow_write": "/tmp"},
+                },
+            })
+
+    def test_profile_match_commands_requires_list_of_strings(self):
+        with pytest.raises(ValueError, match="profiles.github.match_commands"):
+            SandboxSettings.from_config({
+                "backend": "srt",
+                "profiles": {"github": {"match_commands": "gh"}},
+            })
+
+    def test_profile_name_must_be_simple_identifier(self):
+        with pytest.raises(ValueError, match="profile name"):
+            SandboxSettings.from_config({
+                "backend": "srt",
+                "profiles": {"git hub": {"match_commands": ["gh"]}},
+            })
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest -q tests/test_sandbox_runtime.py::TestProfileConfig -q
+```
+
+Expected: FAIL because `SandboxProfile` and `profiles` do not exist yet.
+
+- [ ] **Step 4: Implement profile dataclass and config parsing**
+
+In `loom/core/security/sandbox_runtime.py`, add imports and helpers near `_as_path_list`:
+
+```python
+import re
+
+_PROFILE_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def _profile_key(profile_name: str, field_name: str) -> str:
+    return f"profiles.{profile_name}.{field_name}"
+
+
+def _validate_profile_name(name: str) -> str:
+    if not isinstance(name, str) or not _PROFILE_NAME_RE.match(name):
+        raise ValueError(
+            f"[security.sandbox] profile name must match "
+            f"[A-Za-z0-9_.-]+, got {name!r}."
+        )
+    return name
+```
+
+Add this dataclass before `SandboxSettings`:
+
+```python
+@dataclass(slots=True)
+class SandboxProfile:
+    """Named per-CLI sandbox expansion, activated only through permission grants."""
+
+    match_commands: list[str] = field(default_factory=list)
+    allow_read: list[str] = field(default_factory=list)
+    deny_read: list[str] = field(default_factory=list)
+    allow_write: list[str] = field(default_factory=list)
+    deny_write: list[str] = field(default_factory=list)
+    allowed_domains: list[str] = field(default_factory=list)
+    denied_domains: list[str] = field(default_factory=list)
+    allowed_sockets: list[str] = field(default_factory=list)
+    denied_sockets: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_config(cls, name: str, cfg: dict[str, Any] | None) -> "SandboxProfile":
+        if cfg is None:
+            cfg = {}
+        if not isinstance(cfg, dict):
+            raise ValueError(
+                f"[security.sandbox] profiles.{name} must be a table, "
+                f"got {type(cfg).__name__}: {cfg!r}."
+            )
+        return cls(
+            match_commands=_as_path_list(
+                _profile_key(name, "match_commands"),
+                cfg.get("match_commands"),
+            ),
+            allow_read=_as_path_list(_profile_key(name, "allow_read"), cfg.get("allow_read")),
+            deny_read=_as_path_list(_profile_key(name, "deny_read"), cfg.get("deny_read")),
+            allow_write=_as_path_list(_profile_key(name, "allow_write"), cfg.get("allow_write")),
+            deny_write=_as_path_list(_profile_key(name, "deny_write"), cfg.get("deny_write")),
+            allowed_domains=_as_path_list(
+                _profile_key(name, "allowed_domains"),
+                cfg.get("allowed_domains"),
+            ),
+            denied_domains=_as_path_list(
+                _profile_key(name, "denied_domains"),
+                cfg.get("denied_domains"),
+            ),
+            allowed_sockets=_as_path_list(
+                _profile_key(name, "allowed_sockets"),
+                cfg.get("allowed_sockets"),
+            ),
+            denied_sockets=_as_path_list(
+                _profile_key(name, "denied_sockets"),
+                cfg.get("denied_sockets"),
+            ),
+        )
+```
+
+Extend `SandboxSettings`:
+
+```python
+    profiles: dict[str, SandboxProfile] = field(default_factory=dict)
+```
+
+In `SandboxSettings.from_config`, parse profiles:
+
+```python
+        raw_profiles = cfg.get("profiles", {}) or {}
+        if not isinstance(raw_profiles, dict):
+            raise ValueError(
+                f"[security.sandbox] profiles must be a table, got "
+                f"{type(raw_profiles).__name__}: {raw_profiles!r}."
+            )
+        profiles = {
+            _validate_profile_name(name): SandboxProfile.from_config(name, value)
+            for name, value in raw_profiles.items()
+        }
+```
+
+Pass `profiles=profiles` into the returned `cls(...)`.
+
+- [ ] **Step 5: Run profile parsing tests**
+
+Run:
+
+```bash
+pytest -q tests/test_sandbox_runtime.py::TestProfileConfig
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Write failing tests for command detection and merge**
+
+Add to `tests/test_sandbox_runtime.py`:
+
+```python
+class TestProfileSelectionAndMerge:
+    def _settings(self):
+        return SandboxSettings.from_config({
+            "backend": "srt",
+            "allow_write": ["."],
+            "deny_read": ["~/.ssh"],
+            "allowed_domains": [],
+            "profiles": {
+                "github": {
+                    "match_commands": ["gh", "git"],
+                    "allow_read": ["~/.config/gh"],
+                    "allow_write": [".", "/private/tmp", "~/.cache/gh"],
+                    "allowed_domains": ["api.github.com", "github.com"],
+                },
+            },
+        })
+
+    def test_extract_command_root_skips_env_assignments(self):
+        assert extract_command_root("GH_HOST=github.com gh pr view 387") == "gh"
+
+    def test_select_profile_by_command_root(self):
+        selected = self._settings().select_profile_for_command("gh pr view 387")
+        assert selected == "github"
+
+    def test_explicit_profile_overrides_detection(self):
+        selected = self._settings().select_profile_for_command(
+            "npx wrapper gh pr view 387",
+            explicit="github",
+        )
+        assert selected == "github"
+
+    def test_unknown_explicit_profile_raises(self):
+        with pytest.raises(ValueError, match="Unknown sandbox profile"):
+            self._settings().select_profile_for_command("gh pr view 387", explicit="missing")
+
+    def test_merged_with_profile_preserves_base_denies_and_adds_domains(self):
+        effective = self._settings().merged_with_profile("github")
+        payload = effective.to_srt_json(workspace=Path("/repo"))
+        assert payload["filesystem"]["denyRead"] == [str(Path.home() / ".ssh")]
+        assert payload["filesystem"]["allowWrite"] == ["/repo", "/private/tmp", str(Path.home() / ".cache/gh")]
+        assert payload["network"]["allowedDomains"] == ["api.github.com", "github.com"]
+        assert effective.profiles == {}
+```
+
+- [ ] **Step 7: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest -q tests/test_sandbox_runtime.py::TestProfileSelectionAndMerge
+```
+
+Expected: FAIL because selection and merge helpers do not exist.
+
+- [ ] **Step 8: Implement command detection, profile selection, and merge**
+
+Add these helpers to `loom/core/security/sandbox_runtime.py`:
+
+```python
+def _dedupe(items: list[str]) -> list[str]:
+    out: list[str] = []
+    for item in items:
+        if item not in out:
+            out.append(item)
+    return out
+
+
+def extract_command_root(command: str) -> str | None:
+    """Return the first executable token after leading KEY=value assignments."""
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        return None
+    for token in tokens:
+        if "=" in token and not token.startswith("="):
+            key, _value = token.split("=", 1)
+            if key.replace("_", "").isalnum() and key[0].isalpha():
+                continue
+        return Path(token).name
+    return None
+```
+
+Add methods to `SandboxSettings`:
+
+```python
+    def select_profile_for_command(
+        self, command: str, *, explicit: str | None = None,
+    ) -> str | None:
+        if explicit:
+            if explicit not in self.profiles:
+                raise ValueError(f"Unknown sandbox profile {explicit!r}.")
+            return explicit
+
+        root = extract_command_root(command)
+        if not root:
+            return None
+        matches = [
+            name for name, profile in self.profiles.items()
+            if root in profile.match_commands
+        ]
+        if len(matches) > 1:
+            raise ValueError(
+                f"Command {root!r} matches multiple sandbox profiles: "
+                + ", ".join(sorted(matches))
+            )
+        return matches[0] if matches else None
+
+    def merged_with_profile(self, profile_name: str) -> "SandboxSettings":
+        if profile_name not in self.profiles:
+            raise ValueError(f"Unknown sandbox profile {profile_name!r}.")
+        p = self.profiles[profile_name]
+        return SandboxSettings(
+            backend=self.backend,
+            allow_read=_dedupe(self.allow_read + p.allow_read),
+            deny_read=_dedupe(self.deny_read + p.deny_read),
+            allow_write=_dedupe(self.allow_write + p.allow_write),
+            deny_write=_dedupe(self.deny_write + p.deny_write),
+            allowed_domains=_dedupe(self.allowed_domains + p.allowed_domains),
+            denied_domains=_dedupe(self.denied_domains + p.denied_domains),
+            allowed_sockets=_dedupe(self.allowed_sockets + p.allowed_sockets),
+            denied_sockets=_dedupe(self.denied_sockets + p.denied_sockets),
+            profiles={},
+        )
+```
+
+Export `SandboxProfile` and `extract_command_root` from `loom/core/security/__init__.py`.
+
+- [ ] **Step 9: Run sandbox runtime tests**
+
+Run:
+
+```bash
+pytest -q tests/test_sandbox_runtime.py
+```
+
+Expected: PASS. If srt is installed in a sandboxed developer environment, run with the local escalation path already used for PR #387 so the srt e2e can bind its localhost proxy.
+
+- [ ] **Step 10: Commit Task 1**
+
+Run:
+
+```bash
+git add loom/core/security/sandbox_runtime.py loom/core/security/__init__.py tests/test_sandbox_runtime.py
+git commit -m "feat(sandbox): add CLI sandbox profiles"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 2: Profile-Aware Scope Requirements
+
+**Files:**
+- Modify: `loom/platform/cli/tools.py`
+- Modify: `loom/core/harness/scope.py`
+- Test: `tests/test_scope_phase_b.py`
+
+- [ ] **Step 1: Run GitNexus impact analysis before editing symbols**
+
+Run:
+
+```bash
+npx gitnexus impact _make_run_bash_resolver --direction upstream
+npx gitnexus impact get_matcher --direction upstream
+```
+
+Expected: report direct callers and risk. If risk is HIGH or CRITICAL, stop and warn the user before editing.
+
+- [ ] **Step 2: Write failing resolver tests**
+
+Modify the `_bash_resolver` setup in `tests/test_scope_phase_b.py` so existing tests keep using no profile settings:
+
+```python
+_bash_resolver = _make_run_bash_resolver(_WORKSPACE)
+```
+
+Then add:
+
+```python
+from loom.core.security.sandbox_runtime import SandboxSettings
+
+
+def _profile_settings():
+    return SandboxSettings.from_config({
+        "backend": "srt",
+        "profiles": {
+            "github": {
+                "match_commands": ["gh"],
+                "allow_read": ["~/.config/gh"],
+                "allow_write": [".", "/private/tmp", "~/.cache/gh"],
+                "allowed_domains": ["api.github.com", "github.com"],
+            },
+        },
+    })
+
+
+class TestRunBashSandboxProfileResolver:
+    def test_auto_detects_github_profile(self):
+        resolver = _make_run_bash_resolver(_WORKSPACE, sandbox=_profile_settings())
+        call = _call("run_bash", {"command": "gh pr view 387"}, caps=ToolCapability.EXEC)
+        req = resolver(call)
+
+        profile_reqs = [r for r in req.requirements if r.resource == "sandbox_profile"]
+        assert len(profile_reqs) == 1
+        r = profile_reqs[0]
+        assert r.action == "use"
+        assert r.selector == "github"
+        assert r.constraints["allowed_domains"] == ["api.github.com", "github.com"]
+        assert req.metadata["sandbox_profile"] == "github"
+
+    def test_explicit_profile_argument_selects_profile(self):
+        resolver = _make_run_bash_resolver(_WORKSPACE, sandbox=_profile_settings())
+        call = _call(
+            "run_bash",
+            {"command": "npx wrapper gh pr view 387", "sandbox_profile": "github"},
+            caps=ToolCapability.EXEC,
+        )
+        req = resolver(call)
+        assert req.metadata["sandbox_profile"] == "github"
+
+    def test_unknown_explicit_profile_marks_request_as_invalid(self):
+        resolver = _make_run_bash_resolver(_WORKSPACE, sandbox=_profile_settings())
+        call = _call(
+            "run_bash",
+            {"command": "gh pr view 387", "sandbox_profile": "missing"},
+            caps=ToolCapability.EXEC,
+        )
+        with pytest.raises(ValueError, match="Unknown sandbox profile"):
+            resolver(call)
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest -q tests/test_scope_phase_b.py::TestRunBashSandboxProfileResolver
+```
+
+Expected: FAIL because `_make_run_bash_resolver` does not accept `sandbox`.
+
+- [ ] **Step 4: Add explicit sandbox profile matcher**
+
+In `loom/core/harness/scope.py`, add:
+
+```python
+class SandboxProfileMatcher:
+    """Exact profile-name matcher for per-session sandbox profile grants."""
+    def covers(self, grant: _HasScopeFields, requirement: _HasScopeFields) -> bool:
+        if grant.action != requirement.action:
+            return False
+        return grant.selector == requirement.selector
+```
+
+Then extend `_MATCHERS`:
+
+```python
+    "sandbox_profile": SandboxProfileMatcher(),
+```
+
+- [ ] **Step 5: Extend `_make_run_bash_resolver`**
+
+In `loom/platform/cli/tools.py`, change the signature:
+
+```python
+def _make_run_bash_resolver(workspace: Path, sandbox: SandboxSettings | None = None):
+```
+
+Inside `_resolve`, after the existing exec requirement is built, append profile requirement:
+
+```python
+        requirements = [
+            ScopeRequirement(
+                resource="exec",
+                action="execute",
+                selector="workspace",
+                constraints={"has_absolute_paths": has_absolute},
+                tool_name=call.tool_name,
+                capabilities=call.capabilities,
+            ),
+        ]
+
+        profile_name: str | None = None
+        if sandbox is not None and sandbox.backend == "srt" and sandbox.profiles:
+            explicit_profile = (call.args.get("sandbox_profile") or "").strip() or None
+            profile_name = sandbox.select_profile_for_command(
+                command, explicit=explicit_profile,
+            )
+            if profile_name:
+                profile = sandbox.profiles[profile_name]
+                requirements.append(ScopeRequirement(
+                    resource="sandbox_profile",
+                    action="use",
+                    selector=profile_name,
+                    constraints={
+                        "allow_read": list(profile.allow_read),
+                        "allow_write": list(profile.allow_write),
+                        "allowed_domains": list(profile.allowed_domains),
+                        "allowed_sockets": list(profile.allowed_sockets),
+                    },
+                    tool_name=call.tool_name,
+                    capabilities=call.capabilities,
+                ))
+
+        metadata = {"sandbox_profile": profile_name} if profile_name else {}
+        return ScopeRequest(
+            tool_name=call.tool_name,
+            capabilities=call.capabilities,
+            requirements=requirements,
+            metadata=metadata,
+        )
+```
+
+Preserve the existing `scope_unknown` branch by adding the same profile requirement there when a profile is selected. If parsing is too ambiguous to auto-detect, explicit `sandbox_profile` is still honored.
+
+- [ ] **Step 6: Run resolver tests**
+
+Run:
+
+```bash
+pytest -q tests/test_scope_phase_b.py::TestRunBashResolver tests/test_scope_phase_b.py::TestRunBashSandboxProfileResolver
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 2**
+
+Run:
+
+```bash
+git add loom/platform/cli/tools.py loom/core/harness/scope.py tests/test_scope_phase_b.py
+git commit -m "feat(sandbox): request profile grants for run_bash"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 3: Correct Once vs Lease vs Session Semantics
+
+**Files:**
+- Modify: `loom/core/harness/middleware.py`
+- Test: `tests/test_scope_phase_b.py`
+
+- [ ] **Step 1: Run GitNexus impact analysis before editing symbol**
+
+Run:
+
+```bash
+npx gitnexus impact _scope_aware_process --direction upstream
+```
+
+Expected: report direct callers and risk. If risk is HIGH or CRITICAL, stop and warn the user before editing.
+
+- [ ] **Step 2: Write failing tests for ONCE not creating reusable grants**
+
+Add to `tests/test_scope_phase_b.py`:
+
+```python
+from loom.core.harness.scope import ConfirmDecision
+
+
+class TestScopeConfirmDurations:
+    async def test_once_confirmation_does_not_create_reusable_scope_grant(self):
+        perm = PermissionContext(session_id="test")
+        reg = _make_registry(_tool_def(
+            "write_file",
+            caps=ToolCapability.MUTATES,
+            scope_resolver=_make_write_file_resolver(_WORKSPACE),
+        ))
+        call = _call("write_file", {"path": "doc/once.md"}, caps=ToolCapability.MUTATES)
+
+        result, confirm_fn, handler = await _run_middleware(
+            perm, call, confirm_result=ConfirmDecision.ONCE, registry=reg,
+        )
+
+        assert result.success
+        confirm_fn.assert_called_once()
+        handler.assert_called_once()
+        assert perm.grants == []
+        assert call.metadata["confirm_decision"] == "once"
+
+    async def test_scope_confirmation_creates_ttl_grant(self):
+        perm = PermissionContext(session_id="test")
+        reg = _make_registry(_tool_def(
+            "write_file",
+            caps=ToolCapability.MUTATES,
+            scope_resolver=_make_write_file_resolver(_WORKSPACE),
+        ))
+        call = _call("write_file", {"path": "doc/lease.md"}, caps=ToolCapability.MUTATES)
+
+        result, _confirm_fn, _handler = await _run_middleware(
+            perm, call, confirm_result=ConfirmDecision.SCOPE, registry=reg,
+        )
+
+        assert result.success
+        assert len(perm.grants) == 1
+        assert perm.grants[0].source == "lease"
+        assert perm.grants[0].valid_until > 0
+
+    async def test_auto_confirmation_creates_session_grant(self):
+        perm = PermissionContext(session_id="test")
+        reg = _make_registry(_tool_def(
+            "write_file",
+            caps=ToolCapability.MUTATES,
+            scope_resolver=_make_write_file_resolver(_WORKSPACE),
+        ))
+        call = _call("write_file", {"path": "doc/session.md"}, caps=ToolCapability.MUTATES)
+
+        result, _confirm_fn, _handler = await _run_middleware(
+            perm, call, confirm_result=ConfirmDecision.AUTO, registry=reg,
+        )
+
+        assert result.success
+        assert len(perm.grants) == 1
+        assert perm.grants[0].source == "auto_approve"
+        assert perm.grants[0].valid_until == 0
+```
+
+Update the existing `test_grants_created_after_confirm` so it passes `ConfirmDecision.SCOPE` instead of bare `True`:
+
+```python
+await _run_middleware(perm, call, confirm_result=ConfirmDecision.SCOPE, registry=reg)
+```
+
+- [ ] **Step 3: Run tests to verify ONCE test fails**
+
+Run:
+
+```bash
+pytest -q tests/test_scope_phase_b.py::TestScopeConfirmDurations tests/test_scope_phase_b.py::TestBlastRadiusScopeAware::test_grants_created_after_confirm
+```
+
+Expected: FAIL because ONCE currently adds a reusable grant.
+
+- [ ] **Step 4: Change scope-aware ONCE handling**
+
+In `loom/core/harness/middleware.py`, replace the ONCE branch:
+
+```python
+        if decision == ConfirmDecision.ONCE:
+            call.metadata["once_authorized"] = True
+        elif decision == ConfirmDecision.SCOPE:
+            self._request_to_grants(
+                scope_request, source="lease",
+                valid_until=_time.time() + self._SCOPE_LEASE_TTL,
+            )
+        elif decision == ConfirmDecision.AUTO:
+            self._request_to_grants(scope_request, source="auto_approve")
+```
+
+Leave legacy-path behavior unchanged in this task unless a test shows legacy UI semantics break. This task targets scope-aware calls, which `run_bash` uses.
+
+- [ ] **Step 5: Run scope duration tests**
+
+Run:
+
+```bash
+pytest -q tests/test_scope_phase_b.py::TestScopeConfirmDurations tests/test_scope_phase_b.py::TestBlastRadiusScopeAware
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 3**
+
+Run:
+
+```bash
+git add loom/core/harness/middleware.py tests/test_scope_phase_b.py
+git commit -m "fix(harness): make scope once approvals single-use"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 4: Apply Approved Profiles in run_bash Execution
+
+**Files:**
+- Modify: `loom/platform/cli/tools.py`
+- Test: create `tests/test_run_bash_sandbox_profiles.py`
+
+- [ ] **Step 1: Run GitNexus impact analysis before editing symbol**
+
+Run:
+
+```bash
+npx gitnexus impact make_run_bash_tool --direction upstream
+```
+
+Expected: report direct callers and risk. If risk is HIGH or CRITICAL, stop and warn the user before editing.
+
+- [ ] **Step 2: Write failing tests for per-call profile settings**
+
+Create `tests/test_run_bash_sandbox_profiles.py`:
+
+```python
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from loom.core.harness.middleware import ToolCall
+from loom.core.harness.permissions import ToolCapability, TrustLevel
+from loom.core.harness.scope import PermissionVerdict, ScopeRequirement, ScopeRequest
+from loom.core.security.sandbox_runtime import SandboxSettings
+from loom.platform.cli.tools import make_run_bash_tool
+
+
+def _settings():
+    return SandboxSettings.from_config({
+        "backend": "srt",
+        "allow_write": ["."],
+        "profiles": {
+            "github": {
+                "match_commands": ["gh"],
+                "allow_write": [".", "/private/tmp", "~/.cache/gh"],
+                "allowed_domains": ["api.github.com"],
+            },
+        },
+    })
+
+
+def _call(args, *, authorized=True):
+    call = ToolCall(
+        tool_name="run_bash",
+        args=args,
+        trust_level=TrustLevel.GUARDED,
+        capabilities=ToolCapability.EXEC,
+        session_id="s1",
+    )
+    if authorized:
+        call.metadata["scope_verdict"] = PermissionVerdict.ALLOW
+        call.metadata["scope_request"] = ScopeRequest(
+            tool_name="run_bash",
+            capabilities=ToolCapability.EXEC,
+            requirements=[
+                ScopeRequirement(
+                    resource="sandbox_profile",
+                    action="use",
+                    selector="github",
+                    tool_name="run_bash",
+                    capabilities=ToolCapability.EXEC,
+                ),
+            ],
+            metadata={"sandbox_profile": "github"},
+        )
+    return call
+
+
+async def test_profile_command_uses_merged_settings(tmp_path, monkeypatch):
+    from loom.platform.cli import tools
+
+    monkeypatch.setattr(tools, "srt_available", lambda: True)
+    written = []
+
+    def fake_write(settings, workspace):
+        written.append(settings)
+        return tmp_path / f"settings-{len(written)}.json"
+
+    monkeypatch.setattr(tools, "_srt_write_settings_file", fake_write)
+    monkeypatch.setattr(tools, "_srt_wrap_command", lambda cmd, path: f"srt:{path}:{cmd}")
+
+    captured = {}
+
+    class FakeProc:
+        returncode = 0
+        async def communicate(self):
+            return b"ok", None
+
+    async def fake_shell(command, **kwargs):
+        captured["command"] = command
+        return FakeProc()
+
+    monkeypatch.setattr(tools.asyncio, "create_subprocess_shell", fake_shell)
+    monkeypatch.setattr(tools, "_terminate_proc_group", AsyncMock())
+
+    tool = make_run_bash_tool(tmp_path, sandbox=_settings())
+    result = await tool.executor(_call({"command": "gh pr view 387"}))
+
+    assert result.success is True
+    assert "srt:" in captured["command"]
+    assert len(written) == 2
+    effective = written[-1]
+    assert effective.allowed_domains == ["api.github.com"]
+    assert "/private/tmp" in effective.allow_write
+
+
+async def test_profile_command_without_scope_metadata_fails_closed(tmp_path, monkeypatch):
+    from loom.platform.cli import tools
+
+    monkeypatch.setattr(tools, "srt_available", lambda: True)
+    monkeypatch.setattr(tools, "_srt_write_settings_file", lambda settings, workspace: tmp_path / "settings.json")
+
+    tool = make_run_bash_tool(tmp_path, sandbox=_settings())
+    result = await tool.executor(_call({"command": "gh pr view 387"}, authorized=False))
+
+    assert result.success is False
+    assert result.failure_type == "permission_denied"
+    assert "sandbox profile 'github' was not authorized" in result.error
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest -q tests/test_run_bash_sandbox_profiles.py
+```
+
+Expected: FAIL because executor does not create per-call merged settings or check profile authorization metadata.
+
+- [ ] **Step 4: Add profile authorization helper in `make_run_bash_tool`**
+
+Inside `make_run_bash_tool`, add:
+
+```python
+    def _selected_profile_for_call(call: ToolCall) -> str | None:
+        if not _sandbox_active or sandbox is None:
+            return None
+        explicit_profile = (call.args.get("sandbox_profile") or "").strip() or None
+        return sandbox.select_profile_for_command(
+            call.args.get("command", ""), explicit=explicit_profile,
+        )
+
+    def _profile_authorized_for_call(call: ToolCall, profile_name: str) -> bool:
+        scope_request = call.metadata.get("scope_request")
+        if scope_request is None:
+            return False
+        for req in getattr(scope_request, "requirements", []):
+            if (
+                req.resource == "sandbox_profile"
+                and req.action == "use"
+                and req.selector == profile_name
+            ):
+                return bool(
+                    call.metadata.get("once_authorized")
+                    or call.metadata.get("user_decision")
+                    or call.metadata.get("scope_verdict")
+                )
+        return False
+```
+
+Change `_maybe_wrap` to accept `call`:
+
+```python
+    def _maybe_wrap(cmd: str, call: ToolCall) -> tuple[str, str | None]:
+        if not _sandbox_active or _sandbox_settings_path is None or sandbox is None:
+            return cmd, None
+        profile_name = _selected_profile_for_call(call)
+        settings_path = _sandbox_settings_path
+        if profile_name:
+            if not _profile_authorized_for_call(call, profile_name):
+                raise PermissionError(
+                    f"sandbox profile {profile_name!r} was not authorized for this run_bash call"
+                )
+            effective = sandbox.merged_with_profile(profile_name)
+            settings_path = _srt_write_settings_file(effective, workspace)
+        return _srt_wrap_command(cmd, settings_path), profile_name
+```
+
+In the foreground path:
+
+```python
+            wrapped_command, profile_name = _maybe_wrap(command, call)
+            proc = await asyncio.create_subprocess_shell(
+                wrapped_command,
+                ...
+            )
+```
+
+In the async path, call `_maybe_wrap` before `jobstore.submit`; if it raises `PermissionError`, return a denied `ToolResult` instead of submitting:
+
+```python
+            try:
+                wrapped_command, profile_name = _maybe_wrap(command, call)
+            except PermissionError as exc:
+                return ToolResult(
+                    call_id=call.id,
+                    tool_name=call.tool_name,
+                    success=False,
+                    error=str(exc),
+                    failure_type="permission_denied",
+                )
+            job_id = jobstore.submit(
+                "run_bash",
+                {"command": command, "timeout": timeout, "sandbox_profile": profile_name},
+                lambda: _run_bash_job(wrapped_command, cwd, timeout, scratchpad),
+            )
+```
+
+Apply the same `PermissionError` handling around foreground wrapping.
+
+- [ ] **Step 5: Add `sandbox_profile` to tool schema and wire resolver settings**
+
+In `make_run_bash_tool` input schema, add:
+
+```python
+                "sandbox_profile": {
+                    "type": "string",
+                    "description": (
+                        "Optional named sandbox profile to request for this command. "
+                        "Still requires human approval through the normal permission flow."
+                    ),
+                },
+```
+
+At the return `ToolDefinition`, change:
+
+```python
+        scope_resolver=_make_run_bash_resolver(workspace, sandbox=sandbox),
+```
+
+- [ ] **Step 6: Run run_bash profile tests**
+
+Run:
+
+```bash
+pytest -q tests/test_run_bash_sandbox_profiles.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run existing integration tests for run_bash**
+
+Run:
+
+```bash
+pytest -q tests/test_integration.py::TestTools::test_run_bash_success tests/test_integration.py::TestTools::test_run_bash_timeout
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 4**
+
+Run:
+
+```bash
+git add loom/platform/cli/tools.py tests/test_run_bash_sandbox_profiles.py tests/test_integration.py
+git commit -m "feat(sandbox): apply approved profiles to run_bash"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 5: Session Wiring, Documentation, and Config Examples
+
+**Files:**
+- Modify: `loom/core/session.py`
+- Modify: `loom.toml.example`
+- Modify: `doc/37-loom-toml-參考.md`
+- Modify: `doc/55-Sandbox-Runtime.md`
+- Test: `tests/test_sandbox_runtime.py`
+
+- [ ] **Step 1: Run GitNexus impact analysis before editing session wiring**
+
+Run:
+
+```bash
+npx gitnexus impact LoomSession --direction upstream
+```
+
+Expected: report direct callers and risk. If risk is HIGH or CRITICAL, stop and warn the user before editing.
+
+- [ ] **Step 2: Confirm session wiring already passes `SandboxSettings`**
+
+Inspect `loom/core/session.py` and verify it still passes `sandbox=_sandbox_settings` into `make_run_bash_tool`. If Task 4 only changed the resolver factory inside `make_run_bash_tool`, no session code change is needed.
+
+Run:
+
+```bash
+rg -n "make_run_bash_tool|sandbox=_sandbox_settings" loom/core/session.py
+```
+
+Expected: both strings appear near the run_bash registration.
+
+- [ ] **Step 3: Add docs for profiles**
+
+Add to `loom.toml.example` under `[security.sandbox]`:
+
+```toml
+# Optional CLI-specific profiles. Profiles do not grant access by
+# themselves; they are requested by run_bash and must be approved through
+# the normal permission prompt (once / 30 min / session / deny).
+#
+# [security.sandbox.profiles.github]
+# match_commands = ["gh", "git"]
+# allow_read = ["~/.config/gh", "~/.gitconfig"]
+# allow_write = [".", "/private/tmp", "~/.cache/gh"]
+# allowed_domains = [
+#   "api.github.com",
+#   "github.com",
+#   "raw.githubusercontent.com",
+#   "objects.githubusercontent.com",
+#   "codeload.github.com",
+# ]
+```
+
+Add equivalent concise text to `doc/37-loom-toml-參考.md`:
+
+```markdown
+### Sandbox profiles
+
+Profiles describe CLI-specific sandbox expansions. A profile is not an
+automatic allowlist; `run_bash` requests it and the user approves once, for
+30 minutes, for the current session, or denies it.
+```
+
+Add operational guidance to `doc/55-Sandbox-Runtime.md`:
+
+```markdown
+## CLI profiles
+
+Use profiles for tools such as `gh`, `opencli`, `npm`, `pip`, or project
+wrappers that need a predictable set of domains and config/cache paths.
+Profiles are runtime grants, not persistent authorization.
+```
+
+- [ ] **Step 4: Run docs/config grep checks**
+
+Run:
+
+```bash
+rg -n "sandbox.profiles|match_commands|once / 30 min / session / deny" loom.toml.example doc/37-loom-toml-參考.md doc/55-Sandbox-Runtime.md
+```
+
+Expected: all three docs mention profile runtime authorization.
+
+- [ ] **Step 5: Commit Task 5**
+
+Run:
+
+```bash
+git add loom.toml.example doc/37-loom-toml-參考.md doc/55-Sandbox-Runtime.md loom/core/session.py
+git commit -m "docs(sandbox): document CLI profile grants"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 6: Final Verification and Review Comment
+
+**Files:**
+- No source edits expected unless verification exposes a bug.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+pytest -q tests/test_sandbox_runtime.py tests/test_scope_phase_b.py tests/test_run_bash_sandbox_profiles.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run neighboring security/run_bash test slice**
+
+Run:
+
+```bash
+pytest -q tests -k "sandbox or security or run_bash or command_scanner or self_termination"
+```
+
+Expected: PASS. If local Codex sandbox blocks srt localhost proxy e2e, rerun with the approved local escalation used during PR #387 review.
+
+- [ ] **Step 3: Run formatting and diff checks**
+
+Run:
+
+```bash
+python -m py_compile loom/core/security/sandbox_runtime.py loom/platform/cli/tools.py loom/core/harness/scope.py loom/core/harness/middleware.py
+git diff --check
+```
+
+Expected: no output from `git diff --check`, py_compile exits 0.
+
+- [ ] **Step 4: Run GitNexus change detection**
+
+Run:
+
+```bash
+npx gitnexus detect-changes --scope compare --base-ref master
+```
+
+Expected: risk level is low or medium and affected flows are limited to run_bash / sandbox / permission paths. If high or critical, stop and review the affected process list before creating a PR.
+
+- [ ] **Step 5: Manual smoke through middleware**
+
+Run this focused smoke script:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import asyncio
+
+from loom.core.harness.middleware import BlastRadiusMiddleware, ToolCall, ToolResult
+from loom.core.harness.permissions import PermissionContext, ToolCapability, TrustLevel
+from loom.core.harness.registry import ToolDefinition, ToolRegistry
+from loom.core.harness.scope import ConfirmDecision
+from loom.core.security.sandbox_runtime import SandboxSettings
+from loom.platform.cli.tools import _make_run_bash_resolver
+
+workspace = Path.cwd()
+settings = SandboxSettings.from_config({
+    "backend": "srt",
+    "profiles": {
+        "github": {
+            "match_commands": ["gh"],
+            "allowed_domains": ["api.github.com"],
+            "allow_write": [".", "/private/tmp"],
+        },
+    },
+})
+
+async def run_once(decision):
+    perm = PermissionContext(session_id="smoke")
+    call = ToolCall(
+        tool_name="run_bash",
+        args={"command": "gh pr view 387"},
+        trust_level=TrustLevel.GUARDED,
+        capabilities=ToolCapability.EXEC,
+        session_id="smoke",
+    )
+    reg = ToolRegistry()
+    reg.register(ToolDefinition(
+        name="run_bash",
+        description="smoke",
+        trust_level=TrustLevel.GUARDED,
+        input_schema={},
+        executor=AsyncMock(return_value=ToolResult(call_id=call.id, tool_name="run_bash", success=True)),
+        capabilities=ToolCapability.EXEC,
+        scope_resolver=_make_run_bash_resolver(workspace, sandbox=settings),
+    ))
+    handler = AsyncMock(return_value=ToolResult(call_id=call.id, tool_name="run_bash", success=True))
+    mw = BlastRadiusMiddleware(
+        perm_ctx=perm,
+        confirm_fn=AsyncMock(return_value=decision),
+        registry=reg,
+    )
+    result = await mw.process(call, handler)
+    return result, perm, handler
+
+async def main():
+    once_result, once_perm, once_handler = await run_once(ConfirmDecision.ONCE)
+    assert once_result.success
+    assert once_handler.called
+    assert once_perm.grants == []
+
+    scope_result, scope_perm, _ = await run_once(ConfirmDecision.SCOPE)
+    assert scope_result.success
+    assert len(scope_perm.grants) == 2
+    assert any(g.resource == "sandbox_profile" and g.valid_until > 0 for g in scope_perm.grants)
+
+    session_result, session_perm, _ = await run_once(ConfirmDecision.AUTO)
+    assert session_result.success
+    assert len(session_perm.grants) == 2
+    assert any(g.resource == "sandbox_profile" and g.valid_until == 0 for g in session_perm.grants)
+
+    fresh = PermissionContext(session_id="fresh")
+    assert fresh.grants == []
+    print("sandbox profile permission smoke passed")
+
+asyncio.run(main())
+PY
+```
+
+Expected: `sandbox profile permission smoke passed`.
+
+- [ ] **Step 6: Prepare PR summary**
+
+Use this PR body:
+
+```markdown
+## Summary
+
+- add named srt sandbox profiles for CLI-specific domains and config/cache paths
+- route profile use through existing run_bash scope grants and human confirmation
+- apply approved profiles per call without changing global sandbox settings
+- fix scope-aware ONCE semantics so one-time approval is single-use
+
+## Verification
+
+- `pytest -q tests/test_sandbox_runtime.py tests/test_scope_phase_b.py tests/test_run_bash_sandbox_profiles.py`
+- `pytest -q tests -k "sandbox or security or run_bash or command_scanner or self_termination"`
+- `python -m py_compile loom/core/security/sandbox_runtime.py loom/platform/cli/tools.py loom/core/harness/scope.py loom/core/harness/middleware.py`
+- `git diff --check`
+- `npx gitnexus detect-changes --scope compare --base-ref master`
+```

--- a/docs/superpowers/specs/2026-05-18-sandbox-profile-scope-grants-design.md
+++ b/docs/superpowers/specs/2026-05-18-sandbox-profile-scope-grants-design.md
@@ -1,0 +1,223 @@
+# Sandbox Profile Scope Grants Design
+
+Date: 2026-05-18
+
+## Goal
+
+Make OS-level sandboxing practical for real CLI workflows without turning the
+global sandbox allowlist into a permanent hole.
+
+The sandbox remains the safety wall. Human authorization remains the control
+surface. A CLI such as `gh`, `opencli`, or an Obsidian-related CLI can request a
+named sandbox profile, and the user can approve it once, for 30 minutes, for
+the current session, or deny it. Grants are runtime-only and disappear when the
+session ends or Loom restarts.
+
+## Non-Goals
+
+- No persistent profile authorization across sessions.
+- No unsandboxed automatic escape hatch for CLI tools.
+- No broad global domain/path allowlist as the recommended workflow.
+- No deep shell parser in the first version.
+
+## User Model
+
+When the agent asks to run:
+
+```bash
+gh pr comment 387 --body "..."
+```
+
+Loom detects that `gh` matches the `github` sandbox profile and prompts:
+
+```text
+Allow run_bash with sandbox profile "github"?
+
+This profile adds:
+  network: api.github.com, github.com, raw.githubusercontent.com, ...
+  read: ~/.config/gh, ~/.gitconfig
+  write: ~/.cache/gh, workspace, /private/tmp
+
+Options: once / 30 min / this session / deny
+```
+
+This mirrors existing guarded tool behavior: the agent can propose the action,
+but the user controls whether the profile is available.
+
+## Configuration
+
+Base sandbox config stays strict:
+
+```toml
+[security.sandbox]
+backend = "srt"
+allow_write = [".", "/private/tmp"]
+deny_read = ["~/.ssh", "~/.aws", "~/.gnupg", ".env"]
+allowed_domains = []
+```
+
+Profiles live under the same block:
+
+```toml
+[security.sandbox.profiles.github]
+match_commands = ["gh", "git"]
+allow_read = ["~/.config/gh", "~/.gitconfig"]
+allow_write = [".", "/private/tmp", "~/.cache/gh"]
+allowed_domains = [
+  "api.github.com",
+  "github.com",
+  "raw.githubusercontent.com",
+  "objects.githubusercontent.com",
+  "codeload.github.com",
+]
+```
+
+Future CLIs are added as data, not code:
+
+```toml
+[security.sandbox.profiles.opencli]
+match_commands = ["opencli"]
+allow_read = ["~/.config/opencli"]
+allow_write = [".", "/private/tmp", "~/.cache/opencli"]
+allowed_domains = ["api.openai.com"]
+```
+
+## Detection
+
+The first version supports two ways to select a profile:
+
+1. Automatic detection from the shell command's executable token.
+2. Explicit `run_bash` argument, for wrapper commands or ambiguous shells:
+
+```json
+{
+  "command": "npx some-wrapper gh pr view 387",
+  "sandbox_profile": "github"
+}
+```
+
+Explicit selection does not bypass authorization. It only tells Loom which
+profile to request.
+
+The first version intentionally keeps parsing shallow:
+
+- Parse the first executable token after leading environment assignments.
+- Match against `profiles.*.match_commands`.
+- If the command contains complex shell forms that hide the executable, rely on
+  explicit `sandbox_profile`.
+- If multiple profiles match, fail closed and ask for explicit selection.
+
+## Permission Flow
+
+`run_bash` scope resolution gains a sandbox profile requirement:
+
+```text
+ScopeRequirement(
+  resource="sandbox_profile",
+  action="use",
+  selector="github",
+  constraints={
+    "network": [...],
+    "allow_read": [...],
+    "allow_write": [...],
+  },
+)
+```
+
+This requirement goes through the existing `PermissionContext` and confirm
+middleware:
+
+- Approve once: grants only this call.
+- 30 minutes: creates a TTL scope grant.
+- This session: creates a non-persistent session grant.
+- Deny: command does not run.
+
+Profile grants live only in memory. They are not written to `loom.toml` and are
+not restored after restart.
+
+## Sandbox Merge
+
+Execution uses a per-call effective sandbox:
+
+```text
+effective = base_sandbox + approved_profile
+```
+
+Merge rules:
+
+- Lists are unioned and de-duplicated while preserving stable order.
+- Base deny rules remain present.
+- Profile allow rules may add domains, reads, writes, and sockets.
+- Unknown profile, invalid profile config, or settings render failure is a hard
+  error before subprocess execution.
+- If a profile is detected but not approved, do not run under base settings as
+  a fallback, because that turns an authorization denial into a confusing
+  sandbox failure.
+
+The merged settings file should be generated per call or cached by a stable
+hash of the effective settings.
+
+## UI and Messaging
+
+The confirmation prompt should make profile expansion visible in plain terms:
+
+- Profile name.
+- Matched command.
+- Added network domains.
+- Added readable paths.
+- Added writable paths.
+- Grant duration options.
+
+If srt blocks a command due to missing network/path permission, Loom should
+surface a helpful hint:
+
+```text
+Sandbox blocked network access to api.example.com.
+Add it to a sandbox profile and approve that profile for run_bash.
+```
+
+This is a follow-up nicety, not required for the first merge.
+
+## Security Properties
+
+- Profiles are not automatic allowlists; they are permission requests.
+- Human approval is required before profile privileges affect execution.
+- The sandbox remains active for all profile-based commands.
+- Existing `CommandScanner`, `SelfTerminationGuard`, and run_bash scope checks
+  still run.
+- Deny means deny: no unsandboxed fallback and no global allowlist mutation.
+- Grants are scoped by profile and session lifetime, not by arbitrary command
+  string alone.
+
+## Test Plan
+
+Unit tests:
+
+- Profile config parsing rejects scalar strings and unknown profile references.
+- Command root detection maps `gh ...` to `github`.
+- Explicit `sandbox_profile` selects the requested profile.
+- Ambiguous multiple matches fail closed.
+- Effective sandbox merge preserves base denies and adds profile allow rules.
+
+Permission tests:
+
+- Unapproved profile requirement prompts.
+- Once approval applies only to one call.
+- TTL approval expires.
+- Session approval is available during the same `PermissionContext`.
+- New session has no previous profile grants.
+
+Integration tests:
+
+- `gh` profile renders srt settings with GitHub domains and gh config paths.
+- `run_bash` foreground and async paths both use merged settings.
+- Denied profile does not execute the command.
+- Unknown profile produces a clear tool error before subprocess execution.
+
+## Open Questions
+
+- Whether profile grants should imply `exec: workspace` or remain a separate
+  requirement shown alongside profile use.
+- Whether to provide built-in profile templates for `github`, `python-package`,
+  and `node-package`, or keep all profiles user-defined in the first version.
+- Whether `/scope` should group active grants by profile for easier scanning.

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -414,6 +414,20 @@ backend = "none"   # "none" | "srt"
 
 # Network allowlist.  Empty = no network.
 # allowed_domains = ["pypi.org", "files.pythonhosted.org", "api.github.com"]
+#
+# Named CLI profiles are additive overlays for tools such as gh/opencli/etc.
+# They do not grant access by themselves.  When run_bash selects a profile
+# by command root or explicit sandbox_profile, the normal permission prompt is
+# still required, with once / scoped lease / session / deny choices.
+#
+# [security.sandbox.profiles.github]
+# match_commands   = ["gh"]
+# allow_read       = ["~/.config/gh", "~/.gitconfig"]
+# allow_write      = [".", "/private/tmp", "~/.cache/gh"]
+# allowed_domains  = ["api.github.com", "github.com"]
+#
+# Then either command root matching or explicit selection can request it:
+#   run_bash(command = "gh pr view 387", sandbox_profile = "github", ...)
 
 # ─────────────────────────────────────────────
 # Autonomy Engine

--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -1068,8 +1068,7 @@ class BlastRadiusMiddleware(Middleware):
         # Convert request → grants based on user's decision.
         import time as _time
         if decision == ConfirmDecision.ONCE:
-            # Session-permanent grant with tight scope, no TTL
-            self._request_to_grants(scope_request, source="manual_confirm")
+            call.metadata["once_authorized"] = True
         elif decision == ConfirmDecision.SCOPE:
             # Session-scoped lease: grant with TTL
             self._request_to_grants(

--- a/loom/core/harness/scope.py
+++ b/loom/core/harness/scope.py
@@ -300,6 +300,14 @@ class MutationMatcher:
         return grant.selector == requirement.selector
 
 
+class SandboxProfileMatcher:
+    """Exact profile-name matcher for per-session sandbox profile grants."""
+    def covers(self, grant: _HasScopeFields, requirement: _HasScopeFields) -> bool:
+        if grant.action != requirement.action:
+            return False
+        return grant.selector == requirement.selector
+
+
 # ---------------------------------------------------------------------------
 # Matcher registry
 # ---------------------------------------------------------------------------
@@ -310,6 +318,7 @@ _MATCHERS: dict[str, ScopeMatcher] = {
     "exec": ExecMatcher(),
     "agent": AgentMatcher(),
     "mutation": MutationMatcher(),
+    "sandbox_profile": SandboxProfileMatcher(),
 }
 
 

--- a/loom/core/security/__init__.py
+++ b/loom/core/security/__init__.py
@@ -1,7 +1,9 @@
 from .self_termination_guard import SelfTerminationGuard, GuardVerdict
 from .command_scanner import CommandScanner
 from .sandbox_runtime import (
+    SandboxProfile,
     SandboxSettings,
+    extract_command_root,
     srt_available,
     srt_install_hint,
     wrap_command,
@@ -12,7 +14,9 @@ __all__ = [
     "SelfTerminationGuard",
     "GuardVerdict",
     "CommandScanner",
+    "SandboxProfile",
     "SandboxSettings",
+    "extract_command_root",
     "srt_available",
     "srt_install_hint",
     "wrap_command",

--- a/loom/core/security/sandbox_runtime.py
+++ b/loom/core/security/sandbox_runtime.py
@@ -31,6 +31,7 @@ Installation::
 from __future__ import annotations
 
 import json
+import hashlib
 import logging
 import os
 import re
@@ -53,7 +54,8 @@ _SRT_BINARY = "srt"
 # with srt's `sandbox-schemas.ts`.
 _REQUIRED_SECTIONS = ("filesystem", "network", "unixSockets")
 
-_PROFILE_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+_PROFILE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+_ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 
 
 def _as_path_list(key: str, value: Any) -> list[str]:
@@ -94,7 +96,7 @@ def _validate_profile_name(name: str) -> str:
     if not isinstance(name, str) or not _PROFILE_NAME_RE.match(name):
         raise ValueError(
             f"[security.sandbox] profile name must match "
-            f"[A-Za-z0-9_.-]+, got {name!r}."
+            f"[A-Za-z0-9][A-Za-z0-9_.-]*, got {name!r}."
         )
     return name
 
@@ -114,10 +116,8 @@ def extract_command_root(command: str) -> str | None:
     except ValueError:
         return None
     for token in tokens:
-        if "=" in token and not token.startswith("="):
-            key, _value = token.split("=", 1)
-            if key and key[0].isalpha() and key.replace("_", "").isalnum():
-                continue
+        if _ENV_ASSIGNMENT_RE.match(token):
+            continue
         return Path(token).name
     return None
 
@@ -246,6 +246,16 @@ class SandboxSettings:
             _validate_profile_name(name): SandboxProfile.from_config(name, value)
             for name, value in raw_profiles.items()
         }
+        command_to_profile: dict[str, str] = {}
+        for profile_name, profile in profiles.items():
+            for command in profile.match_commands:
+                previous = command_to_profile.setdefault(command, profile_name)
+                if previous != profile_name:
+                    raise ValueError(
+                        "[security.sandbox] profiles match_commands must be "
+                        f"unique; command {command!r} is used by both "
+                        f"{previous!r} and {profile_name!r}."
+                    )
 
         return cls(
             backend=backend,
@@ -355,17 +365,18 @@ def write_settings_file(
 ) -> Path:
     """Render *settings* to a JSON file and return its path.
 
-    The path is stable per (workspace, pid) so repeated wraps within a
-    session reuse the same file — avoids littering ``$TMPDIR`` with one
-    file per shell call.  Caller is not required to clean up; the OS
-    reaps tmpfiles on the usual schedule.
+    The path is stable per rendered payload so base and profile-merged
+    settings cannot overwrite each other while repeated equivalent wraps
+    reuse one file. Caller is not required to clean up; the OS reaps
+    tmpfiles on the usual schedule.
     """
     payload = settings.to_srt_json(workspace=workspace)
     base = Path(dir) if dir is not None else Path(tempfile.gettempdir())
     base.mkdir(parents=True, exist_ok=True)
-    h = abs(hash((str(workspace), os.getpid()))) % 10**8
+    rendered = json.dumps(payload, indent=2, sort_keys=True)
+    h = hashlib.sha256(rendered.encode("utf-8")).hexdigest()[:12]
     path = base / f"loom-srt-{h}.json"
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    path.write_text(rendered)
     return path
 
 

--- a/loom/core/security/sandbox_runtime.py
+++ b/loom/core/security/sandbox_runtime.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shlex
 import shutil
 import tempfile
@@ -51,6 +52,8 @@ _SRT_BINARY = "srt"
 # renderer always emits every key — even empty arrays.  Keep this in sync
 # with srt's `sandbox-schemas.ts`.
 _REQUIRED_SECTIONS = ("filesystem", "network", "unixSockets")
+
+_PROFILE_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
 def _as_path_list(key: str, value: Any) -> list[str]:
@@ -83,6 +86,101 @@ def _as_path_list(key: str, value: Any) -> list[str]:
     return list(value)
 
 
+def _profile_key(profile_name: str, field_name: str) -> str:
+    return f"profiles.{profile_name}.{field_name}"
+
+
+def _validate_profile_name(name: str) -> str:
+    if not isinstance(name, str) or not _PROFILE_NAME_RE.match(name):
+        raise ValueError(
+            f"[security.sandbox] profile name must match "
+            f"[A-Za-z0-9_.-]+, got {name!r}."
+        )
+    return name
+
+
+def _dedupe(items: list[str]) -> list[str]:
+    out: list[str] = []
+    for item in items:
+        if item not in out:
+            out.append(item)
+    return out
+
+
+def extract_command_root(command: str) -> str | None:
+    """Return the first executable token after leading KEY=value assignments."""
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        return None
+    for token in tokens:
+        if "=" in token and not token.startswith("="):
+            key, _value = token.split("=", 1)
+            if key and key[0].isalpha() and key.replace("_", "").isalnum():
+                continue
+        return Path(token).name
+    return None
+
+
+@dataclass(slots=True)
+class SandboxProfile:
+    """Named per-CLI sandbox expansion, activated only through permission grants."""
+
+    match_commands: list[str] = field(default_factory=list)
+    allow_read: list[str] = field(default_factory=list)
+    deny_read: list[str] = field(default_factory=list)
+    allow_write: list[str] = field(default_factory=list)
+    deny_write: list[str] = field(default_factory=list)
+    allowed_domains: list[str] = field(default_factory=list)
+    denied_domains: list[str] = field(default_factory=list)
+    allowed_sockets: list[str] = field(default_factory=list)
+    denied_sockets: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_config(cls, name: str, cfg: dict[str, Any] | None) -> "SandboxProfile":
+        if cfg is None:
+            cfg = {}
+        if not isinstance(cfg, dict):
+            raise ValueError(
+                f"[security.sandbox] profiles.{name} must be a table, "
+                f"got {type(cfg).__name__}: {cfg!r}."
+            )
+        return cls(
+            match_commands=_as_path_list(
+                _profile_key(name, "match_commands"),
+                cfg.get("match_commands"),
+            ),
+            allow_read=_as_path_list(
+                _profile_key(name, "allow_read"), cfg.get("allow_read"),
+            ),
+            deny_read=_as_path_list(
+                _profile_key(name, "deny_read"), cfg.get("deny_read"),
+            ),
+            allow_write=_as_path_list(
+                _profile_key(name, "allow_write"), cfg.get("allow_write"),
+            ),
+            deny_write=_as_path_list(
+                _profile_key(name, "deny_write"), cfg.get("deny_write"),
+            ),
+            allowed_domains=_as_path_list(
+                _profile_key(name, "allowed_domains"),
+                cfg.get("allowed_domains"),
+            ),
+            denied_domains=_as_path_list(
+                _profile_key(name, "denied_domains"),
+                cfg.get("denied_domains"),
+            ),
+            allowed_sockets=_as_path_list(
+                _profile_key(name, "allowed_sockets"),
+                cfg.get("allowed_sockets"),
+            ),
+            denied_sockets=_as_path_list(
+                _profile_key(name, "denied_sockets"),
+                cfg.get("denied_sockets"),
+            ),
+        )
+
+
 @dataclass(slots=True)
 class SandboxSettings:
     """Resolved sandbox config for a session.
@@ -105,6 +203,7 @@ class SandboxSettings:
     denied_domains: list[str] = field(default_factory=list)
     allowed_sockets: list[str] = field(default_factory=list)
     denied_sockets: list[str] = field(default_factory=list)
+    profiles: dict[str, SandboxProfile] = field(default_factory=dict)
 
     @classmethod
     def from_config(cls, cfg: dict[str, Any] | None) -> "SandboxSettings":
@@ -137,6 +236,17 @@ class SandboxSettings:
                     f"recognized. Valid options: 'none', 'srt'."
                 )
 
+        raw_profiles = cfg.get("profiles", {}) or {}
+        if not isinstance(raw_profiles, dict):
+            raise ValueError(
+                f"[security.sandbox] profiles must be a table, got "
+                f"{type(raw_profiles).__name__}: {raw_profiles!r}."
+            )
+        profiles = {
+            _validate_profile_name(name): SandboxProfile.from_config(name, value)
+            for name, value in raw_profiles.items()
+        }
+
         return cls(
             backend=backend,
             allow_read=_as_path_list("allow_read", cfg.get("allow_read")),
@@ -155,6 +265,46 @@ class SandboxSettings:
             denied_sockets=_as_path_list(
                 "denied_sockets", cfg.get("denied_sockets")
             ),
+            profiles=profiles,
+        )
+
+    def select_profile_for_command(
+        self, command: str, *, explicit: str | None = None,
+    ) -> str | None:
+        if explicit:
+            if explicit not in self.profiles:
+                raise ValueError(f"Unknown sandbox profile {explicit!r}.")
+            return explicit
+
+        root = extract_command_root(command)
+        if not root:
+            return None
+        matches = [
+            name for name, profile in self.profiles.items()
+            if root in profile.match_commands
+        ]
+        if len(matches) > 1:
+            raise ValueError(
+                f"Command {root!r} matches multiple sandbox profiles: "
+                + ", ".join(sorted(matches))
+            )
+        return matches[0] if matches else None
+
+    def merged_with_profile(self, profile_name: str) -> "SandboxSettings":
+        if profile_name not in self.profiles:
+            raise ValueError(f"Unknown sandbox profile {profile_name!r}.")
+        p = self.profiles[profile_name]
+        return SandboxSettings(
+            backend=self.backend,
+            allow_read=_dedupe(self.allow_read + p.allow_read),
+            deny_read=_dedupe(self.deny_read + p.deny_read),
+            allow_write=_dedupe(self.allow_write + p.allow_write),
+            deny_write=_dedupe(self.deny_write + p.deny_write),
+            allowed_domains=_dedupe(self.allowed_domains + p.allowed_domains),
+            denied_domains=_dedupe(self.denied_domains + p.denied_domains),
+            allowed_sockets=_dedupe(self.allowed_sockets + p.allowed_sockets),
+            denied_sockets=_dedupe(self.denied_sockets + p.denied_sockets),
+            profiles={},
         )
 
     def to_srt_json(self, workspace: Path | None = None) -> dict[str, Any]:

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -277,7 +277,9 @@ def _make_write_file_resolver(workspace: Path):
     return _resolve
 
 
-def _make_run_bash_resolver(workspace: Path):
+def _make_run_bash_resolver(
+    workspace: Path, sandbox: SandboxSettings | None = None,
+):
     """
     Return a scope_resolver for run_bash bound to *workspace*.
 
@@ -289,25 +291,66 @@ def _make_run_bash_resolver(workspace: Path):
 
     _SCOPE_UNKNOWN_PATTERNS = re.compile(r'[\|`]|\$\(|\$\{|\$[A-Za-z]|<<|&&|\|\|')
 
+    def _select_profile(command: str, call: ToolCall) -> tuple[str | None, dict]:
+        if sandbox is None or sandbox.backend != "srt" or not sandbox.profiles:
+            return None, {}
+        explicit_profile = (call.args.get("sandbox_profile") or "").strip() or None
+        profile_name = sandbox.select_profile_for_command(
+            command, explicit=explicit_profile,
+        )
+        if not profile_name:
+            return None, {}
+        profile = sandbox.profiles[profile_name]
+        return profile_name, {
+            "allow_read": list(profile.allow_read),
+            "allow_write": list(profile.allow_write),
+            "allowed_domains": list(profile.allowed_domains),
+            "allowed_sockets": list(profile.allowed_sockets),
+        }
+
+    def _profile_requirement(
+        call: ToolCall, profile_name: str | None, constraints: dict,
+    ) -> list[ScopeRequirement]:
+        if not profile_name:
+            return []
+        return [
+            ScopeRequirement(
+                resource="sandbox_profile",
+                action="use",
+                selector=profile_name,
+                constraints=constraints,
+                tool_name=call.tool_name,
+                capabilities=call.capabilities,
+            )
+        ]
+
     def _resolve(call: ToolCall) -> ScopeRequest:
         command = call.args.get("command", "")
+        profile_name, profile_constraints = _select_profile(command, call)
 
         # If command contains patterns we can't analyze, mark scope unknown
         if _SCOPE_UNKNOWN_PATTERNS.search(command):
+            requirements = [
+                ScopeRequirement(
+                    resource="exec",
+                    action="execute",
+                    selector="workspace",
+                    constraints={"scope_unknown": True},
+                    tool_name=call.tool_name,
+                    capabilities=call.capabilities,
+                ),
+            ]
+            requirements.extend(
+                _profile_requirement(call, profile_name, profile_constraints)
+            )
+            metadata = {"scope_unknown": True}
+            if profile_name:
+                metadata["sandbox_profile"] = profile_name
             return ScopeRequest(
                 tool_name=call.tool_name,
                 capabilities=call.capabilities,
-                requirements=[
-                    ScopeRequirement(
-                        resource="exec",
-                        action="execute",
-                        selector="workspace",
-                        constraints={"scope_unknown": True},
-                        tool_name=call.tool_name,
-                        capabilities=call.capabilities,
-                    ),
-                ],
-                metadata={"scope_unknown": True},
+                requirements=requirements,
+                metadata=metadata,
             )
 
         # Check for absolute paths outside workspace
@@ -323,19 +366,25 @@ def _make_run_bash_resolver(workspace: Path):
                 has_absolute = True
                 break
 
+        requirements = [
+            ScopeRequirement(
+                resource="exec",
+                action="execute",
+                selector="workspace",
+                constraints={"has_absolute_paths": has_absolute},
+                tool_name=call.tool_name,
+                capabilities=call.capabilities,
+            ),
+        ]
+        requirements.extend(
+            _profile_requirement(call, profile_name, profile_constraints)
+        )
+        metadata = {"sandbox_profile": profile_name} if profile_name else {}
         return ScopeRequest(
             tool_name=call.tool_name,
             capabilities=call.capabilities,
-            requirements=[
-                ScopeRequirement(
-                    resource="exec",
-                    action="execute",
-                    selector="workspace",
-                    constraints={"has_absolute_paths": has_absolute},
-                    tool_name=call.tool_name,
-                    capabilities=call.capabilities,
-                ),
-            ],
+            requirements=requirements,
+            metadata=metadata,
         )
     return _resolve
 

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -824,10 +824,51 @@ def make_run_bash_tool(
             )
         _sandbox_settings_path = _srt_write_settings_file(sandbox, workspace)
 
-    def _maybe_wrap(cmd: str) -> str:
-        if _sandbox_active and _sandbox_settings_path is not None:
-            return _srt_wrap_command(cmd, _sandbox_settings_path)
-        return cmd
+    def _selected_profile_for_call(call: ToolCall) -> str | None:
+        if not _sandbox_active or sandbox is None or not sandbox.profiles:
+            return None
+        command = call.args.get("command", "")
+        explicit = (call.args.get("sandbox_profile") or "").strip() or None
+        return sandbox.select_profile_for_command(command, explicit=explicit)
+
+    def _has_profile_requirement(call: ToolCall, profile_name: str) -> bool:
+        scope_request = call.metadata.get("scope_request")
+        requirements = getattr(scope_request, "requirements", []) or []
+        for req in requirements:
+            if (
+                getattr(req, "resource", None) == "sandbox_profile"
+                and getattr(req, "action", None) == "use"
+                and getattr(req, "selector", None) == profile_name
+            ):
+                return True
+        return False
+
+    def _profile_authorized_for_call(call: ToolCall, profile_name: str) -> bool:
+        if not _has_profile_requirement(call, profile_name):
+            return False
+        verdict = call.metadata.get("scope_verdict")
+        verdict_value = getattr(verdict, "value", verdict)
+        return (
+            call.metadata.get("once_authorized") is True
+            or call.metadata.get("user_decision") is True
+            or verdict_value == "allow"
+        )
+
+    def _maybe_wrap(cmd: str, call: ToolCall) -> tuple[str, str | None]:
+        if not _sandbox_active or _sandbox_settings_path is None:
+            return cmd, None
+        profile_name = _selected_profile_for_call(call)
+        settings_path = _sandbox_settings_path
+        if profile_name:
+            if sandbox is None or not _profile_authorized_for_call(call, profile_name):
+                raise PermissionError(
+                    f"sandbox profile '{profile_name}' requires explicit authorization"
+                )
+            settings_path = _srt_write_settings_file(
+                sandbox.merged_with_profile(profile_name),
+                workspace,
+            )
+        return _srt_wrap_command(cmd, settings_path), profile_name
     async def _run_bash(call: ToolCall) -> ToolResult:
         command = call.args.get("command", "")
         async_mode = bool(call.args.get("async_mode", False))
@@ -882,18 +923,38 @@ def make_run_bash_tool(
 
         timeout = call.args.get("timeout", 30)
         cwd = str(workspace) if strict_sandbox else None
+        try:
+            wrapped_command, sandbox_profile = _maybe_wrap(command, call)
+        except PermissionError as exc:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error=str(exc),
+                failure_type="permission_denied",
+            )
+        except ValueError as exc:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False, error=str(exc),
+                failure_type="validation_error",
+            )
 
         if async_mode and jobstore is not None and scratchpad is not None:
+            payload = {"command": command, "timeout": timeout}
+            metadata = {"async": True}
+            if sandbox_profile:
+                payload["sandbox_profile"] = sandbox_profile
+                metadata["sandbox_profile"] = sandbox_profile
             job_id = jobstore.submit(
                 "run_bash",
-                {"command": command, "timeout": timeout},
-                lambda: _run_bash_job(_maybe_wrap(command), cwd, timeout, scratchpad),
+                payload,
+                lambda: _run_bash_job(wrapped_command, cwd, timeout, scratchpad),
             )
+            metadata["job_id"] = job_id
             return ToolResult(
                 call_id=call.id, tool_name=call.tool_name,
                 success=True,
                 output=f"Submitted as {job_id}. Poll with jobs_status or jobs_await.",
-                metadata={"job_id": job_id, "async": True},
+                metadata=metadata,
             )
 
         try:
@@ -903,7 +964,7 @@ def make_run_bash_tool(
             # PID, leaving children holding stdout fds and communicate()
             # blocked indefinitely past cancel/timeout.
             proc = await asyncio.create_subprocess_shell(
-                _maybe_wrap(command),
+                wrapped_command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 cwd=cwd,
@@ -951,11 +1012,14 @@ def make_run_bash_tool(
                 marker = f"[Command exited with {proc.returncode}]"
                 output = f"{output}\n{marker}" if output else marker
 
+            metadata = {"exit_code": proc.returncode}
+            if sandbox_profile:
+                metadata["sandbox_profile"] = sandbox_profile
             return ToolResult(
                 call_id=call.id, tool_name=call.tool_name,
                 success=success, output=output,
                 error=None if success else f"Exit code {proc.returncode}",
-                metadata={"exit_code": proc.returncode},
+                metadata=metadata,
             )
         except Exception as exc:
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
@@ -984,6 +1048,7 @@ def make_run_bash_tool(
                 "command": {"type": "string", "description": "Shell command to run"},
                 "timeout": {"type": "integer", "description": "Timeout in seconds (default 30)"},
                 "async_mode": {"type": "boolean", "description": "Run in background; return job_id immediately (default false)."},
+                "sandbox_profile": {"type": "string", "description": "Optional named sandbox profile to request for this command."},
                 "justification": {"type": "string", "description": "簡短說明為何在目前的脈絡下執行此工具是合理且必要的（給人類審核看）。"},
             },
             "required": ["command", "justification"],
@@ -995,7 +1060,7 @@ def make_run_bash_tool(
             "executes shell commands within workspace sandbox",
             "scope unknown for pipes, subshells, or variable expansion",
         ],
-        scope_resolver=_make_run_bash_resolver(workspace),
+        scope_resolver=_make_run_bash_resolver(workspace, sandbox=sandbox),
         post_validator=_verify_run_bash,
     )
 

--- a/tests/test_run_bash_sandbox_profiles.py
+++ b/tests/test_run_bash_sandbox_profiles.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import loom.platform.cli.tools as tools
+from loom.core.harness.middleware import ToolCall
+from loom.core.security.sandbox_runtime import SandboxSettings
+
+
+def _sandbox() -> SandboxSettings:
+    return SandboxSettings.from_config({
+        "backend": "srt",
+        "allow_write": ["."],
+        "allowed_domains": [],
+        "profiles": {
+            "github": {
+                "match_commands": ["gh"],
+                "allow_read": ["~/.config/gh"],
+                "allow_write": [".", "~/.cache/gh"],
+                "allowed_domains": ["api.github.com", "github.com"],
+            },
+        },
+    })
+
+
+class _FakeProc:
+    returncode = 0
+
+    async def communicate(self):
+        return b"ok\n", None
+
+
+def _call(tool, command: str, **extra) -> ToolCall:
+    return ToolCall(
+        tool_name="run_bash",
+        args={"command": command, "justification": "test", **extra},
+        trust_level=tool.trust_level,
+        capabilities=tool.capabilities,
+        session_id="test",
+    )
+
+
+def _authorize_profile(tool, call: ToolCall) -> None:
+    call.metadata["scope_request"] = tool.scope_resolver(call)
+    call.metadata["once_authorized"] = True
+
+
+@pytest.fixture
+def srt_fakes(monkeypatch):
+    written = []
+    wrapped = []
+    launched = []
+
+    def fake_write(settings, workspace):
+        written.append(settings.to_srt_json(workspace=workspace))
+        return Path(f"/tmp/srt-settings-{len(written)}.json")
+
+    def fake_wrap(command, settings_path):
+        wrapped.append((command, settings_path))
+        return f"wrapped:{settings_path.name}:{command}"
+
+    async def fake_create_subprocess_shell(command, **kwargs):
+        launched.append((command, kwargs))
+        return _FakeProc()
+
+    async def fake_terminate(_proc):
+        return None
+
+    monkeypatch.setattr(tools, "srt_available", lambda: True)
+    monkeypatch.setattr(tools, "_srt_write_settings_file", fake_write)
+    monkeypatch.setattr(tools, "_srt_wrap_command", fake_wrap)
+    monkeypatch.setattr(tools.asyncio, "create_subprocess_shell", fake_create_subprocess_shell)
+    monkeypatch.setattr(tools, "_terminate_proc_group", fake_terminate)
+    return written, wrapped, launched
+
+
+@pytest.mark.asyncio
+async def test_run_bash_denies_detected_profile_without_scope_authorization(tmp_path, srt_fakes):
+    written, wrapped, launched = srt_fakes
+    tool = tools.make_run_bash_tool(tmp_path, sandbox=_sandbox())
+    call = _call(tool, "gh pr view 387")
+
+    result = await tool.executor(call)
+
+    assert not result.success
+    assert result.failure_type == "permission_denied"
+    assert "sandbox profile 'github'" in result.error
+    assert len(written) == 1
+    assert wrapped == []
+    assert launched == []
+
+
+@pytest.mark.asyncio
+async def test_run_bash_wraps_detected_profile_after_once_authorization(tmp_path, srt_fakes):
+    written, wrapped, launched = srt_fakes
+    tool = tools.make_run_bash_tool(tmp_path, sandbox=_sandbox())
+    call = _call(tool, "gh pr view 387")
+    _authorize_profile(tool, call)
+
+    result = await tool.executor(call)
+
+    assert result.success
+    assert len(written) == 2
+    assert written[0]["network"]["allowedDomains"] == []
+    assert written[1]["network"]["allowedDomains"] == ["api.github.com", "github.com"]
+    assert str(Path.home() / ".config/gh") in written[1]["filesystem"]["allowRead"]
+    assert wrapped == [("gh pr view 387", Path("/tmp/srt-settings-2.json"))]
+    assert launched[0][0] == "wrapped:srt-settings-2.json:gh pr view 387"
+    assert result.metadata["sandbox_profile"] == "github"
+
+
+@pytest.mark.asyncio
+async def test_run_bash_async_job_uses_authorized_profile_settings(tmp_path, srt_fakes, monkeypatch):
+    written, _wrapped, _launched = srt_fakes
+    recorded = {}
+
+    class JobStore:
+        def submit(self, name, payload, fn):
+            recorded["name"] = name
+            recorded["payload"] = payload
+            recorded["fn"] = fn
+            return "job-1"
+
+    async def fake_run_bash_job(command, cwd, timeout, scratchpad):
+        recorded["job_command"] = command
+        recorded["job_cwd"] = cwd
+        recorded["job_timeout"] = timeout
+        recorded["scratchpad"] = scratchpad
+        return None, "exit 0, 0 chars", None
+
+    monkeypatch.setattr(tools, "_run_bash_job", fake_run_bash_job)
+    scratchpad = object()
+    tool = tools.make_run_bash_tool(
+        tmp_path,
+        sandbox=_sandbox(),
+        jobstore=JobStore(),
+        scratchpad=scratchpad,
+    )
+    call = _call(tool, "gh api user", async_mode=True)
+    _authorize_profile(tool, call)
+
+    result = await tool.executor(call)
+    await recorded["fn"]()
+
+    assert result.success
+    assert result.metadata["sandbox_profile"] == "github"
+    assert recorded["payload"]["sandbox_profile"] == "github"
+    assert recorded["job_command"] == "wrapped:srt-settings-2.json:gh api user"
+    assert recorded["scratchpad"] is scratchpad
+    assert written[1]["network"]["allowedDomains"] == ["api.github.com", "github.com"]
+
+
+def test_run_bash_input_schema_accepts_explicit_sandbox_profile(tmp_path, srt_fakes):
+    tool = tools.make_run_bash_tool(tmp_path, sandbox=_sandbox())
+    props = tool.input_schema["properties"]
+
+    assert "sandbox_profile" in props

--- a/tests/test_run_bash_sandbox_profiles.py
+++ b/tests/test_run_bash_sandbox_profiles.py
@@ -5,7 +5,10 @@ from pathlib import Path
 import pytest
 
 import loom.platform.cli.tools as tools
-from loom.core.harness.middleware import ToolCall
+from loom.core.harness.middleware import BlastRadiusMiddleware, ToolCall
+from loom.core.harness.permissions import PermissionContext
+from loom.core.harness.registry import ToolRegistry
+from loom.core.harness.scope import ConfirmDecision, ScopeGrant
 from loom.core.security.sandbox_runtime import SandboxSettings
 
 
@@ -45,6 +48,20 @@ def _call(tool, command: str, **extra) -> ToolCall:
 def _authorize_profile(tool, call: ToolCall) -> None:
     call.metadata["scope_request"] = tool.scope_resolver(call)
     call.metadata["once_authorized"] = True
+
+
+async def _run_through_scope_middleware(tool, call: ToolCall, perm, confirm_result):
+    async def _confirm(_call):
+        return confirm_result
+
+    registry = ToolRegistry()
+    registry.register(tool)
+    mw = BlastRadiusMiddleware(
+        perm_ctx=perm,
+        confirm_fn=_confirm,
+        registry=registry,
+    )
+    return await mw.process(call, tool.executor)
 
 
 @pytest.fixture
@@ -109,6 +126,62 @@ async def test_run_bash_wraps_detected_profile_after_once_authorization(tmp_path
     assert wrapped == [("gh pr view 387", Path("/tmp/srt-settings-2.json"))]
     assert launched[0][0] == "wrapped:srt-settings-2.json:gh pr view 387"
     assert result.metadata["sandbox_profile"] == "github"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decision", [ConfirmDecision.SCOPE, ConfirmDecision.AUTO])
+async def test_run_bash_applies_profile_on_scope_or_auto_first_call(
+    tmp_path, srt_fakes, decision,
+):
+    written, _wrapped, launched = srt_fakes
+    tool = tools.make_run_bash_tool(tmp_path, sandbox=_sandbox())
+    call = _call(tool, "gh pr view 387")
+    perm = PermissionContext(session_id="test")
+
+    result = await _run_through_scope_middleware(tool, call, perm, decision)
+
+    assert result.success
+    assert call.metadata["user_decision"] is True
+    assert result.metadata["sandbox_profile"] == "github"
+    assert len(written) == 2
+    assert written[1]["network"]["allowedDomains"] == ["api.github.com", "github.com"]
+    assert launched[0][0] == "wrapped:srt-settings-2.json:gh pr view 387"
+
+
+@pytest.mark.asyncio
+async def test_run_bash_applies_profile_when_existing_grant_covers_scope(
+    tmp_path, srt_fakes,
+):
+    written, _wrapped, launched = srt_fakes
+    tool = tools.make_run_bash_tool(tmp_path, sandbox=_sandbox())
+    call = _call(tool, "gh pr view 387")
+    perm = PermissionContext(session_id="test")
+    perm.grants.extend([
+        ScopeGrant(
+            resource="exec",
+            action="execute",
+            selector="workspace",
+            constraints={"absolute_paths": "deny"},
+            source="test",
+        ),
+        ScopeGrant(
+            resource="sandbox_profile",
+            action="use",
+            selector="github",
+            source="test",
+        ),
+    ])
+
+    result = await _run_through_scope_middleware(
+        tool, call, perm, ConfirmDecision.DENY,
+    )
+
+    assert result.success
+    assert call.metadata["scope_verdict"].value == "allow"
+    assert result.metadata["sandbox_profile"] == "github"
+    assert len(written) == 2
+    assert written[1]["network"]["allowedDomains"] == ["api.github.com", "github.com"]
+    assert launched[0][0] == "wrapped:srt-settings-2.json:gh pr view 387"
 
 
 @pytest.mark.asyncio

--- a/tests/test_sandbox_runtime.py
+++ b/tests/test_sandbox_runtime.py
@@ -170,6 +170,23 @@ class TestProfileConfig:
                 "profiles": {"git hub": {"match_commands": ["gh"]}},
             })
 
+    def test_profile_name_must_start_with_alnum(self):
+        with pytest.raises(ValueError, match="profile name"):
+            SandboxSettings.from_config({
+                "backend": "srt",
+                "profiles": {"-github": {"match_commands": ["gh"]}},
+            })
+
+    def test_profile_match_commands_must_be_unique(self):
+        with pytest.raises(ValueError, match="match_commands.*gh"):
+            SandboxSettings.from_config({
+                "backend": "srt",
+                "profiles": {
+                    "github": {"match_commands": ["gh"]},
+                    "github_alt": {"match_commands": ["gh"]},
+                },
+            })
+
 
 class TestProfileSelectionAndMerge:
     def _settings(self):
@@ -190,6 +207,9 @@ class TestProfileSelectionAndMerge:
 
     def test_extract_command_root_skips_env_assignments(self):
         assert extract_command_root("GH_HOST=github.com gh pr view 387") == "gh"
+
+    def test_extract_command_root_skips_leading_underscore_env_assignment(self):
+        assert extract_command_root("_DEBUG=1 gh pr view 387") == "gh"
 
     def test_select_profile_by_command_root(self):
         selected = self._settings().select_profile_for_command("gh pr view 387")
@@ -281,11 +301,27 @@ class TestWriteSettingsFile:
         assert data["filesystem"]["allowWrite"] == [str(tmp_path)]
 
     def test_stable_path_within_session(self, tmp_path):
-        """Repeated writes for the same (workspace, pid) reuse one file."""
+        """Repeated writes for identical content reuse one file."""
         s = SandboxSettings(backend="srt")
         p1 = write_settings_file(s, workspace=tmp_path, dir=tmp_path)
         p2 = write_settings_file(s, workspace=tmp_path, dir=tmp_path)
         assert p1 == p2
+
+    def test_distinct_settings_get_distinct_content_hash_paths(self, tmp_path):
+        base = SandboxSettings(backend="srt")
+        github = SandboxSettings(
+            backend="srt",
+            allowed_domains=["api.github.com"],
+        )
+
+        p1 = write_settings_file(base, workspace=tmp_path, dir=tmp_path)
+        p2 = write_settings_file(github, workspace=tmp_path, dir=tmp_path)
+
+        assert p1 != p2
+        assert json.loads(p1.read_text())["network"]["allowedDomains"] == []
+        assert json.loads(p2.read_text())["network"]["allowedDomains"] == [
+            "api.github.com",
+        ]
 
     def test_creates_target_dir(self, tmp_path):
         target = tmp_path / "nested" / "dir"

--- a/tests/test_sandbox_runtime.py
+++ b/tests/test_sandbox_runtime.py
@@ -17,6 +17,7 @@ import pytest
 
 from loom.core.security.sandbox_runtime import (
     SandboxSettings,
+    extract_command_root,
     srt_available,
     srt_install_hint,
     wrap_command,
@@ -124,6 +125,105 @@ class TestStrictListValidation:
         })
         assert s.allow_write == []
         assert s.allowed_domains == []
+
+
+class TestProfileConfig:
+    def test_profiles_parse_from_config(self):
+        s = SandboxSettings.from_config({
+            "backend": "srt",
+            "allow_write": ["."],
+            "profiles": {
+                "github": {
+                    "match_commands": ["gh", "git"],
+                    "allow_read": ["~/.config/gh", "~/.gitconfig"],
+                    "allow_write": [".", "/private/tmp", "~/.cache/gh"],
+                    "allowed_domains": ["api.github.com", "github.com"],
+                },
+            },
+        })
+
+        assert "github" in s.profiles
+        profile = s.profiles["github"]
+        assert profile.match_commands == ["gh", "git"]
+        assert profile.allowed_domains == ["api.github.com", "github.com"]
+
+    def test_profile_list_fields_reject_scalar_strings(self):
+        with pytest.raises(ValueError, match="profiles.github.allow_write"):
+            SandboxSettings.from_config({
+                "backend": "srt",
+                "profiles": {
+                    "github": {"match_commands": ["gh"], "allow_write": "/tmp"},
+                },
+            })
+
+    def test_profile_match_commands_requires_list_of_strings(self):
+        with pytest.raises(ValueError, match="profiles.github.match_commands"):
+            SandboxSettings.from_config({
+                "backend": "srt",
+                "profiles": {"github": {"match_commands": "gh"}},
+            })
+
+    def test_profile_name_must_be_simple_identifier(self):
+        with pytest.raises(ValueError, match="profile name"):
+            SandboxSettings.from_config({
+                "backend": "srt",
+                "profiles": {"git hub": {"match_commands": ["gh"]}},
+            })
+
+
+class TestProfileSelectionAndMerge:
+    def _settings(self):
+        return SandboxSettings.from_config({
+            "backend": "srt",
+            "allow_write": ["."],
+            "deny_read": ["~/.ssh"],
+            "allowed_domains": [],
+            "profiles": {
+                "github": {
+                    "match_commands": ["gh", "git"],
+                    "allow_read": ["~/.config/gh"],
+                    "allow_write": [".", "/private/tmp", "~/.cache/gh"],
+                    "allowed_domains": ["api.github.com", "github.com"],
+                },
+            },
+        })
+
+    def test_extract_command_root_skips_env_assignments(self):
+        assert extract_command_root("GH_HOST=github.com gh pr view 387") == "gh"
+
+    def test_select_profile_by_command_root(self):
+        selected = self._settings().select_profile_for_command("gh pr view 387")
+        assert selected == "github"
+
+    def test_explicit_profile_overrides_detection(self):
+        selected = self._settings().select_profile_for_command(
+            "npx wrapper gh pr view 387",
+            explicit="github",
+        )
+        assert selected == "github"
+
+    def test_unknown_explicit_profile_raises(self):
+        with pytest.raises(ValueError, match="Unknown sandbox profile"):
+            self._settings().select_profile_for_command(
+                "gh pr view 387", explicit="missing",
+            )
+
+    def test_merged_with_profile_preserves_base_denies_and_adds_domains(self):
+        effective = self._settings().merged_with_profile("github")
+        payload = effective.to_srt_json(workspace=Path("/repo"))
+        assert payload["filesystem"]["denyRead"] == [
+            str(Path.home() / ".ssh"),
+        ]
+        assert payload["filesystem"]["allowWrite"] == [
+            "/repo",
+            "/private/tmp",
+            str(Path.home() / ".cache/gh"),
+        ]
+        assert payload["network"]["allowedDomains"] == [
+            "api.github.com",
+            "github.com",
+        ]
+        assert effective.profiles == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scope_phase_b.py
+++ b/tests/test_scope_phase_b.py
@@ -26,6 +26,7 @@ from loom.core.harness.scope import (
     ScopeRequirement,
     ScopeRequest,
 )
+from loom.core.security.sandbox_runtime import SandboxSettings
 from loom.platform.cli.tools import (
     _fetch_url_resolver,
     _make_run_bash_resolver,
@@ -154,6 +155,65 @@ class TestRunBashResolver:
         assert r.selector == "workspace"
         assert not r.constraints.get("has_absolute_paths")
         assert not req.metadata.get("scope_unknown")
+
+
+def _profile_settings():
+    return SandboxSettings.from_config({
+        "backend": "srt",
+        "profiles": {
+            "github": {
+                "match_commands": ["gh"],
+                "allow_read": ["~/.config/gh"],
+                "allow_write": [".", "/private/tmp", "~/.cache/gh"],
+                "allowed_domains": ["api.github.com", "github.com"],
+            },
+        },
+    })
+
+
+class TestRunBashSandboxProfileResolver:
+    def test_auto_detects_github_profile(self):
+        resolver = _make_run_bash_resolver(_WORKSPACE, sandbox=_profile_settings())
+        call = _call(
+            "run_bash", {"command": "gh pr view 387"},
+            caps=ToolCapability.EXEC,
+        )
+        req = resolver(call)
+
+        profile_reqs = [
+            r for r in req.requirements if r.resource == "sandbox_profile"
+        ]
+        assert len(profile_reqs) == 1
+        r = profile_reqs[0]
+        assert r.action == "use"
+        assert r.selector == "github"
+        assert r.constraints["allowed_domains"] == [
+            "api.github.com", "github.com",
+        ]
+        assert req.metadata["sandbox_profile"] == "github"
+
+    def test_explicit_profile_argument_selects_profile(self):
+        resolver = _make_run_bash_resolver(_WORKSPACE, sandbox=_profile_settings())
+        call = _call(
+            "run_bash",
+            {
+                "command": "npx wrapper gh pr view 387",
+                "sandbox_profile": "github",
+            },
+            caps=ToolCapability.EXEC,
+        )
+        req = resolver(call)
+        assert req.metadata["sandbox_profile"] == "github"
+
+    def test_unknown_explicit_profile_raises(self):
+        resolver = _make_run_bash_resolver(_WORKSPACE, sandbox=_profile_settings())
+        call = _call(
+            "run_bash",
+            {"command": "gh pr view 387", "sandbox_profile": "missing"},
+            caps=ToolCapability.EXEC,
+        )
+        with pytest.raises(ValueError, match="Unknown sandbox profile"):
+            resolver(call)
 
 
 class TestFetchUrlResolver:

--- a/tests/test_scope_phase_b.py
+++ b/tests/test_scope_phase_b.py
@@ -371,6 +371,28 @@ class TestScopeConfirmDurations:
         assert perm.grants == []
         assert call.metadata["confirm_decision"] == "once"
 
+    async def test_once_confirmation_does_not_grant_fetch_url_network_scope(self):
+        perm = PermissionContext(session_id="test")
+        reg = _make_registry(_tool_def(
+            "fetch_url",
+            caps=ToolCapability.NETWORK,
+            scope_resolver=_fetch_url_resolver,
+        ))
+        call = _call(
+            "fetch_url", {"url": "https://example.com"},
+            caps=ToolCapability.NETWORK,
+        )
+
+        result, confirm_fn, handler = await _run_middleware(
+            perm, call, confirm_result=ConfirmDecision.ONCE, registry=reg,
+        )
+
+        assert result.success
+        confirm_fn.assert_called_once()
+        handler.assert_called_once()
+        assert perm.grants == []
+        assert call.metadata["confirm_decision"] == "once"
+
     async def test_scope_confirmation_creates_ttl_grant(self):
         perm = PermissionContext(session_id="test")
         reg = _make_registry(_tool_def(

--- a/tests/test_scope_phase_b.py
+++ b/tests/test_scope_phase_b.py
@@ -20,6 +20,7 @@ from loom.core.harness.middleware import BlastRadiusMiddleware, ToolCall, ToolRe
 from loom.core.harness.permissions import PermissionContext, ToolCapability, TrustLevel
 from loom.core.harness.registry import ToolDefinition, ToolRegistry
 from loom.core.harness.scope import (
+    ConfirmDecision,
     DiffReason,
     PermissionVerdict,
     ScopeGrant,
@@ -319,21 +320,25 @@ class TestBlastRadiusScopeAware:
     async def test_grants_created_after_confirm(self):
         perm, reg = self._setup()
         call = _call("write_file", {"path": "doc/test.md"}, caps=ToolCapability.MUTATES)
-        await _run_middleware(perm, call, confirm_result=True, registry=reg)
+        await _run_middleware(
+            perm, call, confirm_result=ConfirmDecision.SCOPE, registry=reg,
+        )
 
         # After confirmation, a grant should have been added
         assert len(perm.grants) >= 1
         g = perm.grants[-1]
         assert g.resource == "path"
         assert g.action == "write"
-        assert g.source == "manual_confirm"
+        assert g.source == "lease"
 
     async def test_second_call_same_scope_auto_allowed(self):
         perm, reg = self._setup()
 
         # First call — needs confirmation
         call1 = _call("write_file", {"path": "doc/a.md"}, caps=ToolCapability.MUTATES)
-        _, confirm1, _ = await _run_middleware(perm, call1, confirm_result=True, registry=reg)
+        _, confirm1, _ = await _run_middleware(
+            perm, call1, confirm_result=ConfirmDecision.SCOPE, registry=reg,
+        )
         confirm1.assert_called_once()
 
         # Second call — same scope, should be auto-allowed
@@ -341,6 +346,72 @@ class TestBlastRadiusScopeAware:
         _, confirm2, handler2 = await _run_middleware(perm, call2, registry=reg)
         confirm2.assert_not_called()
         handler2.assert_called_once()
+
+
+class TestScopeConfirmDurations:
+    async def test_once_confirmation_does_not_create_reusable_scope_grant(self):
+        perm = PermissionContext(session_id="test")
+        reg = _make_registry(_tool_def(
+            "write_file",
+            caps=ToolCapability.MUTATES,
+            scope_resolver=_make_write_file_resolver(_WORKSPACE),
+        ))
+        call = _call(
+            "write_file", {"path": "doc/once.md"},
+            caps=ToolCapability.MUTATES,
+        )
+
+        result, confirm_fn, handler = await _run_middleware(
+            perm, call, confirm_result=ConfirmDecision.ONCE, registry=reg,
+        )
+
+        assert result.success
+        confirm_fn.assert_called_once()
+        handler.assert_called_once()
+        assert perm.grants == []
+        assert call.metadata["confirm_decision"] == "once"
+
+    async def test_scope_confirmation_creates_ttl_grant(self):
+        perm = PermissionContext(session_id="test")
+        reg = _make_registry(_tool_def(
+            "write_file",
+            caps=ToolCapability.MUTATES,
+            scope_resolver=_make_write_file_resolver(_WORKSPACE),
+        ))
+        call = _call(
+            "write_file", {"path": "doc/lease.md"},
+            caps=ToolCapability.MUTATES,
+        )
+
+        result, _confirm_fn, _handler = await _run_middleware(
+            perm, call, confirm_result=ConfirmDecision.SCOPE, registry=reg,
+        )
+
+        assert result.success
+        assert len(perm.grants) == 1
+        assert perm.grants[0].source == "lease"
+        assert perm.grants[0].valid_until > 0
+
+    async def test_auto_confirmation_creates_session_grant(self):
+        perm = PermissionContext(session_id="test")
+        reg = _make_registry(_tool_def(
+            "write_file",
+            caps=ToolCapability.MUTATES,
+            scope_resolver=_make_write_file_resolver(_WORKSPACE),
+        ))
+        call = _call(
+            "write_file", {"path": "doc/session.md"},
+            caps=ToolCapability.MUTATES,
+        )
+
+        result, _confirm_fn, _handler = await _run_middleware(
+            perm, call, confirm_result=ConfirmDecision.AUTO, registry=reg,
+        )
+
+        assert result.success
+        assert len(perm.grants) == 1
+        assert perm.grants[0].source == "auto_approve"
+        assert perm.grants[0].valid_until == 0
 
 
 # =====================================================================


### PR DESCRIPTION
## Summary
- add named sandbox profiles that can overlay CLI-specific read/write/network/socket allowances
- route run_bash profile use through the existing scope permission flow, including once / lease / session authorization
- make `ConfirmDecision.ONCE` single-use for all scope-aware tools instead of creating a reusable session grant
- apply authorized profiles to per-call content-hashed srt settings and document profile examples

## Verification
- `pytest -q tests/test_sandbox_runtime.py tests/test_scope_phase_b.py tests/test_run_bash_sandbox_profiles.py` — 89 passed
- `pytest -q tests -k "sandbox or security or run_bash or command_scanner or self_termination"` — 91 passed, 1857 deselected, 4 warnings
- `python -m py_compile loom/core/security/sandbox_runtime.py loom/platform/cli/tools.py loom/core/harness/scope.py loom/core/harness/middleware.py`
- `git diff --check`
- `npx gitnexus detect-changes --scope compare --base-ref master` — risk low, affected processes 0
- `npx gitnexus detect-changes --scope staged` for follow-up `808e7a9` — risk low, affected processes 0

## Review Notes
- This PR intentionally keeps the base srt sandbox strict. Profiles are additive overlays only after human authorization.
- `ConfirmDecision.ONCE` is now single-use for scope-aware calls and no longer creates a reusable grant.
- Follow-up `808e7a9` covers SCOPE/AUTO first-call profile use, existing-grant profile use, fetch_url ONCE semantics, underscore env assignments, profile name validation, duplicate `match_commands`, and content-hashed settings files.
- The PR branch excludes the unrelated `news-aggregator` commit that was present on the working branch.