### PR TITLE
feat(discord): render envelope intent and outcome (#420)

### DIFF
--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -174,11 +174,50 @@ _ENVELOPE_STATE_ICONS: dict[str, str] = {
 }
 
 
+_OUTCOME_GLYPHS: dict[str, str] = {
+    "partial": "◐",
+    "unfulfilled": "⚠",
+    "pivoted": "↪",
+    "aborted": "🛑",
+}
+
+
 def _format_envelope_status(view: ExecutionEnvelopeView) -> str:
-    """Format an envelope view into a compact Discord status block."""
+    """Format an envelope view into a compact Discord status block.
+
+    Multi-node batches use the interaction-language header (``▸ <intent>``
+    optionally followed by the parallel-reason label). Single-node calls
+    keep the original compact ``Envelope <id>`` header — the per-node row
+    underneath already names the tool, so an intent line would just
+    duplicate it.
+
+    Outcomes other than ``fulfilled`` add a summary line. Empty
+    ``outcome`` is treated as unknown — when ``status == "failed"`` it
+    is upgraded to ``unfulfilled`` so the user is never shown a passing
+    glyph next to a failed batch. Successful batches show nothing extra
+    so the per-node ✓ icons aren't drowned out.
+    """
+    from loom.platform.interaction_language import (
+        EnvelopeOutcome,
+        format_parallel_reason,
+        synthesize_envelope_intent,
+    )
+
     lines: list[str] = []
+    is_multi = view.node_count > 1
+
     # Header
-    header = f"-# Envelope {view.envelope_id} · {view.node_count} actions"
+    if is_multi:
+        intent = view.intent or synthesize_envelope_intent(
+            parallel_reason=view.parallel_reason,
+            tool_names=[n.tool_name for n in view.nodes],
+        )
+        header = f"-# ▸ {intent}"
+        reason_label = format_parallel_reason(view.parallel_reason)
+        if reason_label:
+            header += f" · {reason_label}"
+    else:
+        header = f"-# Envelope {view.envelope_id} · {view.node_count} actions"
     if view.parallel_groups > 1:
         header += f" · {view.parallel_groups} parallel groups"
     if view.status == "failed":
@@ -203,6 +242,19 @@ def _format_envelope_status(view: ExecutionEnvelopeView) -> str:
                 level_parts.append(f"{icon} {name}{extra}")
         prefix = f"L{level_idx}  " if show_level_prefix else ""
         lines.append(f"-# {prefix}{'  '.join(level_parts)}")
+
+    # Outcome summary (#420). Empty outcome means unknown, not success
+    # — when the status is failed, infer UNFULFILLED so we never imply
+    # things went well. FULFILLED is silent on purpose.
+    outcome = view.outcome
+    if not outcome and view.status == "failed":
+        outcome = EnvelopeOutcome.UNFULFILLED.value
+    if outcome and outcome != EnvelopeOutcome.FULFILLED.value:
+        glyph = _OUTCOME_GLYPHS.get(outcome, "◐")
+        if view.outcome_summary:
+            lines.append(f"-# {glyph} {view.outcome_summary}")
+        elif outcome == EnvelopeOutcome.UNFULFILLED.value:
+            lines.append(f"-# {glyph} envelope did not fulfill its intent")
 
     return "\n".join(lines)
 

--- a/tests/test_discord_interaction_language.py
+++ b/tests/test_discord_interaction_language.py
@@ -1,0 +1,192 @@
+"""Discord rendering of the shared interaction-language envelope view (#420).
+
+Pure-function coverage around ``_format_envelope_status``. Verifies:
+
+- Single-node envelopes keep the compact ``Envelope <id>`` header.
+- Multi-node envelopes render an ``▸ <intent>`` header with the human
+  ``parallel_reason`` label, never leaking the raw enum value.
+- When the agent omits the intent on a multi-node envelope, the renderer
+  falls back to ``synthesize_envelope_intent`` so the user is never shown
+  a bare ``▸ `` row.
+- Outcomes other than ``FULFILLED`` add a trailing summary line with the
+  matching glyph (``⚠`` / ``◐`` / ``↪`` / ``🛑``).
+- An empty ``outcome`` does NOT silently render as success — when status
+  is ``failed`` the renderer still surfaces a warning so the user can
+  tell the batch did not fulfill its intent.
+"""
+from __future__ import annotations
+
+from loom.core.events import ExecutionEnvelopeView, ExecutionNodeView
+from loom.platform.discord.bot import _format_envelope_status
+from loom.platform.interaction_language import EnvelopeOutcome, ParallelReason
+
+
+def _node(node_id: str, tool_name: str, state: str = "executing") -> ExecutionNodeView:
+    return ExecutionNodeView(
+        node_id=node_id,
+        call_id=f"call-{node_id}",
+        action_id=node_id,
+        tool_name=tool_name,
+        level=0,
+        state=state,
+        trust_level="SAFE",
+    )
+
+
+def test_single_node_envelope_keeps_compact_header() -> None:
+    view = ExecutionEnvelopeView(
+        envelope_id="e1",
+        session_id="s1",
+        turn_index=1,
+        status="running",
+        node_count=1,
+        parallel_groups=1,
+        levels=[["n1"]],
+        nodes=[_node("n1", "read_file")],
+    )
+
+    text = _format_envelope_status(view)
+
+    assert "Envelope e1" in text
+    assert "read_file" in text
+    # Single-node batches do not get the intent header glyph
+    assert "▸" not in text
+
+
+def test_multi_node_envelope_renders_intent_and_parallel_reason() -> None:
+    view = ExecutionEnvelopeView(
+        envelope_id="e2",
+        session_id="s1",
+        turn_index=1,
+        status="running",
+        node_count=2,
+        parallel_groups=1,
+        levels=[["n1", "n2"]],
+        nodes=[_node("n1", "pytest"), _node("n2", "pytest")],
+        intent="重複跑測試確認穩定性",
+        parallel_reason=ParallelReason.FAN_OUT_REPLICAS.value,
+    )
+
+    text = _format_envelope_status(view)
+
+    assert "▸ 重複跑測試確認穩定性" in text
+    assert "多次驗證" in text
+    # Never leak the raw enum value to the user
+    assert "fan_out_replicas" not in text
+
+
+def test_multi_node_envelope_synthesizes_intent_when_agent_omits_it() -> None:
+    view = ExecutionEnvelopeView(
+        envelope_id="e4",
+        session_id="s1",
+        turn_index=1,
+        status="running",
+        node_count=3,
+        parallel_groups=1,
+        levels=[["n1", "n2", "n3"]],
+        nodes=[
+            _node("n1", "pytest"),
+            _node("n2", "pytest"),
+            _node("n3", "pytest"),
+        ],
+        parallel_reason=ParallelReason.FAN_OUT_REPLICAS.value,
+    )
+
+    text = _format_envelope_status(view)
+
+    assert "▸ 重複跑同一組 pytest" in text
+    assert "多次驗證" in text
+
+
+def test_unfulfilled_envelope_renders_outcome_summary() -> None:
+    view = ExecutionEnvelopeView(
+        envelope_id="e3",
+        session_id="s1",
+        turn_index=1,
+        status="failed",
+        node_count=2,
+        parallel_groups=1,
+        levels=[["n1", "n2"]],
+        nodes=[
+            _node("n1", "pytest", "observed"),
+            _node("n2", "pytest", "timed_out"),
+        ],
+        intent="驗證測試狀態",
+        outcome=EnvelopeOutcome.UNFULFILLED.value,
+        outcome_summary="其中一組測試逾時，需要重跑",
+    )
+
+    text = _format_envelope_status(view)
+
+    assert "⚠ 其中一組測試逾時，需要重跑" in text
+
+
+def test_empty_outcome_infers_from_failed_status_without_claiming_success() -> None:
+    # Plan invariant: empty ``outcome`` means unknown, never fulfilled.
+    # When ``status == "failed"`` the renderer must still surface a
+    # warning so the user can tell something went wrong even if no
+    # producer wrote an outcome string.
+    view = ExecutionEnvelopeView(
+        envelope_id="e5",
+        session_id="s1",
+        turn_index=1,
+        status="failed",
+        node_count=1,
+        parallel_groups=1,
+        levels=[["n1"]],
+        nodes=[_node("n1", "pytest", "timed_out")],
+        outcome="",
+    )
+
+    text = _format_envelope_status(view)
+
+    assert "failed" in text or "⚠" in text
+
+
+def test_partial_outcome_renders_half_circle_glyph() -> None:
+    view = ExecutionEnvelopeView(
+        envelope_id="e6",
+        session_id="s1",
+        turn_index=1,
+        status="completed",
+        node_count=2,
+        parallel_groups=1,
+        levels=[["n1", "n2"]],
+        nodes=[
+            _node("n1", "pytest", "observed"),
+            _node("n2", "pytest", "timed_out"),
+        ],
+        intent="跑多組測試",
+        outcome=EnvelopeOutcome.PARTIAL.value,
+        outcome_summary="一組成功，一組逾時",
+    )
+
+    text = _format_envelope_status(view)
+
+    assert "◐ 一組成功，一組逾時" in text
+
+
+def test_fulfilled_outcome_does_not_add_summary_line() -> None:
+    # Plain success should not add visual noise — the per-node ✓ icons
+    # already tell the story.
+    view = ExecutionEnvelopeView(
+        envelope_id="e7",
+        session_id="s1",
+        turn_index=1,
+        status="completed",
+        node_count=2,
+        parallel_groups=1,
+        levels=[["n1", "n2"]],
+        nodes=[
+            _node("n1", "pytest", "observed"),
+            _node("n2", "pytest", "observed"),
+        ],
+        outcome=EnvelopeOutcome.FULFILLED.value,
+    )
+
+    text = _format_envelope_status(view)
+
+    # No glyph + summary line stacked after the nodes
+    assert "◐" not in text
+    assert "⚠" not in text
+    assert "↪" not in text


### PR DESCRIPTION
## Summary

Task 5 of the UI interaction-language slice 1 plan. Uses the envelope metadata fields added in #417 to drive the Discord status block:

- **Multi-node envelopes** render ``▸ <intent>`` headers with the human ``parallel_reason`` label (``多次驗證`` / ``並行調查`` / ``多策略對比`` / ``多目標處理``). Raw enum values never leak to the user.
- When the agent omits the intent on a multi-node envelope, ``synthesize_envelope_intent`` fills in a mechanical fallback (``▸ 重複跑同一組 pytest`` etc) so we never show a bare ``▸ `` row.
- **Single-node envelopes** keep the original ``Envelope <id> · N actions`` header — the per-node row already names the tool, so an intent line would duplicate it.
- **Outcomes** other than ``fulfilled`` add a trailing summary line with a glyph (``◐`` partial, ``⚠`` unfulfilled, ``↪`` pivoted, ``🛑`` aborted). Empty ``outcome`` + ``status=failed`` is upgraded to UNFULFILLED so a failed batch never shows a passing glyph. FULFILLED stays silent so the per-node ✓ icons aren't drowned out.

Closes #420.

## Test plan

- [x] ``pytest -q tests/test_discord_interaction_language.py`` — 7 new tests pass (single-node compact, multi-node intent + reason label, synthesized intent fallback, unfulfilled summary, empty-outcome inference, partial glyph, fulfilled-silent invariant)
- [x] ``pytest -q tests/test_discord_*.py tests/test_interaction_language.py`` — 88 pass total (all Discord + interaction-language coverage)
- [x] ``npx gitnexus detect-changes --scope staged`` — risk LOW, 0 affected processes

## Out of scope

- Producer-side outcome metadata (mechanical derivation) → #421
- Prompt-side intent contract → #423
- Stalled-status proxy on Discord → #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)