### PR TITLE
feat(governance): semantic-dup + time-window admission gate (#411)

### DIFF
--- a/loom.toml.example
+++ b/loom.toml.example
@@ -155,6 +155,31 @@ skill_deprecation_threshold = 0.3
 episodic_compress_threshold = 30
 
 # ─────────────────────────────────────────────
+# Memory governance (Issue #43, dedup hardened in #411)
+# ─────────────────────────────────────────────
+# Admission gate scoring + duplicate suppression for facts the
+# session-end compressor proposes to promote into semantic memory.
+#
+# Novelty check (Issue #411): a candidate is duplicate when EITHER
+#   • embedding cosine to a recent fact ≥ ``dup_similarity_threshold``, OR
+#   • lexical Jaccard word overlap > 0.8
+# The first clause catches paraphrases the lexical clause misses (e.g.
+# "diary writes should list_dir first" vs "before diary save, call list_dir").
+#
+# Lookback is by time, not row count — fixes the bug where bursty traffic
+# pushed yesterday's facts out of a 50-row position window within hours.
+
+[memory.governance]
+admission_threshold       = 0.5    # composite score floor for admission
+episodic_ttl_days         = 30     # episodic rows older than this get pruned
+semantic_decay_threshold  = 0.1    # min effective_confidence to keep a fact
+dup_window_days           = 7      # how far back to look for dups
+dup_lookback_limit        = 500    # per-call row cap for lexical scan (perf)
+dup_similarity_threshold  = 0.85   # embedding cosine cutoff (matches the
+                                   # memorize-tool hint default — manual and
+                                   # auto compress paths agree on "near-dup")
+
+# ─────────────────────────────────────────────
 # Memory lifecycle (Issue #281 P3)
 # ─────────────────────────────────────────────
 # Drives the (domain × temporal) decay cycle that demotes recent → archived

--- a/loom/core/memory/governance.py
+++ b/loom/core/memory/governance.py
@@ -140,6 +140,19 @@ class MemoryGovernor:
         self._admission_threshold: float = cfg.get("admission_threshold", 0.5)
         self._episodic_ttl_days: int = cfg.get("episodic_ttl_days", 30)
         self._semantic_decay_threshold: float = cfg.get("semantic_decay_threshold", 0.1)
+        # Issue #411: time-windowed novelty lookback. Old code used
+        # ``list_recent(limit=50)`` — a position window that pushed yesterday's
+        # facts out of comparison range within hours on a busy session, letting
+        # the same idea sneak through gate after gate. Time window survives
+        # bursty writes; the 500-row cap protects perf on bloated DBs.
+        self._dup_window_days: int = cfg.get("dup_window_days", 7)
+        self._dup_lookback_limit: int = cfg.get("dup_lookback_limit", 500)
+        # Issue #411: embedding cosine threshold for semantic-similar duplicates.
+        # 0.85 matches PR #409's manual-memorize hint default so manual + auto
+        # paths agree on what "near-duplicate" means.
+        self._dup_similarity_threshold: float = cfg.get(
+            "dup_similarity_threshold", 0.85
+        )
         # Issue #281 P3: lifecycle throttle. Cross-caller gate so daemon-cron
         # and session.stop() paths skip when the previous run was recent.
         # Read from [memory.lifecycle] in session wiring; 0.0 disables.
@@ -271,18 +284,44 @@ class MemoryGovernor:
         Scoring criteria (each 0.0–1.0, averaged):
         - **Length score**: too short (<15 chars) = low, optimal 30-300 = high
         - **Info density**: ratio of non-stopword tokens
-        - **Novelty**: inverse of max similarity to existing recent facts
+        - **Novelty**: rejected when either the embedding cosine OR the lexical
+          Jaccard exceeds threshold against any recent fact in the time window.
 
         Facts scoring >= ``admission_threshold`` (default 0.5) are admitted.
+
+        Issue #411: novelty now combines embedding cosine (catches paraphrase)
+        with lexical Jaccard (catches near-exact + acts as fallback when the
+        embedding provider is unavailable). Lookback is a time window so
+        yesterday's facts are still comparable today.
         """
         results: list[AdmissionResult] = []
 
-        # Pre-fetch recent facts for novelty check
-        recent_facts = await self._semantic.list_recent(limit=50)
+        # Pre-fetch recent facts for lexical novelty check.
+        cutoff = datetime.now(UTC) - timedelta(days=self._dup_window_days)
+        recent_facts = await self._semantic.list_between(
+            since=cutoff, limit=self._dup_lookback_limit,
+        )
         recent_values = [f.value.lower() for f in recent_facts]
 
         for fact in candidate_facts:
-            score, reason = self._score_fact(fact, recent_values)
+            # Embedding-based semantic dup check — silently skipped when the
+            # embedding provider is missing or fails (find_near_duplicates
+            # returns [] in either case, so lexical path still runs).
+            semantic_dup = False
+            try:
+                near = await self._semantic.find_near_duplicates(
+                    fact,
+                    min_similarity=self._dup_similarity_threshold,
+                    within_days=self._dup_window_days,
+                    limit=1,
+                )
+                semantic_dup = bool(near)
+            except Exception:
+                pass
+
+            score, reason = self._score_fact(
+                fact, recent_values, semantic_dup=semantic_dup,
+            )
             admitted = score >= self._admission_threshold
             results.append(AdmissionResult(
                 fact=fact,
@@ -313,8 +352,15 @@ class MemoryGovernor:
         self,
         fact: str,
         recent_values: list[str],
+        *,
+        semantic_dup: bool = False,
     ) -> tuple[float, str]:
-        """Score a single candidate fact. Returns (score, reason)."""
+        """Score a single candidate fact. Returns (score, reason).
+
+        ``semantic_dup`` is computed by the caller via embedding cosine and
+        OR-combined with the lexical check below — either one tripping is
+        sufficient to mark the fact as duplicate.
+        """
         scores: dict[str, float] = {}
 
         # ── Length score ────────────────────────────────────────────────
@@ -337,7 +383,10 @@ class MemoryGovernor:
         info_words = [w for w in words if w not in _STOPWORDS and len(w) > 1]
         scores["info_density"] = min(1.0, len(info_words) / max(len(words), 1))
 
-        # ── Novelty (inverse max similarity to recent facts) ───────────
+        # ── Novelty: semantic OR lexical (Issue #411) ──────────────────
+        if semantic_dup:
+            return 0.2, "duplicate_semantic"
+
         fact_lower = fact.lower()
         max_overlap = 0.0
         for existing in recent_values:

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -137,9 +137,31 @@ logger = logging.getLogger(__name__)
 
 COMPRESS_PROMPT = """\
 Below are tool calls from an agent session.
-Extract 3-7 concise, reusable facts or learnings that would be valuable in future sessions.
-Format each on its own line starting with "FACT: ".
-Ignore trivial or highly session-specific details.
+Extract 0-7 reusable INSIGHTS that would be valuable in future sessions.
+
+Three tiers of session content — only the middle tier belongs in semantic memory:
+
+  1. OPERATIONAL TRACE (do NOT emit): step-by-step records of what happened
+     this session — "ran tool X with args Y", "called Z before W", "diary
+     write succeeded after list_dir". These are SOPs for *this* run; the
+     episodic log already keeps them.
+
+  2. INSIGHT (EMIT as FACT): durable, reusable knowledge that future sessions
+     would benefit from — non-obvious user preferences, project facts that
+     survive across sessions, lessons learned from failures, conceptual
+     understanding. Should still be true and useful next week.
+
+  3. SNAPSHOT (do NOT emit here): in-progress work state, current TODO,
+     "next we should do X". That belongs in pursuit trackers, not semantic.
+
+Quality bar: if a fact reads like "always do X before Y in this kind of
+operation", that's almost always tier 1 (operational), not tier 2. Insights
+are about *what is true*, not *what procedure to follow*.
+
+It is fine to emit 0 facts if the session contains no genuine insights.
+Do NOT pad to reach a minimum count.
+
+Format each insight on its own line starting with "FACT: ".
 IMPORTANT: Write every FACT in the same language as the session content below.
 
 Session log:

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -216,14 +216,17 @@ async def compress_session(
     )
 
     raw = response.text or ""
+    # Issue #411 review: the old "no FACT: prefix → use raw text as one fact"
+    # fallback turned compliant zero-insight responses ("No reusable
+    # insights found.") into admissible semantic facts. With COMPRESS_PROMPT
+    # now explicitly permitting 0 facts, that fallback is actively harmful —
+    # any response without a FACT: prefix is treated as the model declaring
+    # zero insights.
     facts = [
         line[len("FACT:") :].strip()
         for line in raw.splitlines()
         if line.strip().startswith("FACT:")
     ]
-    # Fallback: if the LLM didn't use FACT: prefixes, save the raw text as one fact.
-    if not facts and raw.strip():
-        facts = [raw.strip()[:800]]
 
     # Issue #43: Admission gate — filter facts through governance
     if governor is not None and facts:
@@ -247,12 +250,13 @@ async def compress_session(
         else:
             await semantic.upsert(entry)
 
-    # Soft-delete: mark the rows we read as compressed so they aren't
-    # re-processed on the next trigger, but keep the content on disk for
-    # audit and potential backfill (the admission gate or the LLM may drop
-    # something that later turns out to matter).
-    if facts:
-        await episodic.mark_compressed([e.id for e in entries])
+    # Soft-delete: mark every entry we sent to the LLM as compressed,
+    # regardless of whether facts survived parsing + admission. Previously
+    # this only ran when ``facts`` was non-empty, which meant duplicate-heavy
+    # or zero-insight sessions kept re-paying the LLM cost on every trigger
+    # (issue #411 review). The episodic rows are soft-deleted, not removed,
+    # so audit + recovery still work via TTL-bounded retention.
+    await episodic.mark_compressed([e.id for e in entries])
 
     # Issue #142: record the yield ratio so a silently degrading extractor
     # (facts << entries) surfaces as an anomaly on the next turn boundary.

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -787,6 +787,69 @@ class TestCompressWithGovernance:
         # "ok" should be filtered out by admission, so 2 facts instead of 3
         assert count == 2
 
+    @pytest.mark.asyncio
+    async def test_zero_insight_response_writes_nothing(
+        self, db, semantic, episodic
+    ):
+        """Issue #411 review: a compliant zero-insight LLM response (no
+        ``FACT:`` prefix) must NOT pollute semantic memory via the old
+        raw-text fallback. The new COMPRESS_PROMPT permits 0 facts, so
+        responses like "No reusable insights found." must round-trip to
+        zero writes."""
+        from loom.platform.cli.main import compress_session
+
+        session_id = "zero-insight-session"
+        await episodic.write(EpisodicEntry(
+            session_id=session_id,
+            event_type="user",
+            content="trivial operational chatter not worth keeping",
+        ))
+
+        mock_router = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = "No reusable insights found."
+        mock_router.chat = AsyncMock(return_value=mock_response)
+
+        count = await compress_session(
+            session_id, episodic, semantic, mock_router, "test-model",
+        )
+
+        assert count == 0
+        # Confirm nothing was written under the session-fact key prefix.
+        recent = await semantic.list_recent(limit=20)
+        assert all(not e.key.startswith(f"session:{session_id}:") for e in recent)
+
+    @pytest.mark.asyncio
+    async def test_zero_facts_still_marks_episodic_compressed(
+        self, db, semantic, episodic
+    ):
+        """Issue #411 review: even when zero facts survive parsing /
+        admission, episodic rows we sent to the LLM must be marked
+        compressed. Otherwise duplicate-heavy or zero-insight sessions
+        burn the LLM repeatedly on the same content every trigger."""
+        from loom.platform.cli.main import compress_session
+
+        session_id = "no-fact-session"
+        await episodic.write(EpisodicEntry(
+            session_id=session_id,
+            event_type="user",
+            content="trivial chatter not worth keeping",
+        ))
+
+        mock_router = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = ""  # LLM emits literally nothing
+        mock_router.chat = AsyncMock(return_value=mock_response)
+
+        await compress_session(
+            session_id, episodic, semantic, mock_router, "test-model",
+        )
+
+        # Re-reading the session with uncompressed_only should now return
+        # nothing — the entries were marked compressed despite zero facts.
+        leftover = await episodic.read_session(session_id, uncompressed_only=True)
+        assert leftover == []
+
 
 # ===========================================================================
 # 8. Backward Compatibility

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -545,6 +545,146 @@ class TestAdmissionGate:
 
 
 # ===========================================================================
+# 5b. MemoryGovernor — Admission gate, Issue #411 (semantic dup + time window)
+# ===========================================================================
+
+class TestAdmissionSemanticNovelty:
+    """PR for #411: novelty now combines embedding cosine with lexical Jaccard,
+    and the lookback window is by time rather than position."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_semantic_paraphrase(
+        self, db, procedural, relational, episodic,
+    ):
+        """Fact that is *paraphrased* (low lexical overlap, high cosine) is
+        rejected once an embedding provider can see the similarity."""
+        provider = AsyncMock()
+        # Same unit vector for both upsert and dup query → cosine = 1.0.
+        provider.embed.return_value = [[1.0, 0.0, 0.0]]
+        semantic = SemanticMemory(db, embedding_provider=provider)
+        await semantic.upsert(SemanticEntry(
+            key="seed",
+            value="diary writes should list_dir before save",
+            source="memorize",
+        ))
+
+        gov = MemoryGovernor(
+            semantic=semantic,
+            procedural=procedural,
+            relational=relational,
+            episodic=episodic,
+            db=db,
+            config={"admission_threshold": 0.5},
+        )
+
+        results = await gov.evaluate_admission(
+            ["before diary save call list_dir"],  # lexically distinct
+            source="session:test",
+        )
+        assert len(results) == 1
+        assert results[0].admitted is False
+        assert results[0].reason == "duplicate_semantic"
+
+    @pytest.mark.asyncio
+    async def test_admits_when_only_lexical_overlap_no_semantic_dup(
+        self, db, procedural, relational, episodic,
+    ):
+        """When the embedding says distinct (orthogonal) and lexical Jaccard
+        stays under 0.8, the fact should still be admitted — avoid over-killing
+        genuinely new facts that happen to share vocabulary with old ones."""
+        provider = AsyncMock()
+        # Seed entry vector vs. query vector are orthogonal → cosine = 0.
+        provider.embed.side_effect = [[[1.0, 0.0, 0.0]], [[0.0, 1.0, 0.0]]]
+        semantic = SemanticMemory(db, embedding_provider=provider)
+        await semantic.upsert(SemanticEntry(
+            key="seed",
+            value="user prefers dark mode in the editor today",
+            source="memorize",
+        ))
+
+        gov = MemoryGovernor(
+            semantic=semantic,
+            procedural=procedural,
+            relational=relational,
+            episodic=episodic,
+            db=db,
+            config={"admission_threshold": 0.5},
+        )
+
+        # Shares "user", "the", "in" with the seed but is conceptually different.
+        results = await gov.evaluate_admission(
+            ["user prefers ginger tea in the morning today"],
+            source="session:test",
+        )
+        assert len(results) == 1
+        assert results[0].admitted is True
+
+    @pytest.mark.asyncio
+    async def test_time_window_skips_old_entries(self, governor, semantic, db):
+        """An entry older than ``dup_window_days`` must not count as a
+        duplicate source — fixes the position-window bug where bursty traffic
+        pushed yesterday's fact out of comparison range."""
+        old_iso = (datetime.now(UTC) - timedelta(days=30)).isoformat()
+        await db.execute(
+            "INSERT INTO semantic_entries "
+            "(id, key, value, confidence, source, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                str(uuid.uuid4()),
+                "ancient:fact",
+                "user prefers dark mode themes everywhere",
+                0.8,
+                "session:old",
+                old_iso,
+                old_iso,
+            ),
+        )
+        await db.commit()
+
+        results = await governor.evaluate_admission(
+            ["user prefers dark mode themes everywhere"],
+            source="session:new",
+        )
+        assert len(results) == 1
+        # No embedding provider on this fixture, lexical-only check on a
+        # 30-day-old entry that is now outside the 7-day window → admitted.
+        assert results[0].admitted is True
+        assert results[0].reason != "duplicate"
+
+    @pytest.mark.asyncio
+    async def test_embedding_failure_falls_back_to_lexical(
+        self, db, procedural, relational, episodic,
+    ):
+        """If the embedding call raises, lexical check still catches near-
+        exact dups — the gate degrades gracefully."""
+        provider = AsyncMock()
+        provider.embed.side_effect = RuntimeError("embed API down")
+        semantic = SemanticMemory(db, embedding_provider=provider)
+        await semantic.upsert(SemanticEntry(
+            key="seed",
+            value="user prefers dark mode themes",
+            source="memorize",
+        ))
+
+        gov = MemoryGovernor(
+            semantic=semantic,
+            procedural=procedural,
+            relational=relational,
+            episodic=episodic,
+            db=db,
+            config={"admission_threshold": 0.5},
+        )
+
+        results = await gov.evaluate_admission(
+            ["user prefers dark mode themes"],
+            source="session:test",
+        )
+        assert len(results) == 1
+        assert results[0].admitted is False
+        assert results[0].reason == "duplicate"
+
+
+# ===========================================================================
 # 6. MemoryGovernor — Decay Cycle
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

Closes #411 — the three structural holes in `compress_session`'s admission gate that were funnelling 6.6k operational notes into semantic memory.

| Hole | Was | Now |
|------|-----|-----|
| Novelty signal | Jaccard word overlap only — paraphrases sailed through | OR-combined with embedding cosine via `SemanticMemory.find_near_duplicates` (same util PR #409 uses for the manual hint — manual + auto agree on \"near-dup\") |
| Lookback window | Last 50 rows by position — yesterday's facts pushed out within hours | Time window: `dup_window_days = 7`, capped at `dup_lookback_limit = 500` rows for perf |
| LLM compress prompt | \"Extract 3-7 reusable facts\" — LLM (correctly) read SOPs as reusable | Three-tier discrimination (operational trace / insight / snapshot), permits emitting 0, points the LLM at \"what is true\" rather than \"what procedure to follow\" |

## Design choices (the 4 decisions issue #411 deferred)

1. **embedding vs lexical**: OR-combined, not replacement. Lexical is the fallback when embeddings are unavailable; embedding catches paraphrase the lexical clause misses.
2. **threshold**: single `admission_threshold` kept (0.5). Embedding cutoff is its own knob (`dup_similarity_threshold = 0.85`) so the two checks don't fight.
3. **prompt change scale**: conservative+ — explicit three-tier guidance, but no over-engineering. The model was already capable; the gap was permission/clarity, not capacity.
4. **duplicate handling**: still hard-reject (score = 0.2, reason = `duplicate_semantic` / `duplicate`). Keeps existing `TestAdmissionGate.test_rejects_duplicate` semantics and is the conservative choice — we can soften later if we observe over-killing on real telemetry.

## Config (dual-written to `loom.toml.example`, runtime `loom.toml` is gitignored)

\`\`\`toml
[memory.governance]
admission_threshold       = 0.5
episodic_ttl_days         = 30
semantic_decay_threshold  = 0.1
dup_window_days           = 7
dup_lookback_limit        = 500
dup_similarity_threshold  = 0.85
\`\`\`

Pre-existing drift fixed in this PR: `[memory.governance]` had no block at all in `loom.toml.example` before. Now it does.

## Impact analysis (GitNexus)

- `evaluate_admission`, `_score_fact`, `compress_session` upstream impact: LOW
- `detect_changes` after edits: medium risk, all affected processes are exactly the admission/decay flows we intentionally touched

## Test plan

- [x] `tests/test_governance.py` — 51 pass (4 new in `TestAdmissionSemanticNovelty`)
  - rejects paraphrased fact (low lexical overlap, high embedding cosine)
  - admits when lexical overlap is high but embedding says distinct (avoid kill zone)
  - admits when an exact-match seed is older than `dup_window_days` (time-window correctness)
  - falls back to lexical when embedding provider raises
- [x] Full suite: 1973 pass / 3 pre-existing scope-grant failures (unchanged from PR #409)

## Follow-ups

- #410 cleanup of existing 6.6k bloat is now safe to schedule — auto path no longer keeps refilling
- Watch telemetry on next few sessions: if too many candidates get marked `duplicate_semantic`, dial `dup_similarity_threshold` up toward 0.88-0.90
- COMPRESS_PROMPT wording is intentionally a first cut; revise after observing a few session-end compressions in the wild

🤖 Generated with [Claude Code](https://claude.com/claude-code)