### PR TITLE
feat(cli): surface tool justification as prose

### DIFF
--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -647,7 +647,53 @@ def tool_begin_line(
     name: str, args: dict[str, Any], width: int | None = None
 ) -> Text:
     """Rich Text for a tool-call-in-progress line (alias for compatibility)."""
-    return tool_spinner_line(name, args, 0, width=width)
+    raw_justification = args.get("justification")
+    justification = (
+        str(raw_justification).replace("\n", " ").strip()
+        if raw_justification is not None
+        else ""
+    )
+    if not justification:
+        return tool_spinner_line(name, args, 0, width=width)
+
+    display_args = {
+        key: value
+        for key, value in args.items()
+        if key != "justification"
+    }
+    justification = _smart_truncate(justification, 80)
+    args_preview = _format_args(display_args)
+    body_plain = f"{name}{f'({args_preview})' if args_preview else ''}"
+    prefix_visual = "  [-] "
+    indent = " " * len(prefix_visual)
+
+    out = Text()
+    out.append("  [", style="loom.muted")
+    out.append("-", style="loom.warning")
+    out.append("] ", style="loom.muted")
+    out.append(justification, style="loom.text")
+    out.append("\n")
+
+    if width is None:
+        # Justified tool begins intentionally stay two-line even
+        # without width-aware wrapping: why first, mechanical call below.
+        out.append(indent, style="loom.muted")
+        out.append(name, style="loom.warning")
+        if args_preview:
+            out.append(f"({args_preview})")
+        return out
+
+    body_width = max(20, width - len(indent))
+    wrapped = _wrap_args_body(body_plain, body_width)
+    first = wrapped[0]
+    out.append(indent, style="loom.muted")
+    assert first.startswith(name)
+    out.append(name, style="loom.warning")
+    out.append(first[len(name):])
+    for cont in wrapped[1:]:
+        out.append("\n")
+        out.append(indent + cont)
+    return out
 
 
 def tool_running_line(name: str, frame_index: int = 0) -> Text:

--- a/tests/test_tool_begin_line.py
+++ b/tests/test_tool_begin_line.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from loom.platform.cli.ui import tool_begin_line
+
+
+def test_tool_begin_line_lifts_justification_above_call() -> None:
+    line = tool_begin_line(
+        "run_bash",
+        {
+            "command": "pytest -q tests/test_app.py",
+            "justification": "較長的測試操作，觀察 footer TOOLING 狀態",
+            "timeout": 30,
+        },
+        width=100,
+    )
+
+    text = line.plain
+
+    assert text.startswith("  [-] 較長的測試操作，觀察 footer TOOLING 狀態\n")
+    assert "\n      run_bash(" in text
+    assert 'command="pytest -q tests/test_app.py"' in text
+    assert "timeout=30" in text
+    assert "justification=" not in text
+
+
+def test_tool_begin_line_without_justification_preserves_single_line_shape() -> None:
+    line = tool_begin_line(
+        "read_file",
+        {"path": "loom/platform/cli/ui.py"},
+        width=100,
+    )
+
+    assert line.plain == '  [-] read_file(path="loom/platform/cli/ui.py")'
+
+
+def test_tool_begin_line_truncates_long_justification() -> None:
+    long_why = "因為" + ("這段理由很長" * 20)
+
+    line = tool_begin_line(
+        "run_bash",
+        {
+            "command": "pytest -q",
+            "justification": long_why,
+        },
+        width=100,
+    )
+
+    first_line = line.plain.splitlines()[0]
+    assert first_line.startswith("  [-] 因為這段理由很長")
+    assert first_line.endswith("…")
+    assert len(first_line.removeprefix("  [-] ")) <= 81
+    assert long_why not in line.plain


### PR DESCRIPTION
## Summary
- lift CLI tool `justification` into a prose line above the mechanical tool call
- omit `justification` from inline args while preserving legacy single-line output when absent
- add unit coverage for justification, no-justification, and long-justification truncation

## Verification
- `pytest -q tests/test_tool_begin_line.py` — 3 passed
- `pytest -q tests/test_tool_begin_line.py tests/test_app.py tests/test_interaction_language.py` — 62 passed
- `git diff --check`
- `npx gitnexus impact tool_begin_line --direction upstream` — LOW, affected processes 0
- `npx gitnexus detect-changes --scope staged` — risk low, affected processes 0

Closes #434