### PR TITLE
feat(onboarding): three loom.toml profile templates + make update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: help update
+
+help:  ## Show this help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
+
+update:  ## Pull latest + reinstall (handles pyproject changes)
+	git pull
+	pip install -e ".[dev]"

--- a/README.md
+++ b/README.md
@@ -339,11 +339,28 @@ cd Loom
 pip install -e ".[dev]"
 ```
 
+Pick a starting configuration by copying one of the templates under
+[`examples/profiles/`](examples/profiles/) into `loom.toml` at the repo root:
+
+| Profile | When to use |
+|---------|-------------|
+| `loom.toml.example.secure` | 企業 / 高敏感資料 / 純 CLI — OS-level sandbox + 網路 allowlist + autonomy 關 |
+| `loom.toml.example.assistant` | 7×24 Discord 助手（**主要推薦**）— Discord bot 主場、autonomy 關、預設安全等級 |
+| `loom.toml.example.autonomous` | 自主智能體 / 獨立設備 / 容器 — autonomy 全開 + scope_grants 預先批准（⚠ 高風險） |
+
+```bash
+cp examples/profiles/loom.toml.example.assistant loom.toml   # 主要推薦
+# 或從根目錄的 loom.toml.example 起步 (dev baseline, 含所有 per-key 教學註解)
+```
+
 Create a `.env` in the project root with at least one provider:
 
 ```env
 OPENAI_API_KEY=your_openai_key_here
 ANTHROPIC_API_KEY=your_key_here
+
+# Discord bot (required by assistant / autonomous profiles)
+DISCORD_BOT_TOKEN=your_bot_token_here
 
 # Local providers (no API key needed)
 OLLAMA_BASE_URL=http://localhost:11434/v1
@@ -358,6 +375,12 @@ loom chat --model codex/gpt-5.5    # Codex OAuth backend
 loom chat --model ollama/llama3.2  # local model
 loom discord start --autonomy --channel <id>
 loom autonomy start
+```
+
+To pull and upgrade in one step (handles `pyproject.toml` changes):
+
+```bash
+make update                       # = git pull && pip install -e ".[dev]"
 ```
 
 Model routing works by prefix — `gpt-*` and `openai/<model>` use

--- a/examples/profiles/README.md
+++ b/examples/profiles/README.md
@@ -1,0 +1,28 @@
+# Loom Profile Templates
+
+三個情境化的 `loom.toml` 範本，反映三種典型使用姿態的差異。每份檔案都是可獨立 `cp` 即用的完整設定。
+
+| 範本檔 | 場景 | 預設姿態 |
+|---|---|---|
+| [`loom.toml.example.secure`](loom.toml.example.secure) | 企業 / 高敏感資料 / 純 CLI | OS-level sandbox (srt) + 網路 allowlist + autonomy 關 |
+| [`loom.toml.example.assistant`](loom.toml.example.assistant) | 7×24 Discord 助手 / 等使用者開口 | Discord bot 主場 + autonomy 關 + 預設安全等級 |
+| [`loom.toml.example.autonomous`](loom.toml.example.autonomous) | 自主智能體 / 獨立設備 / 容器 | autonomy 全開 + scope_grants 預先批准 + ⚠ 高風險 |
+
+## 用法
+
+```bash
+# 從專案 root：
+cp examples/profiles/loom.toml.example.secure     loom.toml   # 企業安全場景
+cp examples/profiles/loom.toml.example.assistant  loom.toml   # 7×24 Discord 助手
+cp examples/profiles/loom.toml.example.autonomous loom.toml   # 自主智能體（高風險）
+```
+
+複製後直接編輯 `loom.toml`（例如填入 timezone、調整 default_model）。完整的 per-key 教學註解請看根目錄的 [`loom.toml.example`](../../loom.toml.example) — 範本檔為求簡潔已精簡通用註解，只保留 profile-specific 的取捨理由。
+
+## 維護姿態
+
+- **主力**：根目錄 `loom.toml.example`（dev baseline）+ 各人本地 `loom.toml`
+- **範本**：這三份 — 只在新增/移除 toml key、或情境定義改變時才同步更新
+- **保留 drift 預算**：三份範本不保證與 baseline 行對行同步，僅保證情境合理性
+
+主要推薦：**assistant** 是大多數使用者的合理起點；**secure** 與 **autonomous** 是兩極場景，按需挑選。

--- a/examples/profiles/loom.toml.example.assistant
+++ b/examples/profiles/loom.toml.example.assistant
@@ -1,0 +1,142 @@
+# ============================================================
+# LOOM PROFILE: 7×24 ASSISTANT  (Discord 為主, CLI 為輔)
+# ============================================================
+# 適用場景:
+#   • 長期在 Discord 上聊天、查資料、修小 patch
+#   • 手機 / 桌面雙端可用，週末也能 ping
+#   • Agent 等使用者開口，不主動排任務
+#
+# 預設姿態:
+#   • Sandbox: pattern scan only (預設等級，不開 srt)
+#   • 寫入路徑: workspace + /tmp + ~/.loom
+#   • Discord bot 預期啟用 —— .env 必須提供 DISCORD_BOT_TOKEN
+#   • Autonomy 預設關 —— bot 連著但不自主排任務
+#   • GUARDED 用 session 緩存（預設行為，session 內第一次 prompt）
+#   • Dream cycle 預設開（背景知識整理）
+#
+# 註: autonomy 排程未來會獨立成獨立檔案管理（issue #444），避免
+#     agent 誤改 loom.toml 引發連鎖錯誤；目前先全關。需要時參考
+#     根目錄 loom.toml.example 的 [[autonomy.schedules]] 範例。
+#
+# 完整 per-key 教學註解請看根目錄 loom.toml.example
+# 此檔僅標註 profile-specific 的取捨理由
+# ============================================================
+
+[loom]
+name    = "loom"
+version = "0.1.0"
+
+[identity]
+soul        = "SOUL.md"
+agent       = "Agent.md"
+personality = ""
+
+[cognition]
+default_model = "claude-sonnet-4-6"
+max_tokens    = 8096
+
+[cognition.tiers]
+1 = "minimax-m2.7"
+2 = "deepseek-v4-pro"
+default_tier         = 1
+reminder_after_turns = 10
+
+[memory]
+backend                     = "sqlite"
+db_path                     = "~/.loom/memory.db"
+episodic_retention_days     = 7
+skill_deprecation_threshold = 0.3
+
+# PROFILE: 長 session 用較小 compress threshold —— Discord 助手會掛幾天
+episodic_compress_threshold = 10
+
+[memory.governance]
+admission_threshold      = 0.5
+episodic_ttl_days        = 30
+semantic_decay_threshold = 0.1
+dup_window_days          = 7
+dup_lookback_limit       = 500
+dup_similarity_threshold = 0.85
+
+[memory.lifecycle]
+enabled         = true
+interval_hours  = 24
+min_gap_minutes = 30
+threshold       = 0.1
+
+[memory.dream]
+enabled        = true
+interval_hours = 12
+sample_size    = 15
+
+[reflection]
+auto_reflect = true
+visibility   = "summary"
+
+[telemetry]
+enabled          = true
+persist_interval = 100
+retention_days   = 30
+
+[session]
+prefetch_enabled = false
+prefetch_top_n   = 3
+
+[cli]
+transient_hints = true
+
+[timezone]
+user     = "Asia/Taipei"
+internal = "UTC"
+
+[harness]
+default_trust_level = "guarded"
+require_audit_log   = true
+
+# PROFILE: 助手場景啟用 task_write Discord 通知
+[task_write]
+discord_reminder           = true
+jit_spill_threshold_tokens = 2000
+mask_age_turns             = 20
+strict_sandbox             = false
+
+# ─────────────────────────────────────────────
+# Sandbox —— ASSISTANT 用 pattern scan 預設（無 srt）
+# ─────────────────────────────────────────────
+# 預設只有 CommandScanner tripwire；如果想加 OS-level 牆，換到 secure profile
+# 或自行改 backend = "srt"（記得先 npm install -g @anthropic-ai/sandbox-runtime）。
+#
+# deny_read 仍保留敏感目錄，pattern scan 抓到時會擋。
+[security.sandbox]
+backend = "none"
+
+allow_write = [".", "/private/tmp", "~/.loom"]
+
+deny_read = ["~/.ssh", "~/.aws", "~/.gnupg", ".env"]
+
+# 空白 = pattern scan 模式下不影響網路（srt 模式下空白才是「禁止網路」）
+allowed_domains = []
+
+# ─────────────────────────────────────────────
+# Autonomy —— ASSISTANT 預設關（bot 連著就好，不主動排任務）
+# ─────────────────────────────────────────────
+# 想啟用自動排程：把 enabled 改 true，再解註解需要的 schedule 範例
+# （完整範例見根目錄 loom.toml.example 的 [[autonomy.schedules]] 區塊）。
+[autonomy]
+enabled = false
+
+[notify]
+default_channel = "discord"
+
+[ledger]
+enabled = true
+
+# ─────────────────────────────────────────────
+# Discord bot 啟動需要的環境變數（.env）
+# ─────────────────────────────────────────────
+# DISCORD_BOT_TOKEN=your_bot_token_here
+#
+# 啟動指令:
+#     loom discord start --channel <CHANNEL_ID>
+# 或同時啟用 autonomy:
+#     loom discord start --autonomy --channel <CHANNEL_ID>

--- a/examples/profiles/loom.toml.example.assistant
+++ b/examples/profiles/loom.toml.example.assistant
@@ -90,15 +90,15 @@ user     = "Asia/Taipei"
 internal = "UTC"
 
 [harness]
-default_trust_level = "guarded"
-require_audit_log   = true
-
-# PROFILE: 助手場景啟用 task_write Discord 通知
-[task_write]
-discord_reminder           = true
+default_trust_level        = "guarded"
+require_audit_log          = true
 jit_spill_threshold_tokens = 2000
 mask_age_turns             = 20
 strict_sandbox             = false
+
+# PROFILE: 助手場景啟用 task_write Discord 通知
+[task_write]
+discord_reminder = true
 
 # ─────────────────────────────────────────────
 # Sandbox —— ASSISTANT 用 pattern scan 預設（無 srt）

--- a/examples/profiles/loom.toml.example.autonomous
+++ b/examples/profiles/loom.toml.example.autonomous
@@ -1,0 +1,198 @@
+# ============================================================
+# LOOM PROFILE: AUTONOMOUS AGENT  (最小授權, 自主執行)
+# ============================================================
+# ⚠️  這是本框架「最高風險」的設定。請務必確認:
+#   • 跑在獨立設備 / 雲端 isolated server / 容器
+#   • 不與使用者個人資料、私鑰、SSH config 共存
+#   • 接受 agent 在無人值守下自主修改檔案、觸發任務
+#
+# ⛔  不適合: 個人筆電、家用 server、有他人共用的環境
+#
+# 預設姿態:
+#   • Sandbox: pattern scan only —— autonomy 需要彈性，不開 srt
+#   • 寫入路徑: workspace + /tmp + ~/.loom
+#   • Autonomy 三類 trigger 全開（cron + event + condition）
+#   • Dream cycle + memory housekeeping 定期跑
+#   • Discord bot 同步啟用（方便人類隨時 ping 進來看狀況）
+#   • GUARDED tool 預先 pre-authorize 給 autonomy schedule —— 無人值守
+#     場景下不能仰賴互動確認
+#
+# 強烈建議搭配:
+#   • 雲端 IAM / 容器網路限制
+#   • 定期 audit ~/.loom/ledger.db
+#   • 不要在這個 profile 下開放任何個人帳號（GitHub、Email、雲服務）
+#
+# 完整 per-key 教學註解請看根目錄 loom.toml.example
+# 此檔僅標註 profile-specific 的取捨理由
+# ============================================================
+
+[loom]
+name    = "loom"
+version = "0.1.0"
+
+[identity]
+soul        = "SOUL.md"
+agent       = "Agent.md"
+personality = ""
+
+[cognition]
+default_model = "claude-sonnet-4-6"
+max_tokens    = 8096
+
+[cognition.tiers]
+1 = "minimax-m2.7"
+2 = "deepseek-v4-pro"
+default_tier         = 1
+reminder_after_turns = 10
+
+[memory]
+backend                     = "sqlite"
+db_path                     = "~/.loom/memory.db"
+episodic_retention_days     = 7
+skill_deprecation_threshold = 0.3
+
+# PROFILE: 自主運行 session 通常很長 —— 提早 compress
+episodic_compress_threshold = 10
+
+[memory.governance]
+admission_threshold      = 0.5
+episodic_ttl_days        = 30
+semantic_decay_threshold = 0.1
+dup_window_days          = 7
+dup_lookback_limit       = 500
+dup_similarity_threshold = 0.85
+
+[memory.lifecycle]
+enabled         = true
+interval_hours  = 24
+min_gap_minutes = 30
+threshold       = 0.1
+
+# PROFILE: 自主運行依賴強健記憶 —— dream cycle 加密 (8h 一次)
+[memory.dream]
+enabled        = true
+interval_hours = 8
+sample_size    = 20
+
+[reflection]
+auto_reflect = true
+visibility   = "summary"
+
+[telemetry]
+enabled          = true
+persist_interval = 100
+retention_days   = 30
+
+[session]
+prefetch_enabled = false
+prefetch_top_n   = 3
+
+[cli]
+transient_hints = true
+
+[timezone]
+user     = "Asia/Taipei"
+internal = "UTC"
+
+[harness]
+default_trust_level = "guarded"
+require_audit_log   = true
+
+[task_write]
+discord_reminder           = true
+jit_spill_threshold_tokens = 2000
+mask_age_turns             = 20
+strict_sandbox             = false
+
+# ─────────────────────────────────────────────
+# Sandbox —— AUTONOMOUS 維持 pattern scan
+# ─────────────────────────────────────────────
+# 不開 srt：autonomy schedule 動態決定行為，sandbox 限制會卡住正常運作。
+# 風險由「跑在 isolated 環境」這個前提條件吸收 —— 看本檔頂端 ⚠️ 警告。
+[security.sandbox]
+backend = "none"
+
+allow_write = [".", "/private/tmp", "~/.loom"]
+
+deny_read = ["~/.ssh", "~/.aws", "~/.gnupg", ".env"]
+
+allowed_domains = []
+
+# ─────────────────────────────────────────────
+# Autonomy —— AUTONOMOUS 全開
+# ─────────────────────────────────────────────
+# 三類 trigger（cron / event / condition）都通；schedule 必須在
+# allowed_tools / scope_grants 預先宣告權限，否則 GUARDED 會被 deny。
+[autonomy]
+enabled = true
+
+# ── 範例 1: 每日記憶整理（dream + housekeeping） ─────────────────
+# [[autonomy.schedules]]
+# name          = "memory_housekeeping"
+# cron          = "0 19 * * 0"            # 19:00 UTC Sunday = 03:00 Asia/Taipei Monday
+# intent        = """Run memory housekeeping. First call memory_prune with
+#                    dry_run=true to preview decayed entries. If any qualify,
+#                    call again with dry_run=false to delete them. Report:
+#                    total examined, pruned, and retained."""
+# trust_level   = "safe"
+# notify        = false
+# notify_thread = 0
+
+# ── 範例 2: 每日 free dream（補 themed 沒覆蓋到的 cross-domain） ────
+# [[autonomy.schedules]]
+# name          = "offline_dreaming_free"
+# cron          = "0 19 * * *"            # 19:00 UTC = 03:00 Asia/Taipei
+# intent        = """Run a free cross-domain dream. Call dream_cycle with
+#                    themed=false so the sample spans all four ontology
+#                    domains at random."""
+# trust_level   = "safe"
+# notify        = false
+# notify_thread = 0
+# allowed_tools = ["dream_cycle", "memorize"]
+
+# ── 範例 3: weekly skill review ────────────────────────────────
+# [[autonomy.schedules]]
+# name          = "skill_weekly_review"
+# cron          = "0 2 * * 6"             # 02:00 UTC Saturday = 10:00 Asia/Taipei
+# intent        = """Run `loom skill weekly` via run_bash, then read the
+#                    generated report and surface items in the 該關注清單."""
+# trust_level   = "safe"
+# notify        = true
+# notify_thread = 0
+# allowed_tools = ["run_bash", "read_file"]
+# scope_grants  = [
+#   { resource = "exec", action = "execute", selector = "workspace" },
+#   { resource = "path", action = "read",    selector = "outputs"   },
+# ]
+# attach_outputs = ["outputs/self_check/*-skill-weekly.md"]
+
+# ── 範例 4: event trigger（外部訊號觸發） ─────────────────────────
+# [[autonomy.triggers]]
+# name          = "deploy_check"
+# event         = "deployment_done"        # 用 `loom autonomy emit deployment_done` 觸發
+# intent        = "Run smoke tests and post results."
+# trust_level   = "guarded"
+# notify        = true
+# notify_thread = 0
+# allowed_tools = ["run_bash"]
+# scope_grants  = [
+#   { resource = "exec", action = "execute", selector = "workspace" },
+# ]
+
+[notify]
+default_channel = "discord"
+
+[ledger]
+enabled = true
+
+# ─────────────────────────────────────────────
+# Discord bot 啟動（建議搭配 --autonomy 旗標）
+# ─────────────────────────────────────────────
+# DISCORD_BOT_TOKEN=your_bot_token_here
+#
+# 啟動指令:
+#     loom discord start --autonomy --channel <CHANNEL_ID>
+#
+# 想看 autonomy 跑得怎麼樣:
+#     loom autonomy status
+#     loom diagnostic recent

--- a/examples/profiles/loom.toml.example.autonomous
+++ b/examples/profiles/loom.toml.example.autonomous
@@ -95,14 +95,14 @@ user     = "Asia/Taipei"
 internal = "UTC"
 
 [harness]
-default_trust_level = "guarded"
-require_audit_log   = true
-
-[task_write]
-discord_reminder           = true
+default_trust_level        = "guarded"
+require_audit_log          = true
 jit_spill_threshold_tokens = 2000
 mask_age_turns             = 20
 strict_sandbox             = false
+
+[task_write]
+discord_reminder = true
 
 # ─────────────────────────────────────────────
 # Sandbox —— AUTONOMOUS 維持 pattern scan

--- a/examples/profiles/loom.toml.example.secure
+++ b/examples/profiles/loom.toml.example.secure
@@ -88,16 +88,16 @@ user     = "Asia/Taipei"
 internal = "UTC"
 
 [harness]
-default_trust_level = "guarded"
-require_audit_log   = true
-
-[task_write]
-discord_reminder           = false
+default_trust_level        = "guarded"
+require_audit_log          = true
 jit_spill_threshold_tokens = 2000
 mask_age_turns             = 20
 
 # PROFILE: strict_sandbox 強制 —— run_bash 限定 workspace cwd
 strict_sandbox = true
+
+[task_write]
+discord_reminder = false
 
 # ─────────────────────────────────────────────
 # Sandbox —— SECURE 啟用 srt OS-level 隔離

--- a/examples/profiles/loom.toml.example.secure
+++ b/examples/profiles/loom.toml.example.secure
@@ -1,0 +1,136 @@
+# ============================================================
+# LOOM PROFILE: SECURE  (企業 / 高敏感場景)
+# ============================================================
+# 適用場景:
+#   • 接觸敏感資料、客戶程式碼、私鑰、SSH config
+#   • 純 CLI 操作，無對外 Discord bot
+#   • 寧可慢、寧可多問，不能讓 agent 自作主張
+#
+# 預設姿態:
+#   • OS-level sandbox (srt) 啟用 —— 缺 binary 仍會啟動但會印
+#     明顯警告，使用者自負風險（你選了這個 profile = 你接受）
+#   • 網路 allowlist 明列（PyPI / GitHub / Anthropic / OpenAI）
+#   • 寫入路徑限 workspace
+#   • Autonomy 完全關閉
+#   • run_bash 強制 strict_sandbox（workspace cwd）
+#   • Dream cycle 關 —— 不跑背景 LLM 呼叫
+#
+# 不適合: 自動化排程、長時運行 bot、需要外連未列入 allowlist 的 API
+#
+# 完整 per-key 教學註解請看根目錄 loom.toml.example
+# 此檔僅標註 profile-specific 的取捨理由
+# ============================================================
+
+[loom]
+name    = "loom"
+version = "0.1.0"
+
+[identity]
+soul        = "SOUL.md"
+agent       = "Agent.md"
+personality = ""
+
+[cognition]
+default_model = "claude-sonnet-4-6"
+max_tokens    = 8096
+
+[cognition.tiers]
+1 = "minimax-m2.7"
+2 = "deepseek-v4-pro"
+default_tier         = 1
+reminder_after_turns = 10
+
+[memory]
+backend                     = "sqlite"
+db_path                     = "~/.loom/memory.db"
+episodic_retention_days     = 7
+skill_deprecation_threshold = 0.3
+episodic_compress_threshold = 30
+
+[memory.governance]
+admission_threshold      = 0.5
+episodic_ttl_days        = 30
+semantic_decay_threshold = 0.1
+dup_window_days          = 7
+dup_lookback_limit       = 500
+dup_similarity_threshold = 0.85
+
+[memory.lifecycle]
+enabled         = true
+interval_hours  = 24
+min_gap_minutes = 30
+threshold       = 0.1
+
+# PROFILE: dream cycle 關閉 —— secure 不跑背景 LLM
+[memory.dream]
+enabled        = false
+interval_hours = 12
+sample_size    = 15
+
+[reflection]
+auto_reflect = true
+visibility   = "summary"
+
+[telemetry]
+enabled          = true
+persist_interval = 100
+retention_days   = 30
+
+[session]
+prefetch_enabled = false
+prefetch_top_n   = 3
+
+[cli]
+transient_hints = true
+
+[timezone]
+user     = "Asia/Taipei"
+internal = "UTC"
+
+[harness]
+default_trust_level = "guarded"
+require_audit_log   = true
+
+[task_write]
+discord_reminder           = false
+jit_spill_threshold_tokens = 2000
+mask_age_turns             = 20
+
+# PROFILE: strict_sandbox 強制 —— run_bash 限定 workspace cwd
+strict_sandbox = true
+
+# ─────────────────────────────────────────────
+# Sandbox —— SECURE 啟用 srt OS-level 隔離
+# ─────────────────────────────────────────────
+# srt 必須先安裝:
+#     npm install -g @anthropic-ai/sandbox-runtime
+#
+# 缺 binary 時 Loom 仍會啟動但會在 console 印警告，使用者自負風險。
+# 寫入限 workspace + /private/tmp；網路只允許明列的 host。
+[security.sandbox]
+backend = "srt"
+
+allow_write = [".", "/private/tmp"]
+
+deny_read = ["~/.ssh", "~/.aws", "~/.gnupg", ".env"]
+
+allowed_domains = [
+    "pypi.org",
+    "files.pythonhosted.org",
+    "api.github.com",
+    "api.anthropic.com",
+    "api.openai.com",
+]
+
+# ─────────────────────────────────────────────
+# Autonomy —— SECURE 完全關閉
+# ─────────────────────────────────────────────
+# 不接受任何 autonomous trigger。需要自動化排程改用 assistant 或 autonomous profile。
+[autonomy]
+enabled = false
+
+[notify]
+default_channel = "cli"
+
+[ledger]
+enabled = true

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -331,14 +331,6 @@ internal = "UTC"
 default_trust_level = "guarded"   # "safe" | "guarded" | "critical"
 require_audit_log   = true
 
-# ─────────────────────────────────────────────
-# Task Write (Issue #207)
-# ─────────────────────────────────────────────
-[task_write]
-# Enables an auto-updating Discord embed notification whenever `task_write` is called.
-# Provides real-time visual feedback of task progress in Discord threads.
-discord_reminder = false
-
 # ── Context management (Issue #197) ──────────────────────────────────────────
 #
 # Just-in-time retrieval: when a tool's output exceeds this token budget,
@@ -394,6 +386,14 @@ mask_age_turns = 20
 # Does not prevent OS-level container escapes — for that, enable the
 # [security.sandbox] block below (Issue #29, Quest A Phase 4).
 strict_sandbox = false
+
+# ─────────────────────────────────────────────
+# Task Write (Issue #207)
+# ─────────────────────────────────────────────
+[task_write]
+# Enables an auto-updating Discord embed notification whenever `task_write` is called.
+# Provides real-time visual feedback of task progress in Discord threads.
+discord_reminder = false
 
 # ─────────────────────────────────────────────
 # Security · Sandbox Runtime (Issue #29)
@@ -691,12 +691,17 @@ enabled  = false           # set true to activate daemon
 # ─────────────────────────────────────────────
 # default_channel is informational; actual routing is determined at runtime
 # by which notifiers are registered (CLI, DiscordBotNotifier, etc.)
+#
+# trust_level + notify interaction:
+#   guarded + notify=false → execute immediately, no confirmation
+#   guarded + notify=true  → Discord Allow/Deny buttons (60s timeout → skip)
+# notify_thread: Discord thread ID to post results into.
+#   0 = use the --notify-channel passed to `loom discord start`
 
 # ─────────────────────────────────────────────
 # Embeddings
 # ─────────────────────────────────────────────
-# Embeddings
-# ─────────────────────────────────────────────
+# Semantic memory uses vector embeddings for similarity search.
 # Two backends selected by the ``provider`` field:
 #   "ollama"   — local Ollama server (no API key required)
 #   "minimax"  — MiniMax cloud API (requires API key)


### PR DESCRIPTION
## Summary

整理使用者入門路徑，把「裝起來之後該怎麼設定」這個痛點變成「cp 一個範本就好」。

- **三個 `loom.toml` 範本**（`examples/profiles/`），覆蓋三種典型使用姿態：
  - `secure` — 企業 / 高敏感場景 / 純 CLI（OS-level sandbox + 網路 allowlist + autonomy 關）
  - `assistant` — 7×24 Discord 助手（**主要推薦**，預設安全等級）
  - `autonomous` — 自主智能體（⚠ 高風險，僅限獨立設備）
- **`Makefile`** 加一個 `make update` target，解決 `git pull` 後忘記重裝 deps 的痛點
- **README Installation 段** 改寫，提供三個 profile 對照表 + 推薦 `assistant` 為起點

## 設計取捨

- **完整可 cp 即用 vs. delta 檔**：選前者。三份範本都是獨立可用的完整 toml，使用者體驗最簡單，代價是 90% 重複內容
- **維護姿態**：baseline `loom.toml.example` 與絲絲本地 `loom.toml` 是主力；三個範本「不定期一起更新」，drift 預算已接受
- **註解策略**：每個範本只保留 profile-specific 取捨理由，per-key 通用教學註解請使用者回看根目錄 `loom.toml.example`

## Verified

- 三份 toml 都通過 `tomllib.load()` parse
- Makefile target 文法 + tab 縮排正確

## 關聯

開了 issue **#444** 追蹤「autonomy schedules 未來獨立成檔案管理」這個結構性建議 —— 寫範本的時候發現 autonomy 段在三個 profile 間差異最大、且 agent 自己可以動 `loom.toml` 是潛在 footgun，值得在後續 PR 處理。

## Out of scope

- `loom init` interactive wizard（用範本檔取代，避免新 code path）
- PyPI 發布（user 確認「git pull workflow 夠用」）
- 自動偵測 `.env` 缺哪個 API key（未來可考慮，但這 PR 不擴大邊界）

🤖 Generated with [Claude Code](https://claude.com/claude-code)