### PR TITLE
feat(tasks): add done_when acceptance criterion to TaskList

### DIFF
--- a/loom/core/tasks/manager.py
+++ b/loom/core/tasks/manager.py
@@ -82,6 +82,11 @@ class TaskListManager:
         ]
         for n in active:
             lines.append(f"  - [{n.id}] {n.content[:80]} — {n.status.value}")
+            # Re-surface the agent's own acceptance criterion. Empty
+            # done_when shows as ``—`` so the agent notices the gap and
+            # can fill it on the next task_write (Issue #437).
+            criterion = n.done_when.strip() if n.done_when else ""
+            lines.append(f"      done when: {criterion or '—'}")
         lines.append("")
         lines.append(
             "Either continue executing now, or — if the work is no longer "

--- a/loom/core/tasks/tasklist.py
+++ b/loom/core/tasks/tasklist.py
@@ -34,6 +34,11 @@ class TaskNode:
     id: str
     content: str
     status: TaskStatus = TaskStatus.PENDING
+    # Optional TDD-style acceptance criterion. Visible in both CLI and
+    # Discord renders; empty values render as ``—`` so absence is loud
+    # rather than silent (Issue #437). No validator: the discipline comes
+    # from re-reading what you wrote, not from a gatekeeper.
+    done_when: str = ""
 
     @property
     def is_active(self) -> bool:
@@ -64,6 +69,7 @@ class TaskList:
             tid = (spec.get("id") or "").strip()
             content = (spec.get("content") or "").strip()
             status_str = (spec.get("status") or "pending").strip().lower()
+            done_when = (spec.get("done_when") or "").strip()
             if not tid:
                 raise ValueError(f"todo at index {i} is missing 'id'")
             if not content:
@@ -78,7 +84,9 @@ class TaskList:
                     f"todo {tid!r} has unknown status {status_str!r} "
                     f"(expected one of: pending, in_progress, completed)"
                 ) from None
-            new_nodes[tid] = TaskNode(id=tid, content=content, status=status)
+            new_nodes[tid] = TaskNode(
+                id=tid, content=content, status=status, done_when=done_when,
+            )
         self._nodes = new_nodes
 
     @property
@@ -96,7 +104,12 @@ class TaskList:
             "total": len(self._nodes),
             "by_status": by_status,
             "todos": [
-                {"id": n.id, "content": n.content, "status": n.status.value}
+                {
+                    "id": n.id,
+                    "content": n.content,
+                    "status": n.status.value,
+                    "done_when": n.done_when,
+                }
                 for n in self._nodes.values()
             ],
         }

--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -913,6 +913,19 @@ class LoomApp:
             else:
                 glyph, cls = "○", "class:tasklist.pending"
             parts.append((cls, f"   {glyph} {content}\n"))
+            # done_when sub-line (Issue #437). Always rendered for
+            # uncompleted items so the visible "—" creates social
+            # pressure to fill in the criterion. Completed items skip
+            # the line — the ✓ already says the agent considered it
+            # done, retroactively shaming a missing criterion is noise.
+            if status != "completed":
+                criterion = (t.get("done_when") or "").strip()
+                if len(criterion) > 60:
+                    criterion = criterion[:59] + "…"
+                parts.append((
+                    "class:tasklist.pending",
+                    f"       done when: {criterion or '—'}\n",
+                ))
         return FormattedText(parts)
 
     def _render_confirm(self) -> FormattedText:

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -3245,13 +3245,22 @@ def make_task_write_tool(
         description=(
             "Maintain your todo list for multi-step work. Pass the FULL "
             "intended list every time — this replaces the previous list. "
-            "Each todo is {id, content, status} where status is "
+            "Each todo is {id, content, status, done_when} where status is "
             "'pending' | 'in_progress' | 'completed'. To 'complete' a "
             "step, rewrite the list with that item's status changed.\n\n"
             "This is your sticky-note board — a reminder of what's left, "
             "not a state container. Real outputs (reports, code, data) "
             "MUST go to files via write_file. The todo list never holds "
             "the result itself, only the fact that the step exists.\n\n"
+            "'done_when' is your own acceptance criterion for the step — "
+            "one short phrase describing the evidence that would prove "
+            "the step is finished (e.g. 'P0–P3 findings each have "
+            "file/line/evidence', 'embed renders correctly in Discord'). "
+            "Writing it forces you to define done before you act, and "
+            "you re-read it every time you update the list. Leave it "
+            "empty when you genuinely cannot yet say what done looks "
+            "like — empty values render as '—' so the gap stays visible "
+            "and you can fill it on a later edit.\n\n"
             "Use it when a goal has 3+ coordinated steps and forgetting "
             "one would be costly. Skip it for trivial single-turn work. "
             "Pass an empty list to clear."
@@ -3279,6 +3288,15 @@ def make_task_write_tool(
                                 "type": "string",
                                 "enum": ["pending", "in_progress", "completed"],
                                 "description": "Current status. Defaults to 'pending'.",
+                            },
+                            "done_when": {
+                                "type": "string",
+                                "description": (
+                                    "Acceptance criterion — one short "
+                                    "phrase describing the evidence that "
+                                    "proves this step is finished. "
+                                    "Optional; empty renders as '—'."
+                                ),
                             },
                         },
                         "required": ["id", "content"],

--- a/loom/platform/discord/middleware.py
+++ b/loom/platform/discord/middleware.py
@@ -57,6 +57,7 @@ class TaskWriteDiscordReminderMiddleware(Middleware):
             status = t.get("status", "pending")
             content_str = t.get("content", "").strip()
             id_str = t.get("id", "").strip()
+            criterion = (t.get("done_when") or "").strip()
 
             if id_str and content_str:
                 display_text = f"**{id_str}**: {content_str}"
@@ -65,12 +66,20 @@ class TaskWriteDiscordReminderMiddleware(Middleware):
             else:
                 display_text = id_str
 
+            # done_when sub-line (Issue #437). Shown for non-completed
+            # rows so the visible "—" creates social pressure to fill
+            # the criterion. Completed rows skip it for the same reason
+            # the CLI panel does.
             if status == "completed":
                 completed.append(f"✅ {display_text}")
-            elif status == "in_progress":
-                in_progress.append(f"▶️ {display_text}")
             else:
-                pending.append(f"⬜ {display_text}")
+                line = "▶️" if status == "in_progress" else "⬜"
+                rendered_criterion = criterion or "—"
+                entry = f"{line} {display_text}\n　　_done when: {rendered_criterion}_"
+                if status == "in_progress":
+                    in_progress.append(entry)
+                else:
+                    pending.append(entry)
 
         # Construct embed description
         desc_lines = []

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -572,6 +572,39 @@ class TestTaskListPanel:
         # Truncate cap is 56 in the source; allow some slack but no full 200
         assert "x" * 60 not in text
 
+    def test_done_when_renders_dash_when_empty(self, app: LoomApp) -> None:
+        # Issue #437: pending/in_progress rows always show the
+        # criterion sub-line; "—" makes the absence visible.
+        app.update_tasklist([
+            {"id": "a", "content": "research", "status": "pending"},
+        ])
+        text = _flat_text(app._render_tasklist())
+        assert "done when: —" in text
+
+    def test_done_when_renders_text_when_filled(self, app: LoomApp) -> None:
+        app.update_tasklist([
+            {
+                "id": "a",
+                "content": "review",
+                "status": "in_progress",
+                "done_when": "P0–P3 findings each have file/line",
+            },
+        ])
+        text = _flat_text(app._render_tasklist())
+        assert "done when: P0–P3 findings each have file/line" in text
+
+    def test_done_when_hidden_for_completed_rows(self, app: LoomApp) -> None:
+        # Once completed, the ✓ is the answer — don't shame a missing
+        # criterion retroactively. Mixed list: completed row hides
+        # done_when, pending row still shows it.
+        app.update_tasklist([
+            {"id": "a", "content": "ship", "status": "completed"},
+            {"id": "b", "content": "next", "status": "pending"},
+        ])
+        text = _flat_text(app._render_tasklist())
+        # Exactly one "done when:" line — for the pending row only.
+        assert text.count("done when:") == 1
+
 
 # ---------------------------------------------------------------------------
 # Confirm + Pause widget rendering

--- a/tests/test_task_write_discord_reminder.py
+++ b/tests/test_task_write_discord_reminder.py
@@ -67,6 +67,53 @@ async def test_middleware_sends_embed_on_success():
         channel.send.assert_called_once()
 
 @pytest.mark.asyncio
+async def test_middleware_renders_done_when_criterion():
+    # Issue #437: Discord embed shows done_when as an italic sub-line
+    # under each non-completed row; "—" when the criterion is empty.
+    client = MockDiscordClient()
+    channel = MockDiscordChannel()
+    client.get_channel.return_value = channel
+
+    session = MockLoomSession({"task_write": {"discord_reminder": True}})
+    middleware = TaskWriteDiscordReminderMiddleware(client, 12345, session)
+
+    call = ToolCall(
+        tool_name="task_write",
+        trust_level=TrustLevel.SAFE,
+        session_id="test",
+        args={
+            "todos": [
+                {
+                    "id": "task1",
+                    "content": "First task",
+                    "status": "in_progress",
+                    "done_when": "tests pass and reviewer signs off",
+                },
+                {"id": "task2", "content": "Second task", "status": "pending"},
+                {
+                    "id": "task3",
+                    "content": "Third task",
+                    "status": "completed",
+                    "done_when": "shipped",
+                },
+            ]
+        },
+    )
+
+    async def mock_handler(c: ToolCall) -> ToolResult:
+        return ToolResult(call_id=c.id, tool_name=c.tool_name, success=True)
+
+    with patch("loom.platform.discord.middleware.discord.Embed") as MockEmbed:
+        await middleware.process(call, mock_handler)
+
+        desc = MockEmbed.call_args.kwargs.get("description", "")
+        assert "_done when: tests pass and reviewer signs off_" in desc
+        assert "_done when: —_" in desc
+        # Completed row hides the criterion — completion is the answer.
+        assert "_done when: shipped_" not in desc
+
+
+@pytest.mark.asyncio
 async def test_middleware_skips_when_config_false():
     client = MockDiscordClient()
     channel = MockDiscordChannel()

--- a/tests/test_tasklist.py
+++ b/tests/test_tasklist.py
@@ -119,6 +119,37 @@ class TestTaskList:
         assert "completed" in summary["by_status"]
         assert len(summary["todos"]) == 2
 
+    def test_done_when_round_trips(self):
+        # Issue #437: optional acceptance criterion threads through
+        # replace() → TaskNode → status_summary() unchanged.
+        lst = TaskList()
+        lst.replace([
+            {
+                "id": "a",
+                "content": "Review PR #435",
+                "done_when": "P0–P3 findings each have file/line/evidence",
+            },
+            {"id": "b", "content": "Quick check"},
+        ])
+        assert lst.nodes[0].done_when == (
+            "P0–P3 findings each have file/line/evidence"
+        )
+        assert lst.nodes[1].done_when == ""
+        summary = lst.status_summary()
+        assert summary["todos"][0]["done_when"] == (
+            "P0–P3 findings each have file/line/evidence"
+        )
+        assert summary["todos"][1]["done_when"] == ""
+
+    def test_done_when_strips_whitespace(self):
+        # Whitespace-only done_when collapses to empty (renders as —)
+        # so the agent can't sneak past the visible gap with a space.
+        lst = TaskList()
+        lst.replace([
+            {"id": "a", "content": "A", "done_when": "   "},
+        ])
+        assert lst.nodes[0].done_when == ""
+
 
 # ── TaskListManager ────────────────────────────────────────────────────
 
@@ -185,6 +216,22 @@ class TestTaskListManager:
         assert "[b]" in msg
         assert "task_write" in msg
 
+    def test_self_check_surfaces_done_when(self, mgr):
+        # Issue #437: nudge shows acceptance criterion (or "—" gap)
+        # so the agent re-reads its own definition of done.
+        mgr.write([
+            {
+                "id": "a",
+                "content": "Audit security review",
+                "done_when": "all findings ranked, evidence linked",
+            },
+            {"id": "b", "content": "Quick smoke test"},
+        ])
+        msg = mgr.build_self_check_message()
+        assert msg is not None
+        assert "done when: all findings ranked, evidence linked" in msg
+        assert "done when: —" in msg
+
     def test_on_change_fires(self, mgr):
         calls = []
         mgr.on_change = lambda s: calls.append(s)
@@ -238,3 +285,22 @@ class TestTaskWriteTool:
         assert result.success
         data = json.loads(result.output)
         assert data["total"] == 0
+
+    async def test_done_when_round_trips_through_tool(self, tool):
+        # Issue #437: tool layer accepts done_when without schema
+        # rewrite at the call site; absent done_when stays empty.
+        call = _tc("task_write", {"todos": [
+            {
+                "id": "a",
+                "content": "A",
+                "done_when": "tests pass and reviewer signs off",
+            },
+            {"id": "b", "content": "B"},
+        ]})
+        result = await tool.executor(call)
+        assert result.success
+        data = json.loads(result.output)
+        assert data["todos"][0]["done_when"] == (
+            "tests pass and reviewer signs off"
+        )
+        assert data["todos"][1]["done_when"] == ""


### PR DESCRIPTION
## Summary

把 TDD「define done before you act」的精神帶進非編碼任務面。每個 `task_write` todo 多一個可選 `done_when` 字串欄位 — agent 自己寫的 acceptance criterion，CLI 跟 Discord 渲染都在非 completed row 下顯示 sub-line，空值顯示 `—` 讓缺口顯眼。

關鍵設計：**visibility creates pressure, no validator**

- Schema always-present, default empty — agent 不能透過「不選」迴避
- `—` 在 UI 顯眼顯示 — 用視覺對比創造社會壓力
- Completed row 隱藏 done_when — `✓` 已經是答案，retroactively shame 沒寫的人是噪音
- Self-check message 也帶 done_when — 任務被 nudge 時 acceptance criterion 一起回到視野
- **不接 judge、不結構化、不 validate** — discipline 來自 agent 反覆重讀自己寫的東西

## Behavior

`task_write` tool description 加入鼓勵段：寫 done_when 強迫先想 done 長什麼樣子；寫不出來就先留空，之後再補。

| Layer | File | Change |
|---|---|---|
| schema | `loom/core/tasks/tasklist.py` | `TaskNode.done_when: str = ""`；`replace()` 讀取並 strip；`status_summary()` 輸出含此欄位 |
| self-check | `loom/core/tasks/manager.py` | 未完任務 nudge 每行底下加 `done when: <text>` 或 `—` |
| tool | `loom/platform/cli/tools.py` | `task_write` input_schema 加 optional `done_when`；description 加 prompt 鼓勵段 |
| CLI render | `loom/platform/cli/app.py` | `_render_tasklist`：非 completed row 加縮排 `done when: ...` 行 |
| Discord render | `loom/platform/discord/middleware.py` | 非 completed row 加 italic `_done when: ..._` sub-line |

## Verification

- `pytest -q tests/` — **2057 passed** (+8 new tests covering schema round-trip, whitespace strip, self-check surfacing, CLI / Discord render, completed row 隱藏)
- `gitnexus impact` on `TaskNode` / `TaskList.replace` / `status_summary` — LOW risk across the board (additive optional field; manager passes todos dict-through)
- `gitnexus detect_changes` — risk **low**, affected_processes **0**, 8 changed files all expected

## Test plan

- [ ] 在 `loom chat` 跑一個多步驟任務，觀察 `task_write` 時 done_when 渲染與空值 `—` 視覺壓力效果
- [ ] 在 Discord thread 觸發 `task_write` reminder (`[task_write] discord_reminder = true`)，確認 italic sub-line 顯示正確
- [ ] 故意省略 done_when，觀察 self-check 被觸發時 `done when: —` 是否出現在 nudge 中

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)