### PR TITLE
chore(audit-A): retire residue — record_outcome, stale TODO, test name

### DIFF
--- a/doc/09-四種記憶詳解.md
+++ b/doc/09-四種記憶詳解.md
@@ -185,39 +185,15 @@ class SkillGenome:
     updated_at: str
 ```
 
-### EMA Confidence 更新
+### Confidence 更新
 
-每次 Skill 執行後，結果回饋寫入，confidence 透過 EMA 更新：
+`SkillGenome.confidence` 由 `SkillOutcomeTracker` 根據 task 結果的 quality_score（1-5）以 EMA 計算，不在 SkillGenome 上直接寫入。
 
-```python
-def record_outcome(self, success: bool):
-    # EMA = α * new + (1 - α) * old
-    # α = 0.3（新鮮度權重）
-    alpha = 0.3
-    self.confidence = alpha * (1.0 if success else 0.0) + (1 - alpha) * self.confidence
-    self.usage_count += 1
-
-    # 成功率同步更新
-    self.success_rate = (
-        (self.success_rate * (self.usage_count - 1) + (1.0 if success else 0.0))
-        / self.usage_count
-    )
-
-    # 自動廢棄檢查
-    if self.confidence <= self.deprecation_threshold:
-        self.deprecate()
-```
+> 舊版 `SkillGenome.record_outcome(success: bool)` 的二元成功/失敗模型已移除（Quest D Phase 1.C / audit-A）。詳見 [10-Skill-Genome.md](10-Skill-Genome.md) §SkillOutcomeTracker。
 
 ### 自動廢棄
 
-```python
-def deprecate(self):
-    self.body = f"[DEPRECATED] {self.body}"
-    self.metadata["deprecated"] = True
-    self.metadata["deprecated_at"] = datetime.now().isoformat()
-```
-
-廢棄的技能仍存在於 DB 中，但 `list_active()` 預設不會返回。
+`SkillGenome.is_deprecated` 是 read-only property：當 `usage_count >= MIN_SAMPLES_BEFORE_DEPRECATION` 且 `confidence <= deprecation_threshold` 時返回 True。`ProceduralMemory.list_active()` 透過 SQL 查詢自動排除，DB row 本身不被修改。
 
 ### Skill Import Pipeline
 

--- a/doc/10-Skill-Genome.md
+++ b/doc/10-Skill-Genome.md
@@ -92,7 +92,7 @@ skills/
 
 ## SkillOutcomeTracker（EMA Confidence 追蹤）
 
-舊版 `SkillGenome.record_outcome()` 已 deprecated。現實使用 `SkillOutcomeTracker` 的 quality-gradient 機制：
+舊版 `SkillGenome.record_outcome()` 已移除（audit-A / PR #401）。現實使用 `SkillOutcomeTracker` 的 quality-gradient 機制：
 
 ```python
 @dataclass

--- a/loom/core/memory/procedural.py
+++ b/loom/core/memory/procedural.py
@@ -9,7 +9,6 @@ and confidence tracking.
 
 import json
 import uuid
-import warnings
 from dataclasses import dataclass, field
 from datetime import datetime, UTC
 
@@ -60,35 +59,6 @@ class SkillGenome:
         if self.usage_count < self.MIN_SAMPLES_BEFORE_DEPRECATION:
             return False
         return self.confidence <= self.deprecation_threshold
-
-    def record_outcome(self, success: bool) -> None:
-        """Update confidence and success_rate after an observed outcome.
-
-        .. deprecated:: Issue #56
-            Binary success/failure tracking is replaced by quality-gradient
-            self-assessment in ``SkillOutcomeTracker``.  This method is kept
-            for backward compatibility but is no longer called by the core
-            session loop.
-        """
-        warnings.warn(
-            "SkillGenome.record_outcome() is deprecated; "
-            "use SkillOutcomeTracker quality-gradient assessment instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        self.usage_count += 1
-        outcome = 1.0 if success else 0.0
-        if self.usage_count == 1:
-            # First observation: set baseline directly instead of blending with
-            # the default 1.0 prior, which would misleadingly inflate confidence.
-            self.success_rate = outcome
-            self.confidence = outcome
-        else:
-            # Exponential moving average — recent outcomes weighted more
-            alpha = 0.1
-            self.success_rate = (1 - alpha) * self.success_rate + alpha * outcome
-            self.confidence = self.success_rate
-        self.updated_at = datetime.now(UTC)
 
 
 class ProceduralMemory:

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -3898,12 +3898,6 @@ class LoomSession:
             )
         )
 
-        # Issue #56: Old binary record_outcome() loop removed.
-        # Skill confidence is now updated by SkillOutcomeTracker via
-        # quality-gradient self-assessment (1-5 score EMA), not per-tool
-        # success/failure.  The old loop also never hit because tool_name
-        # (e.g. "read_file") rarely matches a SkillGenome name (e.g. "loom-engineer").
-
         # Track tool usage for SkillOutcomeTracker
         if self._skill_outcome_tracker is not None:
             self._skill_outcome_tracker.record_tool_usage()

--- a/loom/platform/cli/tui/components/execution_dashboard.py
+++ b/loom/platform/cli/tui/components/execution_dashboard.py
@@ -15,9 +15,6 @@ Phase C (#113):
 - History mode (h key): browse past envelopes from this session
 - ↑↓ navigate history list, Enter expand, Esc back
 - Read-only detail view for historical envelopes
-
-TODO: SwarmDashboard (swarm_dashboard.py) is preserved for backward
-compatibility.  Remove it once this component is confirmed stable.
 """
 
 from __future__ import annotations

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -5,15 +5,9 @@ Tests for the Memory Layer:
   - SemanticMemory: upsert, get, search, list_recent, upsert-update
   - ProceduralMemory / SkillGenome: upsert, get, list_active,
                                      SkillOutcomeTracker, deprecation threshold
-
-  Note: SkillGenome.record_outcome() is deprecated (Issue #56) and no longer
-  called by the core session loop.  Its regression tests are preserved with
-  the _deprecated suffix to document the removed behaviour until the method
-  itself is eventually stripped.
 """
 
 import asyncio
-import warnings
 import pytest
 import pytest_asyncio
 import tempfile
@@ -435,56 +429,6 @@ class TestSkillGenome:
         skill = SkillGenome(name="s", body="x", confidence=0.1,
                             deprecation_threshold=0.3, usage_count=2)
         assert skill.is_deprecated is False
-
-    # ------------------------------------------------------------------
-    # Deprecated API — SkillGenome.record_outcome()
-    # Replaced by SkillOutcomeTracker (Issue #56).
-    # These tests are preserved as regression documentation until the
-    # deprecated method itself is eventually removed.
-    # ------------------------------------------------------------------
-
-    def test_record_outcome_deprecated_increments_usage_count(self):
-        """DEPRECATED (Issue #56): SkillGenome.record_outcome() — regression only."""
-        skill = SkillGenome(name="s", body="x")
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            skill.record_outcome(True)
-            skill.record_outcome(False)
-        assert skill.usage_count == 2
-
-    def test_record_outcome_deprecated_success_keeps_high_confidence(self):
-        """DEPRECATED (Issue #56): SkillGenome.record_outcome() — regression only."""
-        skill = SkillGenome(name="s", body="x", confidence=1.0, success_rate=1.0)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            for _ in range(10):
-                skill.record_outcome(True)
-        assert skill.confidence > 0.9
-
-    def test_record_outcome_deprecated_failures_lower_confidence(self):
-        """DEPRECATED (Issue #56): SkillGenome.record_outcome() — regression only."""
-        skill = SkillGenome(name="s", body="x", confidence=1.0, success_rate=1.0)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            for _ in range(30):
-                skill.record_outcome(False)
-        assert skill.confidence < 0.5
-
-
-    def test_record_outcome_deprecated_updates_timestamp(self):
-        """DEPRECATED (Issue #56): SkillGenome.record_outcome() — regression only."""
-        skill = SkillGenome(name="s", body="x")
-        ts_before = skill.updated_at
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            skill.record_outcome(True)
-        assert skill.updated_at >= ts_before
-
-    def test_record_outcome_emits_deprecation_warning(self):
-        """DEPRECATED (Issue #56): SkillGenome.record_outcome() emits DeprecationWarning."""
-        skill = SkillGenome(name="s", body="x")
-        with pytest.warns(DeprecationWarning, match="record_outcome\\(\\) is deprecated"):
-            skill.record_outcome(True)
 
 
 class TestProceduralMemory:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -381,7 +381,7 @@ class TestOutputMaxTokensResolution:
 
 class TestParallelDispatch:
     @pytest.mark.asyncio
-    async def test_dispatch_parallel_uses_current_task_graph_api_and_preserves_order(self):
+    async def test_dispatch_parallel_preserves_order(self):
         from loom.core.session import LoomSession
         from loom.core.harness.middleware import ToolResult
 


### PR DESCRIPTION
## Summary

audit-A 第一輪殘留清理。Refs #398。

| 項目 | 動作 | 為何安全 |
|------|------|---------|
| \`SkillGenome.record_outcome()\` deprecated method | 移除 (+ unused \`import warnings\`) | Issue #56 close 6 週、無內部 caller、無第三方 |
| 5 個 \`_deprecated_\` regression tests in \`test_memory.py\` | 移除 (+ unused \`import warnings\`、docstring 段落) | 只 cover 上面移除的 method、無其他訊號 |
| \`session.py\` 中 Issue #56 殘留 explanation 註解 | 移除 | 註解描述「why 一段已移除的 code 被移除」，code 都不在了註解也失憶 |
| \`execution_dashboard.py:19-20\` swarm_dashboard TODO | 移除 | swarm_dashboard.py 已不存在；ExecutionDashboard Phase B/C 早已穩定 |
| \`test_dispatch_parallel_uses_current_task_graph_api_and_preserves_order\` | rename → \`test_dispatch_parallel_preserves_order\` | TaskGraph API 在 v0.3.2.1 TaskList pivot 已退役；測試本體實測 \`_dispatch_parallel\`，rename 只是恢復語意一致 |

**Net**: +1 / -96 lines, 5 files.

## Scope rationale

audit-A 三層計畫的第一層 — 退役功能殘留考古。掃過的還有以下確定「**不要動**」的候選（記在 #398 留言或後續 audit-A 留言）：

- \`[mutation]\` config warning — regression test 把守、user-facing
- \`relational_decay_factor\` config key — 接受並 ignore（接 user 舊 loom.toml）
- \`mutation_suggestions\` hydration in \`task_reflector.py\` — 讀舊 SemanticMemory diagnostic JSON
- CLI \`status_bar()\` text function — CLI 模式仍 active
- \`SkillEvolutionHook\` — session compress 仍 active wire（PR \`f561c36\` retire 的是 tools，不是 hook）
- \`dreaming.py\` / \`dream_cycle\` — autonomy daemon + maintenance loop 都在用

## Test plan

- [x] \`tests/test_memory.py tests/test_session.py tests/test_skill_evolution_retirement.py\` 74 passed
- [x] Full suite (skip pre-existing PIL-missing test): 1957 passed, 4 failed — all 4 是 pre-existing scope/grant 失敗（commit \`0452137\` 後遺，與本次無關）；對比 pre-PR 是 1962 passed = 剛好少 5 個被刪掉的 deprecated tests

## Out of scope (follow-up)

- TUI 退役（user 已表示計畫退掉 \`loom/platform/cli/tui/\` 全模組）— 將另開 PR 討論 scope 再執行
- audit-B（結構糾纏熱點）與 audit-C（dead code sweep）— 等本 PR merge 後依序進

🤖 Generated with [Claude Code](https://claude.com/claude-code)