### PR TITLE
refactor(config): extract load_loom_config to public API (#306)

### DIFF
--- a/loom/autonomy/daemon.py
+++ b/loom/autonomy/daemon.py
@@ -494,8 +494,8 @@ class AutonomyDaemon:
         if db is None:
             return None
         try:
-            from loom.core.session import _load_loom_config  # local import: lazy
-            _mem = _load_loom_config().get("memory", {})
+            from loom.core.config import load_loom_config  # local import: lazy
+            _mem = load_loom_config().get("memory", {})
             cfg = _mem.get("lifecycle", {})
             gov_cfg = _mem.get("governance", {})
         except Exception as exc:
@@ -534,8 +534,8 @@ class AutonomyDaemon:
         if memory is None:
             return None
         try:
-            from loom.core.session import _load_loom_config  # local import: lazy
-            cfg = _load_loom_config().get("memory", {}).get("dream", {})
+            from loom.core.config import load_loom_config  # local import: lazy
+            cfg = load_loom_config().get("memory", {}).get("dream", {})
         except Exception as exc:
             logger.debug("[autonomy] dream config load failed: %s", exc)
             return None

--- a/loom/core/cognition/router.py
+++ b/loom/core/cognition/router.py
@@ -31,28 +31,11 @@ Usage
 """
 
 from collections.abc import AsyncIterator
-from pathlib import Path
 from typing import Any
 
-try:
-    import tomllib
-except ImportError:
-    import tomli as tomllib  # type: ignore[no-redef]
+from loom.core.config import load_loom_config
 
 from .providers import LLMProvider, LLMResponse
-
-
-def _load_loom_config() -> dict:
-    """Load loom.toml from cwd or the package root; return {} on miss."""
-    candidates = [
-        Path.cwd() / "loom.toml",
-        Path(__file__).parents[3] / "loom.toml",
-    ]
-    for path in candidates:
-        if path.exists():
-            with open(path, "rb") as fh:
-                return tomllib.load(fh)
-    return {}
 
 
 def get_default_model() -> str:
@@ -60,7 +43,7 @@ def get_default_model() -> str:
     Return the default model from loom.toml [cognition]default_model,
     falling back to "MiniMax-M2.7".
     """
-    config = _load_loom_config()
+    config = load_loom_config()
     model = config.get("cognition", {}).get("default_model", "")
     return model if model else "MiniMax-M2.7"
 

--- a/loom/core/config.py
+++ b/loom/core/config.py
@@ -1,0 +1,32 @@
+"""Public loader for ``loom.toml`` runtime configuration.
+
+Single source of truth for the file-system search + parse logic. Other
+layers (session, autonomy, cognition) import ``load_loom_config`` instead
+of reaching into private session-module helpers — see #306.
+"""
+
+from __future__ import annotations
+
+import tomllib
+import warnings
+from pathlib import Path
+
+
+def load_loom_config() -> dict:
+    """Load ``loom.toml`` from cwd or the package root; return ``{}`` on miss."""
+    candidates = [
+        Path.cwd() / "loom.toml",
+        Path(__file__).parents[2] / "loom.toml",
+    ]
+    for path in candidates:
+        if path.exists():
+            with open(path, "rb") as fh:
+                config = tomllib.load(fh)
+            if "mutation" in config:
+                warnings.warn(
+                    "[mutation] is retired by Quest D Phase 1.C and is safe to delete.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            return config
+    return {}

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -27,9 +27,7 @@ import json
 import logging
 import os
 import time
-import tomllib
 import uuid
-import warnings
 from collections.abc import AsyncIterator
 from datetime import datetime, UTC
 from pathlib import Path
@@ -40,6 +38,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.rule import Rule
 
+from loom.core.config import load_loom_config as _load_loom_config  # re-exported for tests/diagnostic/cli
 from loom.core.diagnostic import DiagnosticReport, StartupDiagnostic
 from loom.core.ledger import (
     CallMeta,
@@ -275,26 +274,6 @@ def _find_partial_tag_suffix(text: str, tag: str) -> int:
 # ---------------------------------------------------------------------------
 # Router factory
 # ---------------------------------------------------------------------------
-
-
-def _load_loom_config() -> dict:
-    """Load loom.toml from cwd or the package root; return {} on miss."""
-    candidates = [
-        Path.cwd() / "loom.toml",
-        Path(__file__).parents[2] / "loom.toml",
-    ]
-    for path in candidates:
-        if path.exists():
-            with open(path, "rb") as fh:
-                config = tomllib.load(fh)
-            if "mutation" in config:
-                warnings.warn(
-                    "[mutation] is retired by Quest D Phase 1.C and is safe to delete.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-            return config
-    return {}
 
 
 # Issue #181: per-model output cap. Different providers have very different

--- a/tests/test_dream_loop.py
+++ b/tests/test_dream_loop.py
@@ -119,7 +119,7 @@ def _make_daemon(session):
 
 def test_maybe_start_dream_loop_skipped_when_disabled(monkeypatch):
     monkeypatch.setattr(
-        "loom.core.session._load_loom_config",
+        "loom.core.config.load_loom_config",
         lambda: {"memory": {"dream": {"enabled": False}}},
     )
     daemon = _make_daemon(_StubSession())
@@ -133,7 +133,7 @@ def test_maybe_start_dream_loop_skipped_without_session(monkeypatch):
 
 def test_maybe_start_dream_loop_skipped_without_db(monkeypatch):
     monkeypatch.setattr(
-        "loom.core.session._load_loom_config",
+        "loom.core.config.load_loom_config",
         lambda: {"memory": {"dream": {"enabled": True}}},
     )
     daemon = _make_daemon(_StubSession(with_db=False))
@@ -143,7 +143,7 @@ def test_maybe_start_dream_loop_skipped_without_db(monkeypatch):
 async def test_maybe_start_dream_loop_launches_and_cancels(monkeypatch):
     monkeypatch.setattr(DreamLoop, "_FIRST_SWEEP_DELAY_SECONDS", 60.0)
     monkeypatch.setattr(
-        "loom.core.session._load_loom_config",
+        "loom.core.config.load_loom_config",
         lambda: {"memory": {"dream": {"enabled": True, "interval_hours": 12}}},
     )
     daemon = _make_daemon(_StubSession())


### PR DESCRIPTION
## Summary

- Moves `loom.toml` loader into new **`loom/core/config.py`** as public `load_loom_config()`
- `autonomy/daemon.py` stops reaching into `loom.core.session._load_loom_config` across layer boundaries — uses the public API instead
- Collapses **duplicate definition** in `loom/core/cognition/router.py` (found during the work — same function, same purpose) onto the public API
- `session.py` keeps `_load_loom_config` as a thin re-export alias so existing monkey-patch tests, `diagnostic/startup.py`, and `cli/main.py` continue to work unchanged

Closes #306.

## Scope rationale

#306 is marked low-priority. This PR does the **minimum change that solves the stated smell** (cross-layer private import) plus the obvious duplicate that surfaced during impact analysis. Out of scope intentionally:

- No `memory_lifecycle_config()` narrow accessor — callers still walk `.get("memory", {}).get("lifecycle", {})`; adding a wrapper for one call site each isn't worth the surface
- No tightening of daemon `try/except` to make schema mismatch loud — that's the "behavior change" half of #306; this PR is the "extract API" half

## Impact analysis

GitNexus `detect_changes` reports affected processes as the two autonomy startup paths only:

- `Start → Half_life_for` / `Start → _decay_factor` / `Start → _read_last_run_at` (via `_maybe_start_maintenance`)
- `Start → Run_forever` (via `_maybe_start_dream_loop`)

No callers outside autonomy were touched semantically — the session/cognition changes are pure de-duplication.

## Test plan

- [x] All 66 tests that directly touch `_load_loom_config` (session config-path regression, dream loop, memory facade, startup diagnostic, ledger session wiring, skill evolution retirement, parallel dispatch) pass
- [x] Full suite: 1962 passed; 4 pre-existing failures in `test_confirm_parity.py` / `test_scope_phase_cd.py` / `test_scoped_approval.py` are unrelated (scope-grant lifecycle, surfaced by recent commit `0452137`)
- [x] Import smoke tests pass for `loom.core.config`, `loom.core.session._load_loom_config` alias, `loom.core.cognition.router.get_default_model`, `loom.autonomy.daemon.AutonomyDaemon`, `loom.platform.cli.main._load_loom_config` (re-import path)
- [x] `inspect.getfile(_load_loom_config)` resolves to `loom/core/config.py`; `parents[2].name == "Loom"` still holds (the regression contract in `tests/test_session.py::TestConfigPathResolution`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)