### PR TITLE
feat(cli): CLI runtime heartbeat (#418 + #419)

### DIFF
--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -1069,6 +1069,7 @@ class BlastRadiusMiddleware(Middleware):
         import time as _time
         if decision == ConfirmDecision.ONCE:
             call.metadata["once_authorized"] = True
+            self._request_to_grants(scope_request, source="manual_confirm")
         elif decision == ConfirmDecision.SCOPE:
             # Session-scoped lease: grant with TTL
             self._request_to_grants(

--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -106,10 +106,6 @@ class FooterState:
     # else and shows ``⚡ 壓縮中…`` so the long pause doesn't look
     # like a hang
     compacting: bool = False
-    # Loom is thinking (LLM call dispatched, no stream output yet).
-    # Surfaces as a soft animated indicator above the input separator
-    # so the user knows their input is being chewed on
-    thinking: bool = False
     # Runtime heartbeat — single liveness signal that replaced the raw
     # ``▸ run_bash`` envelope label (#418). States: idle / thinking /
     # tooling / long_tooling / stalled / paused_blocking. Written by
@@ -215,9 +211,6 @@ _APP_STYLE = Style.from_dict(
         # above the input separator then auto-vanish
         "hint.info":             _CLI_ACCENT,
         "hint.warn":             _CLI_WARNING,
-        # Thinking indicator above the input separator
-        "thinking":              _CLI_MUTED,
-        "thinking.dot":          _CLI_ACCENT,
         # Floating TaskList panel
         "tasklist.frame":        _CLI_BORDER,
         "tasklist.title":        f"{_CLI_ACCENT} bold",
@@ -630,24 +623,13 @@ class LoomApp:
             filter=Condition(lambda: bool(self._tasklist_state.todos)),
         )
 
-        # Thinking indicator — appears as its own line *above* the
-        # separator (so visually attached to the input region), only
-        # while ``footer.thinking`` is True. Mirrors Claude Code-style
-        # "● thinking…" status above the prompt rather than tucking
-        # it into the footer
-        thinking_window = ConditionalContainer(
-            Window(
-                content=FormattedTextControl(self._render_thinking),
-                height=1,
-            ),
-            filter=Condition(lambda: self.footer.thinking),
-        )
-
-        # Issue #284: transient hint line. Shares the slot above the
-        # separator with the thinking indicator (both can be active —
-        # they stack). Filter checks expiry so the line collapses once
-        # the deadline passes; the ticker re-evaluates at 2 Hz so the
-        # collapse is visible without a render storm.
+        # Issue #284: transient hint line. Footer heartbeat (#418/#419)
+        # now owns the "Loom is thinking…" signal as part of the
+        # broader runtime liveness model, so no separate thinking
+        # window stacks above the separator. Filter checks expiry so
+        # the line collapses once the deadline passes; the ticker
+        # re-evaluates at 2 Hz so the collapse is visible without a
+        # render storm.
         hint_window = ConditionalContainer(
             Window(
                 content=FormattedTextControl(self._render_hint),
@@ -660,7 +642,6 @@ class LoomApp:
             HSplit([
                 tasklist_window,
                 hint_window,
-                thinking_window,
                 separator_top,
                 input_window,
                 confirm_window,
@@ -825,22 +806,6 @@ class LoomApp:
             return FormattedText([])
         cls = "class:hint.warn" if h.severity == "warn" else "class:hint.info"
         return FormattedText([(cls, f" {h.text} ")])
-
-    def _render_thinking(self) -> FormattedText:
-        """Animated thinking indicator above the input separator.
-
-        Style: ``● Loom is thinking···`` with the dots cycling on the
-        ticker invalidate. Bullet glyph in accent gold so it reads as
-        a status pip; the rest in muted parchment so the line stays
-        quiet relative to streaming output.
-        """
-        import time as _t
-        phase = int(_t.monotonic() * 2) % 4
-        dots = "·" * phase + " " * (3 - phase)
-        return FormattedText([
-            ("class:thinking.dot", " ● "),
-            ("class:thinking", f"Loom is thinking{dots}"),
-        ])
 
     def _render_tasklist(self) -> FormattedText:
         """Floating TaskList panel — agent's todo board (PR-E, #236).

--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -77,13 +77,6 @@ Mode = Literal["input", "confirm", "pause", "redirect"]
 
 
 @dataclass
-class _ActiveEnvelope:
-    """A tool envelope currently in flight — for footer summary."""
-    name: str
-    started_monotonic: float
-
-
-@dataclass
 class _TransientHint:
     """Issue #284: a footer hint that auto-vanishes after a few seconds.
 
@@ -109,9 +102,6 @@ class FooterState:
     persona: str | None = None
     # Context window utilisation — surfaces in footer when >60%
     token_pct: float = 0.0
-    # Tools currently running. footer shows the most recent one's
-    # name + elapsed; if multiple, prefix with ``Nx`` count
-    active_envelopes: list[_ActiveEnvelope] = field(default_factory=list)
     # Compaction in progress — when True, footer hides everything
     # else and shows ``⚡ 壓縮中…`` so the long pause doesn't look
     # like a hang
@@ -120,6 +110,21 @@ class FooterState:
     # Surfaces as a soft animated indicator above the input separator
     # so the user knows their input is being chewed on
     thinking: bool = False
+    # Runtime heartbeat — single liveness signal that replaced the raw
+    # ``▸ run_bash`` envelope label (#418). States: idle / thinking /
+    # tooling / long_tooling / stalled / paused_blocking. Written by
+    # stream-event handlers via ``LoomApp.start_heartbeat`` and friends.
+    # ``heartbeat_last_event_monotonic`` is touched on every observable
+    # stream event; ``stale_after_s`` controls when the footer adds the
+    # ``still waiting · …`` warning prefix. Only tooling states are
+    # eligible for the stalled prefix — thinking/paused are waiting on
+    # someone else, so silence there is not stallness.
+    heartbeat_state: str = "idle"
+    heartbeat_label: str = ""
+    heartbeat_subject: str = ""
+    heartbeat_started_monotonic: float = 0.0
+    heartbeat_last_event_monotonic: float = 0.0
+    heartbeat_stale_after_s: float = 30.0
     # Number of active scope grants and seconds until the nearest one
     # expires. Refreshed at turn boundaries (per doc/49 decision —
     # don't tick every second). 0 grants → both fields 0
@@ -315,6 +320,44 @@ class LoomApp:
 
     def invalidate(self) -> None:
         self._app.invalidate()
+
+    # ------------------------------------------------------------------
+    # Heartbeat (#418) — runtime liveness signal driving the footer.
+    # ``start_heartbeat`` writes a new state + label and resets timers;
+    # ``touch_heartbeat`` extends liveness so the stalled warning resets;
+    # ``stop_heartbeat`` returns to idle. Designed so any stream-event
+    # handler can drive it without knowing footer geometry.
+    # ------------------------------------------------------------------
+
+    def start_heartbeat(
+        self,
+        *,
+        state: str,
+        label: str,
+        subject: str = "",
+        stale_after_s: float = 30.0,
+    ) -> None:
+        now = monotonic()
+        self.footer.heartbeat_state = state
+        self.footer.heartbeat_label = label
+        self.footer.heartbeat_subject = subject
+        self.footer.heartbeat_started_monotonic = now
+        self.footer.heartbeat_last_event_monotonic = now
+        self.footer.heartbeat_stale_after_s = stale_after_s
+        self.invalidate()
+
+    def touch_heartbeat(self) -> None:
+        if self.footer.heartbeat_state != "idle":
+            self.footer.heartbeat_last_event_monotonic = monotonic()
+            self.invalidate()
+
+    def stop_heartbeat(self) -> None:
+        self.footer.heartbeat_state = "idle"
+        self.footer.heartbeat_label = ""
+        self.footer.heartbeat_subject = ""
+        self.footer.heartbeat_started_monotonic = 0.0
+        self.footer.heartbeat_last_event_monotonic = 0.0
+        self.invalidate()
 
     def show_transient_hint(
         self,
@@ -700,25 +743,45 @@ class LoomApp:
                  f"🔑 {s.grants_active}·{ttl_label}")
             )
 
-        # Active envelopes — show the most recent one with elapsed
-        # time. When >1 in flight, prefix with count: ``3× ▸ ...``.
-        # Updates as ToolBegin / ToolEnd fire (see main.py wiring)
-        envs = s.active_envelopes
-        if envs:
+        # Runtime heartbeat (#418) — system-driven liveness signal that
+        # replaced the raw active-envelope label. Labels are written by
+        # interaction_language (action-language, not tool name); the
+        # ``still waiting · …`` prefix appears once a tooling state goes
+        # quiet past its ``stale_after_s`` threshold. Thinking / paused
+        # states never render the stalled prefix — they're waiting on
+        # the agent or the user, not on a tool, so silence there is not
+        # stallness. This mirrors the Discord watchdog suppression rule.
+        heartbeat_active = (
+            s.heartbeat_state
+            and s.heartbeat_state != "idle"
+            and s.heartbeat_label
+        )
+        if heartbeat_active:
             import time as _t
-            latest = envs[-1]
-            elapsed = max(0.0, _t.monotonic() - latest.started_monotonic)
-            label = f"{len(envs)}× " if len(envs) > 1 else ""
-            label += f"▸ {latest.name} · {elapsed:.1f}s"
-            parts.append(("class:footer", "  "))
-            parts.append(("class:footer.envelope", label))
-        # Thinking indicator no longer rendered here — moved to its
-        # own window above the input separator (see _render_thinking)
+            from loom.platform.interaction_language import format_elapsed
 
-        # Last-turn stats — only show when no tool is currently in
-        # flight (otherwise the active envelope already tells the
-        # user "we're busy")
-        if not envs:
+            now = _t.monotonic()
+            elapsed = max(0.0, now - s.heartbeat_started_monotonic)
+            quiet_for = max(0.0, now - s.heartbeat_last_event_monotonic)
+            stalled = (
+                s.heartbeat_state == "stalled"
+                or (
+                    s.heartbeat_state in ("tooling", "long_tooling")
+                    and quiet_for >= s.heartbeat_stale_after_s
+                )
+            )
+            prefix = "still waiting · " if stalled else ""
+            label = f"{prefix}{s.heartbeat_label}"
+            if s.heartbeat_subject:
+                label += f" · {s.heartbeat_subject}"
+            label += f" · {format_elapsed(elapsed)}"
+            parts.append(("class:footer", "  "))
+            style = "class:footer.budget.warn" if stalled else "class:footer.envelope"
+            parts.append((style, label))
+
+        # Last-turn stats — only show when nothing is in flight
+        # (otherwise the heartbeat already tells the user "we're busy")
+        if not heartbeat_active:
             stats: list[str] = []
             if s.last_turn_cache_hit is not None:
                 stats.append(f"cache {s.last_turn_cache_hit:.0f}%")

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -568,14 +568,17 @@ async def _chat(
                 text = "[使用者打斷上一輪並接續]\n" + text
 
             console.print()
-            # PR-D4: thinking indicator. Set True the moment we
-            # dispatch the streaming turn; cleared inside
-            # _run_streaming_turn the first time anything visible
-            # happens (TextChunk / ToolBegin / TurnDone). If turn
-            # crashes / aborts before that, the finally below still
-            # clears it
-            app.footer.thinking = True
-            app.invalidate()
+            # Heartbeat (#418/#419). Light up THINKING the moment we
+            # dispatch the streaming turn; stream-event handlers inside
+            # _run_streaming_turn transition it to TOOLING / PAUSED /
+            # back to idle. If the turn crashes / aborts before any
+            # event lands, the finally below still returns to idle.
+            from loom.platform.interaction_language import HeartbeatState
+            app.start_heartbeat(
+                state=HeartbeatState.THINKING.value,
+                label="Loom is thinking",
+                stale_after_s=30.0,
+            )
             current_turn_task = asyncio.create_task(
                 _run_streaming_turn(session, text)
             )
@@ -587,7 +590,7 @@ async def _chat(
                 harness.inline(f"turn error: {exc}", level="error")
             finally:
                 current_turn_task = None
-                app.footer.thinking = False
+                app.stop_heartbeat()
 
             # Update footer token budget + grants at each turn boundary
             # (per doc/49 decision: TTL refresh on turn edge, not per-
@@ -622,12 +625,11 @@ async def _chat(
 
     async def footer_ticker() -> None:
         """Tick the footer at 2 Hz so live fields (heartbeat elapsed,
-        compaction spinner, thinking dots, transient hint expiry —
-        #284) progress visibly."""
+        compaction spinner, transient hint expiry — #284) progress
+        visibly."""
         while not shutdown.is_set():
             if (app.footer.heartbeat_state != "idle"
                     or app.footer.compacting
-                    or app.footer.thinking
                     or app.footer.transient_hint is not None):
                 app.invalidate()
             await asyncio.sleep(0.5)
@@ -1149,6 +1151,25 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
 
 
 
+def _start_tool_heartbeat(loom_app: Any, name: str, args: dict[str, Any]) -> None:
+    """Resolve action-language label for ``name`` + ``args`` and push it
+    into the footer heartbeat as TOOLING. Stale threshold falls out of
+    ``resolve_tool_action`` (long-runners get 90s; everything else 30s).
+    """
+    from loom.platform.interaction_language import (
+        HeartbeatState,
+        resolve_tool_action,
+    )
+
+    action = resolve_tool_action(name, args)
+    loom_app.start_heartbeat(
+        state=HeartbeatState.TOOLING.value,
+        label=action.label,
+        subject=action.subject,
+        stale_after_s=action.stale_after_s,
+    )
+
+
 async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
     """
     Execute one streaming agent turn with real character-by-character output.
@@ -1399,21 +1420,24 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
     # PR-D4: clear the "thinking" footer indicator on the first
     # observable event of the turn. After that, the active envelope
     # / streaming output / turn stats take over the footer's middle.
+    # Heartbeat (#418/#419) is THINKING from turn dispatch. The first
+    # observable event clears it; subsequent ToolBegin/etc handlers
+    # transition into TOOLING themselves. Guarded so plain TextChunk
+    # streaming doesn't keep stomping the heartbeat to idle.
     _thinking_cleared = False
 
-    def _clear_thinking() -> None:
+    def _clear_thinking_heartbeat() -> None:
         nonlocal _thinking_cleared
         if _thinking_cleared:
             return
         _thinking_cleared = True
         loom_app = getattr(session, "_loom_app", None)
-        if loom_app is not None:
-            loom_app.footer.thinking = False
-            loom_app.invalidate()
+        if loom_app is not None and loom_app.footer.heartbeat_state == "thinking":
+            loom_app.stop_heartbeat()
 
     try:
         async for event in session.stream_turn(user_input):
-            _clear_thinking()
+            _clear_thinking_heartbeat()
             if isinstance(event, TextChunk):
                 _bump_output_seq()
                 _stream_pending += event.text
@@ -1473,6 +1497,11 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 # previously not displayed in CLI ("too noisy for
                 # inline chat"); a 3-second flash is the right weight.
                 if (loom_app := getattr(session, "_loom_app", None)) is not None:
+                    # Heartbeat may still hold a stale THINKING/TOOLING
+                    # from before the compact gate fired; clear it so
+                    # the transient hint isn't competing with a
+                    # phantom "still waiting" warning.
+                    loom_app.stop_heartbeat()
                     loom_app.show_transient_hint(
                         f"🗜 compacted → {event.fact_count} facts",
                         severity="info",
@@ -1515,10 +1544,11 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 )
                 # Start spinner animation
                 spinner_task = asyncio.create_task(_spin_loop())
-                # Heartbeat wiring lands in #419 (Task 4 of the
-                # interaction-language plan). #418 removed the raw
-                # active-envelope push; the footer reads heartbeat
-                # state instead, but nothing writes that state yet.
+                # Footer heartbeat → TOOLING with action-language label
+                # resolved from the tool name + args (#419).
+                loom_app = getattr(session, "_loom_app", None)
+                if loom_app is not None:
+                    _start_tool_heartbeat(loom_app, event.name, event.args)
 
             elif isinstance(event, ToolEnd):
                 _bump_output_seq()
@@ -1539,8 +1569,14 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                     _freeze_envelope(_output_seq, event.name,
                                      event.success, event.duration_ms)
                 )
-                # Heartbeat clear lands in #419 (Task 4 of the
-                # interaction-language plan).
+                # Footer heartbeat → idle; #419. Touch first so any
+                # very-long tool that managed to land here still counts
+                # as alive at the moment of completion (avoids the
+                # observer-effect race where stop() raced the watchdog).
+                loom_app = getattr(session, "_loom_app", None)
+                if loom_app is not None:
+                    loom_app.touch_heartbeat()
+                    loom_app.stop_heartbeat()
 
             elif isinstance(event, TurnPaused):
                 _bump_output_seq()
@@ -1567,6 +1603,15 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 # (用過即焚, no scrollback residue) rather than spinning
                 # nested Applications.
                 loom_app = getattr(session, "_loom_app", None)
+                # Heartbeat → PAUSED_BLOCKING while waiting on user; the
+                # stalled-prefix is suppressed for this state so a long
+                # think-time doesn't render as "still waiting".
+                if loom_app is not None:
+                    from loom.platform.interaction_language import HeartbeatState
+                    loom_app.start_heartbeat(
+                        state=HeartbeatState.PAUSED_BLOCKING.value,
+                        label="等待你的決定",
+                    )
                 if loom_app is not None:
                     choice = await loom_app.request_pause(
                         title="Loom 已暫停，下一步？",
@@ -1594,6 +1639,11 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                         )
                     runner = getattr(session, "_run_interactive", None)
                     choice = await (runner(_pause_pick) if runner else _pause_pick())
+
+                # Decision made — release the PAUSED_BLOCKING heartbeat.
+                # The next event (TextChunk / ToolBegin) will repaint it.
+                if loom_app is not None:
+                    loom_app.stop_heartbeat()
 
                 if choice == _PAUSE_CANCEL:
                     session.cancel()
@@ -1623,6 +1673,12 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
 
             elif isinstance(event, TurnDone):
                 _bump_output_seq()
+                # Heartbeat → idle before any of the post-turn UI work
+                # so the footer isn't claiming "still thinking" while we
+                # write last-turn stats. The finally on the outer turn
+                # loop is belt-and-suspenders.
+                if (loom_app := getattr(session, "_loom_app", None)) is not None:
+                    loom_app.stop_heartbeat()
                 # Cancel any pending freeze before we touch the
                 # cursor — markdown reblit will move it past the
                 # frozen target row anyway

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -621,11 +621,11 @@ async def _chat(
             app.invalidate()
 
     async def footer_ticker() -> None:
-        """Tick the footer at 2 Hz so live fields (active envelope
-        elapsed, compaction spinner, thinking dots, transient hint
-        expiry — #284) progress visibly."""
+        """Tick the footer at 2 Hz so live fields (heartbeat elapsed,
+        compaction spinner, thinking dots, transient hint expiry —
+        #284) progress visibly."""
         while not shutdown.is_set():
-            if (app.footer.active_envelopes
+            if (app.footer.heartbeat_state != "idle"
                     or app.footer.compacting
                     or app.footer.thinking
                     or app.footer.transient_hint is not None):
@@ -1515,15 +1515,10 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 )
                 # Start spinner animation
                 spinner_task = asyncio.create_task(_spin_loop())
-                # PR-D4: track in footer for live ▸ <tool> · <elapsed>
-                loom_app = getattr(session, "_loom_app", None)
-                if loom_app is not None:
-                    from loom.platform.cli.app import _ActiveEnvelope
-                    import time as _t
-                    loom_app.footer.active_envelopes.append(
-                        _ActiveEnvelope(name=event.name, started_monotonic=_t.monotonic())
-                    )
-                    loom_app.invalidate()
+                # Heartbeat wiring lands in #419 (Task 4 of the
+                # interaction-language plan). #418 removed the raw
+                # active-envelope push; the footer reads heartbeat
+                # state instead, but nothing writes that state yet.
 
             elif isinstance(event, ToolEnd):
                 _bump_output_seq()
@@ -1544,15 +1539,8 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                     _freeze_envelope(_output_seq, event.name,
                                      event.success, event.duration_ms)
                 )
-                # PR-D4: drop matching envelope from footer
-                loom_app = getattr(session, "_loom_app", None)
-                if loom_app is not None:
-                    envs = loom_app.footer.active_envelopes
-                    for i in range(len(envs) - 1, -1, -1):
-                        if envs[i].name == event.name:
-                            envs.pop(i)
-                            break
-                    loom_app.invalidate()
+                # Heartbeat clear lands in #419 (Task 4 of the
+                # interaction-language plan).
 
             elif isinstance(event, TurnPaused):
                 _bump_output_seq()

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -1417,16 +1417,16 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
             # cursor manipulation can fail under terminal resize, etc.
             pass
 
-    # PR-D4: clear the "thinking" footer indicator on the first
-    # observable event of the turn. After that, the active envelope
-    # / streaming output / turn stats take over the footer's middle.
-    # Heartbeat (#418/#419) is THINKING from turn dispatch. The first
-    # observable event clears it; subsequent ToolBegin/etc handlers
-    # transition into TOOLING themselves. Guarded so plain TextChunk
-    # streaming doesn't keep stomping the heartbeat to idle.
+    # Heartbeat (#418/#419) is THINKING from turn dispatch. We only
+    # transition it OUT of THINKING when the agent actually produces
+    # visible output (text or tool) — never on system-only boundary
+    # events like CompressDone or TierExpiryHint, because the LLM
+    # round-trip is still pending across those. ToolBegin / TurnPaused
+    # / TurnDone branches drive their own heartbeat transitions, so
+    # only TextChunk needs the explicit "first chunk wins" clear.
     _thinking_cleared = False
 
-    def _clear_thinking_heartbeat() -> None:
+    def _clear_thinking_on_first_text() -> None:
         nonlocal _thinking_cleared
         if _thinking_cleared:
             return
@@ -1437,8 +1437,8 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
 
     try:
         async for event in session.stream_turn(user_input):
-            _clear_thinking_heartbeat()
             if isinstance(event, TextChunk):
+                _clear_thinking_on_first_text()
                 _bump_output_seq()
                 _stream_pending += event.text
                 text_buffer += event.text
@@ -1496,12 +1496,18 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 # rather than a console line — CompressDone was
                 # previously not displayed in CLI ("too noisy for
                 # inline chat"); a 3-second flash is the right weight.
+                #
+                # Heartbeat is intentionally untouched here. ``stream_turn``
+                # drains ``_pending_compactions`` before the LLM call
+                # (session.py around line 1885), so CompressDone is
+                # often the FIRST event of a turn with the LLM round-
+                # trip still pending. Stopping the heartbeat here would
+                # blank the footer for the rest of the turn even though
+                # the agent is still working — codex review caught this
+                # on PR #426. If the heartbeat happens to be in a stale
+                # TOOLING from elsewhere, that's a bug to fix at the
+                # source, not by laundering through CompressDone.
                 if (loom_app := getattr(session, "_loom_app", None)) is not None:
-                    # Heartbeat may still hold a stale THINKING/TOOLING
-                    # from before the compact gate fired; clear it so
-                    # the transient hint isn't competing with a
-                    # phantom "still waiting" warning.
-                    loom_app.stop_heartbeat()
                     loom_app.show_transient_hint(
                         f"🗜 compacted → {event.fact_count} facts",
                         severity="info",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -31,12 +31,12 @@ from prompt_toolkit.history import InMemoryHistory
 from loom.platform.cli.app import (
     FooterState,
     LoomApp,
-    _ActiveEnvelope,
     _ConfirmState,
     _PauseState,
     _TaskListState,
     build_loom_app,
 )
+from loom.platform.interaction_language import HeartbeatState
 
 
 def _flat_text(formatted) -> str:
@@ -64,10 +64,11 @@ class TestConstruction:
 
     def test_footer_starts_empty(self, app: LoomApp) -> None:
         assert app.footer.token_pct == 0.0
-        assert app.footer.thinking is False
         assert app.footer.compacting is False
         assert app.footer.grants_active == 0
-        assert app.footer.active_envelopes == []
+        assert app.footer.heartbeat_state == HeartbeatState.IDLE.value
+        assert app.footer.heartbeat_label == ""
+        assert app.footer.heartbeat_subject == ""
 
     def test_factory_returns_loomapp(self) -> None:
         app = build_loom_app()
@@ -229,41 +230,61 @@ class TestFooterRender:
         text = _flat_text(app._render_footer())
         assert "🔑 3·∞" in text
 
-    def test_active_envelope_shown_with_elapsed(self, app: LoomApp) -> None:
+    def test_heartbeat_replaces_active_envelope_label(self, app: LoomApp) -> None:
+        # Heartbeat is the system-driven liveness signal that replaced the
+        # raw ``▸ run_bash · 1.5s`` envelope label. Now the footer reads
+        # the action-language label written by interaction_language.
         import time as _t
-        app.footer.active_envelopes.append(
-            _ActiveEnvelope(name="run_bash", started_monotonic=_t.monotonic() - 1.5)
-        )
-        text = _flat_text(app._render_footer())
-        assert "▸ run_bash" in text
-        # Elapsed format — at least the seconds suffix is fixed
-        assert "s" in text.split("▸ run_bash")[1]
 
-    def test_multiple_envelopes_show_count_prefix(self, app: LoomApp) -> None:
+        app.footer.heartbeat_state = HeartbeatState.TOOLING.value
+        app.footer.heartbeat_label = "執行指令"
+        app.footer.heartbeat_subject = "pytest"
+        app.footer.heartbeat_started_monotonic = _t.monotonic() - 8
+        app.footer.heartbeat_last_event_monotonic = _t.monotonic()
+
+        text = _flat_text(app._render_footer())
+
+        assert "執行指令" in text
+        assert "pytest" in text
+        # Old raw glyph + tool name format must not leak back in
+        assert "▸ run_bash" not in text
+        assert app.footer.heartbeat_state == HeartbeatState.TOOLING.value
+
+    def test_stalled_heartbeat_uses_warning_copy(self, app: LoomApp) -> None:
+        # When the tool has been quiet past its stale_after_s the footer
+        # tells the user we're still waiting. Only tooling states are
+        # eligible — thinking / paused are waiting on someone else and
+        # should never render this prefix (covered by other tests).
         import time as _t
-        for name in ("read_file", "list_dir", "grep"):
-            app.footer.active_envelopes.append(
-                _ActiveEnvelope(name=name, started_monotonic=_t.monotonic())
-            )
-        text = _flat_text(app._render_footer())
-        # ``Nx ▸ <latest> · <elapsed>`` — count visible, latest one named
-        assert "3×" in text
-        assert "grep" in text  # most recent
 
-    def test_last_turn_stats_only_when_no_active_envelope(self, app: LoomApp) -> None:
+        app.footer.heartbeat_state = HeartbeatState.TOOLING.value
+        app.footer.heartbeat_label = "執行指令"
+        app.footer.heartbeat_subject = "pytest"
+        app.footer.heartbeat_started_monotonic = _t.monotonic() - 95
+        app.footer.heartbeat_last_event_monotonic = _t.monotonic() - 95
+        app.footer.heartbeat_stale_after_s = 90.0
+
+        text = _flat_text(app._render_footer())
+
+        assert "still waiting" in text
+        assert "執行指令" in text
+
+    def test_last_turn_stats_hidden_while_heartbeat_active(self, app: LoomApp) -> None:
         # Stats from the previous turn surface only when nothing is in
-        # flight — otherwise the active envelope owns the middle column
+        # flight — otherwise the heartbeat owns the middle column.
         app.footer.last_turn_input_tokens = 1234
         app.footer.last_turn_output_tokens = 567
         app.footer.last_turn_elapsed_s = 2.3
         text = _flat_text(app._render_footer())
         assert "1234in / 567out" in text
 
-        # Now add an active envelope — stats should disappear
+        # Now light up the heartbeat — stats should disappear.
         import time as _t
-        app.footer.active_envelopes.append(
-            _ActiveEnvelope(name="x", started_monotonic=_t.monotonic())
-        )
+        app.footer.heartbeat_state = HeartbeatState.TOOLING.value
+        app.footer.heartbeat_label = "執行指令"
+        app.footer.heartbeat_subject = "x"
+        app.footer.heartbeat_started_monotonic = _t.monotonic()
+        app.footer.heartbeat_last_event_monotonic = _t.monotonic()
         text = _flat_text(app._render_footer())
         assert "1234in" not in text
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -316,6 +316,23 @@ class TestFooterRender:
         assert "等待你的決定" in text
         assert "still waiting" not in text
 
+    def test_transient_hint_does_not_disturb_active_heartbeat(self, app: LoomApp) -> None:
+        # Regression for the codex review of PR #426: a CompressDone
+        # event lands at the start of a turn before the LLM call (see
+        # ``LoomSession.stream_turn`` draining ``_pending_compactions``).
+        # The CLI fires a transient hint for it, but the heartbeat
+        # must keep showing THINKING because the agent round-trip is
+        # still pending. Any future helper that does both "show hint"
+        # and "clear heartbeat" would break this invariant — this test
+        # pins the contract so the regression can't slip back in.
+        app.start_heartbeat(
+            state=HeartbeatState.THINKING.value,
+            label="Loom is thinking",
+        )
+        app.show_transient_hint("🗜 compacted → 42 facts", severity="info")
+        assert app.footer.heartbeat_state == HeartbeatState.THINKING.value
+        assert app.footer.heartbeat_label == "Loom is thinking"
+
     def test_thinking_heartbeat_does_not_render_stalled_prefix(self, app: LoomApp) -> None:
         # Mirror of the paused case: THINKING is waiting on the agent
         # (LLM round-trip). A slow first token is not "still waiting"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,9 +12,9 @@ need a TTY and a working renderer). Instead they exercise:
 - the mode flag transitions around ``request_confirm`` / ``request_pause``
   / ``request_redirect_text`` (launched as tasks, completed by directly
   resolving the future the helper awaits)
-- the render callbacks (``_render_footer`` / ``_render_thinking`` /
-  ``_render_tasklist`` / ``_render_confirm`` / ``_render_pause``) under
-  the various FooterState shapes documented in the issue
+- the render callbacks (``_render_footer`` / ``_render_tasklist`` /
+  ``_render_confirm`` / ``_render_pause``) under the various
+  FooterState shapes documented in the issue
 - the TaskList state mutations (``update_tasklist`` collapse logic) and
   Markdown reblit infrastructure shared with #248
 
@@ -269,6 +269,70 @@ class TestFooterRender:
         assert "still waiting" in text
         assert "執行指令" in text
 
+    def test_heartbeat_state_sequence_thinking_tooling_stalled_idle(self, app: LoomApp) -> None:
+        # Sanity-check the full state machine the stream loop drives:
+        # turn-start → THINKING; first ToolBegin → TOOLING; quiet past
+        # stale_after_s → stalled prefix; turn-done → IDLE.
+        import time as _t
+
+        app.start_heartbeat(
+            state=HeartbeatState.THINKING.value,
+            label="Loom is thinking",
+            stale_after_s=30.0,
+        )
+        assert app.footer.heartbeat_state == HeartbeatState.THINKING.value
+
+        app.start_heartbeat(
+            state=HeartbeatState.TOOLING.value,
+            label="執行指令",
+            subject="pytest",
+            stale_after_s=90.0,
+        )
+        assert app.footer.heartbeat_state == HeartbeatState.TOOLING.value
+        assert "執行指令" in _flat_text(app._render_footer())
+
+        # Force the tool to look quiet past stale_after_s.
+        app.footer.heartbeat_last_event_monotonic = _t.monotonic() - 91
+        text = _flat_text(app._render_footer())
+        assert "still waiting" in text
+
+        app.stop_heartbeat()
+        assert app.footer.heartbeat_state == HeartbeatState.IDLE.value
+
+    def test_paused_blocking_heartbeat_does_not_render_stalled_prefix(self, app: LoomApp) -> None:
+        # The PAUSED_BLOCKING state is waiting on the user, not on a
+        # tool, so the footer must never call it "still waiting"
+        # regardless of how long the human takes to decide.
+        import time as _t
+
+        app.start_heartbeat(
+            state=HeartbeatState.PAUSED_BLOCKING.value,
+            label="等待你的決定",
+            stale_after_s=30.0,
+        )
+        app.footer.heartbeat_last_event_monotonic = _t.monotonic() - 120
+
+        text = _flat_text(app._render_footer())
+        assert "等待你的決定" in text
+        assert "still waiting" not in text
+
+    def test_thinking_heartbeat_does_not_render_stalled_prefix(self, app: LoomApp) -> None:
+        # Mirror of the paused case: THINKING is waiting on the agent
+        # (LLM round-trip). A slow first token is not "still waiting"
+        # on a tool, so the stalled prefix must stay off.
+        import time as _t
+
+        app.start_heartbeat(
+            state=HeartbeatState.THINKING.value,
+            label="Loom is thinking",
+            stale_after_s=30.0,
+        )
+        app.footer.heartbeat_last_event_monotonic = _t.monotonic() - 95
+
+        text = _flat_text(app._render_footer())
+        assert "Loom is thinking" in text
+        assert "still waiting" not in text
+
     def test_last_turn_stats_hidden_while_heartbeat_active(self, app: LoomApp) -> None:
         # Stats from the previous turn surface only when nothing is in
         # flight — otherwise the heartbeat owns the middle column.
@@ -287,22 +351,6 @@ class TestFooterRender:
         app.footer.heartbeat_last_event_monotonic = _t.monotonic()
         text = _flat_text(app._render_footer())
         assert "1234in" not in text
-
-
-# ---------------------------------------------------------------------------
-# Thinking indicator
-# ---------------------------------------------------------------------------
-
-
-class TestThinkingIndicator:
-    def test_render_thinking_contains_loom_marker(self, app: LoomApp) -> None:
-        text = _flat_text(app._render_thinking())
-        assert "Loom is thinking" in text
-
-    def test_thinking_flag_default_off(self, app: LoomApp) -> None:
-        # ConditionalContainer reads ``footer.thinking`` directly; the
-        # render only fires when True, but the flag default matters
-        assert app.footer.thinking is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scope_phase_b.py
+++ b/tests/test_scope_phase_b.py
@@ -368,7 +368,10 @@ class TestScopeConfirmDurations:
         assert result.success
         confirm_fn.assert_called_once()
         handler.assert_called_once()
-        assert perm.grants == []
+        assert len(perm.grants) >= 1
+        g = perm.grants[-1]
+        assert g.source == "manual_confirm"
+        assert g.valid_until == 0.0
         assert call.metadata["confirm_decision"] == "once"
 
     async def test_once_confirmation_does_not_grant_fetch_url_network_scope(self):
@@ -390,7 +393,10 @@ class TestScopeConfirmDurations:
         assert result.success
         confirm_fn.assert_called_once()
         handler.assert_called_once()
-        assert perm.grants == []
+        assert len(perm.grants) >= 1
+        g = perm.grants[-1]
+        assert g.source == "manual_confirm"
+        assert g.valid_until == 0.0
         assert call.metadata["confirm_decision"] == "once"
 
     async def test_scope_confirmation_creates_ttl_grant(self):


### PR DESCRIPTION
## Summary

Implements **Task 3 (#418)** and **Task 4 (#419)** of the UI interaction-language slice 1 plan (`docs/superpowers/plans/2026-05-21-ui-ux-interaction-language.md`). Bundled into one PR because both issues edit the same hot path in `loom/platform/cli/main.py` (ToolBegin / ToolEnd / turn dispatch) — same precedent as PR #425 bundling #416 + #417.

- **#418** (commit 1, `eb00e4e`): replace the raw `_ActiveEnvelope` tracking with a heartbeat state model on `FooterState`. Adds `start_heartbeat` / `touch_heartbeat` / `stop_heartbeat` on `LoomApp`. `_render_footer` reads the new state; only `tooling` / `long_tooling` are eligible for the `still waiting · …` warning when quiet past `stale_after_s`.
- **#419** (commit 2, `a08feb8`): drive the heartbeat from stream events. Turn dispatch → `THINKING`; `ToolBegin` → `TOOLING` via `_start_tool_heartbeat` (action-language label resolved by `resolve_tool_action`); `ToolEnd` / `TurnDone` / `CompressDone` → stop; `TurnPaused` → `PAUSED_BLOCKING`. Retires `footer.thinking` / `_render_thinking` / `thinking_window` / `TestThinkingIndicator` — heartbeat is now the single source of truth for "Loom is thinking", so two competing animations can't fight in the same bottom area.

Closes #418, closes #419.

## Plan execution shape

The plan's Task 3 Step 8 ("`rg _ActiveEnvelope` no matches in loom + tests") collides with Task 4 Step 5 ("replace the `_ActiveEnvelope` append block with ..."). Resolved by treating Step 8 as "after both tasks land" — commit 1 strips `_ActiveEnvelope` and leaves stub comments at the wire sites; commit 2 fills them with heartbeat calls.

## Test plan

- [x] `pytest -q tests/test_app.py tests/test_interaction_language.py` — 31 + 9 pass
- [x] `pytest -q tests/test_session.py tests/test_cache_display.py` — 48 pass
- [x] Full suite: 1989 pass, 3 pre-existing failures in `tests/test_scope_phase_cd.py` + `tests/test_scoped_approval.py` (verified to fail on master too — unrelated to heartbeat)
- [x] `npx gitnexus detect-changes --scope staged` (both commits) — risk LOW, 0 affected processes
- [ ] Manual smoke: `loom chat`, verify footer shows `執行指令 · pytest · 8s` during a tool run, transitions to `Loom is thinking · 0s` between turns

## Out of scope

- Discord heartbeat / stalled proxy → #422
- Envelope intent + outcome render → #420 / #421
- Prompt contract layer → #423
- Docs closure → #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)