### PR TITLE
feat(discord): wire envelope metadata producers

### DIFF
--- a/docs/superpowers/specs/2026-05-20-ui-ux-interaction-language-design.md
+++ b/docs/superpowers/specs/2026-05-20-ui-ux-interaction-language-design.md
@@ -591,22 +591,28 @@ implementation that locks it in so future-spec readers can find the seam.
     means the agent changed strategy on purpose — only LLM-authored
     judgement can claim it. The helper falls back to
     ``fulfilled / partial / unfulfilled / aborted`` (#421).
+11. **Envelope metadata producer wiring — hybrid v1.** ``parallel_reason`` is
+    dispatch-classified from the batch shape: identical repeated calls become
+    ``fan_out_replicas``, same tool with different args becomes
+    ``multi_target``, and mixed tools become ``fan_out_independent``. Agent
+    intent uses a lightweight ``▸ `` marker in the text immediately before a
+    multi-tool batch. For terminal multi-node envelopes whose mechanical
+    outcome is not ``fulfilled`` or ``aborted``, the session asks the active
+    model for one bounded Traditional Chinese outcome line before emitting
+    ``EnvelopeCompleted`` (#431). Post-batch outcome glyph markers in the
+    agent's normal follow-up are also captured for recent-envelope memory, but
+    the user-visible completed row is produced before that follow-up exists.
 
 ## Deferred From First Implementation
 
 Slice 1 intentionally narrowed scope on these items. Tracked separately so
 the chain becomes complete in subsequent work.
 
-- **Producer-side capture for envelope metadata — #431** (slice 2).
-  ``view.intent`` / ``view.outcome_summary`` / ``view.parallel_reason`` all
-  have consumer-side wiring (#420) and ``outcome`` has a mechanical fallback
-  (#421), but no producer ever writes the first three today. Sisi-on-Discord
-  manual verification (post-#430) confirmed that multi-tool batches always
-  render the ``▸ 執行 <tool>`` fallback from ``synthesize_envelope_intent``
-  because both intent and parallel_reason stay defaulted. Issue #431 holds
-  the mechanism choice (marker parser vs structured tool call) for intent
-  and outcome_summary, plus a deterministic classifier for parallel_reason
-  in the dispatch layer.
+- **Producer-side capture for envelope metadata — #431** (slice 2, landed).
+  ``view.parallel_reason`` is now dispatch-classified, ``view.intent`` is
+  captured from the agent's ``▸ `` marker before multi-tool batches, and
+  ``view.outcome_summary`` is populated by a bounded active-model summary for
+  non-fulfilled multi-node envelopes before Discord freezes the completed row.
 - **``PermissionLeaseGranted`` event.** Not in slice 1. The footer's
   ``🔑 N·M:SS`` badge stays the durable display for active grants; the
   timeline-level lease event lands after heartbeat is settled.

--- a/loom/core/envelope_outcome.py
+++ b/loom/core/envelope_outcome.py
@@ -43,7 +43,9 @@ class EnvelopeOutcome(str, Enum):
 # ``loom.platform.interaction_language``.
 INTERACTION_LANGUAGE_INSTRUCTIONS = (
     "When you dispatch a multi-tool batch, provide a one-line intent before "
-    "the batch and an outcome judgement after the batch completes. "
+    "the batch starting with '▸ '. After the batch completes, start your "
+    "outcome judgement line with one glyph: '✓ ' fulfilled, '◐ ' partial, "
+    "'⚠ ' unfulfilled, '↪ ' pivoted, or '🛑 ' aborted. "
     "Single-tool calls do not need an intent header. Keep both lines short "
     "enough to display in one UI line."
 )

--- a/loom/core/ledger/envelope_view.py
+++ b/loom/core/ledger/envelope_view.py
@@ -100,6 +100,9 @@ class LedgerEnvelopeProjector:
         call_meta: dict[str, CallMeta],
         auth_expires_lookup: Callable[[str], float] | None = None,
         batch_t0: float = 0.0,
+        intent: str = "",
+        outcome_summary: str = "",
+        parallel_reason: str = "",
     ) -> ExecutionEnvelopeView:
         """Project the ledger into an ExecutionEnvelopeView.
 
@@ -259,9 +262,9 @@ class LedgerEnvelopeProjector:
         else:
             outcome = ""
 
-        # ``intent`` and ``parallel_reason`` stay defaulted in this
-        # task — they're authored by the LLM via the prompt contract
-        # landing in #423 and synthesised by the renderer otherwise.
+        if not parallel_reason:
+            parallel_reason = self._classify_parallel_reason(call_ids, call_meta)
+
         return ExecutionEnvelopeView(
             envelope_id=envelope_id,
             session_id=session_id,
@@ -272,7 +275,10 @@ class LedgerEnvelopeProjector:
             elapsed_ms=elapsed_ms,
             levels=[[n.node_id for n in nodes]] if nodes else [],
             nodes=nodes,
+            intent=intent,
+            parallel_reason=parallel_reason,
             outcome=outcome,
+            outcome_summary=outcome_summary,
         )
 
     # -- helpers ---------------------------------------------------------
@@ -304,6 +310,45 @@ class LedgerEnvelopeProjector:
         # 2) BEGIN seen, no END yet → "executing" (sub-state granularity
         #    is intentionally coarsened — see module docstring).
         return "executing" if "BEGIN" in summary.state_history else "declared"
+
+    @staticmethod
+    def _classify_parallel_reason(
+        call_ids: list[str],
+        call_meta: dict[str, CallMeta],
+    ) -> str:
+        """Classify the batch shape from dispatch metadata.
+
+        This is system-produced, not agent-authored: the dispatcher knows
+        whether a batch repeated the same call, fanned out across targets,
+        or mixed independent tools.
+        """
+        if len(call_ids) <= 1:
+            return "serial"
+
+        metas = [call_meta.get(cid) for cid in call_ids]
+        tool_names = [m.tool_name for m in metas if m is not None]
+        if len(tool_names) != len(call_ids):
+            return "unspecified"
+        if len(set(tool_names)) > 1:
+            return "fan_out_independent"
+
+        args_digests = {
+            LedgerEnvelopeProjector._stable_args_digest(m.full_args)
+            for m in metas
+            if m is not None
+        }
+        if len(args_digests) == 1:
+            return "fan_out_replicas"
+        return "multi_target"
+
+    @staticmethod
+    def _stable_args_digest(args: dict[str, Any]) -> str:
+        import json
+
+        try:
+            return json.dumps(args, sort_keys=True, separators=(",", ":"), default=str)
+        except (TypeError, ValueError):
+            return repr(sorted((str(k), repr(v)) for k, v in args.items()))
 
     @staticmethod
     def _batch_duration_ms(events, call_id: str) -> float:

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -38,6 +38,47 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.rule import Rule
 
+_OUTCOME_MARKERS: dict[str, str] = {
+    "✓": "fulfilled",
+    "◐": "partial",
+    "⚠": "unfulfilled",
+    "↪": "pivoted",
+    "🛑": "aborted",
+}
+
+
+def _clean_envelope_metadata_line(text: str, *, max_len: int = 140) -> str:
+    line = " ".join(str(text or "").strip().split())
+    if len(line) <= max_len:
+        return line
+    return line[: max_len - 1] + "…"
+
+
+def _iter_nonempty_lines(text: str):
+    for line in str(text or "").splitlines():
+        line = line.strip()
+        if line:
+            yield line
+
+
+def _extract_envelope_intent_marker(text: str) -> str:
+    for line in _iter_nonempty_lines(text):
+        if line.startswith("▸"):
+            return _clean_envelope_metadata_line(line.removeprefix("▸"))
+    return ""
+
+
+def _extract_envelope_outcome_marker(text: str) -> tuple[str, str]:
+    for line in _iter_nonempty_lines(text):
+        marker = line[0]
+        outcome = _OUTCOME_MARKERS.get(marker)
+        if outcome is None:
+            continue
+        summary = _clean_envelope_metadata_line(line[1:].lstrip("\ufe0f"))
+        return outcome, summary
+    return "", ""
+
+
 from loom.core.config import load_loom_config as _load_loom_config  # re-exported for tests/diagnostic/cli
 from loom.core.diagnostic import DiagnosticReport, StartupDiagnostic
 from loom.core.ledger import (
@@ -748,6 +789,7 @@ class LoomSession:
         self._envelope_projector: LedgerEnvelopeProjector | None = None
         self._call_metadata: dict[str, CallMeta] = {}
         self._envelope_call_ids: list[str] = []
+        self._envelope_metadata: dict[str, dict[str, str]] = {}
         # Per-turn ledger aggregators (#334). Reset at every turn_start.
         # _turn_token_usage feeds turn_end.token_usage so the placeholder
         # `{}` from Step 2 finally goes away. _thought_buffer holds the
@@ -1870,6 +1912,7 @@ class LoomSession:
         # full_args (which can be sizeable for write_file / shell tool
         # batches).
         self._call_metadata.clear()
+        self._envelope_metadata.clear()
         if self._ledger_emitter is not None:
             _ledger_turn_token = set_turn_id(_turn_id_v2)
             _ledger_corr_token = set_correlation(_turn_corr_id)
@@ -2254,6 +2297,17 @@ class LoomSession:
                 ))
 
                 if response.stop_reason == "end_turn":
+                    _outcome, _summary = _extract_envelope_outcome_marker(
+                        response.text or ""
+                    )
+                    if (_outcome or _summary) and self._recent_envelopes:
+                        _last_envelope = self._recent_envelopes[-1]
+                        if _last_envelope.turn_index == self._turn_index:
+                            if _outcome:
+                                _last_envelope.outcome = _outcome
+                            if _summary:
+                                _last_envelope.outcome_summary = _summary
+
                     # Issue #205: Pre-final-response self-check. If the TaskList
                     # has pending/in-progress nodes and we haven't already nudged
                     # this turn, inject a reminder and loop back into the model.
@@ -2368,6 +2422,14 @@ class LoomSession:
 
                     # ── Issue #106: Create envelope for this tool batch ────────
                     self._envelope_counter += 1
+                    _envelope_id = f"e{self._envelope_counter}"
+                    _intent = ""
+                    if len(response.tool_uses) > 1:
+                        _intent = _extract_envelope_intent_marker(response.text or "")
+                    if _intent:
+                        self._envelope_metadata.setdefault(_envelope_id, {})[
+                            "intent"
+                        ] = _intent
                     # Step 5: reset per-batch call_id ordering (call_metadata
                     # itself is turn-scoped and stays). Pre-populate with
                     # the tool_uses about to dispatch so EnvelopeStarted
@@ -2527,6 +2589,10 @@ class LoomSession:
 
                     # ── Issue #106: Envelope completed ─────────────────────────
                     _completed_view = await self._build_envelope_view(_batch_t0)
+                    _completed_view = await self._author_envelope_outcome_summary(
+                        _completed_view,
+                        model=_active_model,
+                    )
                     yield EnvelopeCompleted(envelope=_completed_view)
                     # Keep last 50 envelopes — covers TUI history display *and*
                     # the Issue #196 turn-boundary judge digest. 10 was enough for
@@ -4104,8 +4170,10 @@ class LoomSession:
             from loom.core.ledger import current_turn_id
 
             turn_id = current_turn_id() or "system"
+            envelope_id = f"e{self._envelope_counter}"
+            metadata = self._envelope_metadata.get(envelope_id, {})
             return await self._envelope_projector.build_view(
-                envelope_id=f"e{self._envelope_counter}",
+                envelope_id=envelope_id,
                 session_id=self.session_id,
                 turn_id=turn_id,
                 turn_index=self._turn_index,
@@ -4113,6 +4181,9 @@ class LoomSession:
                 call_meta=self._call_metadata,
                 auth_expires_lookup=self._auth_expires_for,
                 batch_t0=batch_t0,
+                intent=metadata.get("intent", ""),
+                outcome_summary=metadata.get("outcome_summary", ""),
+                parallel_reason=metadata.get("parallel_reason", ""),
             )
 
         # No ledger wired → return an empty stub. The shape stays the
@@ -4129,8 +4200,77 @@ class LoomSession:
             status="running",
             node_count=0,
             parallel_groups=0,
+            intent=self._envelope_metadata.get(
+                f"e{self._envelope_counter}", {}
+            ).get("intent", ""),
             outcome="",
         )
+
+    async def _author_envelope_outcome_summary(
+        self,
+        view: ExecutionEnvelopeView,
+        *,
+        model: str,
+    ) -> ExecutionEnvelopeView:
+        """Fill one display-line outcome summary for non-fulfilled multi-node batches."""
+        if view.node_count <= 1:
+            return view
+        if view.outcome_summary:
+            return view
+        if view.outcome in ("", "fulfilled", "aborted"):
+            return view
+
+        node_lines = []
+        for node in view.nodes:
+            detail = node.error_snippet or node.output_preview
+            node_lines.append(
+                {
+                    "tool": node.tool_name,
+                    "state": node.state,
+                    "detail": detail[:120] if detail else "",
+                }
+            )
+
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "Write one Traditional Chinese UI outcome line for a tool "
+                    "batch. Be factual, no markdown, no bullet, under 40 Chinese "
+                    "characters. Summarize what did not finish or what needs "
+                    "follow-up."
+                ),
+            },
+            {
+                "role": "user",
+                "content": json.dumps(
+                    {
+                        "intent": view.intent,
+                        "outcome": view.outcome,
+                        "nodes": node_lines,
+                    },
+                    ensure_ascii=False,
+                ),
+            },
+        ]
+        try:
+            response = await self.router.chat(
+                model=model,
+                messages=messages,
+                tools=None,
+                max_tokens=80,
+            )
+        except Exception as exc:
+            logger.debug("Envelope outcome summary skipped: %s", exc)
+            return view
+
+        summary = _clean_envelope_metadata_line(response.text or "", max_len=120)
+        if summary:
+            view.outcome_summary = summary
+            self._envelope_metadata.setdefault(view.envelope_id, {})[
+                "outcome_summary"
+            ] = summary
+        return view
 
     # =========================================================================
     # SECTION 10 — HITL / SCOPE / GRANTS

--- a/tests/test_ledger_envelope_projector.py
+++ b/tests/test_ledger_envelope_projector.py
@@ -296,6 +296,104 @@ async def test_parallel_batch_one_running_one_done(
     assert states["run_bash"] == "executing"
 
 
+async def test_parallel_reason_classifies_replicas_multi_target_and_independent(
+    store: LedgerStore, emitter: LedgerEmitter, projector
+) -> None:
+    base = time.time()
+    for call_id, tool_name in (
+        ("a", "read_file"),
+        ("b", "read_file"),
+        ("c", "run_bash"),
+    ):
+        await _emit_lifecycle_pair(
+            emitter,
+            call_id=call_id,
+            tool_name=tool_name,
+            turn_id="turn_p",
+            timestamps=(base, base + 0.1),
+        )
+
+    replicas = await projector.build_view(
+        envelope_id="e_replicas",
+        session_id="sess_proj",
+        turn_id="turn_p",
+        turn_index=0,
+        call_ids=["a", "b"],
+        call_meta={
+            "a": CallMeta(call_id="a", tool_name="read_file", full_args={"path": "x"}),
+            "b": CallMeta(call_id="b", tool_name="read_file", full_args={"path": "x"}),
+        },
+    )
+    multi_target = await projector.build_view(
+        envelope_id="e_multi_target",
+        session_id="sess_proj",
+        turn_id="turn_p",
+        turn_index=0,
+        call_ids=["a", "b"],
+        call_meta={
+            "a": CallMeta(call_id="a", tool_name="read_file", full_args={"path": "x"}),
+            "b": CallMeta(call_id="b", tool_name="read_file", full_args={"path": "y"}),
+        },
+    )
+    independent = await projector.build_view(
+        envelope_id="e_independent",
+        session_id="sess_proj",
+        turn_id="turn_p",
+        turn_index=0,
+        call_ids=["a", "c"],
+        call_meta={
+            "a": CallMeta(call_id="a", tool_name="read_file", full_args={"path": "x"}),
+            "c": CallMeta(call_id="c", tool_name="run_bash", full_args={"command": "pytest"}),
+        },
+    )
+
+    assert replicas.parallel_reason == "fan_out_replicas"
+    assert multi_target.parallel_reason == "multi_target"
+    assert independent.parallel_reason == "fan_out_independent"
+
+
+async def test_projector_accepts_agent_authored_envelope_metadata(
+    store: LedgerStore, emitter: LedgerEmitter, projector
+) -> None:
+    base = time.time()
+    await _emit_lifecycle_pair(
+        emitter,
+        call_id="a",
+        tool_name="pytest",
+        turn_id="turn_p",
+        timestamps=(base, base + 0.1),
+    )
+    await _emit_lifecycle_pair(
+        emitter,
+        call_id="b",
+        tool_name="pytest",
+        turn_id="turn_p",
+        timestamps=(base, base + 0.2),
+        failure_state="timed_out",
+        error="timeout",
+        result_summary=None,
+    )
+
+    view = await projector.build_view(
+        envelope_id="e_meta",
+        session_id="sess_proj",
+        turn_id="turn_p",
+        turn_index=0,
+        call_ids=["a", "b"],
+        call_meta={
+            "a": CallMeta(call_id="a", tool_name="pytest", full_args={"path": "tests"}),
+            "b": CallMeta(call_id="b", tool_name="pytest", full_args={"path": "tests"}),
+        },
+        intent="重複跑測試確認穩定性",
+        outcome_summary="其中一組測試逾時，需要重跑",
+    )
+
+    assert view.intent == "重複跑測試確認穩定性"
+    assert view.parallel_reason == "fan_out_replicas"
+    assert view.outcome == "partial"
+    assert view.outcome_summary == "其中一組測試逾時，需要重跑"
+
+
 # ---------------------------------------------------------------------------
 # Hidden-failure paths — denied / timed_out / aborted all terminate in
 # ``memorialized``, so ``state in _FAILURE_STATES`` checks against the

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -428,6 +428,95 @@ class TestParallelDispatch:
         assert "Internal dispatch error: boom" in (result.error or "")
 
 
+class TestEnvelopeMetadataCapture:
+    def test_intent_and_outcome_markers_parse_display_lines(self):
+        from loom.core.session import (
+            _extract_envelope_intent_marker,
+            _extract_envelope_outcome_marker,
+        )
+
+        assert (
+            _extract_envelope_intent_marker("▸ 重複跑測試確認穩定性\n")
+            == "重複跑測試確認穩定性"
+        )
+        assert (
+            _extract_envelope_intent_marker(
+                "我先讀這幾個檔案釐清架構。\n▸ 並行讀取 4 個 session 檔案"
+            )
+            == "並行讀取 4 個 session 檔案"
+        )
+        assert _extract_envelope_intent_marker("我先確認一下") == ""
+        assert _extract_envelope_outcome_marker("⚠ 其中一組測試逾時，需要重跑") == (
+            "unfulfilled",
+            "其中一組測試逾時，需要重跑",
+        )
+        assert _extract_envelope_outcome_marker(
+            "整理完剛剛的結果。\n⚠️ 其中一組測試逾時，需要重跑"
+        ) == (
+            "unfulfilled",
+            "其中一組測試逾時，需要重跑",
+        )
+
+    @pytest.mark.asyncio
+    async def test_author_envelope_outcome_summary_uses_active_model(self):
+        from loom.core.events import ExecutionEnvelopeView, ExecutionNodeView
+        from loom.core.session import LoomSession
+
+        class FakeRouter:
+            async def chat(self, *, model, messages, tools, max_tokens):
+                assert model == "fake-model"
+                assert tools is None
+                assert max_tokens == 80
+                assert "unfulfilled" in messages[1]["content"]
+                return SimpleNamespace(text="其中一組測試逾時，需要重跑")
+
+        session = object.__new__(LoomSession)
+        session.router = FakeRouter()
+        session._envelope_metadata = {}
+
+        view = ExecutionEnvelopeView(
+            envelope_id="e1",
+            session_id="sess",
+            turn_index=0,
+            status="failed",
+            node_count=2,
+            parallel_groups=1,
+            nodes=[
+                ExecutionNodeView(
+                    node_id="a",
+                    call_id="a",
+                    action_id="a",
+                    tool_name="pytest",
+                    level=0,
+                    state="memorialized",
+                    trust_level="SAFE",
+                ),
+                ExecutionNodeView(
+                    node_id="b",
+                    call_id="b",
+                    action_id="b",
+                    tool_name="pytest",
+                    level=0,
+                    state="memorialized",
+                    trust_level="SAFE",
+                    error_snippet="timeout",
+                ),
+            ],
+            outcome="unfulfilled",
+        )
+
+        updated = await LoomSession._author_envelope_outcome_summary(
+            session,
+            view,
+            model="fake-model",
+        )
+
+        assert updated.outcome_summary == "其中一組測試逾時，需要重跑"
+        assert session._envelope_metadata["e1"]["outcome_summary"] == (
+            "其中一組測試逾時，需要重跑"
+        )
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Issue #126 — session title tests (L1 provisional + L2 editable)
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- classify envelope `parallel_reason` from dispatch metadata so multi-node Discord status rows get deterministic parallel tags
- capture agent-authored multi-tool intent markers and populate envelope views before render
- add bounded active-model outcome summaries for non-fulfilled multi-node envelopes before Discord freezes the completed row
- update the interaction-language prompt/spec and add regression coverage

## Verification
- `pytest -q tests` — 2049 passed, 68 warnings
- `python -m py_compile loom/core/ledger/envelope_view.py loom/core/session.py loom/core/envelope_outcome.py`
- `git diff --check`
- `npx gitnexus detect-changes --scope staged` — risk low, affected processes 0

Closes #431