### PR TITLE
feat(ui): derive envelope outcomes (#421)

### DIFF
--- a/loom/core/envelope_outcome.py
+++ b/loom/core/envelope_outcome.py
@@ -1,0 +1,80 @@
+"""Envelope outcome vocabulary and mechanical derivation (#421).
+
+Lives in ``loom.core`` rather than under ``loom.platform`` because the
+ledger projector — also a core component — needs to populate
+``ExecutionEnvelopeView.outcome`` at projection time. The architecture
+boundary (CLAUDE.md: ``Platform → Cognition → Harness → Memory``) means
+core cannot import from platform; the outcome data contract therefore
+belongs here next to the dataclass it instantiates.
+
+``loom.platform.interaction_language`` re-exports ``EnvelopeOutcome``
+so UI surfaces (CLI footer, Discord renderer) keep their existing
+import shape. The mechanical helper stays unexported on the platform
+side because only producers call it — renderers consume the strings,
+they don't classify them.
+"""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class EnvelopeOutcome(str, Enum):
+    FULFILLED = "fulfilled"
+    PARTIAL = "partial"
+    UNFULFILLED = "unfulfilled"
+    PIVOTED = "pivoted"
+    ABORTED = "aborted"
+
+
+# ``observed`` / ``validated`` / ``committed`` are intermediate
+# success-y sub-states; today's ledger projector coarsens to terminal
+# states so they rarely appear, but keeping them in the set means the
+# helper stays correct if a future producer emits finer granularity.
+_SUCCESS_STATES: frozenset[str] = frozenset(
+    {"observed", "validated", "committed", "memorialized"}
+)
+# Mirrors what the renderer treats as "the batch didn't finish cleanly",
+# but intentionally EXCLUDES ``"aborted"`` — aborted is its own category
+# so the renderer can show 🛑 (intentional bail) instead of the generic
+# ⚠ (something went wrong). The projector still counts aborted toward
+# envelope ``status=="failed"`` separately; that asymmetry is documented
+# at the projector's failure-count branch.
+_FAILURE_STATES: frozenset[str] = frozenset(
+    {"denied", "timed_out", "reverted", "failed"}
+)
+
+
+def derive_envelope_outcome(states: list[str]) -> str:
+    """Map a list of terminal-ish node states to an EnvelopeOutcome value.
+
+    Callers are responsible for only passing *terminal* states. Running
+    envelopes should not call this — empty/in-flight inputs that aren't
+    failures would otherwise return ``fulfilled`` by fall-through and
+    paint a passing glyph on something still in flight. The ledger
+    projector gates on ``status in ("completed", "failed")``; non-ledger
+    code paths must do the equivalent.
+
+    ``aborted`` is treated as its own category. When aborted mixes with
+    real failures the result degrades to ``unfulfilled`` / ``partial``
+    — the user mostly cares that the batch didn't finish cleanly, not
+    which sub-flavour of "didn't finish" it was.
+
+    PIVOTED is intentionally unreachable: pivoting means the agent
+    changed strategy on purpose, which only the agent's own judgement
+    can claim. Mechanical derivation never returns it.
+    """
+    if not states:
+        return EnvelopeOutcome.FULFILLED.value
+    lowered = [s.lower() for s in states]
+    success_count = sum(1 for s in lowered if s in _SUCCESS_STATES)
+    failure_count = sum(1 for s in lowered if s in _FAILURE_STATES)
+    aborted_count = sum(1 for s in lowered if s == "aborted")
+    if aborted_count and not success_count and not failure_count:
+        return EnvelopeOutcome.ABORTED.value
+    if failure_count or aborted_count:
+        return (
+            EnvelopeOutcome.PARTIAL.value
+            if success_count
+            else EnvelopeOutcome.UNFULFILLED.value
+        )
+    return EnvelopeOutcome.FULFILLED.value

--- a/loom/core/ledger/envelope_view.py
+++ b/loom/core/ledger/envelope_view.py
@@ -34,6 +34,7 @@ import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable
 
+from loom.core.envelope_outcome import derive_envelope_outcome
 from loom.core.events import ExecutionEnvelopeView, ExecutionNodeView
 from loom.core.ledger.replay import reconstruct_tool_calls
 
@@ -129,6 +130,18 @@ class LedgerEnvelopeProjector:
         nodes: list[ExecutionNodeView] = []
         terminal_count = 0
         failure_count = 0
+        # Outcome-state list mirrors node states but upgrades rolled-back
+        # calls to ``"reverted"`` (#421). ``rolled_back`` is stored on
+        # the summary and feeds the envelope-level failure count above,
+        # but it never changes the node's user-visible state — so without
+        # this remap, a single rolled-back call would derive ``fulfilled``
+        # (node.state is still ``memorialized``) even though the envelope
+        # status correctly reads ``failed``. The renderer's
+        # ``status=="failed"`` fallback only triggers on an empty
+        # outcome, not a fulfilled one, which would leave the user with
+        # no summary glyph on a failed batch. Mapping here keeps the
+        # producer truth straight at the source.
+        outcome_states: list[str] = []
 
         for s in summaries:
             meta = call_meta.get(s.tool_call_id)
@@ -142,6 +155,7 @@ class LedgerEnvelopeProjector:
                 terminal_count += 1
             if state in _FAILURE_STATES or s.rolled_back:
                 failure_count += 1
+            outcome_states.append("reverted" if s.rolled_back else state)
 
             duration_ms = self._batch_duration_ms(batch_events, s.tool_call_id)
             auth_expires = (
@@ -211,6 +225,25 @@ class LedgerEnvelopeProjector:
 
         elapsed_ms = (time.monotonic() - batch_t0) * 1000 if batch_t0 else 0.0
 
+        # Mechanical outcome (#421): only derived when the envelope is
+        # terminal. Running envelopes get the empty string ("unknown"),
+        # because ``derive_envelope_outcome`` returns FULFILLED on an
+        # all-in-flight node set and that would paint a passing glyph
+        # on something still in flight. ``outcome_states`` already
+        # remaps rolled-back nodes to ``"reverted"`` so the helper sees
+        # the failure signal that envelope-status saw.
+        if status in ("completed", "failed"):
+            # Missing placeholder nodes (declared but no BEGIN) get
+            # appended after the summary loop; they're never terminal,
+            # so they only appear in a status="running" branch. Safe to
+            # skip them here.
+            outcome = derive_envelope_outcome(outcome_states)
+        else:
+            outcome = ""
+
+        # ``intent`` and ``parallel_reason`` stay defaulted in this
+        # task — they're authored by the LLM via the prompt contract
+        # landing in #423 and synthesised by the renderer otherwise.
         return ExecutionEnvelopeView(
             envelope_id=envelope_id,
             session_id=session_id,
@@ -221,6 +254,7 @@ class LedgerEnvelopeProjector:
             elapsed_ms=elapsed_ms,
             levels=[[n.node_id for n in nodes]] if nodes else [],
             nodes=nodes,
+            outcome=outcome,
         )
 
     # -- helpers ---------------------------------------------------------

--- a/loom/core/ledger/envelope_view.py
+++ b/loom/core/ledger/envelope_view.py
@@ -130,17 +130,20 @@ class LedgerEnvelopeProjector:
         nodes: list[ExecutionNodeView] = []
         terminal_count = 0
         failure_count = 0
-        # Outcome-state list mirrors node states but upgrades rolled-back
-        # calls to ``"reverted"`` (#421). ``rolled_back`` is stored on
-        # the summary and feeds the envelope-level failure count above,
-        # but it never changes the node's user-visible state — so without
-        # this remap, a single rolled-back call would derive ``fulfilled``
-        # (node.state is still ``memorialized``) even though the envelope
-        # status correctly reads ``failed``. The renderer's
-        # ``status=="failed"`` fallback only triggers on an empty
-        # outcome, not a fulfilled one, which would leave the user with
-        # no summary glyph on a failed batch. Mapping here keeps the
-        # producer truth straight at the source.
+        # Outcome-state list mirrors node states but upgrades failures
+        # the way the lifecycle hides them (#421 + codex review of #428).
+        #
+        # The Loom lifecycle memorialises every terminal call — including
+        # ``denied`` / ``timed_out`` / ``aborted`` — so ``_derive_state``
+        # always returns ``"memorialized"`` for terminated calls regardless
+        # of whether they succeeded or failed. The real failure signal
+        # lives in ``state_transitions`` (mid-history) and on the
+        # ``rolled_back`` flag. Without scanning the full history, a
+        # ``timed_out → memorialized`` call gets fed to the outcome helper
+        # as ``"memorialized"`` and derives ``fulfilled`` — wrong; both
+        # the envelope status and the outcome glyph would lie. This loop
+        # consults the full history for both signals so producer truth
+        # stays straight at the source.
         outcome_states: list[str] = []
 
         for s in summaries:
@@ -151,11 +154,26 @@ class LedgerEnvelopeProjector:
             #   1) ledger state_transitions last "to" (authoritative when END seen)
             #   2) "executing" (BEGIN seen, no END yet)
             state = self._derive_state(s)
+            failure_in_history = self._failure_state_in_history(s.state_transitions)
             if state in _TERMINAL_STATES:
                 terminal_count += 1
-            if state in _FAILURE_STATES or s.rolled_back:
+            if (
+                state in _FAILURE_STATES
+                or s.rolled_back
+                or failure_in_history is not None
+            ):
                 failure_count += 1
-            outcome_states.append("reverted" if s.rolled_back else state)
+            # Precedence: rollback flag > history failure > current state.
+            # Rollback is the most user-meaningful signal (something was
+            # accepted then undone), then the specific failure mid-history
+            # (denied / timed_out / aborted preserved for the outcome
+            # glyph), and finally the surface state for plain success.
+            if s.rolled_back:
+                outcome_states.append("reverted")
+            elif failure_in_history is not None:
+                outcome_states.append(failure_in_history)
+            else:
+                outcome_states.append(state)
 
             duration_ms = self._batch_duration_ms(batch_events, s.tool_call_id)
             auth_expires = (
@@ -258,6 +276,24 @@ class LedgerEnvelopeProjector:
         )
 
     # -- helpers ---------------------------------------------------------
+
+    @staticmethod
+    def _failure_state_in_history(transitions: list[dict]) -> str | None:
+        """Find the first failure-state transition in lifecycle history.
+
+        The Loom lifecycle terminates every call by transitioning to
+        ``memorialized`` — even denied / timed_out / aborted ones. The
+        actual failure signal lives mid-history. Returning the first
+        such transition preserves the most user-meaningful failure
+        category (``aborted`` distinct from generic failure) for the
+        outcome glyph. Returns ``None`` for clean histories so callers
+        can fall back to the current state.
+        """
+        for t in transitions:
+            to = (t.get("to") or "").lower()
+            if to in _FAILURE_STATES:
+                return to
+        return None
 
     @staticmethod
     def _derive_state(summary) -> str:

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -4117,7 +4117,11 @@ class LoomSession:
 
         # No ledger wired → return an empty stub. The shape stays the
         # same so EnvelopeStarted / EnvelopeCompleted consumers don't
-        # need a separate code path.
+        # need a separate code path. ``outcome=""`` is explicit (and
+        # not just relying on the dataclass default) so the contract
+        # is visible at the call site: empty means unknown, never
+        # fulfilled — UI surfaces infer UNFULFILLED from
+        # ``status=="failed"`` when no producer wrote anything (#421).
         return ExecutionEnvelopeView(
             envelope_id=f"e{self._envelope_counter}",
             session_id=self.session_id,
@@ -4125,6 +4129,7 @@ class LoomSession:
             status="running",
             node_count=0,
             parallel_groups=0,
+            outcome="",
         )
 
     # =========================================================================

--- a/loom/platform/interaction_language.py
+++ b/loom/platform/interaction_language.py
@@ -11,7 +11,18 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
+from loom.core.envelope_outcome import EnvelopeOutcome, derive_envelope_outcome
 from loom.core.security.sandbox_runtime import extract_command_root
+
+# Re-exported so UI consumers (Discord bot, tests) keep their existing
+# ``from loom.platform.interaction_language import EnvelopeOutcome``
+# import shape. The canonical home is ``loom.core.envelope_outcome`` —
+# the ledger projector needs the enum at projection time and core
+# cannot import from platform (CLAUDE.md layering).
+__all__ = [
+    "EnvelopeOutcome",
+    "derive_envelope_outcome",
+]
 
 
 class HeartbeatState(str, Enum):
@@ -29,14 +40,6 @@ class HeartbeatState(str, Enum):
     LONG_TOOLING = "long_tooling"
     STALLED = "stalled"
     PAUSED_BLOCKING = "paused_blocking"
-
-
-class EnvelopeOutcome(str, Enum):
-    FULFILLED = "fulfilled"
-    PARTIAL = "partial"
-    UNFULFILLED = "unfulfilled"
-    PIVOTED = "pivoted"
-    ABORTED = "aborted"
 
 
 class ParallelReason(str, Enum):

--- a/tests/test_interaction_language.py
+++ b/tests/test_interaction_language.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from loom.platform.interaction_language import (
     HeartbeatState,
     _LABELS_ZH_TW,
+    derive_envelope_outcome,
     format_elapsed,
     format_parallel_reason,
     resolve_tool_action,
@@ -87,3 +88,60 @@ def test_synthesize_envelope_intent_uses_parallel_reason_and_dominant_tool() -> 
         tool_names=["pytest", "pytest", "pytest"],
     )
     assert intent == "重複跑同一組 pytest"
+
+
+# ----------------------------------------------------------------------
+# Mechanical envelope outcome derivation (#421)
+# ----------------------------------------------------------------------
+
+
+def test_derive_envelope_outcome_fulfilled_when_all_success_states() -> None:
+    assert derive_envelope_outcome(["memorialized", "committed"]) == "fulfilled"
+
+
+def test_derive_envelope_outcome_partial_when_mixed_success_and_failure() -> None:
+    assert derive_envelope_outcome(["memorialized", "timed_out"]) == "partial"
+
+
+def test_derive_envelope_outcome_unfulfilled_when_all_failed() -> None:
+    assert derive_envelope_outcome(["denied", "timed_out"]) == "unfulfilled"
+
+
+def test_derive_envelope_outcome_aborted_when_abort_alone() -> None:
+    # Aborted is its own category — distinct from generic failure so
+    # the renderer can show 🛑 instead of the generic ⚠ glyph.
+    assert derive_envelope_outcome(["aborted"]) == "aborted"
+
+
+def test_derive_envelope_outcome_aborted_with_failure_degrades_to_unfulfilled() -> None:
+    # When aborted mixes with a real failure the helper falls back to
+    # unfulfilled — user mostly cares that the batch didn't finish
+    # cleanly, not the exact flavour of "didn't finish".
+    assert derive_envelope_outcome(["aborted", "timed_out"]) == "unfulfilled"
+
+
+def test_derive_envelope_outcome_never_mechanically_pivots() -> None:
+    # Pivoted requires LLM-authored judgement; mechanical derivation
+    # must never return it regardless of state combination.
+    for states in (
+        ["memorialized"],
+        ["memorialized", "timed_out"],
+        ["aborted", "memorialized"],
+        ["denied", "aborted"],
+    ):
+        assert derive_envelope_outcome(states) != "pivoted"
+
+
+def test_derive_envelope_outcome_handles_lowercase_normalization() -> None:
+    # Be tolerant of upper-case ActionState.value strings — the ledger
+    # path normalises but legacy producers may still emit raw names.
+    assert derive_envelope_outcome(["MEMORIALIZED", "TIMED_OUT"]) == "partial"
+
+
+def test_derive_envelope_outcome_empty_list_returns_fulfilled_for_callers_to_gate() -> None:
+    # Documents the contract: the helper does not know whether an
+    # envelope is terminal. Callers must only invoke it after the
+    # batch has all-terminal states; in-flight inputs would otherwise
+    # be misread as fulfilled. ``LedgerEnvelopeProjector`` gates on
+    # ``status in ("completed", "failed")``.
+    assert derive_envelope_outcome([]) == "fulfilled"

--- a/tests/test_ledger_envelope_projector.py
+++ b/tests/test_ledger_envelope_projector.py
@@ -57,7 +57,20 @@ async def _emit_lifecycle_pair(
     rolled_back: bool = False,
     error: str | None = None,
     result_summary: str | None = "ok",
+    failure_state: str | None = None,
 ) -> None:
+    """Emit a BEGIN/END pair for a tool call.
+
+    ``failure_state`` mirrors the Loom lifecycle for non-rollback
+    failure paths (denied / timed_out / aborted): the call transitions
+    ``executing → <failure_state> → memorialized``. Final terminal
+    state stays ``memorialized`` because the lifecycle memorialises
+    every call regardless of how it ended — the failure signal lives
+    in the middle of the history. Pass either ``rolled_back=True`` for
+    the post-validator-reverted path or ``failure_state="..."`` for
+    the lifecycle-failure paths, but not both (the projector treats
+    rollback as the more specific signal).
+    """
     begin_ts, end_ts = timestamps
     await emitter.emit(
         "tool_lifecycle",
@@ -71,26 +84,42 @@ async def _emit_lifecycle_pair(
         correlation_id="c1",
         timestamp=begin_ts,
     )
-    state_transitions = (
-        [
+    if rolled_back:
+        tail = [
+            {"from": "validated", "to": "reverting", "ts": "x", "reason": None},
+            {"from": "reverting", "to": "reverted", "ts": "x", "reason": None},
+            {"from": "reverted", "to": "memorialized", "ts": "x", "reason": None},
+        ]
+        head = [
             {"from": "declared", "to": "authorized", "ts": "x", "reason": None},
             {"from": "authorized", "to": "executing", "ts": "x", "reason": None},
             {"from": "executing", "to": "observed", "ts": "x", "reason": None},
             {"from": "observed", "to": "validated", "ts": "x", "reason": None},
         ]
-        + (
-            [
-                {"from": "validated", "to": "reverting", "ts": "x", "reason": None},
-                {"from": "reverting", "to": "reverted", "ts": "x", "reason": None},
-                {"from": "reverted", "to": "memorialized", "ts": "x", "reason": None},
-            ]
-            if rolled_back
-            else [
-                {"from": "validated", "to": "committed", "ts": "x", "reason": None},
-                {"from": "committed", "to": "memorialized", "ts": "x", "reason": None},
-            ]
-        )
-    )
+    elif failure_state is not None:
+        # denied / aborted / timed_out path: executing → failure_state →
+        # memorialized. No validate/commit step because the call never
+        # produced an observation worth validating.
+        head = [
+            {"from": "declared", "to": "authorized", "ts": "x", "reason": None},
+            {"from": "authorized", "to": "executing", "ts": "x", "reason": None},
+        ]
+        tail = [
+            {"from": "executing", "to": failure_state, "ts": "x", "reason": None},
+            {"from": failure_state, "to": "memorialized", "ts": "x", "reason": None},
+        ]
+    else:
+        head = [
+            {"from": "declared", "to": "authorized", "ts": "x", "reason": None},
+            {"from": "authorized", "to": "executing", "ts": "x", "reason": None},
+            {"from": "executing", "to": "observed", "ts": "x", "reason": None},
+            {"from": "observed", "to": "validated", "ts": "x", "reason": None},
+        ]
+        tail = [
+            {"from": "validated", "to": "committed", "ts": "x", "reason": None},
+            {"from": "committed", "to": "memorialized", "ts": "x", "reason": None},
+        ]
+    state_transitions = head + tail
     await emitter.emit(
         "tool_lifecycle",
         ToolLifecyclePayload(
@@ -265,6 +294,151 @@ async def test_parallel_batch_one_running_one_done(
     assert states["read_file"] == "memorialized"
     # Call B has only BEGIN → "executing" derivation
     assert states["run_bash"] == "executing"
+
+
+# ---------------------------------------------------------------------------
+# Hidden-failure paths — denied / timed_out / aborted all terminate in
+# ``memorialized``, so ``state in _FAILURE_STATES`` checks against the
+# last transition would miss them. The projector scans the full history
+# (#421 codex-review fix) so envelope status and outcome stay honest.
+# ---------------------------------------------------------------------------
+
+
+async def test_denied_path_marks_envelope_failed_and_unfulfilled(
+    store: LedgerStore, emitter: LedgerEmitter, projector
+) -> None:
+    base = time.time()
+    await _emit_lifecycle_pair(
+        emitter,
+        call_id="d",
+        tool_name="run_bash",
+        turn_id="turn_p",
+        timestamps=(base, base + 0.1),
+        failure_state="denied",
+        result_summary=None,
+        error="permission denied",
+    )
+
+    view = await projector.build_view(
+        envelope_id="e_denied",
+        session_id="sess_proj",
+        turn_id="turn_p",
+        turn_index=0,
+        call_ids=["d"],
+        call_meta={"d": CallMeta(call_id="d", tool_name="run_bash")},
+    )
+
+    # Node still terminates in memorialized (Loom lifecycle invariant) —
+    # the failure signal lives mid-history.
+    assert view.nodes[0].state == "memorialized"
+    assert view.status == "failed"
+    assert view.outcome == "unfulfilled"
+
+
+async def test_timed_out_path_marks_envelope_failed_and_unfulfilled(
+    store: LedgerStore, emitter: LedgerEmitter, projector
+) -> None:
+    base = time.time()
+    await _emit_lifecycle_pair(
+        emitter,
+        call_id="t",
+        tool_name="run_bash",
+        turn_id="turn_p",
+        timestamps=(base, base + 0.2),
+        failure_state="timed_out",
+        result_summary=None,
+        error="exceeded 30s",
+    )
+
+    view = await projector.build_view(
+        envelope_id="e_timeout",
+        session_id="sess_proj",
+        turn_id="turn_p",
+        turn_index=0,
+        call_ids=["t"],
+        call_meta={"t": CallMeta(call_id="t", tool_name="run_bash")},
+    )
+
+    assert view.nodes[0].state == "memorialized"
+    assert view.status == "failed"
+    assert view.outcome == "unfulfilled"
+
+
+async def test_aborted_path_keeps_aborted_outcome_glyph_distinct(
+    store: LedgerStore, emitter: LedgerEmitter, projector
+) -> None:
+    # Aborted gets its own outcome category (🛑) instead of the generic
+    # ⚠ that denied/timed_out land on — the user explicitly bailed,
+    # which is meaningfully different from "the tool failed". The
+    # projector preserves this distinction by surfacing the mid-history
+    # ``aborted`` transition to the outcome helper rather than lumping
+    # all failures under ``unfulfilled``.
+    base = time.time()
+    await _emit_lifecycle_pair(
+        emitter,
+        call_id="a",
+        tool_name="run_bash",
+        turn_id="turn_p",
+        timestamps=(base, base + 0.1),
+        failure_state="aborted",
+        result_summary=None,
+        error="cancelled by user",
+    )
+
+    view = await projector.build_view(
+        envelope_id="e_aborted",
+        session_id="sess_proj",
+        turn_id="turn_p",
+        turn_index=0,
+        call_ids=["a"],
+        call_meta={"a": CallMeta(call_id="a", tool_name="run_bash")},
+    )
+
+    assert view.nodes[0].state == "memorialized"
+    assert view.status == "failed"
+    assert view.outcome == "aborted"
+
+
+async def test_mixed_success_and_hidden_failure_yields_partial(
+    store: LedgerStore, emitter: LedgerEmitter, projector
+) -> None:
+    # Success node + a timed_out-then-memorialized node should derive
+    # "partial" — the helper sees ``[memorialized, timed_out]`` after
+    # the projector's history scan, where it would have seen
+    # ``[memorialized, memorialized]`` before the fix.
+    base = time.time()
+    await _emit_lifecycle_pair(
+        emitter,
+        call_id="ok",
+        tool_name="read_file",
+        turn_id="turn_p",
+        timestamps=(base, base + 0.1),
+    )
+    await _emit_lifecycle_pair(
+        emitter,
+        call_id="slow",
+        tool_name="run_bash",
+        turn_id="turn_p",
+        timestamps=(base, base + 0.3),
+        failure_state="timed_out",
+        result_summary=None,
+        error="exceeded 30s",
+    )
+
+    view = await projector.build_view(
+        envelope_id="e_mixed_hidden",
+        session_id="sess_proj",
+        turn_id="turn_p",
+        turn_index=0,
+        call_ids=["ok", "slow"],
+        call_meta={
+            "ok": CallMeta(call_id="ok", tool_name="read_file"),
+            "slow": CallMeta(call_id="slow", tool_name="run_bash"),
+        },
+    )
+
+    assert view.status == "failed"
+    assert view.outcome == "partial"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ledger_envelope_projector.py
+++ b/tests/test_ledger_envelope_projector.py
@@ -155,6 +155,9 @@ async def test_completed_batch_single_call(
 
     assert view.envelope_id == "e1"
     assert view.status == "completed"
+    # #421: producer derives outcome from node states once terminal.
+    # All-memorialized → fulfilled.
+    assert view.outcome == "fulfilled"
     assert view.node_count == 1
     n = view.nodes[0]
     assert n.tool_name == "run_bash"
@@ -199,6 +202,12 @@ async def test_failed_batch_status(
     )
 
     assert view.status == "failed"
+    # #421: a rolled-back call's node state stays "memorialized" at the
+    # node level (rolled_back is recorded separately, see replay.py).
+    # The projector remaps rolled_back → "reverted" when feeding the
+    # outcome helper so a status=failed envelope never reports a
+    # fulfilled outcome.
+    assert view.outcome == "unfulfilled"
     n = view.nodes[0]
     assert n.state == "memorialized"
     # error_snippet truncates at 80
@@ -249,10 +258,59 @@ async def test_parallel_batch_one_running_one_done(
     )
 
     assert view.status == "running"
+    # #421: outcome stays empty while envelope is still running so the
+    # renderer never paints a passing glyph on something in flight.
+    assert view.outcome == ""
     states = {n.tool_name: n.state for n in view.nodes}
     assert states["read_file"] == "memorialized"
     # Call B has only BEGIN → "executing" derivation
     assert states["run_bash"] == "executing"
+
+
+# ---------------------------------------------------------------------------
+# Mixed terminal batch — one success, one rollback → status="failed",
+# outcome="partial" (#421)
+# ---------------------------------------------------------------------------
+
+
+async def test_partial_outcome_when_one_success_one_rollback(
+    store: LedgerStore, emitter: LedgerEmitter, projector
+) -> None:
+    base = time.time()
+    await _emit_lifecycle_pair(
+        emitter,
+        call_id="ok",
+        tool_name="read_file",
+        turn_id="turn_p",
+        timestamps=(base, base + 0.1),
+    )
+    await _emit_lifecycle_pair(
+        emitter,
+        call_id="bad",
+        tool_name="run_bash",
+        turn_id="turn_p",
+        timestamps=(base, base + 0.3),
+        rolled_back=True,
+        error="post-validator rejected",
+    )
+
+    view = await projector.build_view(
+        envelope_id="e_mixed",
+        session_id="sess_proj",
+        turn_id="turn_p",
+        turn_index=0,
+        call_ids=["ok", "bad"],
+        call_meta={
+            "ok": CallMeta(call_id="ok", tool_name="read_file"),
+            "bad": CallMeta(call_id="bad", tool_name="run_bash"),
+        },
+    )
+
+    assert view.status == "failed"
+    # Success + rolled-back → partial: one node fully succeeded, one
+    # was reverted. The mechanical helper sees ``[memorialized,
+    # reverted]`` after the projector's rolled-back remap.
+    assert view.outcome == "partial"
 
 
 # ---------------------------------------------------------------------------
@@ -419,6 +477,8 @@ async def test_empty_envelope_running_status(
     assert view.node_count == 0
     assert view.nodes == []
     assert view.levels == []
+    # #421: outcome is gated on terminal status. Running → empty string.
+    assert view.outcome == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Task 6 of the UI interaction-language slice 1 plan — producer-side mechanical outcome derivation so the renderer doesn't have to fall back to status-inference for every batch. CLI footer and Discord block both already consume ``ExecutionEnvelopeView.outcome``; this PR finally populates it.

## Plan deviations called out

**1. Architecture layering — moved enum + helper to core.**
The plan put ``EnvelopeOutcome`` and ``derive_envelope_outcome`` in ``loom.platform.interaction_language``, but ``LedgerEnvelopeProjector`` (core) needs the helper. ``loom.core`` cannot import from ``loom.platform`` per CLAUDE.md, and ``test_architecture_guards`` enforces it. Created ``loom/core/envelope_outcome.py`` as the canonical home; ``loom.platform.interaction_language`` re-exports both so existing UI imports (Discord bot, tests) are untouched.

**2. Terminal-status gating.**
Plan Step 5 wrote ``outcome = derive_envelope_outcome([n.state for n in nodes])`` unconditionally. That's wrong for running envelopes: an all-executing node set falls through to FULFILLED and paints a passing glyph on something in flight. Added an ``if status in ("completed", "failed")`` gate; running envelopes get ``outcome=""``.

**3. Rolled-back state remap.**
A rolled-back call's ``node.state`` stays ``"memorialized"`` (rolled_back is a separate ledger field that feeds envelope status but not node state). Without compensation, a status=failed envelope with one rolled-back call would derive ``fulfilled``, and the Discord render would silently skip the summary line because outcome inference only triggers on empty outcomes. Added ``outcome_states`` list inside the projector that remaps ``rolled_back → "reverted"`` before feeding the helper.

## Producer contract

- ``derive_envelope_outcome([memorialized, committed])`` → ``fulfilled``
- ``derive_envelope_outcome([memorialized, timed_out])`` → ``partial``
- ``derive_envelope_outcome([denied, timed_out])`` → ``unfulfilled``
- ``derive_envelope_outcome([aborted])`` → ``aborted`` (own category for 🛑 glyph)
- ``derive_envelope_outcome([aborted, timed_out])`` → ``unfulfilled`` (degrades when mixed)
- ``pivoted`` never returned mechanically — requires LLM judgement

## Test plan

- [x] ``pytest -q tests/test_interaction_language.py`` — 20 pass (8 new outcome tests + existing)
- [x] ``pytest -q tests/test_ledger_envelope_projector.py`` — 12 pass including new ``test_partial_outcome_when_one_success_one_rollback``
- [x] ``pytest -q tests/test_architecture_guards.py`` — passes after core/platform split
- [x] Full suite: ``2009 passed, 0 failed`` (vs 1989/3 before)
- [x] ``gitnexus impact`` on ``build_view`` / ``_build_envelope_view`` / ``ExecutionEnvelopeView`` — LOW, 0 affected processes

## Out of scope

- Intent/parallel_reason population by the agent → #423 (prompt contract)
- Discord stalled proxy → #422
- Docs closure → #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)