### PR TITLE
feat(cognition): add xAI OAuth provider

### DIFF
--- a/loom.toml.example
+++ b/loom.toml.example
@@ -110,6 +110,14 @@ reminder_after_turns = 10
 # enabled       = true                 # optional; explicit --model codex/... also registers it
 # base_url      = "https://chatgpt.com/backend-api/codex/responses"
 # default_model = "gpt-5.5"            # bare model name — no "codex/" prefix here
+
+# [providers.xai_oauth]
+# enabled       = true                 # optional; explicit --model xai/... also registers it
+# base_url      = "https://api.x.ai/v1/responses"
+# default_model = "grok-4.3"           # bare model name — no "xai/" prefix here
+#
+# xAI is OAuth-only in Loom. Run `loom auth xai`; XAI_API_KEY is intentionally
+# not used by the xai/<model> provider.
 #
 # ─────────────────────────────────────────────
 # Image generation

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -9,6 +9,7 @@ Supported providers
 -------------------
 OpenAIProvider     — api.openai.com/v1 (OpenAI-compatible chat completions)
 CodexResponsesProvider — chatgpt.com/backend-api/codex/responses (Codex OAuth)
+XAIResponsesProvider — api.x.ai/v1/responses (xAI OAuth)
 AnthropicProvider  — api.anthropic.com  (also MiniMax via base_url="https://api.minimax.io/anthropic")
 OpenRouterProvider — openrouter.ai/api/v1 (OpenAI-compatible aggregator)
 DeepSeek           — official api.deepseek.com via Anthropic-compatible endpoint
@@ -909,6 +910,17 @@ class CodexResponsesProvider(LLMProvider):
     def _api_model(self) -> str:
         return self.model.removeprefix(self.ROUTING_PREFIX)
 
+    def _load_bearer_token(self) -> str:
+        from loom.core.cognition.openai_auth import load_codex_oauth_credential
+
+        credential = load_codex_oauth_credential()
+        if credential is None:
+            raise RuntimeError(
+                "No unexpired Codex OAuth token found. Run `codex login` "
+                "or switch to an API-key OpenAI model such as `gpt-5.5`."
+            )
+        return credential.token
+
     def _build_payload(
         self,
         messages: list[dict[str, Any]],
@@ -1008,15 +1020,8 @@ class CodexResponsesProvider(LLMProvider):
         abort_signal: Any = None,
     ) -> AsyncIterator[tuple[str, LLMResponse | None]]:
         import httpx
-        from loom.core.cognition.openai_auth import load_codex_oauth_credential
 
-        credential = load_codex_oauth_credential()
-        if credential is None:
-            raise RuntimeError(
-                "No unexpired Codex OAuth token found. Run `codex login` "
-                "or switch to an API-key OpenAI model such as `gpt-5.5`."
-            )
-
+        bearer = self._load_bearer_token()
         payload = self._build_payload(messages, tools, max_tokens)
         full_content = ""
         output_items: list[dict[str, Any]] = []
@@ -1031,7 +1036,7 @@ class CodexResponsesProvider(LLMProvider):
                 "POST",
                 self._base_url,
                 headers={
-                    "Authorization": f"Bearer {credential.token}",
+                    "Authorization": f"Bearer {bearer}",
                     "Content-Type": "application/json",
                     "Accept": "text/event-stream",
                 },
@@ -1117,6 +1122,32 @@ class CodexResponsesProvider(LLMProvider):
             "tool_call_id": tool_use_id,
             "content": content if success else f"Error: {content}",
         }
+
+
+class XAIResponsesProvider(CodexResponsesProvider):
+    """
+    xAI Grok OAuth chat via xAI's Responses API.
+
+    Routing prefix: ``xai/``. This provider intentionally has no
+    ``XAI_API_KEY`` fallback; selecting ``xai/...`` means OAuth only.
+    """
+
+    name = "xai"
+    ROUTING_PREFIX = "xai/"
+    DEFAULT_MODEL = "grok-4.3"
+    DEFAULT_BASE_URL = "https://api.x.ai/v1/responses"
+    DEFAULT_TIMEOUT = 180.0
+
+    def _load_bearer_token(self) -> str:
+        from loom.core.cognition.xai_auth import load_xai_oauth_credential
+
+        credential = load_xai_oauth_credential()
+        if credential is None:
+            raise RuntimeError(
+                "No unexpired xAI OAuth token found. Run `loom auth xai` "
+                "before using an OAuth model such as `xai/grok-4.3`."
+            )
+        return credential.token
 
 
 class LMStudioProvider(_OpenAICompatibleBase):

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -1130,6 +1130,8 @@ class XAIResponsesProvider(CodexResponsesProvider):
 
     Routing prefix: ``xai/``. This provider intentionally has no
     ``XAI_API_KEY`` fallback; selecting ``xai/...`` means OAuth only.
+    Coupled to ``CodexResponsesProvider``'s Responses SSE shape; revisit if
+    xAI diverges from that protocol.
     """
 
     name = "xai"

--- a/loom/core/cognition/router.py
+++ b/loom/core/cognition/router.py
@@ -12,6 +12,7 @@ Model routing rules
 "gpt-*"        → OpenAIProvider
 "openai/*"     → OpenAIProvider
 "codex/*"      → CodexResponsesProvider
+"xai/*"        → XAIResponsesProvider
 "ollama/*"     → OllamaProvider    (local Ollama server)
 "lmstudio/*"   → LMStudioProvider  (local LM Studio server)
 (default)      → first registered provider
@@ -59,6 +60,7 @@ class LLMRouter:
         ("gpt-",       "openai"),
         ("openai/",    "openai"),
         ("codex/",     "codex"),
+        ("xai/",       "xai"),
         ("openrouter/", "openrouter"),
         ("deepseek-",  "deepseek"),
         ("ollama/",    "ollama"),

--- a/loom/core/cognition/xai_auth.py
+++ b/loom/core/cognition/xai_auth.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import logging
 import os
 import secrets
 import threading
@@ -23,6 +24,8 @@ from typing import Any
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
 XAI_OAUTH_ISSUER = "https://auth.x.ai"
@@ -172,6 +175,13 @@ def exchange_xai_code_for_tokens(
     code_challenge: str,
     timeout_seconds: float = 20.0,
 ) -> dict[str, Any]:
+    """Exchange an authorization code for xAI tokens.
+
+    xAI's OAuth flow accepts the S256 challenge fields on the token request;
+    Loom sends them together with the required ``code_verifier`` for parity
+    with xAI's browser CLI flow.
+    """
+
     response = httpx.post(
         _validate_xai_oauth_endpoint(token_endpoint, field="token_endpoint"),
         headers={"Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"},
@@ -238,7 +248,13 @@ def _start_callback_server() -> tuple[HTTPServer, threading.Thread, dict[str, An
         allow_reuse_address = True
         daemon_threads = True
 
-    server = _ReuseHTTPServer((XAI_OAUTH_REDIRECT_HOST, XAI_OAUTH_REDIRECT_PORT), handler_cls)
+    try:
+        server = _ReuseHTTPServer((XAI_OAUTH_REDIRECT_HOST, XAI_OAUTH_REDIRECT_PORT), handler_cls)
+    except OSError as exc:
+        raise XAIAuthError(
+            f"xAI OAuth callback port {XAI_OAUTH_REDIRECT_PORT} is unavailable. "
+            "Close the process using it, then run `loom auth xai` again."
+        ) from exc
     redirect_uri = f"http://{XAI_OAUTH_REDIRECT_HOST}:{server.server_address[1]}{XAI_OAUTH_REDIRECT_PATH}"
     thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.1}, daemon=True)
     thread.start()
@@ -270,7 +286,11 @@ def run_xai_oauth_login(
     open_browser: bool = True,
     timeout_seconds: float = 180.0,
 ) -> dict[str, Any]:
-    """Run browser-based xAI OAuth login and return auth state."""
+    """Run browser-based xAI OAuth login and return unsaved auth state.
+
+    The caller is responsible for persisting the returned state with
+    ``save_xai_oauth_state()``.
+    """
 
     discovery = xai_oauth_discovery(timeout_seconds)
     server, thread, callback_result, redirect_uri = _start_callback_server()
@@ -344,9 +364,8 @@ def validate_xai_base_url(value: str, *, fallback: str = DEFAULT_XAI_BASE_URL) -
         return fallback
     parsed = urlparse(candidate)
     host = (parsed.hostname or "").lower()
-    if parsed.scheme != "https":
-        return fallback
-    if host != "x.ai" and not host.endswith(".x.ai"):
+    if parsed.scheme != "https" or (host != "x.ai" and not host.endswith(".x.ai")):
+        logger.warning("Refusing xAI base_url override %r; using %s", candidate, fallback)
         return fallback
     return candidate
 

--- a/loom/core/cognition/xai_auth.py
+++ b/loom/core/cognition/xai_auth.py
@@ -1,0 +1,431 @@
+"""xAI OAuth credential helpers.
+
+This module is intentionally OAuth-only. It never reads ``XAI_API_KEY`` so an
+``xai/...`` OAuth path cannot silently spend API-key quota.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+import threading
+import time
+import uuid
+import webbrowser
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import httpx
+
+DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
+XAI_OAUTH_ISSUER = "https://auth.x.ai"
+XAI_OAUTH_DISCOVERY_URL = f"{XAI_OAUTH_ISSUER}/.well-known/openid-configuration"
+XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
+XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access"
+XAI_OAUTH_REDIRECT_HOST = "127.0.0.1"
+XAI_OAUTH_REDIRECT_PORT = 56121
+XAI_OAUTH_REDIRECT_PATH = "/callback"
+
+
+@dataclass(frozen=True)
+class XAICredential:
+    """Bearer credential plus non-secret provenance."""
+
+    token: str
+    source: str
+    base_url: str
+    expires_at: int | None = None
+
+
+class XAIAuthError(RuntimeError):
+    """xAI OAuth setup failed."""
+
+
+def loom_auth_path() -> Path:
+    """Return Loom's auth store path."""
+
+    home = Path(os.environ.get("LOOM_HOME", Path.home() / ".loom"))
+    return home / "auth.json"
+
+
+def _jwt_exp(token: str) -> int | None:
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    payload = parts[1] + "=" * ((4 - len(parts[1]) % 4) % 4)
+    try:
+        data = json.loads(base64.urlsafe_b64decode(payload.encode("ascii")))
+    except Exception:
+        return None
+    exp = data.get("exp")
+    return int(exp) if isinstance(exp, (int, float)) else None
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _read_auth_store(path: Path | None = None) -> dict[str, Any]:
+    auth_path = path or loom_auth_path()
+    try:
+        raw = json.loads(auth_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _write_auth_store(store: dict[str, Any], path: Path | None = None) -> Path:
+    auth_path = path or loom_auth_path()
+    auth_path.parent.mkdir(parents=True, exist_ok=True)
+    auth_path.parent.chmod(0o700)
+    tmp_path = auth_path.with_suffix(auth_path.suffix + ".tmp")
+    tmp_path.write_text(json.dumps(store, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp_path.chmod(0o600)
+    tmp_path.replace(auth_path)
+    return auth_path
+
+
+def save_xai_oauth_state(state: dict[str, Any], path: Path | None = None) -> Path:
+    store = _read_auth_store(path)
+    store["xai_oauth"] = state
+    return _write_auth_store(store, path)
+
+
+def _validate_xai_oauth_endpoint(url: str, *, field: str) -> str:
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme != "https" or (host != "x.ai" and not host.endswith(".x.ai")):
+        raise XAIAuthError(f"xAI OIDC discovery returned invalid {field}: {url!r}")
+    return url
+
+
+def xai_oauth_discovery(timeout_seconds: float = 15.0) -> dict[str, str]:
+    try:
+        response = httpx.get(
+            XAI_OAUTH_DISCOVERY_URL,
+            headers={"Accept": "application/json"},
+            timeout=max(5.0, timeout_seconds),
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as exc:
+        raise XAIAuthError(f"xAI OIDC discovery failed: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise XAIAuthError("xAI OIDC discovery response was not a JSON object.")
+    authorization_endpoint = str(payload.get("authorization_endpoint", "") or "").strip()
+    token_endpoint = str(payload.get("token_endpoint", "") or "").strip()
+    if not authorization_endpoint or not token_endpoint:
+        raise XAIAuthError("xAI OIDC discovery response was missing required endpoints.")
+    return {
+        "authorization_endpoint": _validate_xai_oauth_endpoint(
+            authorization_endpoint, field="authorization_endpoint"
+        ),
+        "token_endpoint": _validate_xai_oauth_endpoint(token_endpoint, field="token_endpoint"),
+    }
+
+
+def _oauth_pkce_code_verifier() -> str:
+    return secrets.token_urlsafe(64)[:128]
+
+
+def _oauth_pkce_code_challenge(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def build_xai_authorize_url(
+    *,
+    authorization_endpoint: str,
+    redirect_uri: str,
+    code_challenge: str,
+    state: str,
+    nonce: str,
+) -> str:
+    params = {
+        "response_type": "code",
+        "client_id": XAI_OAUTH_CLIENT_ID,
+        "redirect_uri": redirect_uri,
+        "scope": XAI_OAUTH_SCOPE,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+        "nonce": nonce,
+        "plan": "generic",
+        "referrer": "loom",
+    }
+    return f"{authorization_endpoint}?{urlencode(params)}"
+
+
+def exchange_xai_code_for_tokens(
+    *,
+    token_endpoint: str,
+    code: str,
+    redirect_uri: str,
+    code_verifier: str,
+    code_challenge: str,
+    timeout_seconds: float = 20.0,
+) -> dict[str, Any]:
+    response = httpx.post(
+        _validate_xai_oauth_endpoint(token_endpoint, field="token_endpoint"),
+        headers={"Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"},
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": XAI_OAUTH_CLIENT_ID,
+            "code_verifier": code_verifier,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        },
+        timeout=max(20.0, timeout_seconds),
+    )
+    if response.status_code != 200:
+        body = response.text.strip()
+        raise XAIAuthError(
+            f"xAI token exchange failed (HTTP {response.status_code})."
+            + (f" Response: {body}" if body else "")
+        )
+    payload = response.json()
+    if not isinstance(payload, dict) or not payload.get("access_token") or not payload.get("refresh_token"):
+        raise XAIAuthError("xAI token exchange did not return access_token and refresh_token.")
+    return payload
+
+
+def _make_callback_handler(expected_path: str) -> tuple[type[BaseHTTPRequestHandler], dict[str, Any]]:
+    result: dict[str, Any] = {"code": None, "state": None, "error": None, "error_description": None}
+    result_lock = threading.Lock()
+
+    class _CallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            if parsed.path != expected_path:
+                self.send_response(404)
+                self.end_headers()
+                return
+            params = parse_qs(parsed.query)
+            incoming = {
+                "code": params.get("code", [None])[0],
+                "state": params.get("state", [None])[0],
+                "error": params.get("error", [None])[0],
+                "error_description": params.get("error_description", [None])[0],
+            }
+            with result_lock:
+                if not (result["code"] or result["error"]):
+                    result.update(incoming)
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            title = "xAI authorization failed." if incoming["error"] else "xAI authorization received."
+            self.wfile.write(f"<html><body><h1>{title}</h1>You can close this tab.</body></html>".encode())
+
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
+            return
+
+    return _CallbackHandler, result
+
+
+def _start_callback_server() -> tuple[HTTPServer, threading.Thread, dict[str, Any], str]:
+    handler_cls, result = _make_callback_handler(XAI_OAUTH_REDIRECT_PATH)
+
+    class _ReuseHTTPServer(ThreadingHTTPServer):
+        allow_reuse_address = True
+        daemon_threads = True
+
+    server = _ReuseHTTPServer((XAI_OAUTH_REDIRECT_HOST, XAI_OAUTH_REDIRECT_PORT), handler_cls)
+    redirect_uri = f"http://{XAI_OAUTH_REDIRECT_HOST}:{server.server_address[1]}{XAI_OAUTH_REDIRECT_PATH}"
+    thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.1}, daemon=True)
+    thread.start()
+    return server, thread, result, redirect_uri
+
+
+def _wait_for_callback(
+    server: HTTPServer,
+    thread: threading.Thread,
+    result: dict[str, Any],
+    *,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + max(30.0, timeout_seconds)
+    try:
+        while time.monotonic() < deadline:
+            if result["code"] or result["error"]:
+                return result
+            time.sleep(0.1)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
+    raise XAIAuthError("xAI authorization timed out waiting for the local callback.")
+
+
+def run_xai_oauth_login(
+    *,
+    open_browser: bool = True,
+    timeout_seconds: float = 180.0,
+) -> dict[str, Any]:
+    """Run browser-based xAI OAuth login and return auth state."""
+
+    discovery = xai_oauth_discovery(timeout_seconds)
+    server, thread, callback_result, redirect_uri = _start_callback_server()
+    code_verifier = _oauth_pkce_code_verifier()
+    code_challenge = _oauth_pkce_code_challenge(code_verifier)
+    state = uuid.uuid4().hex
+    nonce = uuid.uuid4().hex
+    authorize_url = build_xai_authorize_url(
+        authorization_endpoint=discovery["authorization_endpoint"],
+        redirect_uri=redirect_uri,
+        code_challenge=code_challenge,
+        state=state,
+        nonce=nonce,
+    )
+    print("Open this URL to authorize Loom with xAI:")
+    print(authorize_url)
+    print()
+    print(f"Waiting for callback on {redirect_uri}")
+    if open_browser:
+        try:
+            webbrowser.open(authorize_url)
+        except Exception:
+            pass
+    callback = _wait_for_callback(
+        server,
+        thread,
+        callback_result,
+        timeout_seconds=timeout_seconds,
+    )
+    if callback.get("error"):
+        detail = callback.get("error_description") or callback["error"]
+        raise XAIAuthError(f"xAI authorization failed: {detail}")
+    if callback.get("state") != state:
+        raise XAIAuthError("xAI authorization failed: state mismatch.")
+    code = str(callback.get("code") or "").strip()
+    if not code:
+        raise XAIAuthError("xAI authorization failed: missing authorization code.")
+    payload = exchange_xai_code_for_tokens(
+        token_endpoint=discovery["token_endpoint"],
+        code=code,
+        redirect_uri=redirect_uri,
+        code_verifier=code_verifier,
+        code_challenge=code_challenge,
+        timeout_seconds=timeout_seconds,
+    )
+    return {
+        "tokens": {
+            "access_token": str(payload["access_token"]).strip(),
+            "refresh_token": str(payload["refresh_token"]).strip(),
+            "id_token": str(payload.get("id_token", "") or "").strip(),
+            "expires_in": payload.get("expires_in"),
+            "token_type": str(payload.get("token_type") or "Bearer").strip() or "Bearer",
+        },
+        "discovery": discovery,
+        "redirect_uri": redirect_uri,
+        "base_url": DEFAULT_XAI_BASE_URL,
+        "last_refresh": _utc_now(),
+    }
+
+
+def load_xai_oauth_state(path: Path | None = None) -> dict[str, Any] | None:
+    state = _read_auth_store(path).get("xai_oauth")
+    return state if isinstance(state, dict) else None
+
+
+def validate_xai_base_url(value: str, *, fallback: str = DEFAULT_XAI_BASE_URL) -> str:
+    """Return an HTTPS xAI-origin base URL, ignoring unsafe overrides."""
+
+    candidate = (value or "").strip().rstrip("/")
+    if not candidate:
+        return fallback
+    parsed = urlparse(candidate)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme != "https":
+        return fallback
+    if host != "x.ai" and not host.endswith(".x.ai"):
+        return fallback
+    return candidate
+
+
+def refresh_xai_oauth_state(
+    state: dict[str, Any],
+    *,
+    path: Path | None = None,
+    timeout_seconds: float = 20.0,
+) -> dict[str, Any]:
+    tokens = state.get("tokens") if isinstance(state.get("tokens"), dict) else {}
+    refresh_token = str(tokens.get("refresh_token", "") or "").strip()
+    if not refresh_token:
+        raise XAIAuthError("xAI OAuth state is missing refresh_token. Run `loom auth xai` again.")
+    discovery = state.get("discovery") if isinstance(state.get("discovery"), dict) else {}
+    token_endpoint = str(discovery.get("token_endpoint", "") or "").strip()
+    if not token_endpoint:
+        discovery = xai_oauth_discovery(timeout_seconds)
+        token_endpoint = discovery["token_endpoint"]
+    response = httpx.post(
+        _validate_xai_oauth_endpoint(token_endpoint, field="token_endpoint"),
+        headers={"Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"},
+        data={
+            "grant_type": "refresh_token",
+            "client_id": XAI_OAUTH_CLIENT_ID,
+            "refresh_token": refresh_token,
+        },
+        timeout=max(20.0, timeout_seconds),
+    )
+    if response.status_code != 200:
+        body = response.text.strip()
+        raise XAIAuthError(
+            f"xAI token refresh failed (HTTP {response.status_code})."
+            + (f" Response: {body}" if body else "")
+        )
+    payload = response.json()
+    if not isinstance(payload, dict) or not payload.get("access_token"):
+        raise XAIAuthError("xAI token refresh did not return access_token.")
+    updated = dict(state)
+    updated["tokens"] = dict(tokens)
+    updated["tokens"]["access_token"] = str(payload["access_token"]).strip()
+    updated["tokens"]["refresh_token"] = str(payload.get("refresh_token") or refresh_token).strip()
+    if payload.get("id_token"):
+        updated["tokens"]["id_token"] = str(payload["id_token"]).strip()
+    if payload.get("expires_in") is not None:
+        updated["tokens"]["expires_in"] = payload.get("expires_in")
+    updated["tokens"]["token_type"] = str(payload.get("token_type") or "Bearer").strip() or "Bearer"
+    updated["discovery"] = discovery
+    updated["last_refresh"] = _utc_now()
+    save_xai_oauth_state(updated, path)
+    return updated
+
+
+def load_xai_oauth_credential(
+    path: Path | None = None,
+    *,
+    refresh: bool = True,
+) -> XAICredential | None:
+    """Load an unexpired xAI OAuth bearer if one is available."""
+
+    state = load_xai_oauth_state(path)
+    if not state:
+        return None
+    tokens = state.get("tokens") if isinstance(state.get("tokens"), dict) else {}
+    access_token = str(tokens.get("access_token", "") or "").strip()
+    if not access_token:
+        return None
+    expires_at = _jwt_exp(access_token)
+    if refresh and expires_at is not None and expires_at <= time.time():
+        state = refresh_xai_oauth_state(state, path=path)
+        tokens = state.get("tokens") if isinstance(state.get("tokens"), dict) else {}
+        access_token = str(tokens.get("access_token", "") or "").strip()
+        expires_at = _jwt_exp(access_token)
+    if expires_at is not None and expires_at <= time.time():
+        return None
+    base_url = validate_xai_base_url(str(state.get("base_url", "") or ""))
+    return XAICredential(
+        token=access_token,
+        source="xai_oauth",
+        base_url=base_url,
+        expires_at=expires_at,
+    )

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -542,6 +542,7 @@ def build_router(active_model: str | None = None) -> LLMRouter:
         OpenAIProvider,
         OpenRouterProvider,
     )
+    from loom.core.cognition.xai_auth import validate_xai_base_url
 
     env = _load_env()
     cfg = _load_loom_config()
@@ -635,20 +636,21 @@ def build_router(active_model: str | None = None) -> LLMRouter:
     xai_default = default.startswith("xai/")
     xai_enabled = bool(xai_cfg.get("enabled", False))
     if xai_requested or xai_default or xai_enabled:
-        xai_model = xai_cfg.get("default_model", XAIResponsesProvider.DEFAULT_MODEL)
         if requested_model.startswith("xai/"):
             xai_model = requested_model
         elif default.startswith("xai/"):
             xai_model = default
         else:
-            xai_model = f"xai/{xai_model}"
+            raw_xai_model = str(xai_cfg.get("default_model", XAIResponsesProvider.DEFAULT_MODEL)).strip()
+            xai_model = f"xai/{raw_xai_model.removeprefix('xai/') or XAIResponsesProvider.DEFAULT_MODEL}"
+        xai_base_url = validate_xai_base_url(
+            str(xai_cfg.get("base_url", "") or "").rstrip("/"),
+            fallback=XAIResponsesProvider.DEFAULT_BASE_URL,
+        )
         router.register(
             XAIResponsesProvider(
                 model=xai_model,
-                base_url=(
-                    str(xai_cfg.get("base_url", "") or "").rstrip("/")
-                    or XAIResponsesProvider.DEFAULT_BASE_URL
-                ),
+                base_url=xai_base_url,
             ),
             default=xai_default or xai_requested,
             fallback=xai_default or xai_requested,

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -525,6 +525,7 @@ def build_router(active_model: str | None = None) -> LLMRouter:
       Anthropic  — ANTHROPIC_API_KEY
       OpenAI     — OPENAI_API_KEY
       Codex      — Codex OAuth from `codex login` (explicit codex/<model> prefix)
+      xAI        — xAI OAuth from `loom auth xai` (explicit xai/<model> prefix)
       OpenRouter — OPENROUTER_API_KEY (OpenAI-compatible multi-vendor aggregator)
       DeepSeek   — DEEPSEEK_API_KEY   (official DeepSeek API, OpenAI-compatible)
 
@@ -537,6 +538,7 @@ def build_router(active_model: str | None = None) -> LLMRouter:
         OllamaProvider,
         LMStudioProvider,
         CodexResponsesProvider,
+        XAIResponsesProvider,
         OpenAIProvider,
         OpenRouterProvider,
     )
@@ -623,6 +625,33 @@ def build_router(active_model: str | None = None) -> LLMRouter:
             ),
             default=codex_default or codex_requested,
             fallback=codex_default or codex_requested,
+        )
+
+    # xAI OAuth — explicit opt-in via xai/<model>. This path intentionally
+    # has no XAI_API_KEY fallback so OAuth subscription use and API spend
+    # cannot be confused.
+    xai_cfg = cfg.get("providers", {}).get("xai_oauth", {})
+    xai_requested = requested_model.startswith("xai/")
+    xai_default = default.startswith("xai/")
+    xai_enabled = bool(xai_cfg.get("enabled", False))
+    if xai_requested or xai_default or xai_enabled:
+        xai_model = xai_cfg.get("default_model", XAIResponsesProvider.DEFAULT_MODEL)
+        if requested_model.startswith("xai/"):
+            xai_model = requested_model
+        elif default.startswith("xai/"):
+            xai_model = default
+        else:
+            xai_model = f"xai/{xai_model}"
+        router.register(
+            XAIResponsesProvider(
+                model=xai_model,
+                base_url=(
+                    str(xai_cfg.get("base_url", "") or "").rstrip("/")
+                    or XAIResponsesProvider.DEFAULT_BASE_URL
+                ),
+            ),
+            default=xai_default or xai_requested,
+            fallback=xai_default or xai_requested,
         )
 
     # OpenRouter — OpenAI-compatible aggregator. Single key fronts many vendors.
@@ -718,7 +747,8 @@ def build_router(active_model: str | None = None) -> LLMRouter:
         raise RuntimeError(
             "No LLM provider configured. "
             "Add MINIMAX_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY, or DEEPSEEK_API_KEY to .env, "
-            "or enable a local provider in loom.toml ([providers.ollama] / [providers.lmstudio])."
+            "run `loom auth xai` for xAI OAuth, or enable a local provider in loom.toml "
+            "([providers.ollama] / [providers.lmstudio])."
         )
     return router
 

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -809,6 +809,7 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
                 "[loom.muted]  gpt-*               requires OPENAI_API_KEY in .env (try `loom auth openai`)[/loom.muted]\n"
                 "[loom.muted]  openai/<model>      explicit OpenAI prefix (e.g. openai/gpt-5.5)[/loom.muted]\n"
                 "[loom.muted]  codex/<model>       Codex OAuth backend (e.g. codex/gpt-5.5; run `codex login`)[/loom.muted]\n"
+                "[loom.muted]  xai/<model>         xAI OAuth backend (e.g. xai/grok-4.3; run `loom auth xai`)[/loom.muted]\n"
                 "[loom.muted]  openrouter/<v>/<m>  requires OPENROUTER_API_KEY in .env (e.g. openrouter/deepseek/deepseek-v4-pro)[/loom.muted]\n"
                 "[loom.muted]  deepseek-*          requires DEEPSEEK_API_KEY in .env  (e.g. deepseek-v4-pro)[/loom.muted]\n"
                 "[loom.muted]  ollama/<name>       enable [providers.ollama] in loom.toml[/loom.muted]\n"
@@ -1122,6 +1123,7 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
                 "    [loom.muted]claude-sonnet-4-6       → Anthropic (ANTHROPIC_API_KEY)[/loom.muted]\n"
                 "    [loom.muted]gpt-5.5 / gpt-5.5-pro   → OpenAI (OPENAI_API_KEY; run `loom auth openai`)[/loom.muted]\n"
                 "    [loom.muted]codex/gpt-5.5           → Codex OAuth backend (run `codex login`)[/loom.muted]\n"
+                "    [loom.muted]xai/grok-4.3            → xAI OAuth backend (run `loom auth xai`; no XAI_API_KEY fallback)[/loom.muted]\n"
                 "    [loom.muted]ollama/<model>          → local Ollama  (enable in loom.toml)[/loom.muted]\n"
                 "    [loom.muted]lmstudio/<model>        → local LM Studio  (enable in loom.toml)[/loom.muted]\n"
                 "  [loom.warning]/theme[/loom.warning]                    Show available CLI themes\n"
@@ -1969,6 +1971,39 @@ def auth_openai(api_key: str | None, skip_codex_login: bool, env_file: Path | No
             "[loom.muted]No API key saved. Codex CLI login is still useful for "
             "`codex`, but Loom needs OPENAI_API_KEY for OpenAI provider calls.[/loom.muted]"
         )
+
+
+@auth.command("xai")
+@click.option("--no-browser", is_flag=True, default=False,
+              help="Print the xAI OAuth URL without opening a browser.")
+@click.option("--timeout", default=180.0, show_default=True,
+              help="Seconds to wait for the local OAuth callback.")
+def auth_xai(no_browser: bool, timeout: float) -> None:
+    """Run xAI OAuth login for Loom."""
+    from loom.core.cognition.xai_auth import (
+        XAIAuthError,
+        run_xai_oauth_login,
+        save_xai_oauth_state,
+    )
+
+    console.print("[loom.muted]xAI OAuth setup for Loom[/loom.muted]")
+    console.print(
+        "[loom.muted]This path is OAuth-only; Loom will not use an xAI API key "
+        "for xai/<model>.[/loom.muted]"
+    )
+    try:
+        state = run_xai_oauth_login(
+            open_browser=not no_browser,
+            timeout_seconds=timeout,
+        )
+        saved_to = save_xai_oauth_state(state)
+    except XAIAuthError as exc:
+        console.print(f"[loom.error]xAI OAuth failed: {exc}[/loom.error]")
+        raise click.Abort() from exc
+
+    console.print("[loom.muted]xAI OAuth login completed.[/loom.muted]")
+    console.print(f"[loom.muted]Saved xAI OAuth credentials to {saved_to}.[/loom.muted]")
+    console.print("[loom.muted]Try: loom chat --model xai/grok-4.3[/loom.muted]")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -43,3 +43,33 @@ def test_auth_openai_api_key_is_non_interactive(tmp_path):
 
     assert result.exit_code == 0
     assert env_path.read_text(encoding="utf-8") == "OPENAI_API_KEY=sk-test\n"
+
+
+def test_auth_xai_runs_oauth_only_login(tmp_path, monkeypatch):
+    from loom.core.cognition import xai_auth
+
+    monkeypatch.setenv("LOOM_HOME", str(tmp_path / "loom-home"))
+    monkeypatch.setenv("XAI_API_KEY", "xai-api-key-that-must-not-be-used")
+    calls = []
+
+    def fake_login(*, open_browser, timeout_seconds):
+        calls.append({"open_browser": open_browser, "timeout_seconds": timeout_seconds})
+        return {
+            "tokens": {
+                "access_token": "oauth-access-token",
+                "refresh_token": "oauth-refresh-token",
+            },
+            "base_url": xai_auth.DEFAULT_XAI_BASE_URL,
+        }
+
+    monkeypatch.setattr(xai_auth, "run_xai_oauth_login", fake_login)
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["auth", "xai", "--no-browser", "--timeout", "12"])
+
+    assert result.exit_code == 0
+    assert calls == [{"open_browser": False, "timeout_seconds": 12.0}]
+    auth_text = (tmp_path / "loom-home" / "auth.json").read_text(encoding="utf-8")
+    assert "oauth-access-token" in auth_text
+    assert "xai-api-key-that-must-not-be-used" not in auth_text
+    assert "XAI_API_KEY" not in result.output

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -64,6 +64,24 @@ class TestBuildRouter:
         assert "codex" in router.providers
         assert router.get_provider("codex/gpt-5.5").name == "codex"
 
+    def test_registers_xai_oauth_provider_only_when_requested(self, monkeypatch: pytest.MonkeyPatch):
+        from loom.core import session as session_module
+
+        monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {
+            "XAI_API_KEY": "xai-api-key-that-must-not-register",
+        })
+        monkeypatch.setattr(session_module, "_load_loom_config", lambda: {
+            "cognition": {"default_model": "MiniMax-M2.7"},
+        })
+
+        with pytest.raises(RuntimeError, match="No LLM provider configured"):
+            session_module.build_router()
+
+        router = session_module.build_router(active_model="xai/grok-4.3")
+
+        assert "xai" in router.providers
+        assert router.get_provider("xai/grok-4.3").name == "xai"
+
 
 class TestSetModel:
     def test_lazy_registers_codex_provider_on_switch(self, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_xai_oauth_auth.py
+++ b/tests/test_xai_oauth_auth.py
@@ -1,12 +1,17 @@
 import base64
 import json
+import logging
 import time
+
+import pytest
 
 from loom.core.cognition.xai_auth import (
     DEFAULT_XAI_BASE_URL,
+    XAIAuthError,
     load_xai_oauth_credential,
     run_xai_oauth_login,
     save_xai_oauth_state,
+    validate_xai_base_url,
 )
 
 
@@ -104,6 +109,28 @@ def test_load_xai_oauth_credential_rejects_non_xai_base_url(tmp_path, monkeypatc
 
     assert credential is not None
     assert credential.base_url == DEFAULT_XAI_BASE_URL
+
+
+def test_validate_xai_base_url_warns_when_rejecting_unsafe_override(caplog):
+    caplog.set_level(logging.WARNING, logger="loom.core.cognition.xai_auth")
+
+    assert validate_xai_base_url("https://attacker.example/v1/responses") == DEFAULT_XAI_BASE_URL
+
+    assert "Refusing xAI base_url override" in caplog.text
+    assert "attacker.example" in caplog.text
+
+
+def test_start_callback_server_reports_port_binding_failure(monkeypatch):
+    from loom.core.cognition import xai_auth
+
+    class _BindFailureServer:
+        def __init__(self, *args, **kwargs):
+            raise OSError("address already in use")
+
+    monkeypatch.setattr(xai_auth, "ThreadingHTTPServer", _BindFailureServer)
+
+    with pytest.raises(XAIAuthError, match="port 56121"):
+        xai_auth._start_callback_server()
 
 
 def test_run_xai_oauth_login_uses_pkce_callback_and_token_exchange(monkeypatch):

--- a/tests/test_xai_oauth_auth.py
+++ b/tests/test_xai_oauth_auth.py
@@ -1,0 +1,157 @@
+import base64
+import json
+import time
+
+from loom.core.cognition.xai_auth import (
+    DEFAULT_XAI_BASE_URL,
+    load_xai_oauth_credential,
+    run_xai_oauth_login,
+    save_xai_oauth_state,
+)
+
+
+def _jwt(exp: int) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"exp": exp}).encode()
+    ).rstrip(b"=").decode()
+    return f"{header}.{payload}."
+
+
+def test_load_xai_oauth_credential_reads_saved_oauth_token(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOOM_HOME", str(tmp_path / "loom-home"))
+    token = _jwt(int(time.time()) + 3600)
+    save_xai_oauth_state({
+        "tokens": {
+            "access_token": token,
+            "refresh_token": "refresh-secret",
+            "token_type": "Bearer",
+        },
+        "base_url": DEFAULT_XAI_BASE_URL,
+    })
+
+    credential = load_xai_oauth_credential(refresh=False)
+
+    assert credential is not None
+    assert credential.source == "xai_oauth"
+    assert credential.token == token
+    assert credential.base_url == DEFAULT_XAI_BASE_URL
+
+
+def test_load_xai_oauth_credential_ignores_xai_api_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOOM_HOME", str(tmp_path / "loom-home"))
+    monkeypatch.setenv("XAI_API_KEY", "xai-api-key-that-must-not-be-used")
+
+    assert load_xai_oauth_credential(refresh=False) is None
+
+
+def test_load_xai_oauth_credential_refreshes_expired_token(tmp_path, monkeypatch):
+    from loom.core.cognition import xai_auth
+
+    monkeypatch.setenv("LOOM_HOME", str(tmp_path / "loom-home"))
+    expired = _jwt(int(time.time()) - 10)
+    refreshed = _jwt(int(time.time()) + 3600)
+    save_xai_oauth_state({
+        "tokens": {
+            "access_token": expired,
+            "refresh_token": "refresh-secret",
+        },
+        "discovery": {"token_endpoint": "https://auth.x.ai/oauth2/token"},
+        "base_url": DEFAULT_XAI_BASE_URL,
+    })
+    posts = []
+
+    class _Response:
+        status_code = 200
+        text = ""
+
+        def json(self):
+            return {
+                "access_token": refreshed,
+                "refresh_token": "rotated-refresh-secret",
+                "token_type": "Bearer",
+            }
+
+    def fake_post(url, headers=None, data=None, timeout=None):
+        posts.append({"url": url, "headers": headers, "data": data, "timeout": timeout})
+        return _Response()
+
+    monkeypatch.setattr(xai_auth.httpx, "post", fake_post)
+
+    credential = load_xai_oauth_credential()
+
+    assert credential is not None
+    assert credential.token == refreshed
+    assert posts[0]["url"] == "https://auth.x.ai/oauth2/token"
+    assert posts[0]["data"]["grant_type"] == "refresh_token"
+    assert posts[0]["data"]["refresh_token"] == "refresh-secret"
+    auth_text = (tmp_path / "loom-home" / "auth.json").read_text(encoding="utf-8")
+    assert "rotated-refresh-secret" in auth_text
+
+
+def test_load_xai_oauth_credential_rejects_non_xai_base_url(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOOM_HOME", str(tmp_path / "loom-home"))
+    token = _jwt(int(time.time()) + 3600)
+    save_xai_oauth_state({
+        "tokens": {
+            "access_token": token,
+            "refresh_token": "refresh-secret",
+        },
+        "base_url": "https://attacker.example/v1",
+    })
+
+    credential = load_xai_oauth_credential(refresh=False)
+
+    assert credential is not None
+    assert credential.base_url == DEFAULT_XAI_BASE_URL
+
+
+def test_run_xai_oauth_login_uses_pkce_callback_and_token_exchange(monkeypatch):
+    from loom.core.cognition import xai_auth
+
+    monkeypatch.setattr(
+        xai_auth,
+        "xai_oauth_discovery",
+        lambda timeout_seconds: {
+            "authorization_endpoint": "https://auth.x.ai/oauth2/auth",
+            "token_endpoint": "https://auth.x.ai/oauth2/token",
+        },
+    )
+    monkeypatch.setattr(
+        xai_auth,
+        "_start_callback_server",
+        lambda: (object(), object(), {}, "http://127.0.0.1:56121/callback"),
+    )
+    captured = {}
+
+    def fake_build_authorize_url(**kwargs):
+        captured.update(kwargs)
+        return "https://auth.x.ai/authorize"
+
+    def fake_wait_for_callback(server, thread, result, *, timeout_seconds):
+        return {"code": "auth-code", "state": captured["state"]}
+
+    def fake_exchange(**kwargs):
+        captured["exchange"] = kwargs
+        return {
+            "access_token": "oauth-access-token",
+            "refresh_token": "oauth-refresh-token",
+            "token_type": "Bearer",
+        }
+
+    monkeypatch.setattr(xai_auth, "build_xai_authorize_url", fake_build_authorize_url)
+    monkeypatch.setattr(xai_auth, "_wait_for_callback", fake_wait_for_callback)
+    monkeypatch.setattr(xai_auth, "exchange_xai_code_for_tokens", fake_exchange)
+
+    state = run_xai_oauth_login(open_browser=False, timeout_seconds=12)
+
+    assert captured["authorization_endpoint"] == "https://auth.x.ai/oauth2/auth"
+    assert captured["redirect_uri"] == "http://127.0.0.1:56121/callback"
+    assert captured["code_challenge"]
+    assert captured["nonce"]
+    assert captured["exchange"]["code"] == "auth-code"
+    assert captured["exchange"]["code_verifier"]
+    assert captured["exchange"]["code_challenge"] == captured["code_challenge"]
+    assert state["tokens"]["access_token"] == "oauth-access-token"
+    assert state["tokens"]["refresh_token"] == "oauth-refresh-token"
+    assert state["base_url"] == DEFAULT_XAI_BASE_URL

--- a/tests/test_xai_responses_provider.py
+++ b/tests/test_xai_responses_provider.py
@@ -88,3 +88,46 @@ async def test_xai_provider_streams_with_oauth_token_not_api_key(tmp_path, monke
     assert req["headers"]["Authorization"] == f"Bearer {token}"
     assert "xai-api-key-that-must-not-be-used" not in json.dumps(req)
     assert req["json"]["model"] == "grok-4.3"
+
+
+@pytest.mark.asyncio
+async def test_xai_router_rejects_config_base_url_before_streaming(tmp_path, monkeypatch):
+    import httpx
+    from loom.core import session as session_module
+
+    monkeypatch.setenv("LOOM_HOME", str(tmp_path / "loom-home"))
+    token = _jwt(int(time.time()) + 3600)
+    save_xai_oauth_state({
+        "tokens": {
+            "access_token": token,
+            "refresh_token": "refresh-secret",
+        },
+        "base_url": DEFAULT_XAI_BASE_URL,
+    })
+    monkeypatch.setattr(session_module, "_load_env", lambda project_root=None: {})
+    monkeypatch.setattr(session_module, "_load_loom_config", lambda: {
+        "cognition": {"default_model": "xai/grok-4.3"},
+        "providers": {
+            "xai_oauth": {
+                "enabled": True,
+                "base_url": "https://attacker.example/v1/responses",
+            },
+        },
+    })
+    fake_client = _FakeAsyncClient([
+        "event: response.output_text.delta",
+        'data: {"type":"response.output_text.delta","delta":"pong"}',
+        "",
+        "event: response.completed",
+        'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":3,"output_tokens":4}}}',
+        "",
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+
+    provider = session_module.build_router().get_provider("xai/grok-4.3")
+    response = await provider.chat(messages=[{"role": "user", "content": "ping"}])
+
+    assert response.text == "pong"
+    req = fake_client.requests[0]
+    assert req["url"] == "https://api.x.ai/v1/responses"
+    assert req["headers"]["Authorization"] == f"Bearer {token}"

--- a/tests/test_xai_responses_provider.py
+++ b/tests/test_xai_responses_provider.py
@@ -1,0 +1,90 @@
+import base64
+import json
+import time
+
+import pytest
+
+from loom.core.cognition.providers import XAIResponsesProvider
+from loom.core.cognition.xai_auth import DEFAULT_XAI_BASE_URL, save_xai_oauth_state
+
+
+def _jwt(exp: int) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"exp": exp}).encode()
+    ).rstrip(b"=").decode()
+    return f"{header}.{payload}."
+
+
+class _StreamResponse:
+    status_code = 200
+
+    def __init__(self, lines):
+        self._lines = lines
+
+    def raise_for_status(self):
+        return None
+
+    async def aiter_lines(self):
+        for line in self._lines:
+            yield line
+
+
+class _FakeAsyncClient:
+    def __init__(self, lines):
+        self.lines = lines
+        self.requests = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def stream(self, method, url, headers=None, json=None):
+        self.requests.append({"method": method, "url": url, "headers": headers, "json": json})
+
+        class _Ctx:
+            async def __aenter__(self_inner):
+                return _StreamResponse(self.lines)
+
+            async def __aexit__(self_inner, *exc):
+                return False
+
+        return _Ctx()
+
+
+@pytest.mark.asyncio
+async def test_xai_provider_streams_with_oauth_token_not_api_key(tmp_path, monkeypatch):
+    import httpx
+
+    monkeypatch.setenv("LOOM_HOME", str(tmp_path / "loom-home"))
+    monkeypatch.setenv("XAI_API_KEY", "xai-api-key-that-must-not-be-used")
+    token = _jwt(int(time.time()) + 3600)
+    save_xai_oauth_state({
+        "tokens": {
+            "access_token": token,
+            "refresh_token": "refresh-secret",
+        },
+        "base_url": DEFAULT_XAI_BASE_URL,
+    })
+
+    fake_client = _FakeAsyncClient([
+        "event: response.output_text.delta",
+        'data: {"type":"response.output_text.delta","delta":"pong"}',
+        "",
+        "event: response.completed",
+        'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":3,"output_tokens":4}}}',
+        "",
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = XAIResponsesProvider(model="xai/grok-4.3")
+
+    response = await provider.chat(messages=[{"role": "user", "content": "ping"}])
+
+    assert response.text == "pong"
+    req = fake_client.requests[0]
+    assert req["url"] == "https://api.x.ai/v1/responses"
+    assert req["headers"]["Authorization"] == f"Bearer {token}"
+    assert "xai-api-key-that-must-not-be-used" not in json.dumps(req)
+    assert req["json"]["model"] == "grok-4.3"


### PR DESCRIPTION
## Summary
- add an OAuth-only xAI credential store/login flow backed by `~/.loom/auth.json`
- register `xai/<model>` through an xAI Responses provider that never falls back to `XAI_API_KEY`
- document the opt-in `[providers.xai_oauth]` config and add focused regression coverage for OAuth loading, refresh, routing, CLI login, and provider streaming

## Review Notes
- This PR intentionally does not add an xAI API-key path. If `XAI_API_KEY` is present, it is ignored for `xai/<model>` so OAuth usage cannot accidentally spend API-key quota.
- Direct xAI tools are left for follow-up slices: X Search, image generation, and speech generation should reuse `load_xai_oauth_credential()` rather than introducing API-key fallback.
- The OAuth implementation pins discovery/token/base URLs to `x.ai` or `*.x.ai` to avoid leaking the bearer to an arbitrary override.

## Verification
- `pytest -q tests/test_xai_oauth_auth.py tests/test_xai_responses_provider.py tests/test_cli_auth.py tests/test_session.py::TestBuildRouter tests/test_codex_responses_provider.py` — 15 passed
- `python -m py_compile loom/core/cognition/xai_auth.py loom/core/cognition/providers.py loom/core/cognition/router.py loom/core/session.py loom/platform/cli/main.py`
- `git diff --check`
- `npx gitnexus detect-changes --scope staged` — risk low, affected processes 0
- `grep -rln "XAICredential\|XAIResponsesProvider\|xai_oauth\|xai_auth.py\|xai/<model>\|loom auth xai" doc/` — no matches