### PR TITLE
feat(discord): stalled-status proxy with pause suppression (#422)

### DIFF
--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -216,6 +216,31 @@ def _event_resets_stall_clock(event: Any, last_envelope_render: str) -> bool:
     return True
 
 
+def _envelope_edit_would_clobber_overlay(
+    *,
+    new_render: str,
+    displayed_render: str,
+    stalled_emitted: bool,
+) -> bool:
+    """True when re-editing ``status_msg`` would erase the watchdog
+    overlay without adding any new information.
+
+    The EnvelopeUpdated branch's edit gate uses this helper. The
+    comparison is against ``displayed_render`` (what's actually painted
+    in ``status_msg``), NOT against ``last_envelope_render`` (the most
+    recent observation). Codex review v3 (#422) caught that conflating
+    the two breaks debounce-suppressed catch-up: a real-progress
+    update can land inside the 0.5s debounce window and update the
+    observed render without ever painting; if a later identical
+    fallback then sees observed == new, it would mistakenly skip the
+    catch-up edit. Comparing against displayed instead lets the
+    fallback run the edit and refresh the display, while still
+    skipping when the display is already in sync AND the overlay is
+    up.
+    """
+    return new_render == displayed_render and stalled_emitted
+
+
 def _should_emit_stalled_status(
     *,
     now: float,
@@ -1425,32 +1450,18 @@ class LoomDiscordBot:
         async with message.channel.typing():
             try:
                 async for event in session.stream_turn(content):
-                    # ── Heartbeat + branch gate (#422 codex review v2) ──
-                    # The same decision controls TWO things: whether
-                    # the stall-clock resets AND whether the per-event
-                    # branch runs. Both must be skipped for no-op
-                    # events, otherwise the per-branch ``_safe_edit``
-                    # would overwrite the watchdog's "still waiting"
-                    # overlay with a render-without-overlay even though
-                    # nothing visible changed.
-                    #
-                    # ``_event_resets_stall_clock`` returns False for
-                    # synthetic 1Hz ``EnvelopeUpdated`` fallbacks (no
-                    # render change vs ``_last_envelope_render``) and
-                    # for ``ActionStateChange`` (silent in Discord by
-                    # design). Continue past the whole if-elif chain
-                    # so the message stays exactly as the watchdog
-                    # painted it.
-                    if not _event_resets_stall_clock(
-                        event, _last_envelope_render
-                    ):
-                        continue
-                    _last_runtime_event_at = time.monotonic()
-                    _stalled_emitted = False
-                    # Keep the cached render fresh for the next event's
-                    # comparison. Updated whenever a progress-bearing
-                    # envelope event lands so subsequent fallback ticks
-                    # compare against the most recently observed state.
+                    # ── Stall-clock heartbeat (#422 codex review v1) ──
+                    # Gated on OBSERVED progress — see helper docstring.
+                    # Synthetic fallback ``EnvelopeUpdated`` ticks and
+                    # ``ActionStateChange`` don't reset the clock; all
+                    # other events do.
+                    if _event_resets_stall_clock(event, _last_envelope_render):
+                        _last_runtime_event_at = time.monotonic()
+                        _stalled_emitted = False
+                    # Keep the OBSERVED render fresh for the next clock
+                    # comparison. Updated unconditionally on envelope
+                    # events — even when the branch's debounce later
+                    # suppresses the display edit, observation moves on.
                     if isinstance(
                         event,
                         (EnvelopeStarted, EnvelopeUpdated, EnvelopeCompleted),
@@ -1480,9 +1491,21 @@ class LoomDiscordBot:
                         _last_envelope_view = event.envelope
                         now = time.monotonic()
                         if now - _last_envelope_edit >= _ENVELOPE_DEBOUNCE_S:
-                            tool_buf = _format_envelope_status(event.envelope)
-                            await _safe_edit(status_msg, tool_buf.lstrip())
-                            _last_envelope_edit = now
+                            new_render = _format_envelope_status(event.envelope)
+                            # Overlay-aware edit skip (#422 codex review v3).
+                            # See helper docstring for why this uses
+                            # displayed (``tool_buf``) rather than observed
+                            # (``_last_envelope_render``) state.
+                            if _envelope_edit_would_clobber_overlay(
+                                new_render=new_render,
+                                displayed_render=tool_buf,
+                                stalled_emitted=_stalled_emitted,
+                            ):
+                                pass  # preserve watchdog overlay
+                            else:
+                                tool_buf = new_render
+                                await _safe_edit(status_msg, tool_buf.lstrip())
+                                _last_envelope_edit = now
 
                     elif isinstance(event, EnvelopeCompleted):
                         _last_envelope_view = event.envelope
@@ -1647,10 +1670,8 @@ class LoomDiscordBot:
                             tool_buf += f" — {event.message[:80]}"
                         await _safe_edit(status_msg, tool_buf.lstrip())
 
-                    # ``ActionStateChange`` is intentionally not handled
-                    # here — it's a no-op for Discord display by design
-                    # and the loop's top-level guard skips it via
-                    # ``_event_resets_stall_clock`` returning False.
+                    elif isinstance(event, ActionStateChange):
+                        pass  # too granular for Discord display
 
                     elif isinstance(event, TurnDone):
                         _cache_read_tokens = event.cache_read_input_tokens

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -53,6 +53,7 @@ showing the TTL or grant scope.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import json
 import os
@@ -180,6 +181,33 @@ _OUTCOME_GLYPHS: dict[str, str] = {
     "pivoted": "↪",
     "aborted": "🛑",
 }
+
+
+def _should_emit_stalled_status(
+    *,
+    now: float,
+    last_event_at: float,
+    threshold_s: float,
+    already_emitted: bool,
+    suppressed: bool = False,
+) -> bool:
+    """Decide whether the watchdog should append a ``still waiting`` line.
+
+    Discord lacks a true heartbeat surface (no equivalent to the CLI
+    footer), so #422 proxies it via a periodic edit on the active status
+    message. The watchdog fires at most once per quiet stretch — caller
+    sets ``already_emitted=True`` after the edit and resets it on the
+    next observable event.
+
+    ``suppressed`` is the pause-window guard: when ``TurnPaused`` is
+    waiting on a user reply, the runtime is intentionally quiet on the
+    agent side, so "still waiting" would mislead. This mirrors the CLI
+    heartbeat's PAUSED_BLOCKING state (#419), which never renders the
+    stalled prefix for the same reason.
+    """
+    if suppressed:
+        return False
+    return (not already_emitted) and now - last_event_at >= threshold_s
 
 
 def _format_envelope_status(view: ExecutionEnvelopeView) -> str:
@@ -1314,10 +1342,58 @@ class LoomDiscordBot:
         _had_pause = False
         _had_rollback = False
 
+        # ── Stalled-status watchdog (#422) ───────────────────────────────
+        # Discord has no equivalent of the CLI footer heartbeat, so we
+        # proxy "runtime is still alive" by appending a ``still waiting``
+        # line to the active status_msg when an observable event hasn't
+        # landed in ``_active_stale_threshold_s`` seconds. Fires at most
+        # once per quiet stretch — any subsequent event resets both the
+        # timestamp and the latch so the next stall would re-emit.
+        #
+        # ``_stall_watchdog_suppressed`` is the pause-window guard:
+        # TurnPaused sets it True before waiting on the user reply and
+        # False after, so a slow human decision is never mis-displayed
+        # as a runtime stall. Mirrors the CLI PAUSED_BLOCKING heartbeat
+        # rule (#419) — pause time is on the user, not the agent.
+        _last_runtime_event_at = time.monotonic()
+        _stalled_emitted = False
+        _active_stale_threshold_s = 90.0
+        _turn_done = False
+        _stall_watchdog_suppressed = False
+
+        async def _stall_watchdog() -> None:
+            nonlocal _stalled_emitted
+            while not _turn_done:
+                await asyncio.sleep(5.0)
+                now = time.monotonic()
+                if _should_emit_stalled_status(
+                    now=now,
+                    last_event_at=_last_runtime_event_at,
+                    threshold_s=_active_stale_threshold_s,
+                    already_emitted=_stalled_emitted,
+                    suppressed=_stall_watchdog_suppressed,
+                ):
+                    _stalled_emitted = True
+                    quiet_for = int(now - _last_runtime_event_at)
+                    await _safe_edit(
+                        status_msg,
+                        (tool_buf.lstrip() or "-# ◌ working…")
+                        + f"\n-# still waiting · {quiet_for}s",
+                    )
+
+        _stall_task = asyncio.create_task(_stall_watchdog())
+
         # ── Run turn with typing indicator ────────────────────────────────
         async with message.channel.typing():
             try:
                 async for event in session.stream_turn(content):
+                    # Heartbeat for the watchdog — any observed event
+                    # counts as "agent is alive". TurnPaused will flip
+                    # suppression on its own; we still reset here so the
+                    # post-resume window restarts from "fresh" rather
+                    # than carrying over the pre-pause quiet time.
+                    _last_runtime_event_at = time.monotonic()
+                    _stalled_emitted = False
                     if isinstance(event, TextChunk):
                         narration_buf += event.text
 
@@ -1421,6 +1497,13 @@ class LoomDiscordBot:
                                 and not m.author.bot
                             )
 
+                        # Suppress the stalled watchdog while we wait on
+                        # the user (#422). Pause time is on the human;
+                        # tagging the status as ``still waiting`` would
+                        # mislead. The finally also resets the watchdog
+                        # timestamp so the post-resume window doesn't
+                        # inherit pre-pause quiet time.
+                        _stall_watchdog_suppressed = True
                         try:
                             reply = await self._client.wait_for(
                                 "message", check=_pause_check, timeout=120.0
@@ -1436,6 +1519,10 @@ class LoomDiscordBot:
                         except asyncio.TimeoutError:
                             session.cancel()
                             tool_buf += "\n*(pause timed out — cancelled)*"
+                        finally:
+                            _stall_watchdog_suppressed = False
+                            _last_runtime_event_at = time.monotonic()
+                            _stalled_emitted = False
 
                     elif isinstance(event, CompressDone):
                         await _safe_send(message.channel,
@@ -1558,6 +1645,16 @@ class LoomDiscordBot:
                 except discord.HTTPException:
                     pass
                 return
+            finally:
+                # Stop the stalled watchdog (#422). Setting ``_turn_done``
+                # makes the loop exit naturally next tick; cancel + await
+                # ensures we don't leak the task across turns even when
+                # the asyncio.sleep(5.0) is mid-wait. CancelledError from
+                # the task itself is expected and swallowed.
+                _turn_done = True
+                _stall_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await _stall_task
 
         # typing() context exits here — "Bot is typing…" disappears.
 

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -1425,22 +1425,32 @@ class LoomDiscordBot:
         async with message.channel.typing():
             try:
                 async for event in session.stream_turn(content):
-                    # Heartbeat for the watchdog — only reset on events
-                    # that represent VISIBLE progress (#422 codex review).
-                    # Blanket-resetting starves the watchdog for long
-                    # sequential tools because session.stream_turn fires
-                    # ~1Hz fallback ``EnvelopeUpdated`` ticks. The helper
-                    # gates EnvelopeUpdated on a render comparison and
-                    # drops ActionStateChange (silent in Discord by
-                    # design). Other events are always real activity.
-                    if _event_resets_stall_clock(event, _last_envelope_render):
-                        _last_runtime_event_at = time.monotonic()
-                        _stalled_emitted = False
+                    # ── Heartbeat + branch gate (#422 codex review v2) ──
+                    # The same decision controls TWO things: whether
+                    # the stall-clock resets AND whether the per-event
+                    # branch runs. Both must be skipped for no-op
+                    # events, otherwise the per-branch ``_safe_edit``
+                    # would overwrite the watchdog's "still waiting"
+                    # overlay with a render-without-overlay even though
+                    # nothing visible changed.
+                    #
+                    # ``_event_resets_stall_clock`` returns False for
+                    # synthetic 1Hz ``EnvelopeUpdated`` fallbacks (no
+                    # render change vs ``_last_envelope_render``) and
+                    # for ``ActionStateChange`` (silent in Discord by
+                    # design). Continue past the whole if-elif chain
+                    # so the message stays exactly as the watchdog
+                    # painted it.
+                    if not _event_resets_stall_clock(
+                        event, _last_envelope_render
+                    ):
+                        continue
+                    _last_runtime_event_at = time.monotonic()
+                    _stalled_emitted = False
                     # Keep the cached render fresh for the next event's
-                    # comparison. Updated unconditionally on envelope
-                    # events so fallback ticks compare against the most
-                    # recently observed state, not against a stale
-                    # debounce-skipped frame.
+                    # comparison. Updated whenever a progress-bearing
+                    # envelope event lands so subsequent fallback ticks
+                    # compare against the most recently observed state.
                     if isinstance(
                         event,
                         (EnvelopeStarted, EnvelopeUpdated, EnvelopeCompleted),
@@ -1637,8 +1647,10 @@ class LoomDiscordBot:
                             tool_buf += f" — {event.message[:80]}"
                         await _safe_edit(status_msg, tool_buf.lstrip())
 
-                    elif isinstance(event, ActionStateChange):
-                        pass  # too granular for Discord display
+                    # ``ActionStateChange`` is intentionally not handled
+                    # here — it's a no-op for Discord display by design
+                    # and the loop's top-level guard skips it via
+                    # ``_event_resets_stall_clock`` returning False.
 
                     elif isinstance(event, TurnDone):
                         _cache_read_tokens = event.cache_read_input_tokens

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -183,6 +183,39 @@ _OUTCOME_GLYPHS: dict[str, str] = {
 }
 
 
+def _event_resets_stall_clock(event: Any, last_envelope_render: str) -> bool:
+    """Decide whether ``event`` is real activity for the stalled watchdog.
+
+    Most stream events are genuine signs the runtime is alive, but two
+    cases are noise:
+
+    1. ``LoomSession.stream_turn()`` emits a synthetic ``EnvelopeUpdated``
+       roughly once per second while a tool is in flight (see the
+       ``while not dispatch_task.done()`` loop in session.py around
+       L2475), even when nothing observable changed. For a long
+       sequential ``run_bash``, blanket-resetting the clock on every
+       event would prevent the watchdog from ever reaching its 90s
+       threshold — exactly the case the watchdog is meant to cover.
+       Codex caught this on the PR #429 review.
+
+    2. ``ActionStateChange`` is silent in the Discord display by design
+       (too granular). If 90s of state-machine churn passes without any
+       visible update, the user is still owed a "still waiting" line.
+
+    For ``EnvelopeUpdated``, the helper compares the new render against
+    ``last_envelope_render`` — the most recently OBSERVED render, not
+    what's currently DISPLAYED. The two diverge when the display edit
+    is suppressed by debounce; tracking the observed render separately
+    avoids false positives where a debounced gap makes a no-op fallback
+    look like new progress relative to the stale display.
+    """
+    if isinstance(event, ActionStateChange):
+        return False
+    if isinstance(event, EnvelopeUpdated):
+        return _format_envelope_status(event.envelope) != last_envelope_render
+    return True
+
+
 def _should_emit_stalled_status(
     *,
     now: float,
@@ -1360,6 +1393,11 @@ class LoomDiscordBot:
         _active_stale_threshold_s = 90.0
         _turn_done = False
         _stall_watchdog_suppressed = False
+        # Cached envelope render for the watchdog. Stays in sync with
+        # the most-recently OBSERVED envelope view (not the displayed
+        # one — debounce skips would otherwise let synthetic 1Hz
+        # fallback ``EnvelopeUpdated`` ticks look like new progress).
+        _last_envelope_render = ""
 
         async def _stall_watchdog() -> None:
             nonlocal _stalled_emitted
@@ -1387,13 +1425,27 @@ class LoomDiscordBot:
         async with message.channel.typing():
             try:
                 async for event in session.stream_turn(content):
-                    # Heartbeat for the watchdog — any observed event
-                    # counts as "agent is alive". TurnPaused will flip
-                    # suppression on its own; we still reset here so the
-                    # post-resume window restarts from "fresh" rather
-                    # than carrying over the pre-pause quiet time.
-                    _last_runtime_event_at = time.monotonic()
-                    _stalled_emitted = False
+                    # Heartbeat for the watchdog — only reset on events
+                    # that represent VISIBLE progress (#422 codex review).
+                    # Blanket-resetting starves the watchdog for long
+                    # sequential tools because session.stream_turn fires
+                    # ~1Hz fallback ``EnvelopeUpdated`` ticks. The helper
+                    # gates EnvelopeUpdated on a render comparison and
+                    # drops ActionStateChange (silent in Discord by
+                    # design). Other events are always real activity.
+                    if _event_resets_stall_clock(event, _last_envelope_render):
+                        _last_runtime_event_at = time.monotonic()
+                        _stalled_emitted = False
+                    # Keep the cached render fresh for the next event's
+                    # comparison. Updated unconditionally on envelope
+                    # events so fallback ticks compare against the most
+                    # recently observed state, not against a stale
+                    # debounce-skipped frame.
+                    if isinstance(
+                        event,
+                        (EnvelopeStarted, EnvelopeUpdated, EnvelopeCompleted),
+                    ):
+                        _last_envelope_render = _format_envelope_status(event.envelope)
                     if isinstance(event, TextChunk):
                         narration_buf += event.text
 

--- a/tests/test_discord_interaction_language.py
+++ b/tests/test_discord_interaction_language.py
@@ -377,3 +377,78 @@ def test_long_sequential_dispatch_eventually_triggers_stalled() -> None:
         threshold_s=90.0,
         already_emitted=False,
     ), "watchdog must fire after 90s of no-op envelope ticks"
+
+
+def test_no_op_envelope_update_skips_entire_branch_to_preserve_overlay() -> None:
+    """Regression for the codex P2 v2 finding (PR #429 re-review).
+
+    Sequence:
+    1. Long ``run_bash`` starts → ``EnvelopeStarted`` → ``tool_buf`` is set
+       to the running-envelope render, ``status_msg`` displays it.
+    2. ~90s of no-op fallback ``EnvelopeUpdated`` ticks land. The
+       clock-gate (codex P2 v1 fix) means none of them reset the
+       stall clock, so the watchdog eventually fires and edits
+       ``status_msg`` to ``tool_buf + still waiting · 90s``.
+    3. Another fallback ``EnvelopeUpdated`` arrives — same render.
+       Pre-fix: the ``elif EnvelopeUpdated`` branch would call
+       ``_safe_edit(status_msg, tool_buf.lstrip())``, overwriting
+       the watchdog's overlay. Post-fix: the top-of-loop
+       ``continue`` skips the entire branch.
+
+    This test pins the WIRING GUARANTEE: ``_event_resets_stall_clock``
+    returns ``False`` for the no-op envelope update, which is what
+    causes ``_run_turn`` to ``continue`` past the if-elif chain and
+    leave the watchdog's overlay intact. If a refactor ever splits
+    the clock gate from the branch gate, this test still asserts
+    the helper-level invariant — but the comment above is the
+    canonical record of the wiring contract.
+    """
+    envelope = _running_envelope("e1", "run_bash")
+    rendered = _format_envelope_status(envelope)
+
+    # Step 1: initial envelope render is cached.
+    last_envelope_render = rendered
+
+    # Step 2: simulated watchdog fire — latch is now True. (The
+    # watchdog runs on a separate task in production; we just record
+    # its post-condition here for clarity.)
+    stalled_emitted = True
+
+    # Step 3: no-op fallback EnvelopeUpdated arrives. The wiring
+    # contract requires _event_resets_stall_clock to return False so
+    # the main loop continues past the branch.
+    no_op = EnvelopeUpdated(envelope=envelope)
+    assert _event_resets_stall_clock(no_op, last_envelope_render) is False
+
+    # And the watchdog must still consider itself emitted — no new
+    # progress event has reset the latch.
+    assert _should_emit_stalled_status(
+        now=200.0,
+        last_event_at=0.0,
+        threshold_s=90.0,
+        already_emitted=stalled_emitted,
+    ) is False
+
+
+def test_real_progress_envelope_update_resets_latch_and_reenables_stalled() -> None:
+    """Mirror of the above: when REAL progress lands after a stalled
+    emit, the helper says reset, the main loop runs the branch and
+    re-renders status_msg with the new content (which naturally lacks
+    the stalled overlay — and that's correct, because we're no longer
+    stalled). Pins that the contract distinguishes real-progress from
+    no-op updates correctly.
+    """
+    previous_render = _format_envelope_status(_running_envelope("e1", "run_bash"))
+    progress_view = ExecutionEnvelopeView(
+        envelope_id="e1",
+        session_id="s1",
+        turn_index=1,
+        status="completed",  # tool finished
+        node_count=1,
+        parallel_groups=1,
+        levels=[["n1"]],
+        nodes=[_node("n1", "run_bash", state="memorialized")],
+    )
+    progress = EnvelopeUpdated(envelope=progress_view)
+
+    assert _event_resets_stall_clock(progress, previous_render) is True

--- a/tests/test_discord_interaction_language.py
+++ b/tests/test_discord_interaction_language.py
@@ -17,7 +17,10 @@ Pure-function coverage around ``_format_envelope_status``. Verifies:
 from __future__ import annotations
 
 from loom.core.events import ExecutionEnvelopeView, ExecutionNodeView
-from loom.platform.discord.bot import _format_envelope_status
+from loom.platform.discord.bot import (
+    _format_envelope_status,
+    _should_emit_stalled_status,
+)
 from loom.platform.interaction_language import EnvelopeOutcome, ParallelReason
 
 
@@ -190,3 +193,64 @@ def test_fulfilled_outcome_does_not_add_summary_line() -> None:
     assert "◐" not in text
     assert "⚠" not in text
     assert "↪" not in text
+
+
+# ----------------------------------------------------------------------
+# Stalled-status proxy (#422)
+# ----------------------------------------------------------------------
+
+
+def test_stalled_status_emits_once_after_threshold() -> None:
+    # First check past the threshold returns True; once the caller has
+    # recorded the emit, subsequent ticks must not retrigger until the
+    # next observable event resets ``already_emitted``.
+    assert _should_emit_stalled_status(
+        now=100.0,
+        last_event_at=9.0,
+        threshold_s=90.0,
+        already_emitted=False,
+    )
+    assert not _should_emit_stalled_status(
+        now=100.0,
+        last_event_at=9.0,
+        threshold_s=90.0,
+        already_emitted=True,
+    )
+
+
+def test_stalled_status_does_not_emit_before_threshold() -> None:
+    assert not _should_emit_stalled_status(
+        now=100.0,
+        last_event_at=20.0,  # only 80s of quiet, threshold is 90s
+        threshold_s=90.0,
+        already_emitted=False,
+    )
+
+
+def test_stalled_status_is_suppressed_while_waiting_for_user() -> None:
+    # During a TurnPaused window, the runtime is quiet on the agent
+    # side because we're waiting on a human. The watchdog must not
+    # call this "still waiting" — same invariant as the CLI footer's
+    # PAUSED_BLOCKING heartbeat state (#419).
+    assert not _should_emit_stalled_status(
+        now=200.0,
+        last_event_at=0.0,
+        threshold_s=90.0,
+        already_emitted=False,
+        suppressed=True,
+    )
+
+
+def test_stalled_status_suppression_takes_precedence_over_already_emitted() -> None:
+    # Even if the watchdog had already fired (and would normally just
+    # stay quiet), the suppression flag is the dominant signal. This
+    # protects against a race where a pause arrives right after a
+    # stalled emit — we want the pause window to govern, not the
+    # stalled latch.
+    assert not _should_emit_stalled_status(
+        now=200.0,
+        last_event_at=0.0,
+        threshold_s=90.0,
+        already_emitted=True,
+        suppressed=True,
+    )

--- a/tests/test_discord_interaction_language.py
+++ b/tests/test_discord_interaction_language.py
@@ -267,7 +267,10 @@ from loom.core.events import (
     EnvelopeUpdated,
     TextChunk,
 )
-from loom.platform.discord.bot import _event_resets_stall_clock
+from loom.platform.discord.bot import (
+    _envelope_edit_would_clobber_overlay,
+    _event_resets_stall_clock,
+)
 
 
 def _running_envelope(envelope_id: str, tool_name: str) -> ExecutionEnvelopeView:
@@ -379,76 +382,149 @@ def test_long_sequential_dispatch_eventually_triggers_stalled() -> None:
     ), "watchdog must fire after 90s of no-op envelope ticks"
 
 
-def test_no_op_envelope_update_skips_entire_branch_to_preserve_overlay() -> None:
-    """Regression for the codex P2 v2 finding (PR #429 re-review).
+# ----------------------------------------------------------------------
+# Overlay-aware envelope edit gating (#422 codex review v3)
+# ----------------------------------------------------------------------
+# v1 fixed the stall-clock starvation by gating clock reset on observed
+# render. v2 then tried to unify clock-gate and branch-skip into a
+# single ``continue`` at the loop top — but that conflated observed
+# state with displayed state and broke debounce-suppressed catch-up.
+# v3 splits them back apart:
+#
+# - ``_event_resets_stall_clock`` (clock) compares OBSERVED render.
+# - ``_envelope_edit_would_clobber_overlay`` (edit) compares DISPLAYED
+#   render. The displayed timeline lags the observed one whenever an
+#   earlier update lost its edit to debounce, which is the exact case
+#   v2 broke.
+#
+# Tests below pin both contracts so future refactors can't re-merge.
 
-    Sequence:
-    1. Long ``run_bash`` starts → ``EnvelopeStarted`` → ``tool_buf`` is set
-       to the running-envelope render, ``status_msg`` displays it.
-    2. ~90s of no-op fallback ``EnvelopeUpdated`` ticks land. The
-       clock-gate (codex P2 v1 fix) means none of them reset the
-       stall clock, so the watchdog eventually fires and edits
-       ``status_msg`` to ``tool_buf + still waiting · 90s``.
-    3. Another fallback ``EnvelopeUpdated`` arrives — same render.
-       Pre-fix: the ``elif EnvelopeUpdated`` branch would call
-       ``_safe_edit(status_msg, tool_buf.lstrip())``, overwriting
-       the watchdog's overlay. Post-fix: the top-of-loop
-       ``continue`` skips the entire branch.
 
-    This test pins the WIRING GUARANTEE: ``_event_resets_stall_clock``
-    returns ``False`` for the no-op envelope update, which is what
-    causes ``_run_turn`` to ``continue`` past the if-elif chain and
-    leave the watchdog's overlay intact. If a refactor ever splits
-    the clock gate from the branch gate, this test still asserts
-    the helper-level invariant — but the comment above is the
-    canonical record of the wiring contract.
-    """
-    envelope = _running_envelope("e1", "run_bash")
-    rendered = _format_envelope_status(envelope)
+def test_edit_skip_preserves_overlay_on_identical_displayed_render() -> None:
+    # The v2-class case: watchdog overlay is up, display matches
+    # observation, and a no-op fallback arrives. Skipping the edit
+    # preserves the ``still waiting`` overlay.
+    rendered = _format_envelope_status(_running_envelope("e1", "run_bash"))
+    assert _envelope_edit_would_clobber_overlay(
+        new_render=rendered,
+        displayed_render=rendered,
+        stalled_emitted=True,
+    ) is True
 
-    # Step 1: initial envelope render is cached.
-    last_envelope_render = rendered
 
-    # Step 2: simulated watchdog fire — latch is now True. (The
-    # watchdog runs on a separate task in production; we just record
-    # its post-condition here for clarity.)
-    stalled_emitted = True
-
-    # Step 3: no-op fallback EnvelopeUpdated arrives. The wiring
-    # contract requires _event_resets_stall_clock to return False so
-    # the main loop continues past the branch.
-    no_op = EnvelopeUpdated(envelope=envelope)
-    assert _event_resets_stall_clock(no_op, last_envelope_render) is False
-
-    # And the watchdog must still consider itself emitted — no new
-    # progress event has reset the latch.
-    assert _should_emit_stalled_status(
-        now=200.0,
-        last_event_at=0.0,
-        threshold_s=90.0,
-        already_emitted=stalled_emitted,
+def test_edit_runs_when_no_overlay_to_preserve() -> None:
+    # Without an active overlay there's nothing to clobber, so even
+    # identical renders should re-edit. This is the load-bearing case
+    # for v3: a debounce-suppressed real-progress update means the
+    # observed render moved on but the displayed render didn't. The
+    # next identical fallback finds ``new_render != tool_buf`` (because
+    # tool_buf is the stale pre-progress render) — but the helper
+    # also has to allow re-edit when ``new_render == tool_buf`` if
+    # stalled isn't set, in case a later refactor relies on idempotent
+    # re-edits to refresh the display.
+    rendered = _format_envelope_status(_running_envelope("e1", "run_bash"))
+    assert _envelope_edit_would_clobber_overlay(
+        new_render=rendered,
+        displayed_render=rendered,
+        stalled_emitted=False,
     ) is False
 
 
-def test_real_progress_envelope_update_resets_latch_and_reenables_stalled() -> None:
-    """Mirror of the above: when REAL progress lands after a stalled
-    emit, the helper says reset, the main loop runs the branch and
-    re-renders status_msg with the new content (which naturally lacks
-    the stalled overlay — and that's correct, because we're no longer
-    stalled). Pins that the contract distinguishes real-progress from
-    no-op updates correctly.
+def test_edit_runs_when_render_differs_even_with_overlay() -> None:
+    # Real progress overrides the overlay: the new render reflects new
+    # state, the user is no longer stalled, the overlay shouldn't
+    # survive. ``new_render != tool_buf`` is the catch-up case where
+    # the displayed render was suppressed by debounce earlier.
+    old = _format_envelope_status(_running_envelope("e1", "run_bash"))
+    new = _format_envelope_status(
+        ExecutionEnvelopeView(
+            envelope_id="e1",
+            session_id="s1",
+            turn_index=1,
+            status="completed",
+            node_count=1,
+            parallel_groups=1,
+            levels=[["n1"]],
+            nodes=[_node("n1", "run_bash", state="memorialized")],
+        )
+    )
+    assert _envelope_edit_would_clobber_overlay(
+        new_render=new,
+        displayed_render=old,
+        stalled_emitted=True,
+    ) is False
+
+
+def test_debounce_suppressed_progress_catches_up_via_later_fallback() -> None:
+    """Regression for the codex P2 v3 finding (PR #429 third review).
+
+    Sequence:
+    1. T=0   ``EnvelopeStarted`` render A → ``tool_buf = A``,
+       displayed = A, ``_last_envelope_edit = 0``.
+    2. T=0.3 ``EnvelopeUpdated`` render B (real progress). Top
+       guard: B != A, clock resets, ``_last_envelope_render = B``.
+       Branch: debounce blocks (0.3 < 0.5s), ``tool_buf`` stays A.
+       Observation moved on, display did not.
+    3. T=1.3 fallback ``EnvelopeUpdated`` render B (no further
+       state change). Top guard: B == B, clock unchanged. Branch:
+       debounce passes (1.0 > 0.5s).
+
+    The wiring guarantee at step 3:
+
+    - v2 (bug): the loop's top ``continue`` skipped the branch
+      entirely because observed == new. Display stayed at A forever.
+    - v3 (fix): the loop runs the branch. The branch's
+      overlay-aware skip compares against DISPLAYED, finds
+      ``new_render (B) != tool_buf (A)``, runs the edit. Display
+      catches up to B.
+
+    This test exercises the helper at step 3 with the exact arguments
+    the production branch would supply.
     """
-    previous_render = _format_envelope_status(_running_envelope("e1", "run_bash"))
+    rendered_a = _format_envelope_status(_running_envelope("e1", "run_bash"))
     progress_view = ExecutionEnvelopeView(
         envelope_id="e1",
         session_id="s1",
         turn_index=1,
-        status="completed",  # tool finished
+        status="completed",
         node_count=1,
         parallel_groups=1,
         levels=[["n1"]],
         nodes=[_node("n1", "run_bash", state="memorialized")],
     )
-    progress = EnvelopeUpdated(envelope=progress_view)
+    rendered_b = _format_envelope_status(progress_view)
 
-    assert _event_resets_stall_clock(progress, previous_render) is True
+    # tool_buf stale at A; new render is B; no overlay (real progress
+    # at T=0.3 reset _stalled_emitted on the clock gate).
+    assert _envelope_edit_would_clobber_overlay(
+        new_render=rendered_b,
+        displayed_render=rendered_a,
+        stalled_emitted=False,
+    ) is False  # → branch will run the edit → display catches up
+
+    # Also confirm the clock-gate side: observed (B) == observed (B)
+    # so a redundant fallback after we already observed B does NOT
+    # reset the clock. Two timelines, two gates.
+    fallback = EnvelopeUpdated(envelope=progress_view)
+    assert _event_resets_stall_clock(fallback, rendered_b) is False
+
+
+def test_no_op_envelope_update_with_stalled_overlay_preserves_message() -> None:
+    """v2 case restated against the v3 mechanism.
+
+    After the watchdog has fired and ``_stalled_emitted = True``, a
+    fallback envelope update with identical displayed render must skip
+    the edit. The v3 mechanism still pins this — the helper returns
+    True for ``displayed == new AND stalled`` and the branch responds
+    with ``pass``.
+    """
+    rendered = _format_envelope_status(_running_envelope("e1", "run_bash"))
+    assert _envelope_edit_would_clobber_overlay(
+        new_render=rendered,
+        displayed_render=rendered,
+        stalled_emitted=True,
+    ) is True
+    # The clock-gate side also still returns False for this case so
+    # the latch doesn't accidentally reset.
+    no_op = EnvelopeUpdated(envelope=_running_envelope("e1", "run_bash"))
+    assert _event_resets_stall_clock(no_op, rendered) is False

--- a/tests/test_discord_interaction_language.py
+++ b/tests/test_discord_interaction_language.py
@@ -254,3 +254,126 @@ def test_stalled_status_suppression_takes_precedence_over_already_emitted() -> N
         already_emitted=True,
         suppressed=True,
     )
+
+
+# ----------------------------------------------------------------------
+# Stall-clock heartbeat gating (#422 codex review)
+# ----------------------------------------------------------------------
+
+
+from loom.core.events import (
+    ActionStateChange,
+    EnvelopeStarted,
+    EnvelopeUpdated,
+    TextChunk,
+)
+from loom.platform.discord.bot import _event_resets_stall_clock
+
+
+def _running_envelope(envelope_id: str, tool_name: str) -> ExecutionEnvelopeView:
+    """Single-node running envelope — what a long sequential ``run_bash``
+    looks like to the Discord consumer between ``EnvelopeStarted`` and
+    ``EnvelopeCompleted``."""
+    return ExecutionEnvelopeView(
+        envelope_id=envelope_id,
+        session_id="s1",
+        turn_index=1,
+        status="running",
+        node_count=1,
+        parallel_groups=1,
+        levels=[["n1"]],
+        nodes=[_node("n1", tool_name)],
+    )
+
+
+def test_envelope_started_always_resets_stall_clock() -> None:
+    event = EnvelopeStarted(envelope=_running_envelope("e1", "run_bash"))
+    assert _event_resets_stall_clock(event, last_envelope_render="") is True
+
+
+def test_envelope_updated_with_no_render_change_does_not_reset_clock() -> None:
+    # The pathological case codex caught: ``LoomSession.stream_turn``
+    # emits a synthetic ``EnvelopeUpdated`` every ~1s while a tool is
+    # running. If those reset the clock, a long sequential ``run_bash``
+    # never reaches the 90s threshold.
+    envelope = _running_envelope("e1", "run_bash")
+    rendered = _format_envelope_status(envelope)
+    event = EnvelopeUpdated(envelope=envelope)
+    assert _event_resets_stall_clock(event, last_envelope_render=rendered) is False
+
+
+def test_envelope_updated_with_state_change_resets_clock() -> None:
+    # When a node transitions (e.g., one of N parallel tools just
+    # finished), the rendered status differs from the previous view —
+    # that's real progress and must reset the clock.
+    previous = _format_envelope_status(_running_envelope("e1", "run_bash"))
+    new_view = ExecutionEnvelopeView(
+        envelope_id="e1",
+        session_id="s1",
+        turn_index=1,
+        status="running",
+        node_count=2,
+        parallel_groups=1,
+        levels=[["n1", "n2"]],
+        nodes=[_node("n1", "run_bash"), _node("n2", "pytest")],
+    )
+    event = EnvelopeUpdated(envelope=new_view)
+    assert _event_resets_stall_clock(event, last_envelope_render=previous) is True
+
+
+def test_action_state_change_never_resets_clock() -> None:
+    # Silent in Discord display by design (#422). User sees no edit,
+    # so 90s of state-machine churn still warrants a stalled message.
+    event = ActionStateChange(
+        action_id="n1",
+        tool_name="run_bash",
+        call_id="n1",
+        old_state="executing",
+        new_state="observed",
+    )
+    assert _event_resets_stall_clock(event, last_envelope_render="anything") is False
+
+
+def test_text_chunk_always_resets_clock() -> None:
+    event = TextChunk(text="hello")
+    assert _event_resets_stall_clock(event, last_envelope_render="") is True
+
+
+def test_long_sequential_dispatch_eventually_triggers_stalled() -> None:
+    """End-to-end shape: simulate the codex-described scenario.
+
+    A single long ``run_bash`` produces ``EnvelopeStarted`` followed by
+    ~90 fallback ``EnvelopeUpdated`` ticks at 1s intervals before the
+    user-visible state changes. With the unconditional heartbeat (pre
+    codex fix) the clock would reset every tick and the watchdog would
+    never fire. With the render-gated heartbeat, after 90s of identical
+    fallback ticks the threshold is crossed and a single stalled emit
+    must be allowed.
+    """
+    envelope = _running_envelope("e1", "run_bash")
+    rendered = _format_envelope_status(envelope)
+
+    started = EnvelopeStarted(envelope=envelope)
+    last_event_at = 0.0
+    if _event_resets_stall_clock(started, last_envelope_render=""):
+        last_event_at = 0.0  # turn start
+    last_envelope_render = rendered
+
+    # 90 fallback updates at 1s intervals — none change the rendered
+    # status, so none reset the clock.
+    for tick in range(1, 91):
+        now = float(tick)
+        ev = EnvelopeUpdated(envelope=envelope)
+        if _event_resets_stall_clock(ev, last_envelope_render):
+            last_event_at = now
+        # Outer loop would also keep ``last_envelope_render`` fresh; it
+        # never actually changes here so the assignment is a no-op.
+        last_envelope_render = _format_envelope_status(ev.envelope)
+
+    now = 90.5  # half a watchdog poll-tick past the threshold boundary
+    assert _should_emit_stalled_status(
+        now=now,
+        last_event_at=last_event_at,
+        threshold_s=90.0,
+        already_emitted=False,
+    ), "watchdog must fire after 90s of no-op envelope ticks"


### PR DESCRIPTION
## Summary

Task 7 of the UI interaction-language slice 1 plan — Discord's analogue of the CLI heartbeat. Since Discord has no persistent footer surface, this proxies "runtime is still alive" by appending a ``still waiting · <Ns>`` line to the active ``status_msg`` when no observable event has landed within ``_active_stale_threshold_s`` (default 90s).

Closes #422.

## Behaviour

| Trigger | Effect |
|---|---|
| Any stream event arrives | Reset ``_last_runtime_event_at`` + clear ``_stalled_emitted`` latch |
| Watchdog tick + quiet ≥ threshold + not suppressed + not already emitted | Edit status_msg with ``still waiting · <Ns>`` line |
| ``TurnPaused`` enters | Suppress watchdog; pause time is on the human |
| Pause resolves (resume/cancel/redirect/timeout) | Re-enable + reset timestamp |
| Turn ends (TurnDone / Exception / CancelledError) | ``finally`` cancels watchdog, awaits cleanup |

## Plan deviations called out

**Suppression precedes already-emitted.** Plan helper signature has both flags separately, but the test I added (``test_stalled_status_suppression_takes_precedence_over_already_emitted``) pins the order: if a pause arrives right after a stalled emit, the latch must not block the suppression from kicking in. Otherwise the latched ``True`` would let the pause window inherit stale "still waiting" state.

**Watchdog spawned outside the typing() context-manager.** The plan suggests inside; either works, but outside means the cancel/await in the finally runs before the typing context exits, keeping the bot-is-typing indicator coherent with watchdog teardown.

**Reset on pause resolve.** Plan only set suppression False after pause. I also reset ``_last_runtime_event_at`` and ``_stalled_emitted`` in the finally — without this, the resume path would inherit the pre-pause quiet time and potentially fire a stalled message immediately.

## Test plan

- [x] ``pytest -q tests/test_discord_interaction_language.py`` — 11 pass (7 existing + 4 new stalled tests)
- [x] ``pytest -q tests/test_discord_*.py`` — 92 pass
- [x] Full suite: **2017 pass, 0 failed**
- [x] ``gitnexus impact`` on ``_run_turn`` — LOW, 0 affected processes
- [x] ``gitnexus detect-changes --scope staged`` — risk LOW

## Out of scope

- Prompt-side intent contract (envelope intent + outcome authored by the agent) → #423
- Docs closure → #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)