### PR TITLE
chore(audit-A r2): clean retired-feature stragglers from Loom self-audit

### DIFF
--- a/doc/43-Harness-Execution-可視化規劃.md
+++ b/doc/43-Harness-Execution-可視化規劃.md
@@ -1,6 +1,8 @@
 # Harness Execution 可視化規劃
 
-本文件定義 Loom 下一階段在 **TUI** 與 **Discord** 的可視化升級方向。
+> **⚠️ 部分退役 — 2026-05-19**：本文件以「TUI + Discord」雙端為前提。整個 Textual TUI 子系統已於 PR #404 退役（見 [doc/34](34-TUI-使用指南.md)），後續 §241 以後的 TUI 規劃章節保留為**歷史脈絡**，不再驅動實作。Discord 端的可視化敘事仍有效；如需新 envelope/dashboard 設計，請以 Discord 端 + CLI（prompt_toolkit `LoomApp`）為對象重新規劃。
+
+本文件定義 Loom 在 **Discord** 與 **CLI** 的可視化升級方向（原稿涵蓋 TUI，已退役）。
 
 核心目標不是把 agent 畫成「待辦事項 DAG」，而是把 Loom 的 **harness-first engineering** 精神以可觀察、可審計、可理解的方式呈現出來。
 

--- a/loom/core/config.py
+++ b/loom/core/config.py
@@ -8,7 +8,6 @@ of reaching into private session-module helpers — see #306.
 from __future__ import annotations
 
 import tomllib
-import warnings
 from pathlib import Path
 
 
@@ -21,12 +20,5 @@ def load_loom_config() -> dict:
     for path in candidates:
         if path.exists():
             with open(path, "rb") as fh:
-                config = tomllib.load(fh)
-            if "mutation" in config:
-                warnings.warn(
-                    "[mutation] is retired by Quest D Phase 1.C and is safe to delete.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-            return config
+                return tomllib.load(fh)
     return {}

--- a/loom/core/memory/procedural.py
+++ b/loom/core/memory/procedural.py
@@ -1,10 +1,8 @@
 """
 Procedural Memory — persisted metadata for loadable skills.
 
-The retired Quest D skill-evolution lifecycle used this module for candidate
-pools and version history. Phase 1.C removed that lifecycle; ProceduralMemory
-now only keeps the active SkillGenome rows used by skill loading, indexing,
-and confidence tracking.
+Tracks active SkillGenome rows for skill loading, indexing, and confidence
+tracking.
 """
 
 import json

--- a/skills/meta-skill-engineer/SKILL.md
+++ b/skills/meta-skill-engineer/SKILL.md
@@ -5,7 +5,7 @@ precondition_checks:
   - ref: checks.require_skills_dir_target
     applies_to: [write_file]
     description: "只能寫入 skills/ 目錄，不可修改框架或使用者程式碼"
-tags: [meta, skill, create, register, manage, evolution]
+tags: [meta, skill, create, register, manage]
 ---
 
 # Meta Skill Engineer — 元技能工程師

--- a/tests/test_skill_evolution_retirement.py
+++ b/tests/test_skill_evolution_retirement.py
@@ -20,9 +20,15 @@ def test_retired_skill_lifecycle_tool_factories_are_not_exported() -> None:
     assert "skill_gate" not in inspect.signature(skill_tools.make_load_skill_tool).parameters
 
 
-def test_load_loom_config_warns_about_retired_mutation_section(
+def test_load_loom_config_silently_accepts_legacy_mutation_section(
     tmp_path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Legacy [mutation] section is parsed without error (silently ignored).
+
+    The earlier UserWarning was removed in audit-A round 2 (#398) after the
+    section had been retired long enough that anyone with it in their
+    loom.toml would already have seen — and acted on — the warning.
+    """
     from loom.core import session
 
     (tmp_path / "loom.toml").write_text(
@@ -33,7 +39,8 @@ def test_load_loom_config_warns_about_retired_mutation_section(
     )
     monkeypatch.chdir(tmp_path)
 
-    with pytest.warns(UserWarning, match=r"\[mutation\].*retired.*safe to delete"):
-        cfg = session._load_loom_config()
+    cfg = session._load_loom_config()
 
+    # Toml is parsed; the [mutation] section is harmlessly ignored by every
+    # consumer in the current codebase.
     assert cfg["mutation"]["enabled"] is True


### PR DESCRIPTION
## Summary

audit-A round 2 closes the loop on residue that survived the first pass. 4 actionable findings from 絲絲's self-audit report (`outputs/doc/audit-A.md`, attached to #398) applied; 1 dropped as false positive.

Closes #398 follow-up (issue stays open as the parent tracker if there's audit-A round 3 ever).

## What changed

| Finding | File | Action |
|---------|------|--------|
| 1 | `loom/core/memory/procedural.py` | Module docstring: drop "retired Quest D skill-evolution lifecycle" historical aside — describe the active path directly. |
| 2 | `skills/meta-skill-engineer/SKILL.md` | Frontmatter: drop `evolution` tag (body explicitly says skill doesn't run a shadow/promote/candidate lifecycle). |
| 3 | `loom/core/config.py` | Drop the `[mutation] is retired` UserWarning. ~3 weeks since f561c36 retire; \`loom.toml.example\` long-clean; no consumer reads the section. config.py shrinks 32 → 22 lines. |
| 4 | `tests/test_skill_evolution_retirement.py` | Rewrite the regression: was «warns on legacy [mutation]», now «silently accepts legacy [mutation]» — locks in the new contract. |
| 5 | `doc/43-Harness-Execution-可視化規劃.md` | Top banner notes TUI half retired in PR #404; rest of doc preserved as historical context. |

## What's NOT in this PR

絲絲's «3 empty TUI shell directories» finding was a **false positive**:

- `git ls-files | grep cli/tui` is empty since PR #404
- The directories 絲絲 saw locally were stale `__pycache__` + worktree state
- User already cleaned the worktree; local cache cleanup is dev hygiene, not a repo change

## Test plan

- [x] `pytest tests/test_skill_evolution_retirement.py tests/test_session.py::TestConfigPathResolution tests/test_doc_integrity.py` — 8 passed
- [x] Full suite: **1962 passed**, 3 failed (pre-existing scope-grant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)