### PR TITLE
feat(prompt): envelope intent contract layer (#423)

### DIFF
--- a/loom/core/cognition/prompt_stack.py
+++ b/loom/core/cognition/prompt_stack.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from loom.core.envelope_outcome import INTERACTION_LANGUAGE_INSTRUCTIONS
+
 
 @dataclass
 class PromptLayer:
@@ -45,6 +47,10 @@ class PromptStack:
     """
 
     LAYER_SEPARATOR = "\n\n---\n\n"
+    # Re-exposed on the class so tests + downstream consumers can read
+    # the contract phrasing without importing it from another module.
+    # Source of truth is ``loom.core.envelope_outcome`` (#423).
+    INTERACTION_LANGUAGE_INSTRUCTIONS = INTERACTION_LANGUAGE_INSTRUCTIONS
 
     def __init__(
         self,
@@ -87,6 +93,22 @@ class PromptStack:
                 "agent",
                 self._agent_path.read_text(encoding="utf-8"),
                 self._agent_path,
+            ))
+
+        # Layer 2.5 — built-in interaction-language contract (#423).
+        # Tells the agent to author intent + outcome metadata for
+        # multi-tool batches; renderers (#420) consume those fields
+        # and producers fall back to mechanical derivation (#421)
+        # when absent. Slots after project Agent.md so it inherits
+        # the project's context, and before personality so persona
+        # lenses can phrase-tune on top. Gated on ``self._layers``
+        # being non-empty so prompt-free configurations stay empty —
+        # keeps ``test_empty_stack_returns_empty_string`` semantics.
+        if self._layers:
+            self._layers.append(PromptLayer(
+                "interaction_language",
+                INTERACTION_LANGUAGE_INSTRUCTIONS,
+                None,
             ))
 
         # Layer 3 — Personality

--- a/loom/core/envelope_outcome.py
+++ b/loom/core/envelope_outcome.py
@@ -1,17 +1,25 @@
-"""Envelope outcome vocabulary and mechanical derivation (#421).
+"""Envelope interaction vocabulary — outcome derivation + prompt contract.
 
-Lives in ``loom.core`` rather than under ``loom.platform`` because the
-ledger projector — also a core component — needs to populate
-``ExecutionEnvelopeView.outcome`` at projection time. The architecture
-boundary (CLAUDE.md: ``Platform → Cognition → Harness → Memory``) means
-core cannot import from platform; the outcome data contract therefore
-belongs here next to the dataclass it instantiates.
+Hosts core data the agent + producers + renderers share around an
+``ExecutionEnvelopeView``:
 
-``loom.platform.interaction_language`` re-exports ``EnvelopeOutcome``
-so UI surfaces (CLI footer, Discord renderer) keep their existing
-import shape. The mechanical helper stays unexported on the platform
-side because only producers call it — renderers consume the strings,
-they don't classify them.
+- ``EnvelopeOutcome`` enum + ``derive_envelope_outcome`` helper for the
+  mechanical fallback when no LLM-authored outcome is present (#421).
+- ``INTERACTION_LANGUAGE_INSTRUCTIONS`` — the prompt-stack contract that
+  asks the agent to author intent + outcome for multi-tool batches (#423).
+
+Lives in ``loom.core`` rather than under ``loom.platform`` because both
+the ledger projector AND ``PromptStack`` (cognition layer) need this
+vocabulary, and core cannot import from platform per CLAUDE.md
+(``Platform → Cognition → Harness → Memory``). The two concepts
+co-locate because they're the producer/consumer ends of the same
+envelope-language: the prompt asks the agent to write intent/outcome,
+and the helpers classify outcomes mechanically when the agent omits
+them. Keeping them in one file means future contract changes touch
+one place.
+
+``loom.platform.interaction_language`` re-exports the public surface so
+UI consumers (Discord renderer, tests) keep their existing import shape.
 """
 from __future__ import annotations
 
@@ -24,6 +32,21 @@ class EnvelopeOutcome(str, Enum):
     UNFULFILLED = "unfulfilled"
     PIVOTED = "pivoted"
     ABORTED = "aborted"
+
+
+# Prompt-stack contract layer (#423). Slots between the project's Agent.md
+# and any active personality so the contract sits with project-level
+# context but persona lenses can still adjust phrasing on top of it.
+# Phrasing is intentionally compact — the layer appears in every turn's
+# system prompt and shouldn't bloat the cache prefix. Future localization
+# follows the same registry pattern as the label dicts in
+# ``loom.platform.interaction_language``.
+INTERACTION_LANGUAGE_INSTRUCTIONS = (
+    "When you dispatch a multi-tool batch, provide a one-line intent before "
+    "the batch and an outcome judgement after the batch completes. "
+    "Single-tool calls do not need an intent header. Keep both lines short "
+    "enough to display in one UI line."
+)
 
 
 # ``observed`` / ``validated`` / ``committed`` are intermediate

--- a/loom/platform/interaction_language.py
+++ b/loom/platform/interaction_language.py
@@ -11,16 +11,21 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
-from loom.core.envelope_outcome import EnvelopeOutcome, derive_envelope_outcome
+from loom.core.envelope_outcome import (
+    INTERACTION_LANGUAGE_INSTRUCTIONS,
+    EnvelopeOutcome,
+    derive_envelope_outcome,
+)
 from loom.core.security.sandbox_runtime import extract_command_root
 
-# Re-exported so UI consumers (Discord bot, tests) keep their existing
-# ``from loom.platform.interaction_language import EnvelopeOutcome``
+# Re-exported so UI consumers (Discord bot, tests, prompt_stack) keep
+# their existing ``from loom.platform.interaction_language import …``
 # import shape. The canonical home is ``loom.core.envelope_outcome`` —
-# the ledger projector needs the enum at projection time and core
-# cannot import from platform (CLAUDE.md layering).
+# both the ledger projector AND PromptStack need this vocabulary and
+# core cannot import from platform (CLAUDE.md layering).
 __all__ = [
     "EnvelopeOutcome",
+    "INTERACTION_LANGUAGE_INSTRUCTIONS",
     "derive_envelope_outcome",
 ]
 
@@ -61,16 +66,10 @@ class ToolAction:
 
 _LONG_RUNNER_THRESHOLD_S = 90.0
 
-# Prompt contract for envelope-level intent and outcome.
-# Lives next to the data and UI behaviour it instructs about so prompt_stack
-# stays a pure layering mechanism. Future localization follows the same
-# registry pattern as the label dicts below.
-INTERACTION_LANGUAGE_INSTRUCTIONS = (
-    "When you dispatch a multi-tool batch, provide a one-line intent before "
-    "the batch and an outcome judgement after the batch completes. "
-    "Single-tool calls do not need an intent header. Keep both lines short "
-    "enough to display in one UI line."
-)
+# ``INTERACTION_LANGUAGE_INSTRUCTIONS`` lives in ``loom.core.envelope_outcome``
+# now and is re-exported above. PromptStack (core/cognition) needed it
+# at layer-injection time; keeping it in core also keeps the architecture
+# guard happy (#423).
 
 _LABELS_ZH_TW: dict[str, tuple[str, ...]] = {
     "read_file": ("查詢檔案",),

--- a/tests/test_prompt_stack.py
+++ b/tests/test_prompt_stack.py
@@ -67,15 +67,18 @@ class TestComposition:
     def test_soul_only(self, tmp_soul):
         stack = PromptStack(soul_path=tmp_soul)
         result = stack.load()
-        assert result == "I am SOUL."
-        assert stack.layer_names == ["soul"]
+        sep = PromptStack.LAYER_SEPARATOR
+        instr = PromptStack.INTERACTION_LANGUAGE_INSTRUCTIONS
+        assert result == f"I am SOUL.{sep}{instr}"
+        assert stack.layer_names == ["soul", "interaction_language"]
 
     def test_soul_and_agent(self, tmp_soul, tmp_agent):
         stack = PromptStack(soul_path=tmp_soul, agent_path=tmp_agent)
         result = stack.load()
         sep = PromptStack.LAYER_SEPARATOR
-        assert result == f"I am SOUL.{sep}I am Agent."
-        assert stack.layer_names == ["soul", "agent"]
+        instr = PromptStack.INTERACTION_LANGUAGE_INSTRUCTIONS
+        assert result == f"I am SOUL.{sep}I am Agent.{sep}{instr}"
+        assert stack.layer_names == ["soul", "agent", "interaction_language"]
 
     def test_three_layers(self, tmp_soul, tmp_agent, tmp_personalities):
         p_path = tmp_personalities / "adversarial.md"
@@ -87,14 +90,23 @@ class TestComposition:
         )
         result = stack.load()
         sep = PromptStack.LAYER_SEPARATOR
-        assert result == f"I am SOUL.{sep}I am Agent.{sep}I challenge assumptions."
-        assert stack.layer_names == ["soul", "agent", "personality"]
+        instr = PromptStack.INTERACTION_LANGUAGE_INSTRUCTIONS
+        assert result == (
+            f"I am SOUL.{sep}I am Agent.{sep}{instr}{sep}I challenge assumptions."
+        )
+        assert stack.layer_names == [
+            "soul",
+            "agent",
+            "interaction_language",
+            "personality",
+        ]
 
     def test_missing_files_are_skipped(self, tmp_path):
         stack = PromptStack(
             soul_path=tmp_path / "nonexistent_soul.md",
             agent_path=tmp_path / "nonexistent_agent.md",
         )
+        # No user layer loaded → no built-in layer either.
         assert stack.load() == ""
         assert stack.layer_names == []
 
@@ -103,8 +115,10 @@ class TestComposition:
             soul_path=tmp_soul,
             agent_path=tmp_path / "ghost.md",
         )
-        assert stack.load() == "I am SOUL."
-        assert stack.layer_names == ["soul"]
+        sep = PromptStack.LAYER_SEPARATOR
+        instr = PromptStack.INTERACTION_LANGUAGE_INSTRUCTIONS
+        assert stack.load() == f"I am SOUL.{sep}{instr}"
+        assert stack.layer_names == ["soul", "interaction_language"]
 
     def test_separator_is_present_between_layers(self, tmp_soul, tmp_agent):
         stack = PromptStack(soul_path=tmp_soul, agent_path=tmp_agent)
@@ -140,7 +154,7 @@ class TestProperties:
     def test_layer_names_reflects_loaded_layers(self, tmp_soul, tmp_agent):
         stack = PromptStack(soul_path=tmp_soul, agent_path=tmp_agent)
         stack.load()
-        assert stack.layer_names == ["soul", "agent"]
+        assert stack.layer_names == ["soul", "agent", "interaction_language"]
 
 
 # ---------------------------------------------------------------------------
@@ -238,7 +252,9 @@ class TestClearPersonality:
         )
         stack.load()
         stack.clear_personality()
-        assert stack.layer_names == ["soul", "agent"]
+        # Built-in layer stays — it's anchored to the SOUL+Agent
+        # configuration, not to whether a personality is active.
+        assert stack.layer_names == ["soul", "agent", "interaction_language"]
 
     def test_clear_resets_current_personality(self, tmp_personalities):
         p_path = tmp_personalities / "adversarial.md"
@@ -307,14 +323,18 @@ class TestFromConfig:
         stack = PromptStack.from_config(config, base_dir=tmp_path)
         result = stack.load()
         sep = PromptStack.LAYER_SEPARATOR
-        assert result == f"soul{sep}agent{sep}adv"
+        instr = PromptStack.INTERACTION_LANGUAGE_INSTRUCTIONS
+        assert result == f"soul{sep}agent{sep}{instr}{sep}adv"
 
     def test_no_identity_section(self, tmp_path):
         (tmp_path / "SOUL.md").write_text("soul", encoding="utf-8")
         stack = PromptStack.from_config({}, base_dir=tmp_path)
-        # Default soul path is SOUL.md relative to base_dir
+        # Default soul path is SOUL.md relative to base_dir; built-in
+        # interaction-language layer slots after it.
         result = stack.load()
-        assert result == "soul"
+        sep = PromptStack.LAYER_SEPARATOR
+        instr = PromptStack.INTERACTION_LANGUAGE_INSTRUCTIONS
+        assert result == f"soul{sep}{instr}"
 
     def test_empty_personality_string_treated_as_none(self, tmp_path):
         (tmp_path / "SOUL.md").write_text("soul", encoding="utf-8")
@@ -328,10 +348,96 @@ class TestFromConfig:
         (tmp_path / "SOUL.md").write_text("soul content", encoding="utf-8")
         config = {"identity": {"soul": "SOUL.md"}}
         stack = PromptStack.from_config(config, base_dir=tmp_path)
-        assert stack.load() == "soul content"
+        sep = PromptStack.LAYER_SEPARATOR
+        instr = PromptStack.INTERACTION_LANGUAGE_INSTRUCTIONS
+        assert stack.load() == f"soul content{sep}{instr}"
 
     def test_missing_optional_fields_produce_no_layers(self, tmp_path):
         # No SOUL.md exists in tmp_path
         config = {"identity": {}}
         stack = PromptStack.from_config(config, base_dir=tmp_path)
         assert stack.load() == ""
+
+
+# ---------------------------------------------------------------------------
+# Built-in interaction-language layer (#423)
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltInInteractionLanguageLayer:
+    """``PromptStack.load`` inserts a built-in layer carrying the envelope
+    intent/outcome contract whenever at least one user prompt layer is
+    loaded. The layer slots between project-level Agent.md and any active
+    personality so personas can adjust phrasing on top of it while the
+    contract sits with stable project context.
+    """
+
+    def test_layer_present_after_soul_and_agent(self, tmp_soul, tmp_agent):
+        stack = PromptStack(soul_path=tmp_soul, agent_path=tmp_agent)
+        stack.load()
+        assert stack.layer_names == ["soul", "agent", "interaction_language"]
+
+    def test_layer_slots_after_agent_before_personality(
+        self, tmp_soul, tmp_agent, tmp_personalities
+    ):
+        p_path = tmp_personalities / "adversarial.md"
+        stack = PromptStack(
+            soul_path=tmp_soul,
+            agent_path=tmp_agent,
+            personality_path=p_path,
+            personalities_dir=tmp_personalities,
+        )
+        stack.load()
+        assert stack.layer_names == [
+            "soul",
+            "agent",
+            "interaction_language",
+            "personality",
+        ]
+
+    def test_layer_present_with_soul_only(self, tmp_soul):
+        # Even without an Agent.md, the contract still applies — it's
+        # about how the agent writes envelope metadata, not about
+        # project-specific behaviour. So soul-only stacks also get it.
+        stack = PromptStack(soul_path=tmp_soul)
+        stack.load()
+        assert stack.layer_names == ["soul", "interaction_language"]
+
+    def test_no_layer_when_no_user_prompt_loaded(self, tmp_path):
+        # An empty stack stays empty — the built-in layer needs at
+        # least one user prompt layer to anchor to. This keeps
+        # ``test_empty_stack_returns_empty_string`` semantics intact
+        # and prevents the built-in layer from leaking into agents
+        # configured to run prompt-free.
+        stack = PromptStack(
+            soul_path=tmp_path / "nonexistent_soul.md",
+            agent_path=tmp_path / "nonexistent_agent.md",
+        )
+        assert stack.load() == ""
+        assert stack.layer_names == []
+
+    def test_layer_content_mentions_envelope_intent_contract(self, tmp_agent):
+        stack = PromptStack(agent_path=tmp_agent)
+        prompt = stack.load()
+        # Pin the load-bearing phrases so a future docstring tweak
+        # can't quietly weaken the contract.
+        assert "multi-tool batch" in prompt
+        assert "one-line intent" in prompt
+        assert "outcome judgement" in prompt
+        assert "Single-tool calls do not need an intent header" in prompt
+
+    def test_layer_separator_between_agent_and_built_in(self, tmp_soul, tmp_agent):
+        stack = PromptStack(soul_path=tmp_soul, agent_path=tmp_agent)
+        result = stack.load()
+        sep = PromptStack.LAYER_SEPARATOR
+        # The built-in layer sits AFTER the agent layer; the standard
+        # separator must appear between them so layers don't run together.
+        assert f"I am Agent.{sep}" in result
+
+    def test_class_attribute_exposes_contract_text(self):
+        # Tests that haven't loaded a stack still need to assert the
+        # contract phrasing — exposing it as a class attribute keeps
+        # the import shape consistent across consumers.
+        from loom.core.envelope_outcome import INTERACTION_LANGUAGE_INSTRUCTIONS
+
+        assert PromptStack.INTERACTION_LANGUAGE_INSTRUCTIONS == INTERACTION_LANGUAGE_INSTRUCTIONS


### PR DESCRIPTION
## Summary

Adds the prompt-stack contract layer that tells the agent to author envelope intent + outcome metadata for multi-tool batches. Closes Task 8 of the UI interaction-language slice 1 plan.

**Scope is prompt-only** — see "Known seam" below before reading too much into the end-user impact.

Closes #423.

## What this PR actually does

- ``loom.core.envelope_outcome`` now hosts ``INTERACTION_LANGUAGE_INSTRUCTIONS`` (moved from ``loom.platform.interaction_language`` to satisfy ``core → platform`` layering; platform re-exports for backward compat).
- ``PromptStack.load`` inserts a built-in ``interaction_language`` layer after the agent layer and before any personality layer, when at least one user prompt layer is loaded.
- ``PromptStack.INTERACTION_LANGUAGE_INSTRUCTIONS`` class attribute exposes the contract text for tests and downstream consumers.

## Known seam — producer-side capture missing (followed up as #431)

Codex caught on review that this PR alone does **not** make Discord/CLI display the agent's authored intent in the envelope row. The chain is:

\`\`\`
prompt asks agent to author    ← this PR ✓
agent writes intent/outcome as natural language    ← happens
???   ← MISSING: nothing parses authored text into view.intent / view.outcome_summary
view.intent / view.outcome_summary populated    ← stays empty
renderer (#420) falls back to synthesize_envelope_intent / mechanical outcome    ← still mechanical
\`\`\`

So in practice with just this PR:

- The agent's intent/outcome lines show as plain ``TextChunk`` narration **around** the envelope row.
- The envelope row itself continues to use ``synthesize_envelope_intent`` fallback (#420) and mechanical outcome derivation (#421).

Producer-side capture (marker parser vs structured tool call) is a design decision deferred to **#431** in milestone slice 2. The user does get a real change here — the agent's narration around tool batches is richer — but the structured envelope metadata stays mechanical until #431 lands.

## Architecture move called out

Same trap #421 hit: plan put the constant in ``loom.platform.interaction_language``, but ``PromptStack`` lives in ``loom.core.cognition`` and core cannot import from platform (CLAUDE.md layering, enforced by ``test_architecture_guards``). Constant now lives in ``loom.core.envelope_outcome``; platform re-exports.

## Layer wiring

\`\`\`
[soul, agent, interaction_language, personality]
\`\`\`

Built-in layer slots after agent so personas can phrase-tune on top of the contract while the contract sits with stable project context. Gated on ``self._layers`` non-empty so prompt-free configurations don't inherit the built-in.

## Test plan

- [x] ``pytest -q tests/test_prompt_stack.py`` — 39 pass (30 existing updated + 7 new ``TestBuiltInInteractionLanguageLayer`` + 2 cross-referenced)
- [x] ``pytest -q tests/test_interaction_language.py tests/test_architecture_guards.py tests/test_discord_interaction_language.py`` — 44 pass
- [x] Full suite: **2035 passed, 0 failed**
- [x] ``gitnexus impact PromptStack.load`` — LOW

## Out of scope

- Producer-side capture wiring → **#431** (slice 2)
- Docs closure → #424 (last item in slice 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)