### PR TITLE
fix(subagent): result_write append default + tool_not_found self-recovery (#440)

### DIFF
--- a/loom/core/agent/subagent.py
+++ b/loom/core/agent/subagent.py
@@ -148,22 +148,40 @@ async def run_subagent(
                 error="'content' must be a string",
                 failure_type="validation_error",
             )
-        _result_slot_cell["value"] = content
+        mode = call.args.get("mode", "append")
+        if mode not in ("append", "replace"):
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name,
+                success=False,
+                error=f"'mode' must be 'append' or 'replace', got {mode!r}",
+                failure_type="validation_error",
+            )
+        prev = _result_slot_cell["value"]
+        if mode == "replace" or not prev:
+            _result_slot_cell["value"] = content
+        else:
+            # append: join with a single blank line so sections stay readable
+            joiner = "" if prev.endswith("\n\n") else ("\n" if prev.endswith("\n") else "\n\n")
+            _result_slot_cell["value"] = prev + joiner + content
+        new_len = len(_result_slot_cell["value"] or "")
         return ToolResult(
             call_id=call.id, tool_name=call.tool_name,
             success=True,
-            output=f"[result slot updated, {len(content)} chars]",
+            output=f"[result slot {mode}d, +{len(content)} chars, total {new_len}]",
         )
 
     child_registry.register(ToolDefinition(
         name="result_write",
         description=(
-            "Overwrite your best-effort task result. Each call replaces the slot "
-            "entirely — there is no append. The parent agent receives the latest "
-            "slot content even if you run out of turns, so write incrementally: "
-            "save what you have at every meaningful checkpoint, refine on the "
-            "next turn. Empty / never-called slot ⇒ parent gets your end_turn "
-            "text on success or nothing on max_turns."
+            "Commit your best-effort task result to the hand-off slot the parent "
+            "receives when you exit (end_turn or max_turns). Default mode is "
+            "'append' — each call concatenates onto what is already there with a "
+            "blank-line separator, ideal for multi-section reports / audits / "
+            "reviews. Use mode='replace' when you want to overwrite (e.g. to "
+            "refine a single coherent answer). Whatever is in the slot at exit "
+            "is what the parent gets; empty / never-called ⇒ parent gets your "
+            "end_turn text on success or nothing on max_turns. Call early and "
+            "often: write something useful before any long tool chain."
         ),
         trust_level=TrustLevel.SAFE,
         input_schema={
@@ -171,7 +189,15 @@ async def run_subagent(
             "properties": {
                 "content": {
                     "type": "string",
-                    "description": "Best-effort result so far. Replaces any prior slot.",
+                    "description": "Text to commit to the slot.",
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": ["append", "replace"],
+                    "description": (
+                        "'append' (default) concatenates onto the existing slot "
+                        "with a blank-line separator. 'replace' overwrites."
+                    ),
                 },
             },
             "required": ["content"],
@@ -255,6 +281,7 @@ async def run_subagent(
 
     # ── Build initial messages ────────────────────────────────────────────────
     now_str = user_timestamp()
+    available_tools = ", ".join(sorted(child_registry._tools.keys())) or "none"
     system_prompt = (
         f"You are a sub-agent (id: {agent_id}) spawned by a parent agent.\n"
         f"Your workspace is: {workspace}\n"
@@ -262,15 +289,24 @@ async def run_subagent(
         f"Complete the following task and respond with a clear, concise result.\n"
         f"Do not ask clarifying questions — work with what you have.\n"
         f"\n"
-        f"IMPORTANT — result_write contract:\n"
-        f"At every meaningful checkpoint, call `result_write(content=...)` "
-        f"to commit your best-effort result so far. The slot is overwrite-only "
-        f"(each call replaces the previous content). Whatever is in the slot "
-        f"when you exit — whether you reach end_turn naturally or run out of "
-        f"turns — is what the parent agent receives. Treat it as your hand-off "
-        f"buffer: write something useful early, refine it as you go.\n"
+        f"AVAILABLE TOOLS (this list is exhaustive — no other tools exist in "
+        f"your environment):\n"
+        f"  {available_tools}\n"
+        f"If the task description names a tool not in this list (for example "
+        f"`write_file` or `run_bash`), DO NOT attempt to call it. Treat the "
+        f"task's wording as intent, not literal instruction: route any file or "
+        f"shell output you would have produced through `result_write` instead.\n"
         f"\n"
-        f"Available tools: {', '.join(child_registry._tools.keys()) or 'none'}."
+        f"HAND-OFF CONTRACT — result_write:\n"
+        f"Your only channel back to the parent agent is the result_write slot. "
+        f"Whatever is in the slot when you exit (end_turn or max_turns) is what "
+        f"the parent receives — nothing else (no files, no console output, no "
+        f"end_turn free text once the slot is non-empty) is observed. "
+        f"Default mode is 'append': each call concatenates onto the slot, ideal "
+        f"for multi-section reports / reviews / audits. Use mode='replace' only "
+        f"when you want to overwrite (e.g. refining a single coherent answer). "
+        f"Call result_write early — write something useful before any long tool "
+        f"chain, so a max_turns cut never costs you the work."
     )
     messages: list[dict[str, Any]] = [
         {"role": "system", "content": system_prompt},
@@ -367,7 +403,24 @@ async def run_subagent(
                 total_tool_calls += 1
                 tool_def = child_registry.get(tu.name)
                 if tool_def is None:
-                    tool_output = f"Unknown tool: {tu.name}"
+                    available = sorted(child_registry._tools.keys())
+                    # File-output redirect hint: the most common cause of an
+                    # "unknown tool" hit in sub-agents is the LLM reaching for
+                    # write_file / run_bash when they were not whitelisted by
+                    # the parent. Point it at result_write so it does not burn
+                    # turns retrying.
+                    redirect = ""
+                    if tu.name in ("write_file", "run_bash"):
+                        redirect = (
+                            " To produce output, call result_write(content=..., "
+                            "mode='append') — the parent agent will persist whatever "
+                            "is in the slot when you exit."
+                        )
+                    tool_output = (
+                        f"Unknown tool: {tu.name!r}. This tool is not in your "
+                        f"available set; do not retry it. Available tools: "
+                        f"{', '.join(available) or 'none'}.{redirect}"
+                    )
                     result = ToolResult(
                         call_id=tu.id, tool_name=tu.name,
                         success=False, error=tool_output,
@@ -421,9 +474,10 @@ async def run_subagent(
                     "content": (
                         "<system-reminder>\n"
                         "You have 2 turns left. On your next turn, call "
-                        "`result_write(content=...)` with your best-effort "
-                        "result so far, then end_turn. Do not start new long "
-                        "tool chains — wrap up.\n"
+                        "`result_write(content=..., mode='append')` (or "
+                        "mode='replace' for a final coherent rewrite) to "
+                        "commit your best-effort result, then end_turn. "
+                        "Do not start new long tool chains — wrap up.\n"
                         "</system-reminder>"
                     ),
                 })

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -3122,8 +3122,18 @@ def make_spawn_agent_tool(parent_session: Any) -> "ToolDefinition":
         description=(
             "Spawn an ephemeral sub-agent to complete a bounded, self-contained task. "
             "The sub-agent runs independently with its own context and returns a result. "
-            "Use this to delegate research, file analysis, or parallel investigation tasks. "
-            "The sub-agent cannot interact with the user — it works autonomously until done."
+            "Use this to delegate research, file analysis, or external review tasks. "
+            "The sub-agent cannot interact with the user — it works autonomously until done.\n"
+            "\n"
+            "Tool scope: by default the sub-agent only sees SAFE tools (read_file, "
+            "fetch_url, web_search, list_dir, scratchpad_read, plus result_write). "
+            "If your task description requires write_file, run_bash, or any other "
+            "GUARDED tool, you MUST list it in `tools=[...]` — otherwise the "
+            "sub-agent will reach for a tool that does not exist and burn turns. "
+            "Result hand-off goes through the sub-agent's result_write slot; the "
+            "sub-agent CANNOT persist files for you under default tool scope, "
+            "so prefer instructing it to put everything in result_write and "
+            "letting the parent persist the artifact after."
         ),
         trust_level=TrustLevel.GUARDED,
         capabilities=ToolCapability.AGENT_SPAN | ToolCapability.MUTATES,
@@ -3140,7 +3150,9 @@ def make_spawn_agent_tool(parent_session: Any) -> "ToolDefinition":
                     "description": (
                         "Tool whitelist for the sub-agent. "
                         "List of tool names (e.g. ['read_file', 'web_search']) or comma-separated string. "
-                        "Omit or null for SAFE-only tools. CRITICAL tools are always blocked."
+                        "Omit or null for SAFE-only tools. CRITICAL tools are always blocked. "
+                        "MUST explicitly include GUARDED tools like 'write_file' or 'run_bash' if "
+                        "the task needs them — otherwise the sub-agent has no way to call them."
                     ),
                 },
                 "max_turns": {

--- a/skills/wiki_maintenance/SKILL.md
+++ b/skills/wiki_maintenance/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: wiki_maintenance
+description: "Research Library 維護技能。當使用者說「蒸餾這個進 wiki」、「整理 outputs/ 文件」、「跑一下 wiki lint」、「檢查 orphan pages」、「更新 index」時使用。也適用于：建立了新的研究報告需要收進 Research Library、發現有 orphan pages、每週定期維護時觸發。"
+tags: [research, file_organization, knowledge_management, maintenance]
+---
+
+# Wiki Maintenance — Research Library 維護技能
+
+Research Library 是絲絲的「研究作品圖書館」——消化完畢、值得長期留存的知識櫃。
+這個技能負責把研究成果蒸餾寫入 wiki、維持結構健康、持續積累。
+
+---
+
+## 成功定義
+
+- **產出**：完成蒸餾 / lint / index 更新，寫進正確位置並更新 `_meta/` 紀錄
+- **品質指標**：蒸餾後的 wiki 頁面有 `[[wikilinks]]` 互相引用、有 frontmatter、有「下一步」路標；lint 能找出 orphan pages 與矛盾
+- **驗收方式**：蒸餾出來的頁面在 `_meta/index.md` 可找到；log 有新增 entry；舊文件在蒸餾後視情況歸檔或刪除
+
+---
+
+## 核心概念：蒸餾 vs 總結
+
+| | 總結 | 蒸餾 |
+|--|------|------|
+| 內容 | 課堂筆記：講了什麼 | 觀點濃縮：我學到了什麼 |
+| 輸出 | 「這份報告談了X、Y、Z」 | 「關於X，我的核心洞察是Y」 |
+| 格式 | 列點敘述 | 帶結構、帶關係、帶懷疑 |
+
+蒸餾時：「有觀點，不只是敘述」+「留下連結，不只是總結」+「標注不確定性」。
+
+---
+
+## 工作流程
+
+### 情境 A：蒸餾新研究進 wiki
+
+1. **確認來源**：讀取待蒸餾的原始檔案（如 `outputs/doc/indirect_measurement_research.md`）
+2. **確認目標分類**：`taxonomy.md` 的 research/ 分類結構（cognitive / ai / system / philosophy 等）
+3. **寫入 wiki 頁面**：格式見下方「Wiki 頁面標準格式」
+4. **更新 `_meta/index.md`**：在對應分類下新增 entry
+5. **更新 `_meta/log.md`**：append log entry（格式：`## [YYYY-MM-DD] distill | {filename} — {一句話描述}））
+6. **評估舊檔案**：蒸餾完成後，原檔案是否該刪除/歸檔？若需要，執行並在 log 標注
+
+### 情境 B：Wiki Lint（健康檢查）
+
+1. 讀取 `_meta/index.md` 確認所有頁面現況
+2. 讀取 `_meta/log.md` 確認上次 lint 時間
+3. 依序檢查：
+   - **Orphan pages**：哪些頁面沒有被其他頁面用 `[[wikilink]]` 引用？
+   - **矛盾**：主題 A 的結論和主題 B 是否有明顯衝突？
+   - **過時**：有新的研究是否覆蓋了舊頁面的結論？
+   - **該補的連結**：提到了某概念但沒有建立 link
+4. 發現問題寫入 `_meta/audit.md`（或直接口報，視嚴重程度）
+
+### 情境 C：更新 index / 整理結構
+
+1. 讀取 `_meta/index.md`
+2. 根據 taxonomy 結構，檢查是否有新頁面未列入、分類是否正確
+3. 修正並更新 log entry
+
+---
+
+## Wiki 頁面標準格式
+
+蒸餾後的 wiki 頁面頂部需要有 YAML frontmatter：
+
+```yaml
+---
+title: 標題
+date: YYYY-MM-DD
+category: cognitive / ai / system / philosophy / etc.
+tags: [tag1, tag2]
+status: active / archived
+related:
+  - "[[相關頁面標題]]"
+---
+
+# 頁面標題
+
+## 核心問題
+（這個研究在回答什麼問題）
+
+## 主要發現
+（bullet points，最重要的洞察）
+
+## 開放問題
+（還沒有答案的地方，標注 [⚠️推測] 或 [❓待驗證]）
+
+## 下一步
+（順著這條線可以繼續讀什麼，用 [[wikilink]]）
+```
+
+**Wikilink 格式**：`[[目標頁面標題]]` — 不寫 `.md`，讓系統自動解析。
+
+---
+
+## Taxonomy 分類（供蒸餾時參考）
+
+```
+research/
+├── cognitive/     ← 認知、記憶、間接測量、思維模型
+├── ai/           ← LLM、AI系統、Agent架構
+├── system/       ← Loom框架技術、工具開發
+├── philosophy/   ← 哲學、宗教、抽象概念
+├── history/      ← 歷史研究
+└── _index.md     ← 該目錄的子索引
+```
+
+蒸餾時根據主題選擇對應子目錄，沒有對應子目錄就放 `research/` 根目錄。
+
+---
+
+## _meta/ 結構（維護的維度）
+
+```
+_meta/
+├── taxonomy.md    ← Schema 定義（分類規範、命名慣例）
+├── index.md      ← 全部 wiki 頁面的內容目錄（按主題分類）
+├── log.md        ← 依時間順序的維護日誌（append-only）
+└── audit.md      ← Lint 發現的問題（可選）
+```
+
+---
+
+## 不在範圍
+
+- `task_list` 的便利貼管理 → 那個技能負責
+- `pursuit` 的長期追蹤 → 那個機制負責
+- 框架代碼修改 → 由 harness 的 `precondition_checks` 阻擋
+- 沒有至少一次完整執行的內容，不會主動蒸餾（需要先有研究產出）
+
+---
+
+## 觸發關鍵詞
+
+- 「蒸餾」「寫進 wiki」「整理進 library」
+- 「lint」「健康檢查」「orphan」
+- 「更新 index」「整理 outputs/」
+- 「每週維護」「wiki maintenance」
+
+---
+
+## 與其他技能的關係
+
+| 技能 | 分工 |
+|------|------|
+| `deep_researcher` | 執行研究（多維度並行抓資料、寫報告） |
+| `memory_hygiene` | 維護絲絲的 Semantic Memory 健康（去重、清理過期） |
+| `wiki_maintenance` | 維護 Research Library（蒸餾、lint、整理文件） |
+
+三者各有所屬：**研究執行 → 蒸餾 → Semantic Memory**，形成完整的知識處理流水線。
+
+---
+
+*wiki_maintenance v0.1 — 2026-05-22*

--- a/skills/wiki_maintenance/SKILL.md
+++ b/skills/wiki_maintenance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wiki_maintenance
-description: "Research Library 維護技能。當使用者說「蒸餾這個進 wiki」、「整理 outputs/ 文件」、「跑一下 wiki lint」、「檢查 orphan pages」、「更新 index」時使用。也適用于：建立了新的研究報告需要收進 Research Library、發現有 orphan pages、每週定期維護時觸發。"
+description: "Research Library 維護技能。當使用者說「蒸餾這個進 wiki」、「整理 outputs/ 文件」、「跑一下 wiki lint」、「檢查 orphan pages」、「更新 index」時使用。也適用於：建立了新的研究報告需要收進 Research Library、發現有 orphan pages、每週定期維護時觸發。"
 tags: [research, file_organization, knowledge_management, maintenance]
 ---
 
@@ -15,7 +15,7 @@ Research Library 是絲絲的「研究作品圖書館」——消化完畢、值
 
 - **產出**：完成蒸餾 / lint / index 更新，寫進正確位置並更新 `_meta/` 紀錄
 - **品質指標**：蒸餾後的 wiki 頁面有 `[[wikilinks]]` 互相引用、有 frontmatter、有「下一步」路標；lint 能找出 orphan pages 與矛盾
-- **驗收方式**：蒸餾出來的頁面在 `_meta/index.md` 可找到；log 有新增 entry；舊文件在蒸餾後視情況歸檔或刪除
+- **驗收方式**：蒸餾出來的頁面在 `_meta/index.md` 可找到；log 有新增 entry；原始檔案進 archive/distilled/{date}/
 
 ---
 
@@ -35,12 +35,15 @@ Research Library 是絲絲的「研究作品圖書館」——消化完畢、值
 
 ### 情境 A：蒸餾新研究進 wiki
 
-1. **確認來源**：讀取待蒸餾的原始檔案（如 `outputs/doc/indirect_measurement_research.md`）
-2. **確認目標分類**：`taxonomy.md` 的 research/ 分類結構（cognitive / ai / system / philosophy 等）
+1. **確認來源**：讀取待蒸餾的原始檔案
+2. **確認目標分類**：根據 `taxonomy.md` 選擇 cognitive / ai / system / philosophy 等
 3. **寫入 wiki 頁面**：格式見下方「Wiki 頁面標準格式」
 4. **更新 `_meta/index.md`**：在對應分類下新增 entry
-5. **更新 `_meta/log.md`**：append log entry（格式：`## [YYYY-MM-DD] distill | {filename} — {一句話描述}））
-6. **評估舊檔案**：蒸餾完成後，原檔案是否該刪除/歸檔？若需要，執行並在 log 標注
+5. **更新 `_meta/log.md`**：append log entry
+6. **處理原始檔案**：蒸餾完成後，原始檔案移入 `archive/distilled/{YYYYMMDD}/`
+   - 若同一批次蒸餾多個檔案，用同一個 date 目錄
+   - `archive/distilled/` 是原始檔案的「冷儲存」，未來 lint 發現 orphan 可再次評估刪除
+7. **呼叫 `unload_skill("wiki_maintenance")` 收尾**
 
 ### 情境 B：Wiki Lint（健康檢查）
 
@@ -51,13 +54,16 @@ Research Library 是絲絲的「研究作品圖書館」——消化完畢、值
    - **矛盾**：主題 A 的結論和主題 B 是否有明顯衝突？
    - **過時**：有新的研究是否覆蓋了舊頁面的結論？
    - **該補的連結**：提到了某概念但沒有建立 link
+   - **archive/orphan**：archive/ 中是否有從未被 wiki 吸收的原始檔案？
 4. 發現問題寫入 `_meta/audit.md`（或直接口報，視嚴重程度）
+5. **呼叫 `unload_skill("wiki_maintenance")` 收尾**
 
 ### 情境 C：更新 index / 整理結構
 
 1. 讀取 `_meta/index.md`
 2. 根據 taxonomy 結構，檢查是否有新頁面未列入、分類是否正確
 3. 修正並更新 log entry
+4. **呼叫 `unload_skill("wiki_maintenance")` 收尾**
 
 ---
 
@@ -104,10 +110,28 @@ research/
 ├── system/       ← Loom框架技術、工具開發
 ├── philosophy/   ← 哲學、宗教、抽象概念
 ├── history/      ← 歷史研究
-└── _index.md     ← 該目錄的子索引
+└── meta/         ← 關於 wiki 自身的記錄
 ```
 
-蒸餾時根據主題選擇對應子目錄，沒有對應子目錄就放 `research/` 根目錄。
+---
+
+## 原始檔案處理流程（標準步驟）
+
+```
+研究完成
+    ↓
+蒸餾進 wiki（寫入正確分類目錄）
+    ↓
+更新 _meta/index.md + _meta/log.md
+    ↓
+原始檔案 move archive/distilled/{YYYYMMDD}/
+    ↓（未來）
+lint 時若發現 archive/ 檔案也 orphan → 評估刪除
+```
+
+**為什麼要這樣處理：**
+- `archive/distilled/` 是「冷儲存」，不是垃圾筒——有需要的原始檔案（如有引用價值的審查記錄、過程紀錄）可以回溯
+- lint 時的 orphan 檢查會順便看 archive/，減少長期噪音累積
 
 ---
 
@@ -118,6 +142,7 @@ _meta/
 ├── taxonomy.md    ← Schema 定義（分類規範、命名慣例）
 ├── index.md      ← 全部 wiki 頁面的內容目錄（按主題分類）
 ├── log.md        ← 依時間順序的維護日誌（append-only）
+├── lint_report_*.md ← 歷次 lint 報告
 └── audit.md      ← Lint 發現的問題（可選）
 ```
 
@@ -153,4 +178,4 @@ _meta/
 
 ---
 
-*wiki_maintenance v0.1 — 2026-05-22*
+*wiki_maintenance v0.2 — 2026-05-22*

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -606,18 +606,23 @@ class TestSubAgentFailureCodes:
 # ── result_write slot — issue #225 ──────────────────────────────────────────
 
 
-def _result_write_response(call_id: str, content: str) -> LLMResponse:
-    """Assistant calls result_write(content=...) — registered by run_subagent."""
+def _result_write_response(
+    call_id: str, content: str, mode: str | None = None,
+) -> LLMResponse:
+    """Assistant calls result_write(content=..., mode=...) — registered by run_subagent."""
+    args: dict = {"content": content}
+    if mode is not None:
+        args["mode"] = mode
     return LLMResponse(
         text=None,
-        tool_uses=[ToolUse(id=call_id, name="result_write", args={"content": content})],
+        tool_uses=[ToolUse(id=call_id, name="result_write", args=args)],
         stop_reason="tool_use",
         raw_message={
             "role": "assistant",
             "content": [
                 {
                     "type": "tool_use", "id": call_id,
-                    "name": "result_write", "input": {"content": content},
+                    "name": "result_write", "input": args,
                 },
             ],
             "tool_calls": [
@@ -626,7 +631,7 @@ def _result_write_response(call_id: str, content: str) -> LLMResponse:
                     "type": "function",
                     "function": {
                         "name": "result_write",
-                        "arguments": json.dumps({"content": content}),
+                        "arguments": json.dumps(args),
                     },
                 }
             ],
@@ -763,18 +768,18 @@ class TestResultWriteSlot:
         payload = json.loads(scratchpad.read(f"subagent_failure:sub-slot-maxturns"))
         assert payload["result_slot"] == "checkpoint A: 3/5 done"
 
-    async def test_slot_overwrites_on_repeated_writes(
+    async def test_slot_replace_mode_overwrites(
         self,
         semantic: SemanticMemory,
         episodic: EpisodicMemory,
         procedural: ProceduralMemory,
         tmp_path: Path,
     ) -> None:
-        """Each result_write replaces the slot — last write wins."""
+        """mode='replace' overwrites — last write wins."""
         registry = ToolRegistry()
         router = _FakeRouter([
-            _result_write_response("c1", "version 1"),
-            _result_write_response("c2", "version 2 — refined"),
+            _result_write_response("c1", "version 1", mode="replace"),
+            _result_write_response("c2", "version 2 — refined", mode="replace"),
             _end_turn_response("done"),
         ])
 
@@ -797,6 +802,91 @@ class TestResultWriteSlot:
 
         assert result.result_slot == "version 2 — refined"
         assert result.output == "version 2 — refined"
+
+    async def test_slot_append_is_default_and_concatenates(
+        self,
+        semantic: SemanticMemory,
+        episodic: EpisodicMemory,
+        procedural: ProceduralMemory,
+        tmp_path: Path,
+    ) -> None:
+        """Issue #440: default mode is 'append' — multi-section calls accumulate.
+
+        Previously the slot was overwrite-only, so a sub-agent told to produce
+        a 3-section audit would have only section #3 survive. Now successive
+        calls without an explicit mode concatenate with a blank-line separator.
+        """
+        registry = ToolRegistry()
+        router = _FakeRouter([
+            _result_write_response("c1", "## Section A\nfinding 1"),
+            _result_write_response("c2", "## Section B\nfinding 2"),
+            _result_write_response("c3", "## Section C\nfinding 3"),
+            _end_turn_response("done"),
+        ])
+
+        result = await run_subagent(
+            SubAgentConfig(
+                task="audit in three sections",
+                model="gpt-test",
+                allowed_tools=[],
+                max_turns=5,
+                agent_id="sub-append",
+            ),
+            router=router,
+            episodic=episodic,
+            semantic=semantic,
+            procedural=procedural,
+            tool_registry=registry,
+            parent_session_id="parent-1",
+            workspace=tmp_path,
+        )
+
+        assert result.success is True
+        assert result.result_slot is not None
+        # All three sections survive
+        assert "Section A" in result.result_slot
+        assert "Section B" in result.result_slot
+        assert "Section C" in result.result_slot
+        assert "finding 1" in result.result_slot
+        assert "finding 2" in result.result_slot
+        assert "finding 3" in result.result_slot
+        # Sections are separated, not glued together
+        assert "finding 1\n\n## Section B" in result.result_slot
+
+    async def test_slot_mode_validation_rejects_garbage(
+        self,
+        semantic: SemanticMemory,
+        episodic: EpisodicMemory,
+        procedural: ProceduralMemory,
+        tmp_path: Path,
+    ) -> None:
+        """Invalid mode value returns a validation error — slot stays untouched."""
+        registry = ToolRegistry()
+        router = _FakeRouter([
+            _result_write_response("c1", "initial", mode="replace"),
+            _result_write_response("c2", "ignored", mode="overwrite"),  # invalid
+            _end_turn_response("done"),
+        ])
+
+        result = await run_subagent(
+            SubAgentConfig(
+                task="x",
+                model="gpt-test",
+                allowed_tools=[],
+                max_turns=5,
+                agent_id="sub-mode-validate",
+            ),
+            router=router,
+            episodic=episodic,
+            semantic=semantic,
+            procedural=procedural,
+            tool_registry=registry,
+            parent_session_id="parent-1",
+            workspace=tmp_path,
+        )
+
+        # First write committed; second rejected ⇒ slot unchanged
+        assert result.result_slot == "initial"
 
 
 class TestWrapupReminder:
@@ -915,3 +1005,128 @@ class TestWrapupReminder:
                     isinstance(m.get("content"), str)
                     and "2 turns left" in m["content"]
                 ), "no reminder expected when max_turns < 3"
+
+
+def _bare_tool_use_response(call_id: str, tool_name: str) -> LLMResponse:
+    """Tool call to an arbitrary name — used to probe unknown-tool handling."""
+    return LLMResponse(
+        text=None,
+        tool_uses=[ToolUse(id=call_id, name=tool_name, args={})],
+        stop_reason="tool_use",
+        raw_message={
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "id": call_id, "name": tool_name, "input": {}},
+            ],
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": tool_name, "arguments": "{}"},
+                }
+            ],
+        },
+    )
+
+
+class TestUnknownToolHint:
+    """Issue #440: unknown-tool error must guide the sub-agent to self-recover."""
+
+    async def test_unknown_tool_lists_available_tools(
+        self,
+        semantic: SemanticMemory,
+        episodic: EpisodicMemory,
+        procedural: ProceduralMemory,
+        tmp_path: Path,
+    ) -> None:
+        """Calling a tool that does not exist returns an error listing what does."""
+        registry = ToolRegistry()
+
+        seen_messages: list[list[dict]] = []
+
+        class _SpyRouter(_FakeRouter):
+            async def stream_chat(self, model, messages, tools=None, max_tokens=8096):
+                seen_messages.append([dict(m) for m in messages])
+                async for chunk, final in super().stream_chat(model, messages, tools, max_tokens):
+                    yield chunk, final
+
+        router = _SpyRouter([
+            _bare_tool_use_response("c1", "nonexistent_thing"),
+            _end_turn_response("ok"),
+        ])
+
+        await run_subagent(
+            SubAgentConfig(
+                task="x",
+                model="gpt-test",
+                allowed_tools=[],
+                max_turns=4,
+                agent_id="sub-unknown",
+            ),
+            router=router,
+            episodic=episodic,
+            semantic=semantic,
+            procedural=procedural,
+            tool_registry=registry,
+            parent_session_id="parent-1",
+            workspace=tmp_path,
+        )
+
+        # The tool_result that flows into the LLM on turn 2 must carry the
+        # helpful error message — not just "Unknown tool: X".
+        second_call = seen_messages[1]
+        tool_msgs = [m for m in second_call if m.get("role") == "tool"]
+        assert tool_msgs, "expected a tool result message back to the agent"
+        body = tool_msgs[-1].get("content") or ""
+        assert "nonexistent_thing" in body
+        assert "Available tools" in body
+        # result_write is always registered, so it should appear in the list
+        assert "result_write" in body
+
+    async def test_unknown_write_file_redirects_to_result_write(
+        self,
+        semantic: SemanticMemory,
+        episodic: EpisodicMemory,
+        procedural: ProceduralMemory,
+        tmp_path: Path,
+    ) -> None:
+        """Issue #440: when the agent reaches for write_file (the most common
+        confusion), the error explicitly redirects it to result_write."""
+        registry = ToolRegistry()
+
+        seen_messages: list[list[dict]] = []
+
+        class _SpyRouter(_FakeRouter):
+            async def stream_chat(self, model, messages, tools=None, max_tokens=8096):
+                seen_messages.append([dict(m) for m in messages])
+                async for chunk, final in super().stream_chat(model, messages, tools, max_tokens):
+                    yield chunk, final
+
+        router = _SpyRouter([
+            _bare_tool_use_response("c1", "write_file"),
+            _end_turn_response("ok"),
+        ])
+
+        await run_subagent(
+            SubAgentConfig(
+                task="audit and write to tmp/audit.md",
+                model="gpt-test",
+                allowed_tools=[],
+                max_turns=4,
+                agent_id="sub-redirect",
+            ),
+            router=router,
+            episodic=episodic,
+            semantic=semantic,
+            procedural=procedural,
+            tool_registry=registry,
+            parent_session_id="parent-1",
+            workspace=tmp_path,
+        )
+
+        second_call = seen_messages[1]
+        tool_msgs = [m for m in second_call if m.get("role") == "tool"]
+        body = tool_msgs[-1].get("content") or ""
+        assert "result_write" in body
+        # The redirect language should be specific enough to be actionable
+        assert "persist" in body or "parent" in body


### PR DESCRIPTION
## Summary

- Issue #440 Plan A — sub-agent 工具邊界不再洩漏到 skill 層,但維持 default-deny scope。
- `result_write` 預設 append、加 `mode` 參數;deep_researcher 那種多段審查場景現在多次 call 會自動串接而不互相覆蓋。
- `tool_not_found` 錯誤訊息改帶可用工具清單與 redirect 提示(`write_file` / `run_bash` → 改走 `result_write`),sub-agent 撞到不存在的工具時能自復原。
- system_prompt + `spawn_agent` description 重寫,把「該怎麼做」明確化(parent 要顯式 whitelist GUARDED tools / sub-agent 只有 result_write 一條 hand-off 通道)。

## Test plan

- [x] `pytest tests/test_subagent.py` — 26 tests pass(含 4 個新增 case:append 預設、replace 顯式、mode 校驗、unknown_tool redirect)
- [x] GitNexus impact analysis: LOW(`run_subagent`、`make_spawn_agent_tool` 都無 upstream caller)
- [x] GitNexus detect_changes: low risk, 0 affected processes
- [ ] 絲絲 跑 deep_researcher 完整 flow 實測(尤其第 3 步外部審核多段 append)

## Notes

- 向後相容:`mode` 預設值改了,但既有測試已更新為顯式 `mode="replace"`;外部沒有其他 caller 直接呼叫 sub-agent 的 result_write。
- skill 端:本地 `skills/deep_researcher/SKILL.md` 已 bump v6 並改寫第 3 步指令範式(gitignored,未進 PR)。

Fixes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)