### PR TITLE
fix(sandbox): bypass_sandbox profile flag for TLS-incompatible CLIs (#402)

### DIFF
--- a/loom.toml.example
+++ b/loom.toml.example
@@ -421,13 +421,25 @@ backend = "none"   # "none" | "srt"
 # still required, with once / scoped lease / session / deny choices.
 #
 # [security.sandbox.profiles.github]
-# match_commands   = ["gh"]
+# match_commands   = ["gh", "git"]
 # allow_read       = ["~/.config/gh", "~/.gitconfig"]
 # allow_write      = [".", "/private/tmp", "~/.cache/gh"]
 # allowed_domains  = ["api.github.com", "github.com"]
 #
 # Then either command root matching or explicit selection can request it:
 #   run_bash(command = "gh pr view 387", sandbox_profile = "github", ...)
+#
+# Issue #402 — bypass_sandbox: some CLIs (gh: Go crypto/x509; git HTTPS push)
+# cannot complete TLS through srt's HTTP CONNECT proxy on macOS, and srt's
+# network filter and file sandbox are coupled (unsetting HTTPS_PROXY inside
+# the sandbox breaks DNS too). `bypass_sandbox = true` runs matched commands
+# in the parent environment instead of through srt — the scope grant flow
+# above still gates activation, so it's an authorized opt-out per profile.
+# Adding a new bypass-only CLI is two lines:
+#
+# [security.sandbox.profiles.opencli]
+# match_commands = ["opencli"]
+# bypass_sandbox = true
 
 # ─────────────────────────────────────────────
 # Autonomy Engine

--- a/loom/core/security/sandbox_runtime.py
+++ b/loom/core/security/sandbox_runtime.py
@@ -135,6 +135,12 @@ class SandboxProfile:
     denied_domains: list[str] = field(default_factory=list)
     allowed_sockets: list[str] = field(default_factory=list)
     denied_sockets: list[str] = field(default_factory=list)
+    # Issue #402: when True, matched commands skip the srt wrap entirely and
+    # run in the parent environment. Required for CLIs whose TLS stack is
+    # incompatible with srt's HTTP CONNECT proxy (gh, opencli). The scope
+    # grant flow still gates activation — bypass is opt-in per profile,
+    # not an unauthorized escape hatch.
+    bypass_sandbox: bool = False
 
     @classmethod
     def from_config(cls, name: str, cfg: dict[str, Any] | None) -> "SandboxProfile":
@@ -144,6 +150,12 @@ class SandboxProfile:
             raise ValueError(
                 f"[security.sandbox] profiles.{name} must be a table, "
                 f"got {type(cfg).__name__}: {cfg!r}."
+            )
+        bypass_raw = cfg.get("bypass_sandbox", False)
+        if not isinstance(bypass_raw, bool):
+            raise ValueError(
+                f"[security.sandbox] profiles.{name}.bypass_sandbox must be "
+                f"a boolean, got {type(bypass_raw).__name__}: {bypass_raw!r}."
             )
         return cls(
             match_commands=_as_path_list(
@@ -178,6 +190,7 @@ class SandboxProfile:
                 _profile_key(name, "denied_sockets"),
                 cfg.get("denied_sockets"),
             ),
+            bypass_sandbox=bypass_raw,
         )
 
 

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -864,6 +864,12 @@ def make_run_bash_tool(
                 raise PermissionError(
                     f"sandbox profile '{profile_name}' requires explicit authorization"
                 )
+            profile = sandbox.profiles[profile_name]
+            if profile.bypass_sandbox:
+                # Issue #402: profile opts out of srt entirely. Required for
+                # CLIs like `gh` that fail TLS through srt's HTTP CONNECT
+                # proxy. Authorization above still gates activation.
+                return cmd, profile_name
             settings_path = _srt_write_settings_file(
                 sandbox.merged_with_profile(profile_name),
                 workspace,

--- a/tests/test_run_bash_sandbox_profiles.py
+++ b/tests/test_run_bash_sandbox_profiles.py
@@ -230,3 +230,61 @@ def test_run_bash_input_schema_accepts_explicit_sandbox_profile(tmp_path, srt_fa
     props = tool.input_schema["properties"]
 
     assert "sandbox_profile" in props
+
+
+# ---------------------------------------------------------------------------
+# Issue #402 — bypass_sandbox profiles run outside srt entirely (but still
+# require scope authorization).
+# ---------------------------------------------------------------------------
+
+
+def _bypass_sandbox() -> SandboxSettings:
+    return SandboxSettings.from_config({
+        "backend": "srt",
+        "allow_write": ["."],
+        "allowed_domains": [],
+        "profiles": {
+            "github": {
+                "match_commands": ["gh"],
+                "bypass_sandbox": True,
+            },
+        },
+    })
+
+
+@pytest.mark.asyncio
+async def test_run_bash_bypass_profile_skips_srt_wrap_when_authorized(
+    tmp_path, srt_fakes,
+):
+    written, wrapped, launched = srt_fakes
+    tool = tools.make_run_bash_tool(tmp_path, sandbox=_bypass_sandbox())
+    call = _call(tool, "gh pr view 387")
+    _authorize_profile(tool, call)
+
+    result = await tool.executor(call)
+
+    assert result.success
+    assert result.metadata["sandbox_profile"] == "github"
+    # The base settings file is still written (sandbox is active for other
+    # commands in this session), but the matched bypass profile does NOT
+    # write a merged settings file or wrap the command.
+    assert len(written) == 1
+    assert wrapped == []
+    assert launched[0][0] == "gh pr view 387"
+
+
+@pytest.mark.asyncio
+async def test_run_bash_bypass_profile_still_requires_authorization(
+    tmp_path, srt_fakes,
+):
+    written, wrapped, launched = srt_fakes
+    tool = tools.make_run_bash_tool(tmp_path, sandbox=_bypass_sandbox())
+    call = _call(tool, "gh pr view 387")
+
+    result = await tool.executor(call)
+
+    assert not result.success
+    assert result.failure_type == "permission_denied"
+    assert "sandbox profile 'github'" in result.error
+    assert wrapped == []
+    assert launched == []

--- a/tests/test_sandbox_runtime.py
+++ b/tests/test_sandbox_runtime.py
@@ -187,6 +187,31 @@ class TestProfileConfig:
                 },
             })
 
+    def test_profile_bypass_sandbox_defaults_to_false(self):
+        s = SandboxSettings.from_config({
+            "backend": "srt",
+            "profiles": {"github": {"match_commands": ["gh"]}},
+        })
+        assert s.profiles["github"].bypass_sandbox is False
+
+    def test_profile_bypass_sandbox_parses_when_set(self):
+        s = SandboxSettings.from_config({
+            "backend": "srt",
+            "profiles": {
+                "github": {"match_commands": ["gh"], "bypass_sandbox": True},
+            },
+        })
+        assert s.profiles["github"].bypass_sandbox is True
+
+    def test_profile_bypass_sandbox_rejects_non_bool(self):
+        with pytest.raises(ValueError, match="bypass_sandbox"):
+            SandboxSettings.from_config({
+                "backend": "srt",
+                "profiles": {
+                    "github": {"match_commands": ["gh"], "bypass_sandbox": "yes"},
+                },
+            })
+
 
 class TestProfileSelectionAndMerge:
     def _settings(self):


### PR DESCRIPTION
## Summary

- Adds a per-profile `bypass_sandbox: bool` flag to `SandboxProfile`. When `true`, matched commands run in the parent environment instead of through srt, but still go through the existing scope grant flow (once / 30-min lease / session / deny).
- Fixes #402 — `gh` (Go's `crypto/x509`) cannot complete TLS through srt's HTTP CONNECT proxy on macOS (`errSecUnknownKeychainError`), and `git` HTTPS push/fetch hits the same wall. Issue Test #2 confirmed that simply unsetting `HTTPS_PROXY` inside srt also breaks DNS — SRT's network filter and file sandbox are coupled, so the only working path is skipping the wrap entirely.
- Authorization is unchanged: bypass profiles require the same scope grant as wrapped ones. Bypass is an authorized opt-out, not an unauthorized escape hatch.

Adding a new bypass-only CLI is two lines:

```toml
[security.sandbox.profiles.opencli]
match_commands = ["opencli"]
bypass_sandbox = true
```

## User-side `loom.toml` update

`loom.toml` is gitignored, so users who run with `backend = "srt"` should add `bypass_sandbox = true` to their `github` profile after pulling:

```toml
[security.sandbox.profiles.github]
match_commands  = ["gh", "git"]
bypass_sandbox  = true
...
```

## Future direction

When SRT upstream accepts a `noProxyExtra` (or per-command bypass) config, we can flip the flag back off without rewriting profiles. The non-bypass fields (`allow_read`, `allowed_domains`, etc.) are kept for that future.

## Test plan

- [x] `pytest tests/test_sandbox_runtime.py tests/test_run_bash_sandbox_profiles.py` — 62 passed
- [x] New unit tests:
  - `bypass_sandbox` defaults to `False`
  - Parses `True` when set
  - Rejects non-bool values
  - Authorized bypass profile → command runs raw, srt wrap is skipped, `sandbox_profile` metadata still attached
  - Unauthorized bypass profile → still `permission_denied`
- [ ] Manual: with `backend = "srt"` + `bypass_sandbox = true` on `github` profile, `gh pr view 402` succeeds inside Loom

🤖 Generated with [Claude Code](https://claude.com/claude-code)