### PR TITLE
fix(memory_hygiene): align dedup default cosine to 0.85 (#413 follow-up)

### DIFF
--- a/skills/memory_hygiene/dedup.py
+++ b/skills/memory_hygiene/dedup.py
@@ -272,8 +272,10 @@ async def main() -> int:
                         help="Path to memory.db (default: ~/.loom/memory.db).")
     parser.add_argument("--sample", type=int, default=10,
                         help="How many top clusters to print (default: 10).")
-    parser.add_argument("--cosine", type=float, default=0.95,
-                        help="Pass-2 embedding cosine threshold (default: 0.95).")
+    parser.add_argument("--cosine", type=float, default=0.85,
+                        help="Pass-2 embedding cosine threshold (default: 0.85, "
+                             "matching the live admission gate in PR #409 / #412 — "
+                             "what the gate would reject now is what cleanup deletes).")
     args = parser.parse_args()
 
     if not (args.analyze or args.apply):


### PR DESCRIPTION
## Summary

絲絲 caught a default mismatch during PR #413 review: `dedup.py` argparse defaulted `--cosine 0.95`, but the audit-A r3 run used `0.85` (matching the live admission gate from PR #409 / #412), and SKILL.md already documents the default as 0.85.

The mismatch means a future `--analyze` invocation without an explicit `--cosine` would surface different numbers from the documented baseline — silent footgun for the next maintenance pass.

## Change

One-line argparse default: `0.95` → `0.85`. Help text updated to explain the rationale (alignment with write-side gates).

## Test plan

- [x] `python skills/memory_hygiene/dedup.py --analyze` now matches what was applied at audit-A r3 (cosine 0.85).
- [x] SKILL.md docs already say 0.85 — no doc change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)