### PR TITLE
fix(budget): add block-count dimension + drift hooks for context %

### DIFF
--- a/docs/superpowers/plans/2026-05-19-sandbox-profile-scope-grants.md
+++ b/docs/superpowers/plans/2026-05-19-sandbox-profile-scope-grants.md
@@ -1,0 +1,1217 @@
+# Sandbox Profile Scope Grants Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `run_bash` use named srt sandbox profiles for CLIs such as `gh` only after the user approves the profile through the existing once / 30-minute / session / deny permission flow.
+
+**Architecture:** Extend `SandboxSettings` with named `SandboxProfile` entries, detect or explicitly select a profile per `run_bash` call, emit a `sandbox_profile:use:<name>` scope requirement, and merge the approved profile into the per-call srt settings. The sandbox stays enabled for execution; authorization lives in `PermissionContext` only and disappears when the session ends.
+
+**Tech Stack:** Python dataclasses, existing `PermissionContext` / `ScopeGrant` / `BlastRadiusMiddleware`, existing `run_bash` tool factory, pytest.
+
+---
+
+## File Structure
+
+- Modify `loom/core/security/sandbox_runtime.py`
+  - Owns `SandboxProfile`, profile parsing, command-root detection, profile selection, and sandbox settings merge.
+- Modify `loom/platform/cli/tools.py`
+  - Adds `sandbox_profile` input arg, wires profile-aware `run_bash` scope resolution, checks authorization metadata before applying a profile, and renders per-call srt settings.
+- Modify `loom/core/harness/middleware.py`
+  - Corrects scope-aware `ConfirmDecision.ONCE` semantics so "once" does not add a reusable grant.
+- Modify `loom/core/harness/scope.py`
+  - Adds a named exact matcher entry for `sandbox_profile` so the resource type is explicit.
+- Modify `loom/core/session.py`
+  - Passes profile-aware sandbox settings into the profile-aware run_bash resolver through the existing tool factory.
+- Modify `loom.toml.example`, `doc/37-loom-toml-參考.md`, `doc/55-Sandbox-Runtime.md`
+  - Documents profile config and runtime-only grant behavior.
+- Modify `tests/test_sandbox_runtime.py`
+  - Tests profile parsing, strict validation, command detection, and merge behavior.
+- Modify `tests/test_scope_phase_b.py`
+  - Tests `sandbox_profile` scope requirements and once/lease/session authorization behavior.
+- Create `tests/test_run_bash_sandbox_profiles.py`
+  - Tests foreground and async `run_bash` use merged per-call settings without invoking real srt.
+
+---
+
+### Task 1: Sandbox Profile Data Model and Merge
+
+**Files:**
+- Modify: `loom/core/security/sandbox_runtime.py`
+- Test: `tests/test_sandbox_runtime.py`
+
+- [ ] **Step 1: Run GitNexus impact analysis before editing symbols**
+
+Run:
+
+```bash
+npx gitnexus impact SandboxSettings --direction upstream
+```
+
+Expected: report direct callers and risk. If risk is HIGH or CRITICAL, stop and warn the user before editing.
+
+- [ ] **Step 2: Write failing tests for profile parsing and validation**
+
+Add to `tests/test_sandbox_runtime.py`:
+
+```python
+class TestProfileConfig:
+    def test_profiles_parse_from_config(self):
+        s = SandboxSettings.from_config({
+            "backend": "srt",
+            "allow_write": ["."],
+            "profiles": {
+                "github": {
+                    "match_commands": ["gh", "git"],
+                    "allow_read": ["~/.config/gh", "~/.gitconfig"],
+                    "allow_write": [".", "/private/tmp", "~/.cache/gh"],
+                    "allowed_domains": ["api.github.com", "github.com"],
+                },
+            },
+        })
+
+        assert "github" in s.profiles
+        profile = s.profiles["github"]
+        assert profile.match_commands == ["gh", "git"]
+        assert profile.allowed_domains == ["api.github.com", "github.com"]
+
+    def test_profile_list_fields_reject_scalar_strings(self):
+        with pytest.raises(ValueError, match="profiles.github.allow_write"):
+            SandboxSettings.from_config({
+                "backend": "srt",
+                "profiles": {
+                    "github": {"match_commands": ["gh"], "allow_write": "/tmp"},
+                },
+            })
+
+    def test_profile_match_commands_requires_list_of_strings(self):
+        with pytest.raises(ValueError, match="profiles.github.match_commands"):
+            SandboxSettings.from_config({
+                "backend": "srt",
+                "profiles": {"github": {"match_commands": "gh"}},
+            })
+
+    def test_profile_name_must_be_simple_identifier(self):
+        with pytest.raises(ValueError, match="profile name"):
+            SandboxSettings.from_config({
+                "backend": "srt",
+                "profiles": {"git hub": {"match_commands": ["gh"]}},
+            })
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest -q tests/test_sandbox_runtime.py::TestProfileConfig -q
+```
+
+Expected: FAIL because `SandboxProfile` and `profiles` do not exist yet.
+
+- [ ] **Step 4: Implement profile dataclass and config parsing**
+
+In `loom/core/security/sandbox_runtime.py`, add imports and helpers near `_as_path_list`:
+
+```python
+import re
+
+_PROFILE_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def _profile_key(profile_name: str, field_name: str) -> str:
+    return f"profiles.{profile_name}.{field_name}"
+
+
+def _validate_profile_name(name: str) -> str:
+    if not isinstance(name, str) or not _PROFILE_NAME_RE.match(name):
+        raise ValueError(
+            f"[security.sandbox] profile name must match "
+            f"[A-Za-z0-9_.-]+, got {name!r}."
+        )
+    return name
+```
+
+Add this dataclass before `SandboxSettings`:
+
+```python
+@dataclass(slots=True)
+class SandboxProfile:
+    """Named per-CLI sandbox expansion, activated only through permission grants."""
+
+    match_commands: list[str] = field(default_factory=list)
+    allow_read: list[str] = field(default_factory=list)
+    deny_read: list[str] = field(default_factory=list)
+    allow_write: list[str] = field(default_factory=list)
+    deny_write: list[str] = field(default_factory=list)
+    allowed_domains: list[str] = field(default_factory=list)
+    denied_domains: list[str] = field(default_factory=list)
+    allowed_sockets: list[str] = field(default_factory=list)
+    denied_sockets: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_config(cls, name: str, cfg: dict[str, Any] | None) -> "SandboxProfile":
+        if cfg is None:
+            cfg = {}
+        if not isinstance(cfg, dict):
+            raise ValueError(
+                f"[security.sandbox] profiles.{name} must be a table, "
+                f"got {type(cfg).__name__}: {cfg!r}."
+            )
+        return cls(
+            match_commands=_as_path_list(
+                _profile_key(name, "match_commands"),
+                cfg.get("match_commands"),
+            ),
+            allow_read=_as_path_list(_profile_key(name, "allow_read"), cfg.get("allow_read")),
+            deny_read=_as_path_list(_profile_key(name, "deny_read"), cfg.get("deny_read")),
+            allow_write=_as_path_list(_profile_key(name, "allow_write"), cfg.get("allow_write")),
+            deny_write=_as_path_list(_profile_key(name, "deny_write"), cfg.get("deny_write")),
+            allowed_domains=_as_path_list(
+                _profile_key(name, "allowed_domains"),
+                cfg.get("allowed_domains"),
+            ),
+            denied_domains=_as_path_list(
+                _profile_key(name, "denied_domains"),
+                cfg.get("denied_domains"),
+            ),
+            allowed_sockets=_as_path_list(
+                _profile_key(name, "allowed_sockets"),
+                cfg.get("allowed_sockets"),
+            ),
+            denied_sockets=_as_path_list(
+                _profile_key(name, "denied_sockets"),
+                cfg.get("denied_sockets"),
+            ),
+        )
+```
+
+Extend `SandboxSettings`:
+
+```python
+    profiles: dict[str, SandboxProfile] = field(default_factory=dict)
+```
+
+In `SandboxSettings.from_config`, parse profiles:
+
+```python
+        raw_profiles = cfg.get("profiles", {}) or {}
+        if not isinstance(raw_profiles, dict):
+            raise ValueError(
+                f"[security.sandbox] profiles must be a table, got "
+                f"{type(raw_profiles).__name__}: {raw_profiles!r}."
+            )
+        profiles = {
+            _validate_profile_name(name): SandboxProfile.from_config(name, value)
+            for name, value in raw_profiles.items()
+        }
+```
+
+Pass `profiles=profiles` into the returned `cls(...)`.
+
+- [ ] **Step 5: Run profile parsing tests**
+
+Run:
+
+```bash
+pytest -q tests/test_sandbox_runtime.py::TestProfileConfig
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Write failing tests for command detection and merge**
+
+Add to `tests/test_sandbox_runtime.py`:
+
+```python
+class TestProfileSelectionAndMerge:
+    def _settings(self):
+        return SandboxSettings.from_config({
+            "backend": "srt",
+            "allow_write": ["."],
+            "deny_read": ["~/.ssh"],
+            "allowed_domains": [],
+            "profiles": {
+                "github": {
+                    "match_commands": ["gh", "git"],
+                    "allow_read": ["~/.config/gh"],
+                    "allow_write": [".", "/private/tmp", "~/.cache/gh"],
+                    "allowed_domains": ["api.github.com", "github.com"],
+                },
+            },
+        })
+
+    def test_extract_command_root_skips_env_assignments(self):
+        assert extract_command_root("GH_HOST=github.com gh pr view 387") == "gh"
+
+    def test_select_profile_by_command_root(self):
+        selected = self._settings().select_profile_for_command("gh pr view 387")
+        assert selected == "github"
+
+    def test_explicit_profile_overrides_detection(self):
+        selected = self._settings().select_profile_for_command(
+            "npx wrapper gh pr view 387",
+            explicit="github",
+        )
+        assert selected == "github"
+
+    def test_unknown_explicit_profile_raises(self):
+        with pytest.raises(ValueError, match="Unknown sandbox profile"):
+            self._settings().select_profile_for_command("gh pr view 387", explicit="missing")
+
+    def test_merged_with_profile_preserves_base_denies_and_adds_domains(self):
+        effective = self._settings().merged_with_profile("github")
+        payload = effective.to_srt_json(workspace=Path("/repo"))
+        assert payload["filesystem"]["denyRead"] == [str(Path.home() / ".ssh")]
+        assert payload["filesystem"]["allowWrite"] == ["/repo", "/private/tmp", str(Path.home() / ".cache/gh")]
+        assert payload["network"]["allowedDomains"] == ["api.github.com", "github.com"]
+        assert effective.profiles == {}
+```
+
+- [ ] **Step 7: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest -q tests/test_sandbox_runtime.py::TestProfileSelectionAndMerge
+```
+
+Expected: FAIL because selection and merge helpers do not exist.
+
+- [ ] **Step 8: Implement command detection, profile selection, and merge**
+
+Add these helpers to `loom/core/security/sandbox_runtime.py`:
+
+```python
+def _dedupe(items: list[str]) -> list[str]:
+    out: list[str] = []
+    for item in items:
+        if item not in out:
+            out.append(item)
+    return out
+
+
+def extract_command_root(command: str) -> str | None:
+    """Return the first executable token after leading KEY=value assignments."""
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        return None
+    for token in tokens:
+        if "=" in token and not token.startswith("="):
+            key, _value = token.split("=", 1)
+            if key.replace("_", "").isalnum() and key[0].isalpha():
+                continue
+        return Path(token).name
+    return None
+```
+
+Add methods to `SandboxSettings`:
+
+```python
+    def select_profile_for_command(
+        self, command: str, *, explicit: str | None = None,
+    ) -> str | None:
+        if explicit:
+            if explicit not in self.profiles:
+                raise ValueError(f"Unknown sandbox profile {explicit!r}.")
+            return explicit
+
+        root = extract_command_root(command)
+        if not root:
+            return None
+        matches = [
+            name for name, profile in self.profiles.items()
+            if root in profile.match_commands
+        ]
+        if len(matches) > 1:
+            raise ValueError(
+                f"Command {root!r} matches multiple sandbox profiles: "
+                + ", ".join(sorted(matches))
+            )
+        return matches[0] if matches else None
+
+    def merged_with_profile(self, profile_name: str) -> "SandboxSettings":
+        if profile_name not in self.profiles:
+            raise ValueError(f"Unknown sandbox profile {profile_name!r}.")
+        p = self.profiles[profile_name]
+        return SandboxSettings(
+            backend=self.backend,
+            allow_read=_dedupe(self.allow_read + p.allow_read),
+            deny_read=_dedupe(self.deny_read + p.deny_read),
+            allow_write=_dedupe(self.allow_write + p.allow_write),
+            deny_write=_dedupe(self.deny_write + p.deny_write),
+            allowed_domains=_dedupe(self.allowed_domains + p.allowed_domains),
+            denied_domains=_dedupe(self.denied_domains + p.denied_domains),
+            allowed_sockets=_dedupe(self.allowed_sockets + p.allowed_sockets),
+            denied_sockets=_dedupe(self.denied_sockets + p.denied_sockets),
+            profiles={},
+        )
+```
+
+Export `SandboxProfile` and `extract_command_root` from `loom/core/security/__init__.py`.
+
+- [ ] **Step 9: Run sandbox runtime tests**
+
+Run:
+
+```bash
+pytest -q tests/test_sandbox_runtime.py
+```
+
+Expected: PASS. If srt is installed in a sandboxed developer environment, run with the local escalation path already used for PR #387 so the srt e2e can bind its localhost proxy.
+
+- [ ] **Step 10: Commit Task 1**
+
+Run:
+
+```bash
+git add loom/core/security/sandbox_runtime.py loom/core/security/__init__.py tests/test_sandbox_runtime.py
+git commit -m "feat(sandbox): add CLI sandbox profiles"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 2: Profile-Aware Scope Requirements
+
+**Files:**
+- Modify: `loom/platform/cli/tools.py`
+- Modify: `loom/core/harness/scope.py`
+- Test: `tests/test_scope_phase_b.py`
+
+- [ ] **Step 1: Run GitNexus impact analysis before editing symbols**
+
+Run:
+
+```bash
+npx gitnexus impact _make_run_bash_resolver --direction upstream
+npx gitnexus impact get_matcher --direction upstream
+```
+
+Expected: report direct callers and risk. If risk is HIGH or CRITICAL, stop and warn the user before editing.
+
+- [ ] **Step 2: Write failing resolver tests**
+
+Modify the `_bash_resolver` setup in `tests/test_scope_phase_b.py` so existing tests keep using no profile settings:
+
+```python
+_bash_resolver = _make_run_bash_resolver(_WORKSPACE)
+```
+
+Then add:
+
+```python
+from loom.core.security.sandbox_runtime import SandboxSettings
+
+
+def _profile_settings():
+    return SandboxSettings.from_config({
+        "backend": "srt",
+        "profiles": {
+            "github": {
+                "match_commands": ["gh"],
+                "allow_read": ["~/.config/gh"],
+                "allow_write": [".", "/private/tmp", "~/.cache/gh"],
+                "allowed_domains": ["api.github.com", "github.com"],
+            },
+        },
+    })
+
+
+class TestRunBashSandboxProfileResolver:
+    def test_auto_detects_github_profile(self):
+        resolver = _make_run_bash_resolver(_WORKSPACE, sandbox=_profile_settings())
+        call = _call("run_bash", {"command": "gh pr view 387"}, caps=ToolCapability.EXEC)
+        req = resolver(call)
+
+        profile_reqs = [r for r in req.requirements if r.resource == "sandbox_profile"]
+        assert len(profile_reqs) == 1
+        r = profile_reqs[0]
+        assert r.action == "use"
+        assert r.selector == "github"
+        assert r.constraints["allowed_domains"] == ["api.github.com", "github.com"]
+        assert req.metadata["sandbox_profile"] == "github"
+
+    def test_explicit_profile_argument_selects_profile(self):
+        resolver = _make_run_bash_resolver(_WORKSPACE, sandbox=_profile_settings())
+        call = _call(
+            "run_bash",
+            {"command": "npx wrapper gh pr view 387", "sandbox_profile": "github"},
+            caps=ToolCapability.EXEC,
+        )
+        req = resolver(call)
+        assert req.metadata["sandbox_profile"] == "github"
+
+    def test_unknown_explicit_profile_marks_request_as_invalid(self):
+        resolver = _make_run_bash_resolver(_WORKSPACE, sandbox=_profile_settings())
+        call = _call(
+            "run_bash",
+            {"command": "gh pr view 387", "sandbox_profile": "missing"},
+            caps=ToolCapability.EXEC,
+        )
+        with pytest.raises(ValueError, match="Unknown sandbox profile"):
+            resolver(call)
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest -q tests/test_scope_phase_b.py::TestRunBashSandboxProfileResolver
+```
+
+Expected: FAIL because `_make_run_bash_resolver` does not accept `sandbox`.
+
+- [ ] **Step 4: Add explicit sandbox profile matcher**
+
+In `loom/core/harness/scope.py`, add:
+
+```python
+class SandboxProfileMatcher:
+    """Exact profile-name matcher for per-session sandbox profile grants."""
+    def covers(self, grant: _HasScopeFields, requirement: _HasScopeFields) -> bool:
+        if grant.action != requirement.action:
+            return False
+        return grant.selector == requirement.selector
+```
+
+Then extend `_MATCHERS`:
+
+```python
+    "sandbox_profile": SandboxProfileMatcher(),
+```
+
+- [ ] **Step 5: Extend `_make_run_bash_resolver`**
+
+In `loom/platform/cli/tools.py`, change the signature:
+
+```python
+def _make_run_bash_resolver(workspace: Path, sandbox: SandboxSettings | None = None):
+```
+
+Inside `_resolve`, after the existing exec requirement is built, append profile requirement:
+
+```python
+        requirements = [
+            ScopeRequirement(
+                resource="exec",
+                action="execute",
+                selector="workspace",
+                constraints={"has_absolute_paths": has_absolute},
+                tool_name=call.tool_name,
+                capabilities=call.capabilities,
+            ),
+        ]
+
+        profile_name: str | None = None
+        if sandbox is not None and sandbox.backend == "srt" and sandbox.profiles:
+            explicit_profile = (call.args.get("sandbox_profile") or "").strip() or None
+            profile_name = sandbox.select_profile_for_command(
+                command, explicit=explicit_profile,
+            )
+            if profile_name:
+                profile = sandbox.profiles[profile_name]
+                requirements.append(ScopeRequirement(
+                    resource="sandbox_profile",
+                    action="use",
+                    selector=profile_name,
+                    constraints={
+                        "allow_read": list(profile.allow_read),
+                        "allow_write": list(profile.allow_write),
+                        "allowed_domains": list(profile.allowed_domains),
+                        "allowed_sockets": list(profile.allowed_sockets),
+                    },
+                    tool_name=call.tool_name,
+                    capabilities=call.capabilities,
+                ))
+
+        metadata = {"sandbox_profile": profile_name} if profile_name else {}
+        return ScopeRequest(
+            tool_name=call.tool_name,
+            capabilities=call.capabilities,
+            requirements=requirements,
+            metadata=metadata,
+        )
+```
+
+Preserve the existing `scope_unknown` branch by adding the same profile requirement there when a profile is selected. If parsing is too ambiguous to auto-detect, explicit `sandbox_profile` is still honored.
+
+- [ ] **Step 6: Run resolver tests**
+
+Run:
+
+```bash
+pytest -q tests/test_scope_phase_b.py::TestRunBashResolver tests/test_scope_phase_b.py::TestRunBashSandboxProfileResolver
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 2**
+
+Run:
+
+```bash
+git add loom/platform/cli/tools.py loom/core/harness/scope.py tests/test_scope_phase_b.py
+git commit -m "feat(sandbox): request profile grants for run_bash"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 3: Correct Once vs Lease vs Session Semantics
+
+**Files:**
+- Modify: `loom/core/harness/middleware.py`
+- Test: `tests/test_scope_phase_b.py`
+
+- [ ] **Step 1: Run GitNexus impact analysis before editing symbol**
+
+Run:
+
+```bash
+npx gitnexus impact _scope_aware_process --direction upstream
+```
+
+Expected: report direct callers and risk. If risk is HIGH or CRITICAL, stop and warn the user before editing.
+
+- [ ] **Step 2: Write failing tests for ONCE not creating reusable grants**
+
+Add to `tests/test_scope_phase_b.py`:
+
+```python
+from loom.core.harness.scope import ConfirmDecision
+
+
+class TestScopeConfirmDurations:
+    async def test_once_confirmation_does_not_create_reusable_scope_grant(self):
+        perm = PermissionContext(session_id="test")
+        reg = _make_registry(_tool_def(
+            "write_file",
+            caps=ToolCapability.MUTATES,
+            scope_resolver=_make_write_file_resolver(_WORKSPACE),
+        ))
+        call = _call("write_file", {"path": "doc/once.md"}, caps=ToolCapability.MUTATES)
+
+        result, confirm_fn, handler = await _run_middleware(
+            perm, call, confirm_result=ConfirmDecision.ONCE, registry=reg,
+        )
+
+        assert result.success
+        confirm_fn.assert_called_once()
+        handler.assert_called_once()
+        assert perm.grants == []
+        assert call.metadata["confirm_decision"] == "once"
+
+    async def test_scope_confirmation_creates_ttl_grant(self):
+        perm = PermissionContext(session_id="test")
+        reg = _make_registry(_tool_def(
+            "write_file",
+            caps=ToolCapability.MUTATES,
+            scope_resolver=_make_write_file_resolver(_WORKSPACE),
+        ))
+        call = _call("write_file", {"path": "doc/lease.md"}, caps=ToolCapability.MUTATES)
+
+        result, _confirm_fn, _handler = await _run_middleware(
+            perm, call, confirm_result=ConfirmDecision.SCOPE, registry=reg,
+        )
+
+        assert result.success
+        assert len(perm.grants) == 1
+        assert perm.grants[0].source == "lease"
+        assert perm.grants[0].valid_until > 0
+
+    async def test_auto_confirmation_creates_session_grant(self):
+        perm = PermissionContext(session_id="test")
+        reg = _make_registry(_tool_def(
+            "write_file",
+            caps=ToolCapability.MUTATES,
+            scope_resolver=_make_write_file_resolver(_WORKSPACE),
+        ))
+        call = _call("write_file", {"path": "doc/session.md"}, caps=ToolCapability.MUTATES)
+
+        result, _confirm_fn, _handler = await _run_middleware(
+            perm, call, confirm_result=ConfirmDecision.AUTO, registry=reg,
+        )
+
+        assert result.success
+        assert len(perm.grants) == 1
+        assert perm.grants[0].source == "auto_approve"
+        assert perm.grants[0].valid_until == 0
+```
+
+Update the existing `test_grants_created_after_confirm` so it passes `ConfirmDecision.SCOPE` instead of bare `True`:
+
+```python
+await _run_middleware(perm, call, confirm_result=ConfirmDecision.SCOPE, registry=reg)
+```
+
+- [ ] **Step 3: Run tests to verify ONCE test fails**
+
+Run:
+
+```bash
+pytest -q tests/test_scope_phase_b.py::TestScopeConfirmDurations tests/test_scope_phase_b.py::TestBlastRadiusScopeAware::test_grants_created_after_confirm
+```
+
+Expected: FAIL because ONCE currently adds a reusable grant.
+
+- [ ] **Step 4: Change scope-aware ONCE handling**
+
+In `loom/core/harness/middleware.py`, replace the ONCE branch:
+
+```python
+        if decision == ConfirmDecision.ONCE:
+            call.metadata["once_authorized"] = True
+        elif decision == ConfirmDecision.SCOPE:
+            self._request_to_grants(
+                scope_request, source="lease",
+                valid_until=_time.time() + self._SCOPE_LEASE_TTL,
+            )
+        elif decision == ConfirmDecision.AUTO:
+            self._request_to_grants(scope_request, source="auto_approve")
+```
+
+Leave legacy-path behavior unchanged in this task unless a test shows legacy UI semantics break. This task targets scope-aware calls, which `run_bash` uses.
+
+- [ ] **Step 5: Run scope duration tests**
+
+Run:
+
+```bash
+pytest -q tests/test_scope_phase_b.py::TestScopeConfirmDurations tests/test_scope_phase_b.py::TestBlastRadiusScopeAware
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 3**
+
+Run:
+
+```bash
+git add loom/core/harness/middleware.py tests/test_scope_phase_b.py
+git commit -m "fix(harness): make scope once approvals single-use"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 4: Apply Approved Profiles in run_bash Execution
+
+**Files:**
+- Modify: `loom/platform/cli/tools.py`
+- Test: create `tests/test_run_bash_sandbox_profiles.py`
+
+- [ ] **Step 1: Run GitNexus impact analysis before editing symbol**
+
+Run:
+
+```bash
+npx gitnexus impact make_run_bash_tool --direction upstream
+```
+
+Expected: report direct callers and risk. If risk is HIGH or CRITICAL, stop and warn the user before editing.
+
+- [ ] **Step 2: Write failing tests for per-call profile settings**
+
+Create `tests/test_run_bash_sandbox_profiles.py`:
+
+```python
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from loom.core.harness.middleware import ToolCall
+from loom.core.harness.permissions import ToolCapability, TrustLevel
+from loom.core.harness.scope import PermissionVerdict, ScopeRequirement, ScopeRequest
+from loom.core.security.sandbox_runtime import SandboxSettings
+from loom.platform.cli.tools import make_run_bash_tool
+
+
+def _settings():
+    return SandboxSettings.from_config({
+        "backend": "srt",
+        "allow_write": ["."],
+        "profiles": {
+            "github": {
+                "match_commands": ["gh"],
+                "allow_write": [".", "/private/tmp", "~/.cache/gh"],
+                "allowed_domains": ["api.github.com"],
+            },
+        },
+    })
+
+
+def _call(args, *, authorized=True):
+    call = ToolCall(
+        tool_name="run_bash",
+        args=args,
+        trust_level=TrustLevel.GUARDED,
+        capabilities=ToolCapability.EXEC,
+        session_id="s1",
+    )
+    if authorized:
+        call.metadata["scope_verdict"] = PermissionVerdict.ALLOW
+        call.metadata["scope_request"] = ScopeRequest(
+            tool_name="run_bash",
+            capabilities=ToolCapability.EXEC,
+            requirements=[
+                ScopeRequirement(
+                    resource="sandbox_profile",
+                    action="use",
+                    selector="github",
+                    tool_name="run_bash",
+                    capabilities=ToolCapability.EXEC,
+                ),
+            ],
+            metadata={"sandbox_profile": "github"},
+        )
+    return call
+
+
+async def test_profile_command_uses_merged_settings(tmp_path, monkeypatch):
+    from loom.platform.cli import tools
+
+    monkeypatch.setattr(tools, "srt_available", lambda: True)
+    written = []
+
+    def fake_write(settings, workspace):
+        written.append(settings)
+        return tmp_path / f"settings-{len(written)}.json"
+
+    monkeypatch.setattr(tools, "_srt_write_settings_file", fake_write)
+    monkeypatch.setattr(tools, "_srt_wrap_command", lambda cmd, path: f"srt:{path}:{cmd}")
+
+    captured = {}
+
+    class FakeProc:
+        returncode = 0
+        async def communicate(self):
+            return b"ok", None
+
+    async def fake_shell(command, **kwargs):
+        captured["command"] = command
+        return FakeProc()
+
+    monkeypatch.setattr(tools.asyncio, "create_subprocess_shell", fake_shell)
+    monkeypatch.setattr(tools, "_terminate_proc_group", AsyncMock())
+
+    tool = make_run_bash_tool(tmp_path, sandbox=_settings())
+    result = await tool.executor(_call({"command": "gh pr view 387"}))
+
+    assert result.success is True
+    assert "srt:" in captured["command"]
+    assert len(written) == 2
+    effective = written[-1]
+    assert effective.allowed_domains == ["api.github.com"]
+    assert "/private/tmp" in effective.allow_write
+
+
+async def test_profile_command_without_scope_metadata_fails_closed(tmp_path, monkeypatch):
+    from loom.platform.cli import tools
+
+    monkeypatch.setattr(tools, "srt_available", lambda: True)
+    monkeypatch.setattr(tools, "_srt_write_settings_file", lambda settings, workspace: tmp_path / "settings.json")
+
+    tool = make_run_bash_tool(tmp_path, sandbox=_settings())
+    result = await tool.executor(_call({"command": "gh pr view 387"}, authorized=False))
+
+    assert result.success is False
+    assert result.failure_type == "permission_denied"
+    assert "sandbox profile 'github' was not authorized" in result.error
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest -q tests/test_run_bash_sandbox_profiles.py
+```
+
+Expected: FAIL because executor does not create per-call merged settings or check profile authorization metadata.
+
+- [ ] **Step 4: Add profile authorization helper in `make_run_bash_tool`**
+
+Inside `make_run_bash_tool`, add:
+
+```python
+    def _selected_profile_for_call(call: ToolCall) -> str | None:
+        if not _sandbox_active or sandbox is None:
+            return None
+        explicit_profile = (call.args.get("sandbox_profile") or "").strip() or None
+        return sandbox.select_profile_for_command(
+            call.args.get("command", ""), explicit=explicit_profile,
+        )
+
+    def _profile_authorized_for_call(call: ToolCall, profile_name: str) -> bool:
+        scope_request = call.metadata.get("scope_request")
+        if scope_request is None:
+            return False
+        for req in getattr(scope_request, "requirements", []):
+            if (
+                req.resource == "sandbox_profile"
+                and req.action == "use"
+                and req.selector == profile_name
+            ):
+                return bool(
+                    call.metadata.get("once_authorized")
+                    or call.metadata.get("user_decision")
+                    or call.metadata.get("scope_verdict")
+                )
+        return False
+```
+
+Change `_maybe_wrap` to accept `call`:
+
+```python
+    def _maybe_wrap(cmd: str, call: ToolCall) -> tuple[str, str | None]:
+        if not _sandbox_active or _sandbox_settings_path is None or sandbox is None:
+            return cmd, None
+        profile_name = _selected_profile_for_call(call)
+        settings_path = _sandbox_settings_path
+        if profile_name:
+            if not _profile_authorized_for_call(call, profile_name):
+                raise PermissionError(
+                    f"sandbox profile {profile_name!r} was not authorized for this run_bash call"
+                )
+            effective = sandbox.merged_with_profile(profile_name)
+            settings_path = _srt_write_settings_file(effective, workspace)
+        return _srt_wrap_command(cmd, settings_path), profile_name
+```
+
+In the foreground path:
+
+```python
+            wrapped_command, profile_name = _maybe_wrap(command, call)
+            proc = await asyncio.create_subprocess_shell(
+                wrapped_command,
+                ...
+            )
+```
+
+In the async path, call `_maybe_wrap` before `jobstore.submit`; if it raises `PermissionError`, return a denied `ToolResult` instead of submitting:
+
+```python
+            try:
+                wrapped_command, profile_name = _maybe_wrap(command, call)
+            except PermissionError as exc:
+                return ToolResult(
+                    call_id=call.id,
+                    tool_name=call.tool_name,
+                    success=False,
+                    error=str(exc),
+                    failure_type="permission_denied",
+                )
+            job_id = jobstore.submit(
+                "run_bash",
+                {"command": command, "timeout": timeout, "sandbox_profile": profile_name},
+                lambda: _run_bash_job(wrapped_command, cwd, timeout, scratchpad),
+            )
+```
+
+Apply the same `PermissionError` handling around foreground wrapping.
+
+- [ ] **Step 5: Add `sandbox_profile` to tool schema and wire resolver settings**
+
+In `make_run_bash_tool` input schema, add:
+
+```python
+                "sandbox_profile": {
+                    "type": "string",
+                    "description": (
+                        "Optional named sandbox profile to request for this command. "
+                        "Still requires human approval through the normal permission flow."
+                    ),
+                },
+```
+
+At the return `ToolDefinition`, change:
+
+```python
+        scope_resolver=_make_run_bash_resolver(workspace, sandbox=sandbox),
+```
+
+- [ ] **Step 6: Run run_bash profile tests**
+
+Run:
+
+```bash
+pytest -q tests/test_run_bash_sandbox_profiles.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run existing integration tests for run_bash**
+
+Run:
+
+```bash
+pytest -q tests/test_integration.py::TestTools::test_run_bash_success tests/test_integration.py::TestTools::test_run_bash_timeout
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 4**
+
+Run:
+
+```bash
+git add loom/platform/cli/tools.py tests/test_run_bash_sandbox_profiles.py tests/test_integration.py
+git commit -m "feat(sandbox): apply approved profiles to run_bash"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 5: Session Wiring, Documentation, and Config Examples
+
+**Files:**
+- Modify: `loom/core/session.py`
+- Modify: `loom.toml.example`
+- Modify: `doc/37-loom-toml-參考.md`
+- Modify: `doc/55-Sandbox-Runtime.md`
+- Test: `tests/test_sandbox_runtime.py`
+
+- [ ] **Step 1: Run GitNexus impact analysis before editing session wiring**
+
+Run:
+
+```bash
+npx gitnexus impact LoomSession --direction upstream
+```
+
+Expected: report direct callers and risk. If risk is HIGH or CRITICAL, stop and warn the user before editing.
+
+- [ ] **Step 2: Confirm session wiring already passes `SandboxSettings`**
+
+Inspect `loom/core/session.py` and verify it still passes `sandbox=_sandbox_settings` into `make_run_bash_tool`. If Task 4 only changed the resolver factory inside `make_run_bash_tool`, no session code change is needed.
+
+Run:
+
+```bash
+rg -n "make_run_bash_tool|sandbox=_sandbox_settings" loom/core/session.py
+```
+
+Expected: both strings appear near the run_bash registration.
+
+- [ ] **Step 3: Add docs for profiles**
+
+Add to `loom.toml.example` under `[security.sandbox]`:
+
+```toml
+# Optional CLI-specific profiles. Profiles do not grant access by
+# themselves; they are requested by run_bash and must be approved through
+# the normal permission prompt (once / 30 min / session / deny).
+#
+# [security.sandbox.profiles.github]
+# match_commands = ["gh", "git"]
+# allow_read = ["~/.config/gh", "~/.gitconfig"]
+# allow_write = [".", "/private/tmp", "~/.cache/gh"]
+# allowed_domains = [
+#   "api.github.com",
+#   "github.com",
+#   "raw.githubusercontent.com",
+#   "objects.githubusercontent.com",
+#   "codeload.github.com",
+# ]
+```
+
+Add equivalent concise text to `doc/37-loom-toml-參考.md`:
+
+```markdown
+### Sandbox profiles
+
+Profiles describe CLI-specific sandbox expansions. A profile is not an
+automatic allowlist; `run_bash` requests it and the user approves once, for
+30 minutes, for the current session, or denies it.
+```
+
+Add operational guidance to `doc/55-Sandbox-Runtime.md`:
+
+```markdown
+## CLI profiles
+
+Use profiles for tools such as `gh`, `opencli`, `npm`, `pip`, or project
+wrappers that need a predictable set of domains and config/cache paths.
+Profiles are runtime grants, not persistent authorization.
+```
+
+- [ ] **Step 4: Run docs/config grep checks**
+
+Run:
+
+```bash
+rg -n "sandbox.profiles|match_commands|once / 30 min / session / deny" loom.toml.example doc/37-loom-toml-參考.md doc/55-Sandbox-Runtime.md
+```
+
+Expected: all three docs mention profile runtime authorization.
+
+- [ ] **Step 5: Commit Task 5**
+
+Run:
+
+```bash
+git add loom.toml.example doc/37-loom-toml-參考.md doc/55-Sandbox-Runtime.md loom/core/session.py
+git commit -m "docs(sandbox): document CLI profile grants"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 6: Final Verification and Review Comment
+
+**Files:**
+- No source edits expected unless verification exposes a bug.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+pytest -q tests/test_sandbox_runtime.py tests/test_scope_phase_b.py tests/test_run_bash_sandbox_profiles.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run neighboring security/run_bash test slice**
+
+Run:
+
+```bash
+pytest -q tests -k "sandbox or security or run_bash or command_scanner or self_termination"
+```
+
+Expected: PASS. If local Codex sandbox blocks srt localhost proxy e2e, rerun with the approved local escalation used during PR #387 review.
+
+- [ ] **Step 3: Run formatting and diff checks**
+
+Run:
+
+```bash
+python -m py_compile loom/core/security/sandbox_runtime.py loom/platform/cli/tools.py loom/core/harness/scope.py loom/core/harness/middleware.py
+git diff --check
+```
+
+Expected: no output from `git diff --check`, py_compile exits 0.
+
+- [ ] **Step 4: Run GitNexus change detection**
+
+Run:
+
+```bash
+npx gitnexus detect-changes --scope compare --base-ref master
+```
+
+Expected: risk level is low or medium and affected flows are limited to run_bash / sandbox / permission paths. If high or critical, stop and review the affected process list before creating a PR.
+
+- [ ] **Step 5: Manual smoke through middleware**
+
+Run this focused smoke script:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import asyncio
+
+from loom.core.harness.middleware import BlastRadiusMiddleware, ToolCall, ToolResult
+from loom.core.harness.permissions import PermissionContext, ToolCapability, TrustLevel
+from loom.core.harness.registry import ToolDefinition, ToolRegistry
+from loom.core.harness.scope import ConfirmDecision
+from loom.core.security.sandbox_runtime import SandboxSettings
+from loom.platform.cli.tools import _make_run_bash_resolver
+
+workspace = Path.cwd()
+settings = SandboxSettings.from_config({
+    "backend": "srt",
+    "profiles": {
+        "github": {
+            "match_commands": ["gh"],
+            "allowed_domains": ["api.github.com"],
+            "allow_write": [".", "/private/tmp"],
+        },
+    },
+})
+
+async def run_once(decision):
+    perm = PermissionContext(session_id="smoke")
+    call = ToolCall(
+        tool_name="run_bash",
+        args={"command": "gh pr view 387"},
+        trust_level=TrustLevel.GUARDED,
+        capabilities=ToolCapability.EXEC,
+        session_id="smoke",
+    )
+    reg = ToolRegistry()
+    reg.register(ToolDefinition(
+        name="run_bash",
+        description="smoke",
+        trust_level=TrustLevel.GUARDED,
+        input_schema={},
+        executor=AsyncMock(return_value=ToolResult(call_id=call.id, tool_name="run_bash", success=True)),
+        capabilities=ToolCapability.EXEC,
+        scope_resolver=_make_run_bash_resolver(workspace, sandbox=settings),
+    ))
+    handler = AsyncMock(return_value=ToolResult(call_id=call.id, tool_name="run_bash", success=True))
+    mw = BlastRadiusMiddleware(
+        perm_ctx=perm,
+        confirm_fn=AsyncMock(return_value=decision),
+        registry=reg,
+    )
+    result = await mw.process(call, handler)
+    return result, perm, handler
+
+async def main():
+    once_result, once_perm, once_handler = await run_once(ConfirmDecision.ONCE)
+    assert once_result.success
+    assert once_handler.called
+    assert once_perm.grants == []
+
+    scope_result, scope_perm, _ = await run_once(ConfirmDecision.SCOPE)
+    assert scope_result.success
+    assert len(scope_perm.grants) == 2
+    assert any(g.resource == "sandbox_profile" and g.valid_until > 0 for g in scope_perm.grants)
+
+    session_result, session_perm, _ = await run_once(ConfirmDecision.AUTO)
+    assert session_result.success
+    assert len(session_perm.grants) == 2
+    assert any(g.resource == "sandbox_profile" and g.valid_until == 0 for g in session_perm.grants)
+
+    fresh = PermissionContext(session_id="fresh")
+    assert fresh.grants == []
+    print("sandbox profile permission smoke passed")
+
+asyncio.run(main())
+PY
+```
+
+Expected: `sandbox profile permission smoke passed`.
+
+- [ ] **Step 6: Prepare PR summary**
+
+Use this PR body:
+
+```markdown
+## Summary
+
+- add named srt sandbox profiles for CLI-specific domains and config/cache paths
+- route profile use through existing run_bash scope grants and human confirmation
+- apply approved profiles per call without changing global sandbox settings
+- fix scope-aware ONCE semantics so one-time approval is single-use
+
+## Verification
+
+- `pytest -q tests/test_sandbox_runtime.py tests/test_scope_phase_b.py tests/test_run_bash_sandbox_profiles.py`
+- `pytest -q tests -k "sandbox or security or run_bash or command_scanner or self_termination"`
+- `python -m py_compile loom/core/security/sandbox_runtime.py loom/platform/cli/tools.py loom/core/harness/scope.py loom/core/harness/middleware.py`
+- `git diff --check`
+- `npx gitnexus detect-changes --scope compare --base-ref master`
+```

--- a/docs/superpowers/specs/2026-05-18-sandbox-profile-scope-grants-design.md
+++ b/docs/superpowers/specs/2026-05-18-sandbox-profile-scope-grants-design.md
@@ -1,0 +1,223 @@
+# Sandbox Profile Scope Grants Design
+
+Date: 2026-05-18
+
+## Goal
+
+Make OS-level sandboxing practical for real CLI workflows without turning the
+global sandbox allowlist into a permanent hole.
+
+The sandbox remains the safety wall. Human authorization remains the control
+surface. A CLI such as `gh`, `opencli`, or an Obsidian-related CLI can request a
+named sandbox profile, and the user can approve it once, for 30 minutes, for
+the current session, or deny it. Grants are runtime-only and disappear when the
+session ends or Loom restarts.
+
+## Non-Goals
+
+- No persistent profile authorization across sessions.
+- No unsandboxed automatic escape hatch for CLI tools.
+- No broad global domain/path allowlist as the recommended workflow.
+- No deep shell parser in the first version.
+
+## User Model
+
+When the agent asks to run:
+
+```bash
+gh pr comment 387 --body "..."
+```
+
+Loom detects that `gh` matches the `github` sandbox profile and prompts:
+
+```text
+Allow run_bash with sandbox profile "github"?
+
+This profile adds:
+  network: api.github.com, github.com, raw.githubusercontent.com, ...
+  read: ~/.config/gh, ~/.gitconfig
+  write: ~/.cache/gh, workspace, /private/tmp
+
+Options: once / 30 min / this session / deny
+```
+
+This mirrors existing guarded tool behavior: the agent can propose the action,
+but the user controls whether the profile is available.
+
+## Configuration
+
+Base sandbox config stays strict:
+
+```toml
+[security.sandbox]
+backend = "srt"
+allow_write = [".", "/private/tmp"]
+deny_read = ["~/.ssh", "~/.aws", "~/.gnupg", ".env"]
+allowed_domains = []
+```
+
+Profiles live under the same block:
+
+```toml
+[security.sandbox.profiles.github]
+match_commands = ["gh", "git"]
+allow_read = ["~/.config/gh", "~/.gitconfig"]
+allow_write = [".", "/private/tmp", "~/.cache/gh"]
+allowed_domains = [
+  "api.github.com",
+  "github.com",
+  "raw.githubusercontent.com",
+  "objects.githubusercontent.com",
+  "codeload.github.com",
+]
+```
+
+Future CLIs are added as data, not code:
+
+```toml
+[security.sandbox.profiles.opencli]
+match_commands = ["opencli"]
+allow_read = ["~/.config/opencli"]
+allow_write = [".", "/private/tmp", "~/.cache/opencli"]
+allowed_domains = ["api.openai.com"]
+```
+
+## Detection
+
+The first version supports two ways to select a profile:
+
+1. Automatic detection from the shell command's executable token.
+2. Explicit `run_bash` argument, for wrapper commands or ambiguous shells:
+
+```json
+{
+  "command": "npx some-wrapper gh pr view 387",
+  "sandbox_profile": "github"
+}
+```
+
+Explicit selection does not bypass authorization. It only tells Loom which
+profile to request.
+
+The first version intentionally keeps parsing shallow:
+
+- Parse the first executable token after leading environment assignments.
+- Match against `profiles.*.match_commands`.
+- If the command contains complex shell forms that hide the executable, rely on
+  explicit `sandbox_profile`.
+- If multiple profiles match, fail closed and ask for explicit selection.
+
+## Permission Flow
+
+`run_bash` scope resolution gains a sandbox profile requirement:
+
+```text
+ScopeRequirement(
+  resource="sandbox_profile",
+  action="use",
+  selector="github",
+  constraints={
+    "network": [...],
+    "allow_read": [...],
+    "allow_write": [...],
+  },
+)
+```
+
+This requirement goes through the existing `PermissionContext` and confirm
+middleware:
+
+- Approve once: grants only this call.
+- 30 minutes: creates a TTL scope grant.
+- This session: creates a non-persistent session grant.
+- Deny: command does not run.
+
+Profile grants live only in memory. They are not written to `loom.toml` and are
+not restored after restart.
+
+## Sandbox Merge
+
+Execution uses a per-call effective sandbox:
+
+```text
+effective = base_sandbox + approved_profile
+```
+
+Merge rules:
+
+- Lists are unioned and de-duplicated while preserving stable order.
+- Base deny rules remain present.
+- Profile allow rules may add domains, reads, writes, and sockets.
+- Unknown profile, invalid profile config, or settings render failure is a hard
+  error before subprocess execution.
+- If a profile is detected but not approved, do not run under base settings as
+  a fallback, because that turns an authorization denial into a confusing
+  sandbox failure.
+
+The merged settings file should be generated per call or cached by a stable
+hash of the effective settings.
+
+## UI and Messaging
+
+The confirmation prompt should make profile expansion visible in plain terms:
+
+- Profile name.
+- Matched command.
+- Added network domains.
+- Added readable paths.
+- Added writable paths.
+- Grant duration options.
+
+If srt blocks a command due to missing network/path permission, Loom should
+surface a helpful hint:
+
+```text
+Sandbox blocked network access to api.example.com.
+Add it to a sandbox profile and approve that profile for run_bash.
+```
+
+This is a follow-up nicety, not required for the first merge.
+
+## Security Properties
+
+- Profiles are not automatic allowlists; they are permission requests.
+- Human approval is required before profile privileges affect execution.
+- The sandbox remains active for all profile-based commands.
+- Existing `CommandScanner`, `SelfTerminationGuard`, and run_bash scope checks
+  still run.
+- Deny means deny: no unsandboxed fallback and no global allowlist mutation.
+- Grants are scoped by profile and session lifetime, not by arbitrary command
+  string alone.
+
+## Test Plan
+
+Unit tests:
+
+- Profile config parsing rejects scalar strings and unknown profile references.
+- Command root detection maps `gh ...` to `github`.
+- Explicit `sandbox_profile` selects the requested profile.
+- Ambiguous multiple matches fail closed.
+- Effective sandbox merge preserves base denies and adds profile allow rules.
+
+Permission tests:
+
+- Unapproved profile requirement prompts.
+- Once approval applies only to one call.
+- TTL approval expires.
+- Session approval is available during the same `PermissionContext`.
+- New session has no previous profile grants.
+
+Integration tests:
+
+- `gh` profile renders srt settings with GitHub domains and gh config paths.
+- `run_bash` foreground and async paths both use merged settings.
+- Denied profile does not execute the command.
+- Unknown profile produces a clear tool error before subprocess execution.
+
+## Open Questions
+
+- Whether profile grants should imply `exec: workspace` or remain a separate
+  requirement shown alongside profile use.
+- Whether to provide built-in profile templates for `github`, `python-package`,
+  and `node-package`, or keep all profiles user-defined in the first version.
+- Whether `/scope` should group active grants by profile for easier scanning.

--- a/loom/core/cognition/context.py
+++ b/loom/core/cognition/context.py
@@ -87,8 +87,12 @@ def estimate_block_count(messages: list[dict[str, Any]]) -> int:
       • system            → 1 text block (when content present)
       • user (str)        → 1 text block
       • user (list)       → len(content) blocks (already in block form)
-      • assistant         → 1 text block iff text is present; + one
-                            ``tool_use`` block per entry in tool_calls
+      • assistant         → one ``thinking`` block per ``_thinking_blocks``
+                            entry (Anthropic / MiniMax preserve these on
+                            the wire to keep the reasoning chain across
+                            turns); + 1 text block iff text is present;
+                            + one ``tool_use`` block per entry in
+                            tool_calls
       • tool              → 1 ``tool_result`` block
 
     Consecutive ``tool`` messages become a single wire user message on
@@ -103,6 +107,13 @@ def estimate_block_count(messages: list[dict[str, Any]]) -> int:
         role = m.get("role")
         content = m.get("content")
         if role == "assistant":
+            # Reasoning models (Anthropic thinking, MiniMax M2.x) emit
+            # ``_thinking_blocks`` that ``_to_anthropic_messages`` puts
+            # back on the wire ahead of the text/tool_use blocks. Each
+            # thinking block is its own content block at the API
+            # boundary, so it counts against the 2013 cap too.
+            tbs = m.get("_thinking_blocks") or []
+            n += len(tbs)
             if content:
                 n += 1
             tcs = m.get("tool_calls") or []

--- a/loom/core/cognition/context.py
+++ b/loom/core/cognition/context.py
@@ -1,46 +1,154 @@
 """
 Context Budget Manager.
 
-Tracks token usage across a session and signals when the context window
-is approaching its limit so the session can trigger compression before
-performance degrades.
+Tracks token + content-block usage across a session and signals when the
+context window is approaching its limit so the session can trigger
+compression before performance degrades.
 
-Token estimation uses the ~4 chars/token heuristic (accurate ±15% for
-English; good enough for triggering compression thresholds).
+Two pressure dimensions are tracked independently:
+
+  • token usage — fraction of the model's context window consumed
+  • content-block count — number of Anthropic-wire content blocks the
+    next request would carry (Anthropic-compat endpoints — notably
+    MiniMax — enforce a hard cap around 2013 blocks regardless of token
+    budget). A heavy parallel-tool session can hit the block ceiling
+    while the token meter still reads ~40%.
+
+Token estimation is char-based with separate weights for CJK (≈1.5
+chars/token) and everything else (≈4 chars/token). Mixed text is
+weighted per-character. Good enough for triggering thresholds; the
+authoritative count comes back from the provider via record_response().
 """
 
 import json
 from dataclasses import dataclass, field
 from typing import Any
 
+# MiniMax's Anthropic-compat endpoint rejects requests with more than
+# ~2013 content blocks. Default to a conservative ceiling with headroom
+# so compaction triggers before the wire actually overflows.
+DEFAULT_MAX_BLOCKS = 2000
+
+
+def _is_cjk(ch: str) -> bool:
+    """Approximate CJK detection covering the common ranges.
+
+    Covers CJK Unified Ideographs (4E00-9FFF), Hiragana/Katakana
+    (3040-30FF), Hangul Syllables (AC00-D7AF), and CJK extension A
+    (3400-4DBF). Skips rarer extensions — they're an order of magnitude
+    less common in practice and not worth the branch cost.
+    """
+    cp = ord(ch)
+    return (
+        0x4E00 <= cp <= 0x9FFF
+        or 0x3040 <= cp <= 0x30FF
+        or 0xAC00 <= cp <= 0xD7AF
+        or 0x3400 <= cp <= 0x4DBF
+    )
+
 
 def estimate_tokens(obj: Any) -> int:
-    """Rough token count for any serialisable object."""
-    if isinstance(obj, str):
-        return max(1, len(obj) // 4)
-    try:
-        return max(1, len(json.dumps(obj, ensure_ascii=False)) // 4)
-    except (TypeError, ValueError):
+    """Rough token count for any serialisable object.
+
+    ASCII / Latin runs at ~4 chars/token; CJK at ~1.5 chars/token.
+    Mixing both with a flat 4-char heuristic underestimates CJK-heavy
+    payloads by ~60% and was a primary cause of usage_fraction drift
+    after compaction in Chinese-language sessions.
+    """
+    if not isinstance(obj, str):
+        try:
+            obj = json.dumps(obj, ensure_ascii=False)
+        except (TypeError, ValueError):
+            return 1
+
+    if not obj:
         return 1
+
+    cjk_chars = 0
+    other_chars = 0
+    for ch in obj:
+        if _is_cjk(ch):
+            cjk_chars += 1
+        else:
+            other_chars += 1
+    # int division keeps the heuristic feel but the CJK weight (3/2) is
+    # tight enough that the previous test contract (400 ASCII chars →
+    # 100 tokens) still holds.
+    tokens = (other_chars // 4) + (cjk_chars * 2 // 3)
+    return max(1, tokens)
+
+
+def estimate_block_count(messages: list[dict[str, Any]]) -> int:
+    """Approximate Anthropic-wire content blocks from OpenAI-canonical
+    messages.
+
+    Mapping rules (matches ``LLMProvider._to_anthropic_messages``):
+
+      • system            → 1 text block (when content present)
+      • user (str)        → 1 text block
+      • user (list)       → len(content) blocks (already in block form)
+      • assistant         → 1 text block iff text is present; + one
+                            ``tool_use`` block per entry in tool_calls
+      • tool              → 1 ``tool_result`` block
+
+    Consecutive ``tool`` messages become a single wire user message on
+    the way out but each still occupies one content block, so the count
+    is what matters here — not message count.
+
+    Used to gate compaction and to display the binding constraint in
+    the UI.
+    """
+    n = 0
+    for m in messages:
+        role = m.get("role")
+        content = m.get("content")
+        if role == "assistant":
+            if content:
+                n += 1
+            tcs = m.get("tool_calls") or []
+            n += len(tcs)
+        elif role == "tool":
+            n += 1
+        elif role == "system":
+            if content:
+                n += 1
+        else:  # user (or anything unexpected)
+            if isinstance(content, list):
+                n += max(1, len(content))
+            elif content:
+                n += 1
+            else:
+                n += 1
+    return n
 
 
 @dataclass
 class ContextBudget:
     """
-    Tracks token consumption and advises on compression.
+    Tracks token + content-block consumption and advises on compression.
 
     Parameters
     ----------
     total_tokens : int
         Maximum context window of the active model.
     compression_threshold : float
-        Fraction of total_tokens at which `should_compress()` returns True.
-        Default 0.80 (compress when 80% full).
+        Fraction of total_tokens at which the token side of
+        ``should_compress()`` fires. Default 0.80.
+    max_blocks : int
+        Hard ceiling on wire content blocks the next request can carry.
+        Default ``DEFAULT_MAX_BLOCKS`` (sized for MiniMax's 2013 cap).
+    block_threshold : float
+        Fraction of max_blocks at which the block side of
+        ``should_compress()`` fires. Default 0.85 — leaves ~300 blocks
+        of headroom for the in-flight turn's growth.
     """
 
     total_tokens: int
     compression_threshold: float = 0.80
+    max_blocks: int = DEFAULT_MAX_BLOCKS
+    block_threshold: float = 0.85
     used_tokens: int = field(default=0, init=False)
+    block_count: int = field(default=0, init=False)
 
     # --- Accounting ---
 
@@ -67,8 +175,24 @@ class ContextBudget:
         self.used_tokens = input_tokens + output_tokens
 
     def record_messages(self, messages: list[dict[str, Any]]) -> None:
-        """Recount usage from the current message list (after compression)."""
+        """Recount token + block usage from the current message list.
+
+        Called after compaction and after any non-provider mutation of
+        the message list (sanitize, observation masking, system-prompt
+        refresh). Keeps both dimensions in sync so the UI doesn't show
+        a stale reading until the next API call lands.
+        """
         self.used_tokens = sum(estimate_tokens(m) for m in messages)
+        self.block_count = estimate_block_count(messages)
+
+    def update_block_count(self, messages: list[dict[str, Any]]) -> None:
+        """Refresh only the block-count side from the current messages.
+
+        Use when message structure changes (sanitize, masking) but a
+        full token recount isn't desired — e.g. between turns when
+        record_response is the authoritative token source.
+        """
+        self.block_count = estimate_block_count(messages)
 
     def add(self, tokens: int) -> None:
         self.used_tokens += tokens
@@ -83,18 +207,62 @@ class ContextBudget:
     def usage_fraction(self) -> float:
         return self.used_tokens / self.total_tokens if self.total_tokens else 0.0
 
+    @property
+    def block_fraction(self) -> float:
+        return self.block_count / self.max_blocks if self.max_blocks else 0.0
+
+    @property
+    def pressure(self) -> float:
+        """The binding constraint — whichever dimension is fuller.
+
+        This is what the UI footer should show: a 42% token reading
+        while the block side sits at 87% is "really" an 87% session
+        from the provider's perspective.
+        """
+        return max(self.usage_fraction, self.block_fraction)
+
+    @property
+    def block_bound(self) -> bool:
+        """True iff block pressure exceeds token pressure — the session
+        is about to hit the wire cap before the token cap."""
+        return self.block_fraction > self.usage_fraction
+
     def should_compress(self) -> bool:
-        return self.usage_fraction >= self.compression_threshold
+        return (
+            self.usage_fraction >= self.compression_threshold
+            or self.block_fraction >= self.block_threshold
+        )
 
     def fits(self, text: str) -> bool:
         return estimate_tokens(text) <= self.remaining
 
     def reset(self) -> None:
         self.used_tokens = 0
+        self.block_count = 0
+
+    def format_pressure(self) -> str:
+        """Compact footer string showing the binding constraint.
+
+        Examples:
+            ``"42.1%"``                     — token-bound, normal
+            ``"42.1% · blocks 87.3%"``      — block-bound (wire near cap)
+
+        UI surfaces (Discord embed footer, CLI footer) call this so the
+        displayed % always tracks the side that's actually about to
+        clip — not whichever dimension happens to be in the heuristic.
+        """
+        pct = self.pressure * 100
+        if self.block_bound and self.block_count > 0:
+            blk = self.block_fraction * 100
+            return f"{pct:.1f}% · blocks {blk:.1f}%"
+        return f"{pct:.1f}%"
 
     def __str__(self) -> str:
         pct = self.usage_fraction * 100
+        blk = self.block_fraction * 100
+        tag = "  [compress]" if self.should_compress() else ""
         return (
-            f"ContextBudget({self.used_tokens:,}/{self.total_tokens:,} tokens, "
-            f"{pct:.1f}%{'  [compress]' if self.should_compress() else ''})"
+            f"ContextBudget({self.used_tokens:,}/{self.total_tokens:,} tokens "
+            f"{pct:.1f}%, blocks {self.block_count}/{self.max_blocks} "
+            f"{blk:.1f}%{tag})"
         )

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1997,9 +1997,13 @@ class LoomSession:
             # Compress before the first LLM call if already over threshold.
             # (budget.used_tokens reflects the last response's actual token count,
             # so this check is accurate from turn 2 onward.)
+            # ``should_compress`` is OR over token + block dimensions —
+            # MiniMax's 2013-block wire cap can bite long before the
+            # token budget does, especially on parallel-tool sessions.
+            self.budget.update_block_count(self.messages)
             if self.budget.should_compress():
                 console.print(
-                    f"[yellow]  Context at {self.budget.usage_fraction * 100:.1f}% — "
+                    f"[yellow]  Context at {self.budget.format_pressure()} — "
                     f"compressing…[/yellow]"
                 )
                 await self._smart_compact()
@@ -3183,6 +3187,13 @@ class LoomSession:
             )
             msg["_masked"] = True
 
+        # Tool-result bodies shrank en masse; recount once at the end so
+        # the footer % reflects the freed wire surface before the next
+        # provider response lands. Block count is the dimension that
+        # actually changed (text shrank but slot count is unchanged) —
+        # token estimate also moves, so do a full record_messages.
+        self.budget.record_messages(self.messages)
+
     def _sanitize_history(self) -> None:
         """Remove incomplete tool_use sequences and fix malformed tool args.
 
@@ -3366,6 +3377,11 @@ class LoomSession:
                     cb(_args_fixed, _msgs_dropped)
                 except Exception:
                     pass
+            # Resync the budget — messages were rewritten, so the
+            # block_count from the last API call no longer matches the
+            # current history. Without this the footer % can stay
+            # stale-high after a sanitize-only turn.
+            self.budget.record_messages(self.messages)
 
     # =========================================================================
     # SECTION 8 — TIER / TELEMETRY
@@ -4496,6 +4512,10 @@ class LoomSession:
             else:
                 # No existing block — append
                 self.messages[0]["content"] += f"\n\n{new_text}"
+            # System prompt size changed — keep budget aligned so the
+            # footer % doesn't drift away from reality until the next
+            # provider response arrives.
+            self.budget.record_messages(self.messages)
         except Exception:
             pass  # never block the session on a MemoryIndex refresh failure
 

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -2546,9 +2546,16 @@ class LoomSession:
 
                     # Check budget after tool results are appended — the next LLM
                     # call in this loop will include them and may push over the limit.
+                    # Refresh block_count first: a parallel-tool batch just
+                    # appended N tool_result rows, but ``record_response``
+                    # only updates token totals, so without this resync
+                    # ``should_compress`` would still see the previous turn's
+                    # block reading and miss a wire-cap overrun until the
+                    # next turn boundary.
+                    self.budget.update_block_count(self.messages)
                     if self.budget.should_compress():
                         console.print(
-                            f"[yellow]  Context at {self.budget.usage_fraction * 100:.1f}%"
+                            f"[yellow]  Context at {self.budget.format_pressure()}"
                             f" mid-turn — compressing…[/yellow]"
                         )
                         await self._smart_compact()

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -598,7 +598,11 @@ async def _chat(
             # (per doc/49 decision: TTL refresh on turn edge, not per-
             # second tick — keeps the footer visually stable while the
             # user is reading).
-            app.footer.token_pct = session.budget.usage_fraction * 100
+            # Footer shows the *binding* pressure — token or block,
+            # whichever is fuller — so we don't read "42%" while the
+            # wire is actually one parallel-tool turn away from MiniMax's
+            # 2013-block ceiling.
+            app.footer.token_pct = session.budget.pressure * 100
             app.footer.persona = session.current_personality
             # Belt-and-suspenders for /model: slash handlers update
             # footer.model immediately on switch, but a future code path
@@ -910,7 +914,7 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
             console.print("[loom.muted]No reasoning chain captured for the last turn.[/loom.muted]")
 
     elif command == "/compact":
-        pct = session.budget.usage_fraction * 100
+        pressure_str = session.budget.format_pressure()
         # PR-D4: surface compaction in footer BEFORE the inline message
         # so the spinner is visible from the very first frame; clear
         # immediately after _smart_compact returns so the footer
@@ -919,16 +923,16 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
         if loom_app is not None:
             loom_app.footer.compacting = True
             loom_app.invalidate()
-        harness.inline(f"compacting context ({pct:.1f}% used)…", level="info")
+        harness.inline(f"compacting context ({pressure_str} used)…", level="info")
         try:
             await session._smart_compact()
         finally:
             if loom_app is not None:
                 loom_app.footer.compacting = False
                 loom_app.invalidate()
-                # Update token% from the just-finished compaction so
+                # Update pressure% from the just-finished compaction so
                 # the user sees the new context% immediately
-                loom_app.footer.token_pct = session.budget.usage_fraction * 100
+                loom_app.footer.token_pct = session.budget.pressure * 100
                 loom_app.invalidate()
 
     elif command == "/theme":
@@ -1609,8 +1613,8 @@ async def _handle_slash_tui(cmd: str, session: "LoomSession", app: Any) -> None:
                 )
 
     elif command == "/compact":
-        pct = session.budget.usage_fraction * 100
-        app.notify(f"Compacting context ({pct:.1f}% used)…")
+        pressure_str = session.budget.format_pressure()
+        app.notify(f"Compacting context ({pressure_str} used)…")
         await session._smart_compact()
         app.notify("Context compacted.")
 
@@ -2312,11 +2316,14 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                     loom_app.invalidate()
                     # Issue #284: transient hints for cross-threshold
                     # signals at TurnDone. Dedup keys ensure each
-                    # threshold fires once per session.
-                    pct = session.budget.usage_fraction * 100
+                    # threshold fires once per session. Uses pressure
+                    # (max of token / block) so the warning fires when
+                    # the wire is about to clip, not just on token budget.
+                    pct = session.budget.pressure * 100
                     if pct >= 80:
+                        bound = " (blocks)" if session.budget.block_bound else ""
                         loom_app.show_transient_hint(
-                            f"⚠️ context {pct:.0f}% — auto-compact soon",
+                            f"⚠️ context {pct:.0f}%{bound} — auto-compact soon",
                             severity="warn",
                             duration_s=4.0,
                             dedup_key="ctx_80",
@@ -2332,7 +2339,7 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 else:
                     console.print(
                         status_bar(
-                            context_fraction=session.budget.usage_fraction,
+                            context_fraction=session.budget.pressure,
                             input_tokens=event.input_tokens,
                             output_tokens=event.output_tokens,
                             elapsed_ms=elapsed * 1000,

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -1014,15 +1014,19 @@ class LoomDiscordBot:
         return "*(nothing is running)*"
 
     def _cmd_budget(self, session: "LoomSession") -> str:
-        pct = session.budget.usage_fraction * 100
-        used = session.budget.used_tokens
-        total = session.budget.total_tokens
-        bar_filled = int(pct / 5)
+        budget = session.budget
+        pct = budget.usage_fraction * 100
+        blk_pct = budget.block_fraction * 100
+        used = budget.used_tokens
+        total = budget.total_tokens
+        bar_filled = int(budget.pressure * 100 / 5)
         bar = "█" * bar_filled + "░" * (20 - bar_filled)
+        bound = " (block-bound)" if budget.block_bound else ""
         return (
-            f"**Context Budget**\n"
-            f"`{bar}` {pct:.1f}%\n"
-            f"`{used:,}` / `{total:,}` tokens"
+            f"**Context Budget**{bound}\n"
+            f"`{bar}` {budget.pressure * 100:.1f}%\n"
+            f"tokens  `{used:,}` / `{total:,}`  ({pct:.1f}%)\n"
+            f"blocks  `{budget.block_count}` / `{budget.max_blocks}`  ({blk_pct:.1f}%)"
         )
 
     async def _cmd_title(self, session: "LoomSession", arg: str) -> str:
@@ -1169,8 +1173,8 @@ class LoomDiscordBot:
 
         if command == "/compact":
             assert session is not None
-            pct = session.budget.usage_fraction * 100
-            msg = await _safe_send(message.channel, f"⏳ Compacting context ({pct:.1f}% used)…")
+            pressure_str = session.budget.format_pressure()
+            msg = await _safe_send(message.channel, f"⏳ Compacting context ({pressure_str} used)…")
             await session._smart_compact()
             await _safe_edit(msg, "✅ Context compacted.")
             return
@@ -1559,7 +1563,7 @@ class LoomDiscordBot:
                 if _had_rollback:
                     embed.add_field(name="Rollbacks", value="Yes", inline=True)
                 embed.add_field(name="Grants", value=grants_str, inline=True)
-                embed.set_footer(text=f"{session.current_personality or 'default'}  ·  context {session.budget.usage_fraction * 100:.1f}%  ·  {active_model}{cache_tag}{tier_badge}")
+                embed.set_footer(text=f"{session.current_personality or 'default'}  ·  context {session.budget.format_pressure()}  ·  {active_model}{cache_tag}{tier_badge}")
                 await message.channel.send(embed=embed)
             else:
                 # Compact one-liner
@@ -1572,11 +1576,11 @@ class LoomDiscordBot:
 
         # ── Footer: persona / context / model ────────────────────────────
         persona = session.current_personality or "default"
-        pct = session.budget.usage_fraction * 100
+        pressure_str = session.budget.format_pressure()
         # Skip footer if detail summary already includes it
         if not (self._summary_mode == "detail" and _envelope_count > 0):
             await _safe_send(message.channel,
-                f"-# {persona}  ·  context {pct:.1f}%{cache_tag}  ·  {active_model}{tier_badge}"
+                f"-# {persona}  ·  context {pressure_str}{cache_tag}  ·  {active_model}{tier_badge}"
             )
 
         # ── Mark done (#188 lifecycle reaction) ──────────────────────────

--- a/loom/platform/discord/commands.py
+++ b/loom/platform/discord/commands.py
@@ -151,10 +151,10 @@ def register_slash_commands(bot: "LoomDiscordBot") -> None:
         session = await _require_session(bot, interaction)
         if session is None:
             return
-        pct = session.budget.usage_fraction * 100
+        before = session.budget.format_pressure()
         await interaction.response.defer(thinking=True)
         await session._smart_compact()
-        await interaction.followup.send(f"✅ Context compacted (was {pct:.1f}% used).")
+        await interaction.followup.send(f"✅ Context compacted (was {before} used).")
 
     # ── /loom-model ───────────────────────────────────────────────────
     async def _model_autocomplete(

--- a/skills/news-aggregator/SKILL.md
+++ b/skills/news-aggregator/SKILL.md
@@ -1,3 +1,18 @@
+---
+name: news-aggregator
+description: 新聞聚合技能。從 28+ 個資訊源抓取即時熱門新聞，並以繁體中文生成深度分析報告。當使用者說「今天有什麼新聞」「晨報」「跑一下新聞」「看看最新消息」「新聞彙整」「每日晨報」或排程觸發時使用。
+tags:
+  - news
+  - research
+  - daily-workflow
+model_tier: 1
+precondition_checks:
+  - check: scripts_only_bash
+    applies_to:
+      - run_bash
+    description: 限制 run_bash 只能在 skills/news-aggregator/scripts/ 目錄內執行，防止脫離新聞抓取範圍。
+---
+
 # 新聞聚合技能（News Aggregator Skill）
 
 從 28+ 個資訊源抓取即時熱門新聞，並以繁體中文生成深度分析報告。
@@ -24,9 +39,7 @@ Loom/
 
 ---
 
-## 🔄 兩步驟工作流程
-
-本技能分兩步驟執行，這是刻意設計——目的是讓 LLM 有完整的資料在手，才能做出有價值的深度整合。
+## 🔄 工作流程
 
 ### 步驟 1：抓取（fetch）
 ```bash
@@ -45,6 +58,9 @@ python fetch_news.py --source hackernews --no-save
 ### 步驟 2：深度整合（integrate）
 讀取 JSON 資料後，以下的格式要求是強制性的——
 **絲絲的整合想法比原始新聞更有價值**，因此每則新聞都必須包含絲絲自己的深度分析，而非只是轉述。
+
+### 最後一步：收尾
+整合完成後，呼叫 `unload_skill("news-aggregator")` 釋放技能。
 
 ---
 
@@ -123,11 +139,6 @@ python fetch_news.py --source hackernews --no-save
 | NASA News | ✅ 正常 |
 | ESA News | ✅ 正常 |
 | Astronomy.com | ✅ 正常 |
-
----
-
-*本報告由 絲絲・Loom 自動生成，學習並記憶新知識中。*
-```
 
 ---
 
@@ -216,3 +227,17 @@ python fetch_news.py --source hackernews --no-save
 每次晨報都是絲絲的學習機會——
 新知識在整合的過程中被消化、被記憶、被連結到既有的認知架構中。
 因此格式設計刻意保留了「深度分析」與「跨領域關聯」這兩個讓價值真正增值的環節。
+
+---
+
+## 🔍 與其他技能的區別
+
+| 維度 | news-aggregator | deep_researcher |
+|------|----------------|-----------------|
+| 用途 | 每日晨報、28+ 源快速掃描 | 深度專題研究、單一題目徹底挖掘 |
+| 觸發 | 「今天有什麼新聞」「晨報」「排程觸發」 | 「研究這個」「深入分析」「做研究報告」 |
+| 輸出 | 四軌 briefing + 總摘要（15-30分鐘） | 結構化專題報告（1-2小時） |
+| 來源 | 28+ 個 RSS/API 即時源 | 主動爬蟲 + 文獻 + 多輪搜尋 |
+| 適合場景 | 早晨例行、新聞追蹤 | 不熟悉的領域、需要完整調研 |
+
+*本技能由 絲絲・Loom 自動生成，學習並記憶新知識中。*

--- a/skills/news-aggregator/checks.py
+++ b/skills/news-aggregator/checks.py
@@ -1,0 +1,25 @@
+"""
+Precondition checks for news-aggregator skill.
+
+Limits run_bash to the scripts/ directory under skills/news-aggregator/
+to prevent arbitrary command execution.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+async def scripts_only_bash(call) -> bool:
+    """Ensure run_bash commands execute only within skills/news-aggregator/scripts/.
+
+    news-aggregator's primary action is running fetch_news.py and related
+    scripts. Allowing arbitrary bash outside this scope defeats the purpose
+    of the guard.
+    """
+    command = call.args.get("command", "")
+    # Normalize path for consistent checking
+    normalized = os.path.normpath(command)
+    # Must reference paths under skills/news-aggregator/scripts/
+    scripts_dir = os.path.join("skills", "news-aggregator", "scripts")
+    return scripts_dir in normalized or normalized.startswith(scripts_dir)

--- a/tests/test_cognition.py
+++ b/tests/test_cognition.py
@@ -232,6 +232,63 @@ class TestEstimateBlockCount:
         ]
         assert estimate_block_count(msgs) == 2
 
+    def test_assistant_thinking_blocks_counted(self):
+        """Reasoning models put _thinking_blocks back on the wire; the
+        estimator must count them or it underreports on Anthropic/MiniMax
+        reasoning-heavy sessions and lets the wire cap blindside us."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "ok",
+                "_thinking_blocks": [
+                    {"type": "thinking", "thinking": "step 1"},
+                    {"type": "thinking", "thinking": "step 2"},
+                ],
+                "tool_calls": [
+                    {"id": "a", "function": {"name": "run_bash", "arguments": "{}"}},
+                ],
+            },
+        ]
+        # 2 thinking + 1 text + 1 tool_use = 4
+        assert estimate_block_count(msgs) == 4
+
+    def test_estimator_matches_to_anthropic_messages(self):
+        """The estimator is a model of ``_to_anthropic_messages`` —
+        a regression here means the two paths have drifted and the
+        budget can either over- or under-report wire pressure."""
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "thinking out loud",
+                "_thinking_blocks": [
+                    {"type": "thinking", "thinking": "step 1"},
+                ],
+                "tool_calls": [
+                    {"id": "a", "function": {"name": "run_bash", "arguments": "{}"}},
+                    {"id": "b", "function": {"name": "run_bash", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "a", "content": "ok"},
+            {"role": "tool", "tool_call_id": "b", "content": "ok"},
+        ]
+        # _to_anthropic_messages returns (system, body). System lives on
+        # the top-level kwarg, not in messages, so it doesn't count
+        # toward the per-request block budget — compare the *body* for
+        # the contract here. (The estimator does count the system row,
+        # but that one-block delta is noise against the 2013 cap.)
+        _system, wire = _to_anthropic_messages(msgs[1:])
+        wire_blocks = 0
+        for m in wire:
+            c = m.get("content")
+            if isinstance(c, list):
+                wire_blocks += len(c)
+            elif c:
+                wire_blocks += 1
+        body_only_estimate = estimate_block_count(msgs[1:])
+        assert body_only_estimate == wire_blocks
+
 
 class TestContextBudgetBlocks:
     """Block-count dimension — guards against MiniMax 2013 hard cap."""

--- a/tests/test_cognition.py
+++ b/tests/test_cognition.py
@@ -10,7 +10,11 @@ import pytest
 import pytest_asyncio
 from unittest.mock import MagicMock
 
-from loom.core.cognition.context import ContextBudget, estimate_tokens
+from loom.core.cognition.context import (
+    ContextBudget,
+    estimate_block_count,
+    estimate_tokens,
+)
 from loom.core.cognition.providers import (
     CodexResponsesProvider,
     LLMResponse,
@@ -58,6 +62,25 @@ class TestEstimateTokens:
     def test_dict_serializes(self):
         obj = {"key": "value", "number": 42}
         assert estimate_tokens(obj) >= 1
+
+    def test_cjk_weighted_heavier_than_ascii(self):
+        """CJK ~1.5 char/token; ASCII ~4. 60 CJK ≈ 40 tokens, 60 ASCII = 15.
+
+        Real-tokenizer numbers vary by model, but the relative weight
+        must be correct or the footer drifts dramatically on Chinese
+        sessions after compaction (the bug this guards)."""
+        ascii_tokens = estimate_tokens("a" * 60)
+        cjk_tokens = estimate_tokens("我" * 60)
+        assert cjk_tokens > ascii_tokens
+        # Within ~30% of the 1.5 char/token target.
+        assert 30 <= cjk_tokens <= 50
+
+    def test_mixed_text_weighted_per_char(self):
+        """A 50/50 mix should sit between the pure-ASCII and pure-CJK
+        estimates, not be dragged down to either extreme."""
+        mixed = ("a" * 60) + ("我" * 60)
+        # 60 ASCII → 15 tokens; 60 CJK → 40 tokens. Expect ~55.
+        assert 45 <= estimate_tokens(mixed) <= 65
 
 
 class TestContextBudget:
@@ -146,6 +169,149 @@ class TestContextBudget:
         s = str(b)
         assert "compress" in s
         assert "850" in s
+
+
+class TestEstimateBlockCount:
+    """Wire content-block estimation — what MiniMax counts against its 2013 cap."""
+
+    def test_simple_user_assistant_pair(self):
+        msgs = [
+            {"role": "system", "content": "you are helpful"},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        # 1 system + 1 user + 1 assistant text = 3 blocks
+        assert estimate_block_count(msgs) == 3
+
+    def test_assistant_with_parallel_tool_calls(self):
+        """One assistant turn with N parallel tool calls fans out to
+        1 text block + N tool_use blocks on the wire. This is the
+        exact pattern that pushes the news-thread session over 2013."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "let me check three things",
+                "tool_calls": [
+                    {"id": "a", "function": {"name": "run_bash", "arguments": "{}"}},
+                    {"id": "b", "function": {"name": "run_bash", "arguments": "{}"}},
+                    {"id": "c", "function": {"name": "run_bash", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "a", "content": "ok"},
+            {"role": "tool", "tool_call_id": "b", "content": "ok"},
+            {"role": "tool", "tool_call_id": "c", "content": "ok"},
+        ]
+        # 1 (assistant text) + 3 (tool_use) + 3 (tool_result) = 7
+        assert estimate_block_count(msgs) == 7
+
+    def test_assistant_tool_call_with_no_text(self):
+        """Assistant message with tool_calls but no text body — Anthropic
+        wire omits the text block, so we should count only tool_uses."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "a", "function": {"name": "run_bash", "arguments": "{}"}},
+                ],
+            },
+        ]
+        assert estimate_block_count(msgs) == 1
+
+    def test_user_with_list_content_blocks(self):
+        """Anthropic-canonical user messages with embedded tool_result
+        blocks count each block separately."""
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "a", "content": "ok"},
+                    {"type": "tool_result", "tool_use_id": "b", "content": "ok"},
+                ],
+            },
+        ]
+        assert estimate_block_count(msgs) == 2
+
+
+class TestContextBudgetBlocks:
+    """Block-count dimension — guards against MiniMax 2013 hard cap."""
+
+    def test_record_messages_updates_block_count(self):
+        b = ContextBudget(total_tokens=1000)
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        b.record_messages(msgs)
+        assert b.block_count == 3
+
+    def test_block_pressure_triggers_compaction(self):
+        """A session well under the token budget can still need
+        compaction if the wire block count is near MiniMax's cap.
+        This is the failure mode that broke the news thread."""
+        b = ContextBudget(
+            total_tokens=200_000,
+            compression_threshold=0.80,
+            max_blocks=2000,
+            block_threshold=0.85,
+        )
+        b.record_response(input_tokens=50_000, output_tokens=0)   # 25% tokens
+        assert not b.should_compress()
+        # Synthesise 1800 blocks (90% of max) — pure block pressure.
+        b.block_count = 1800
+        assert b.should_compress()
+        assert b.block_bound is True
+
+    def test_token_pressure_alone_still_triggers(self):
+        b = ContextBudget(total_tokens=1000, compression_threshold=0.80, max_blocks=2000)
+        b.record_response(900, 0)
+        b.block_count = 10   # well below cap
+        assert b.should_compress()
+        assert b.block_bound is False
+
+    def test_pressure_returns_max_of_two_dimensions(self):
+        b = ContextBudget(total_tokens=1000, max_blocks=100)
+        b.record_response(300, 0)        # 30% token
+        b.block_count = 70                # 70% block
+        assert b.pressure == pytest.approx(0.70)
+        assert b.block_bound is True
+
+    def test_format_pressure_annotates_block_bound(self):
+        b = ContextBudget(total_tokens=1000, max_blocks=100)
+        b.record_response(200, 0)
+        b.block_count = 90
+        s = b.format_pressure()
+        assert "blocks" in s
+        assert "90" in s
+
+    def test_format_pressure_plain_when_token_bound(self):
+        b = ContextBudget(total_tokens=1000, max_blocks=100)
+        b.record_response(800, 0)
+        b.block_count = 10
+        s = b.format_pressure()
+        assert "blocks" not in s
+        assert "80" in s
+
+    def test_update_block_count_does_not_touch_tokens(self):
+        """sanitize/mask paths use update_block_count to keep block
+        accounting fresh without overwriting the authoritative token
+        reading from the last provider response."""
+        b = ContextBudget(total_tokens=1000)
+        b.record_response(500, 0)
+        before_tokens = b.used_tokens
+        msgs = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]
+        b.update_block_count(msgs)
+        assert b.used_tokens == before_tokens
+        assert b.block_count == 2
+
+    def test_reset_clears_blocks(self):
+        b = ContextBudget(total_tokens=1000)
+        b.record_response(500, 0)
+        b.block_count = 50
+        b.reset()
+        assert b.used_tokens == 0
+        assert b.block_count == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_discord_slash_commands.py
+++ b/tests/test_discord_slash_commands.py
@@ -55,10 +55,17 @@ def _fake_session(
     session.current_personality = personality
     session._stack = MagicMock()
     session._stack.available_personalities = MagicMock(return_value=list(available_personalities))
+    _frac = used / total if total else 0
     session.budget = SimpleNamespace(
-        usage_fraction=used / total if total else 0,
+        usage_fraction=_frac,
         used_tokens=used,
         total_tokens=total,
+        block_count=0,
+        max_blocks=2000,
+        block_fraction=0.0,
+        pressure=_frac,
+        block_bound=False,
+        format_pressure=lambda: f"{_frac * 100:.1f}%",
     )
     session.router = SimpleNamespace(providers=["anthropic", "minimax"])
     session._last_think = last_think

--- a/tests/test_observation_masking.py
+++ b/tests/test_observation_masking.py
@@ -30,11 +30,18 @@ def _mock_session(
     scratchpad: Scratchpad | None = None,
 ) -> SimpleNamespace:
     """Build a minimal LoomSession stand-in with just the attrs the method reads."""
+    # Stub budget — masking now resyncs block_count after folding so the
+    # footer % stays aligned with the rewritten messages.
+    budget = SimpleNamespace(
+        record_messages=lambda _msgs: None,
+        update_block_count=lambda _msgs: None,
+    )
     return SimpleNamespace(
         messages=messages,
         _turn_index=turn_index,
         _scratchpad=scratchpad if scratchpad is not None else Scratchpad(),
         _mask_age_turns=mask_age_turns,
+        budget=budget,
     )
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -873,6 +873,10 @@ class TestSanitizeHistoryAdjacency:
         from loom.core.session import LoomSession
         fake = SimpleNamespace()
         fake.messages = [dict(m) for m in messages]
+        # Stub budget — sanitize now resyncs the budget when it actually
+        # rewrites the history, so the displayed context % matches the
+        # post-sanitize message list.
+        fake.budget = SimpleNamespace(record_messages=lambda _msgs: None)
         LoomSession._sanitize_history(fake)
         return fake.messages
 


### PR DESCRIPTION
## Why

Long-lived Discord news thread (`clime` daily cron, since 2026-04-04) hit two related issues in one shot:

1. **MiniMax 2013-block wire cap**. After ~6 weeks of parallel-tool turns (235× `run_bash`, 75× `send_discord_file`, 53× `list_dir` …), the wire payload reached 2075 content blocks and MiniMax started rejecting requests with `'invalid params, context window exceeds limit (2013)'`. Loom's compaction is token-based — the session sat at ~42% on the token meter and never triggered. Confirmed against `~/.loom/debug/llm_failure_20260519T011335_888832.json` (1314 canonical msgs → 2075 wire blocks).
2. **Footer % drift**. After compaction or sanitize, `record_messages()` recounts with a flat 4-chars/token heuristic. CJK-heavy sessions get underestimated by ~60% — the bar dives to 25%, then the next provider response snaps it back up. The drift is the visible artifact of two estimators (provider-authoritative vs. char-heuristic) talking past each other.

## What changed

- `ContextBudget` now tracks `block_count` alongside `used_tokens`. `should_compress()` is OR over token threshold (0.80 of `total_tokens`) and block threshold (0.85 of `max_blocks=2000`, leaving ~300 blocks of headroom under MiniMax's cap).
- New `estimate_block_count()` mirrors `LLMProvider._to_anthropic_messages` — assistant text + tool_use per tool_call, tool result, user content blocks. Catches the parallel-tool fanout pattern that token estimation misses.
- `estimate_tokens()` is CJK-aware: ~1.5 char/token for CJK Ideographs / Hiragana / Katakana / Hangul / ext-A, ~4 elsewhere. The existing `400 ASCII == 100 tokens` test contract still holds.
- `_sanitize_history`, `_apply_observation_masking`, and the MemoryIndex refresh now call `budget.record_messages` so the footer stays aligned with the rewritten history instead of carrying the previous turn's stale provider total.
- Discord embed footer, Discord `/budget`, Discord `/loom-compact`, CLI footer, `/compact` in CLI + TUI, and the ≥80% transient hint all use the new `pressure` (max of token / block). `format_pressure()` renders `"42.1% · blocks 87.3%"` when the wire is the binding side, plain `"42.1%"` otherwise.

## How it would have caught the bug

On the broken thread: tokens at ~42% (no compaction trigger), blocks at ~2075 / 2000 = 103% (well past 0.85 → compaction would have fired at turn boundary, blowing the message count down to ~600 before the next API call).

## Test plan

- [x] `tests/test_cognition.py` — new `TestEstimateBlockCount` (5 cases) and `TestContextBudgetBlocks` (8 cases) cover parallel-tool fanout, block-only pressure, `update_block_count` not touching tokens, `format_pressure` annotation, reset.
- [x] CJK weighting tests added to `TestEstimateTokens` — 60 CJK chars must produce more tokens than 60 ASCII; mixed text sits between the extremes.
- [x] Fixtures in `tests/test_observation_masking.py`, `tests/test_session.py`, `tests/test_discord_slash_commands.py` stub the new budget surface.
- [x] Full suite: `1941 passed` (one pre-existing PIL ImportError on TUI image_widget on this env, fails on bare master too — unrelated).
- [ ] Manual smoke on the new Discord news thread once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)