### PR TITLE
feat(memorize): surface near-duplicate hint at write time

### DIFF
--- a/loom/core/memory/semantic.py
+++ b/loom/core/memory/semantic.py
@@ -11,7 +11,7 @@ import json
 import logging
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime, UTC
+from datetime import datetime, timedelta, UTC
 from typing import TYPE_CHECKING, Any
 
 logger = logging.getLogger(__name__)
@@ -376,6 +376,78 @@ class SemanticMemory:
         )
         rows = await cursor.fetchall()
         return [_row_to_entry(r) for r in rows]
+
+    async def find_near_duplicates(
+        self,
+        text: str,
+        *,
+        min_similarity: float = 0.85,
+        within_days: int | None = 7,
+        limit: int = 3,
+        exclude_key: str | None = None,
+    ) -> list[tuple[SemanticEntry, float]]:
+        """Embedding-based near-duplicate detection.
+
+        Returns recent semantic entries whose ``value`` has cosine similarity
+        ``>= min_similarity`` to *text*, ordered by similarity descending.
+        Returns an empty list when no embedding provider is wired or no
+        embedded entries fall in the window — never raises.
+
+        Used by ``memorize`` (cli/tools.py) to surface a hint when the agent
+        is about to write something very similar to a recent entry, per the
+        memory-hygiene reflection in #398.
+        """
+        if self._embeddings is None:
+            return []
+
+        try:
+            query_vectors = await self._embeddings.embed([text])
+        except Exception:
+            # Embedding outages should never block a write; just skip the hint.
+            return []
+        if not query_vectors:
+            return []
+        query_vec = query_vectors[0]
+
+        time_where = ""
+        time_params: tuple = ()
+        if within_days is not None:
+            cutoff = datetime.now(UTC) - timedelta(days=within_days)
+            time_where = " AND updated_at >= ?"
+            time_params = (cutoff.isoformat(),)
+
+        exclude_where = ""
+        exclude_params: tuple = ()
+        if exclude_key:
+            exclude_where = " AND key != ?"
+            exclude_params = (exclude_key,)
+
+        cursor = await self._db.execute(
+            f"""
+            SELECT {_SELECT_COLS},
+                   1.0 - vec_distance_cosine(embedding, ?) AS score
+            FROM semantic_entries
+            WHERE embedding IS NOT NULL{time_where}{exclude_where}
+            ORDER BY vec_distance_cosine(embedding, ?) ASC
+            LIMIT ?
+            """,
+            (
+                json.dumps(query_vec),
+                *time_params,
+                *exclude_params,
+                json.dumps(query_vec),
+                limit,
+            ),
+        )
+        rows = await cursor.fetchall()
+
+        results: list[tuple[SemanticEntry, float]] = []
+        for r in rows:
+            score = r[11]
+            if score is None or score < min_similarity:
+                continue
+            results.append((_row_to_entry(r[:11]), float(score)))
+        return results
 
     async def list_by_prefix(self, prefix: str, limit: int = 10) -> list[SemanticEntry]:
         """Return entries whose key starts with *prefix*, newest first.

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -1498,6 +1498,23 @@ def make_memorize_tool(
             domain=normalize_domain(domain_raw),
             temporal=normalize_temporal(temporal_raw),
         )
+
+        # Near-dup hint: surface recent semantically-similar entries so the
+        # agent can self-correct duplicate writes. Catches operational-record
+        # bloat (memory-hygiene reflection, #398). Never blocks the write;
+        # the agent decides whether the new fact is genuinely distinct.
+        near_dups: list = []
+        try:
+            near_dups = await memory.semantic.find_near_duplicates(
+                value,
+                min_similarity=0.85,
+                within_days=7,
+                limit=3,
+                exclude_key=key,
+            )
+        except Exception:
+            pass  # embedding/db failure must never block memorize
+
         gov_result = await memory.memorize(entry)
 
         if not gov_result.written:
@@ -1522,6 +1539,16 @@ def make_memorize_tool(
             msg = f"Memorized: {key!r} (overwrote previous value — history preserved)"
         else:
             msg = f"Memorized: {key!r}"
+
+        if near_dups:
+            dup_lines = []
+            for dup_entry, score in near_dups:
+                snippet = dup_entry.value[:60] + ("…" if len(dup_entry.value) > 60 else "")
+                dup_lines.append(f"  • {dup_entry.key!r} (sim={score:.2f}) — {snippet}")
+            msg += (
+                "\n\n⚠ near-duplicate(s) in last 7d — verify this is a distinct "
+                "insight, not an operational repeat:\n" + "\n".join(dup_lines)
+            )
 
         return ToolResult(call_id=call.id, tool_name=call.tool_name,
                           success=True, output=msg,

--- a/tests/test_memory_search.py
+++ b/tests/test_memory_search.py
@@ -718,3 +718,123 @@ class TestMemorySearchEmbeddingTier:
         results = await search.recall("查詢完全不相關", type="semantic", limit=5)
         assert len(results) == 1
         assert results[0].metadata.get("fallback") is True
+
+
+# ---------------------------------------------------------------------------
+# find_near_duplicates + memorize tool near-dup hint (#398 follow-up)
+# ---------------------------------------------------------------------------
+
+
+class TestFindNearDuplicates:
+    """Embedding-based dedup guard for the memorize path.
+
+    Catches operational-record bloat (絲絲's memory-hygiene reflection):
+    when a value is semantically very close to a recent entry, surface it
+    so the agent can self-correct instead of silently growing semantic.
+    """
+
+    async def test_returns_empty_without_embedding_provider(self, semantic):
+        # ``semantic`` fixture is constructed without a provider.
+        results = await semantic.find_near_duplicates("any text", min_similarity=0.85)
+        assert results == []
+
+    async def test_finds_similar_recent_entry(self, db_conn):
+        provider = AsyncMock()
+        provider.embed.return_value = [[1.0, 0.0, 0.0]]
+        sem = SemanticMemory(db_conn, embedding_provider=provider)
+        await sem.upsert(SemanticEntry(
+            key="diary:list_dir_rule",
+            value="diary write should call list_dir first",
+        ))
+
+        results = await sem.find_near_duplicates(
+            "before diary write, run list_dir", min_similarity=0.85,
+        )
+        assert len(results) == 1
+        entry, score = results[0]
+        assert entry.key == "diary:list_dir_rule"
+        assert score == pytest.approx(1.0)
+
+    async def test_skips_when_below_threshold(self, db_conn):
+        provider = AsyncMock()
+        # Upsert path uses [1,0,0]; query uses [0,1,0] → cosine = 0 → skipped.
+        provider.embed.side_effect = [[[1.0, 0.0, 0.0]], [[0.0, 1.0, 0.0]]]
+        sem = SemanticMemory(db_conn, embedding_provider=provider)
+        await sem.upsert(SemanticEntry(key="alpha", value="alpha"))
+
+        results = await sem.find_near_duplicates("beta", min_similarity=0.85)
+        assert results == []
+
+    async def test_exclude_key_filters_self(self, db_conn):
+        provider = AsyncMock()
+        provider.embed.return_value = [[1.0, 0.0, 0.0]]
+        sem = SemanticMemory(db_conn, embedding_provider=provider)
+        await sem.upsert(SemanticEntry(key="self_key", value="x"))
+
+        results = await sem.find_near_duplicates(
+            "x", min_similarity=0.85, exclude_key="self_key",
+        )
+        assert results == []
+
+    async def test_embedding_failure_returns_empty_not_raises(self, db_conn):
+        provider = AsyncMock()
+        # First call (the test's upsert) succeeds; second call (the dedup
+        # query) blows up. find_near_duplicates must swallow it.
+        provider.embed.side_effect = [
+            [[1.0, 0.0, 0.0]],
+            RuntimeError("embedding API down"),
+        ]
+        sem = SemanticMemory(db_conn, embedding_provider=provider)
+        await sem.upsert(SemanticEntry(key="k", value="seed"))
+
+        results = await sem.find_near_duplicates("anything", min_similarity=0.85)
+        assert results == []
+
+
+class TestMemorizeNearDupHint:
+    """Integration: make_memorize_tool surfaces near-dup hint without blocking write."""
+
+    async def test_hint_appended_to_output_on_near_dup(self, db_conn, procedural):
+        provider = AsyncMock()
+        provider.embed.return_value = [[1.0, 0.0, 0.0]]
+        sem = SemanticMemory(db_conn, embedding_provider=provider)
+        # Seed an existing semantically-identical entry.
+        await sem.upsert(SemanticEntry(
+            key="diary:rule_v1",
+            value="diary writes should list_dir before save",
+            source="memorize",
+        ))
+
+        tool = make_memorize_tool(_facade(semantic=sem, procedural=procedural))
+        call = _make_call("memorize", {
+            "key": "diary:rule_v2",
+            "value": "before diary save call list_dir",
+        })
+        result = await tool.executor(call)
+
+        # Write still succeeds — the hint never blocks the agent.
+        assert result.success is True
+        stored = await sem.get("diary:rule_v2")
+        assert stored is not None
+
+        # The hint surfaces the duplicate so the agent can self-correct.
+        assert "near-duplicate" in result.output.lower()
+        assert "diary:rule_v1" in result.output
+
+    async def test_no_hint_when_no_near_dup(self, db_conn, procedural):
+        provider = AsyncMock()
+        # Orthogonal vectors — every entry looks dissimilar.
+        provider.embed.side_effect = [
+            [[1.0, 0.0, 0.0]],  # seed upsert
+            [[0.0, 1.0, 0.0]],  # query in find_near_duplicates
+            [[0.0, 1.0, 0.0]],  # upsert of new entry
+        ]
+        sem = SemanticMemory(db_conn, embedding_provider=provider)
+        await sem.upsert(SemanticEntry(key="x", value="x", source="memorize"))
+
+        tool = make_memorize_tool(_facade(semantic=sem, procedural=procedural))
+        call = _make_call("memorize", {"key": "y", "value": "y"})
+        result = await tool.executor(call)
+
+        assert result.success is True
+        assert "near-duplicate" not in result.output.lower()


### PR DESCRIPTION
## Background

Loom-the-agent's self-audit (full report in `outputs/doc/audit-A.md`, attached to #398) found a real memory-hygiene failure: **operational notes and state snapshots leak into `semantic_memory`** where they don't belong. Examples 絲絲 surfaced:

- "diary 寫入前應先 list_dir ..." stored twice on the same day
- "task_status 指令可用於快速確認..." stored twice
- A run of "Self-check 完成（YYYY-MM-DD）..." snapshots that only matter as deltas

We talked it through and converged on: the failure is on the **write side**. By the time a downstream skill like memory_hygiene inspects semantic, the noise is already there. The harness can help **at the memorize call itself**, without overstepping into identity territory.

絲絲 already took the identity-layer move (SOUL.md added "memory quality" as a value, AGENT.md adds a pre-write discipline question). This PR is the harness-side complement.

Refs #398.

## Approach

**Write-time hint, not enforcement.** Agent keeps judgment; harness just exposes information the agent didn't have when calling `memorize`.

## Changes

| File | What |
|------|------|
| `loom/core/memory/semantic.py` | New public `SemanticMemory.find_near_duplicates(text, *, min_similarity=0.85, within_days=7, limit=3, exclude_key=None)`. Reuses sqlite-vec cosine + time-window filter. Returns `[]` on no provider / API failure / empty — never raises. |
| `loom/platform/cli/tools.py` (`make_memorize_tool`) | Calls `find_near_duplicates` before governance write. On hits, appends a "⚠ near-duplicate(s) in last 7d" block to `ToolResult.output` listing keys + similarity + snippet. **Write still proceeds**; agent decides. |
| `tests/test_memory_search.py` | 7 new tests (5 unit + 2 integration). |

## Decisions

| Decision | Choice | Why |
|----------|--------|-----|
| API location | `SemanticMemory` public method | Cleaner than reaching into `MemorySearch._search_semantic_embedding` from another module |
| Policy | **Write-with-hint** (not reject) | Respects agent judgment; mirrors 絲絲's voluntary write-side discipline |
| Threshold | `0.85` | Conservative — tune after observing real hit rate from existing 6.6k facts |
| Window | 7 days | Catches «duplicate write within a working sprint» without flagging genuine reinforcement of a stable principle |

## Out of scope

- **Batch cleanup of existing 6.6k semantic entries** — audit-A round 3 territory; needs separate decision
- **Classification metadata** (operation / insight / snapshot in schema) — that's 絲絲's identity-layer concern, not harness's place
- **Threshold/policy auto-tuning** — wait for telemetry first

## Test plan

- [x] `pytest tests/test_memory_search.py::TestFindNearDuplicates tests/test_memory_search.py::TestMemorizeNearDupHint` — 7 passed
- [x] Full suite: **1969 passed**, 3 failed (pre-existing scope-grant, unrelated)
- [x] Smoke: `from loom.core.memory.semantic import SemanticMemory` + `from loom.platform.cli.tools import make_memorize_tool` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)