### PR TITLE
chore(audit-C r1): remove 3 confirmed-dead imports (#400)

### DIFF
--- a/loom/core/memory/search.py
+++ b/loom/core/memory/search.py
@@ -22,7 +22,6 @@ import json
 import logging
 import math
 import re
-from collections import Counter
 from datetime import UTC, datetime
 from dataclasses import dataclass, field
 from typing import Any, Literal
@@ -31,7 +30,6 @@ from loom.core.timezone import user_zone
 
 logger = logging.getLogger(__name__)
 
-from loom.core.memory.embeddings import cosine_similarity
 from loom.core.memory.procedural import ProceduralMemory
 from loom.core.memory.semantic import (
     SemanticMemory,

--- a/loom/extensibility/mcp_server.py
+++ b/loom/extensibility/mcp_server.py
@@ -45,7 +45,6 @@ try:
     from mcp.server import Server
     from mcp.server.stdio import stdio_server
     from mcp.types import (
-        CallToolResult,
         TextContent,
         Tool,
     )


### PR DESCRIPTION
## Summary

Round 1 of audit-C (dead-code sweep, #400). The cheap first-pass tactic was: run vulture at conservative confidence (≥80), grep for retired-feature stragglers, filter against reflection patterns. Total yield is **3 confirmed-dead imports** — confirming the prediction that audit-A/B's earlier cleanup left very little for audit-C.

## Findings

### Confirmed dead (this PR removes):
- `loom/core/memory/search.py:25` — `from collections import Counter` (never referenced)
- `loom/core/memory/search.py:34` — `from loom.core.memory.embeddings import cosine_similarity` (never referenced)
- `loom/extensibility/mcp_server.py:48` — `CallToolResult` import (never referenced)

### Confirmed alive (kept):
- `loom/extensibility/mcp_client.py:59` `CallToolResult` — vulture-flagged because string annotations don't count as uses, but it IS used as a forward-ref `-> \"CallToolResult\"`. Removing breaks IDE / type-checker resolution. False positive.

### Surveyed but no hits:
- Retired-feature import grep (`tui`, `TextualLoomApp`, `record_outcome`, `TaskGraph`, `seven_layer`, `task_reflector` paths) — no `.py` references survive. PR #404 / #408 / #401 were thorough.
- Empty stub files — only standard package-marker `__init__.py`s.

### Deferred to potential Round 2:
- `vulture --min-confidence 60` returns 233 hits. Virtually all are reflection-likely (tool registry string-lookup, skill auto-import, dataclass field FPs, middleware/notifier class registries, dynamic CLI dispatch). Distinguishing genuinely-dead from genuinely-reflective in this bucket requires narrative judgment about how the harness reaches each symbol — beyond what an outer Round 1 pass should attempt.
- Recommendation: if symbol-count growth slows future maintenance, brief 絲絲 to do `outputs/doc/audit-C.md` (vulture + pytest coverage + GitNexus orphan-node cross-reference). For now, the noise floor doesn't justify the false-positive risk.

## Test plan

- [x] Smoke imports: `MemorySearch`, `run_mcp_server` both still importable
- [x] Full test suite: 1975 passed / 3 pre-existing scope-grant failures (unchanged from PR #412 / #413 baseline)

## Closes

#400 — assuming Round 1 was the cheap pass it was scoped to be. If Round 2 is wanted later, it's a separate brief and PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)