### PR TITLE
feat(tools): add tts_generate via xAI OAuth

### DIFF
--- a/doc/33-CLI-命令.md
+++ b/doc/33-CLI-命令.md
@@ -92,6 +92,34 @@ Codex OAuth access token；若 Codex backend 拒絕且 `.env` 有 `OPENAI_API_KE
 `subject_reference` 目前支援 Codex OAuth path，會把 workspace 內的參照圖轉成 Codex Responses
 `input_image`，用於角色或主體一致性；API key path 會明確拒絕而非靜默忽略。
 
+### `tts_generate`
+
+Agent 可用工具，將文字合成語音並寫入 workspace。預設不註冊；在 `loom.toml`
+設定 `[tools.tts].enabled = true` 且 `default_provider = "xai"` 後，Loom 會註冊
+canonical `tts_generate`，目前背後使用 xAI TTS（**OAuth-only**：先跑 `loom auth xai`；
+即使 `.env` 有 `XAI_API_KEY` 也刻意不使用，避免 OAuth 訂閱跟 API 計費混淆）：
+
+```json
+{
+  "text": "Hello from Loom.",
+  "voice_id": "eve",
+  "language": "auto",
+  "format": "mp3",
+  "speed": 1.0,
+  "output_path": "outputs/intro.mp3"
+}
+```
+
+`voice_id` 接受 xAI 內建 voice（`eve` / `ara` / `leo` / `rex` / `sal`）或 custom voice id。
+`language` 用 BCP-47 codes（如 `en` / `zh` / `pt-BR`）或 `auto`。`format` 支援
+`mp3 | wav | pcm | mulaw | alaw`；省略 `output_path` 時預設寫到
+`outputs/tts-<id>.<codec-ext>`。`speed`、`sample_rate`（Hz）與 `bit_rate`（bps，只對 mp3 生效）
+為選填；不送則由 xAI 用 server-side default（24 kHz / 128 kbps）。
+
+`auth_mode` 目前只有 `oauth` 一個有效值——這個欄位保留是為了未來加 path 時 schema
+不需要重塑。請求結束後工具回傳 `{path, provider, voice_id, format, bytes}` 給 agent，
+audio bytes 不會在回傳裡攜帶（只寫到指定檔案）。
+
 ---
 
 ## 對話中 HITL 命令

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -139,6 +139,29 @@ reminder_after_turns = 10
 # OpenAI Images API.
 
 # ─────────────────────────────────────────────
+# Text-to-speech
+# ─────────────────────────────────────────────
+# Disabled by default. Enable this block to expose the canonical
+# tts_generate tool backed by xAI TTS (OAuth-only — run `loom auth xai`).
+#
+# [tools.tts]
+# enabled = true
+# default_provider = "xai"
+#
+# [tools.tts.xai]
+# enabled     = true
+# voice_id    = "eve"     # eve | ara | leo | rex | sal | <custom-voice-id>
+# language    = "auto"    # BCP-47 (e.g. en, zh, pt-BR) or auto
+# format      = "mp3"     # mp3 | wav | pcm | mulaw | alaw
+# auth_mode   = "oauth"   # OAuth-only — XAI_API_KEY is intentionally ignored
+# sample_rate = 24000     # optional; omit to use xAI server default
+# bit_rate    = 128000    # optional; applied only for mp3
+#
+# Defaults above are also the per-call defaults inside tts_generate; the
+# agent can override voice_id / language / format / speed / sample_rate /
+# bit_rate per request.
+
+# ─────────────────────────────────────────────
 # Memory
 # ─────────────────────────────────────────────
 

--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -169,6 +169,28 @@ def _extract_image_generate_artifact(
     }
 
 
+def _extract_tts_generate_artifact(
+    call: "ToolCall", result: "ToolResult"
+) -> dict | None:
+    import hashlib
+    import json as _json
+    try:
+        payload = _json.loads(result.output or "{}")
+    except Exception:
+        payload = {}
+    size_bytes = int(payload.get("bytes", 0) or 0)
+    digest_input = (
+        f"{payload.get('path','')}|{size_bytes}|"
+        f"{payload.get('voice_id','')}|{payload.get('format','')}"
+    ).encode("utf-8")
+    return {
+        "artifact_type": "audio",
+        "size_bytes": size_bytes,
+        "digest": "sha256:" + hashlib.sha256(digest_input).hexdigest(),
+        "location": payload.get("path"),
+    }
+
+
 def _extract_pursuit_write_artifact(
     call: "ToolCall", result: "ToolResult"
 ) -> dict | None:
@@ -192,6 +214,7 @@ _ARTIFACT_EXTRACTORS: dict[str, Callable[["ToolCall", "ToolResult"], dict | None
     "write_file": _extract_write_file_artifact,
     "image_generate": _extract_image_generate_artifact,
     "openai__text_to_image": _extract_image_generate_artifact,
+    "tts_generate": _extract_tts_generate_artifact,
     "pursuit_write": _extract_pursuit_write_artifact,
 }
 

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1310,6 +1310,7 @@ class LoomSession:
             make_exec_escape_fn,
             make_fetch_url_tool,
             make_openai_image_generation_tool,
+            make_xai_tts_tool,
             make_memorize_tool,
             make_memory_health_tool,
             make_query_relations_tool,
@@ -1494,6 +1495,48 @@ class LoomSession:
             logger.warning(
                 "[tools.image] provider %r is not supported; skipping image_generate.",
                 _image_provider,
+            )
+
+        _tts_cfg = (_load_loom_config().get("tools", {}).get("tts", {}) or {})
+        _tts_enabled = bool(_tts_cfg.get("enabled", False))
+        _tts_provider = str(_tts_cfg.get("default_provider", "")).strip().lower()
+        _xai_tts_cfg = (_tts_cfg.get("xai", {}) or {})
+        _xai_tts_enabled = bool(_xai_tts_cfg.get("enabled", True))
+        if _tts_enabled and _tts_provider == "xai" and _xai_tts_enabled:
+            def _positive_int_or_none(raw: Any) -> int | None:
+                try:
+                    value = int(raw)
+                except (TypeError, ValueError):
+                    return None
+                return value if value > 0 else None
+
+            self.registry.register(
+                make_xai_tts_tool(
+                    self.workspace,
+                    default_voice_id=str(
+                        _xai_tts_cfg.get("voice_id", "eve")
+                    ).strip() or "eve",
+                    default_language=str(
+                        _xai_tts_cfg.get("language", "auto")
+                    ).strip() or "auto",
+                    default_format=str(
+                        _xai_tts_cfg.get("format", "mp3")
+                    ).strip().lower() or "mp3",
+                    default_auth_mode=str(
+                        _xai_tts_cfg.get("auth_mode", "oauth")
+                    ).strip().lower() or "oauth",
+                    default_sample_rate=_positive_int_or_none(
+                        _xai_tts_cfg.get("sample_rate")
+                    ),
+                    default_bit_rate=_positive_int_or_none(
+                        _xai_tts_cfg.get("bit_rate")
+                    ),
+                )
+            )
+        elif _tts_enabled and _tts_provider and _tts_provider != "xai":
+            logger.warning(
+                "[tools.tts] provider %r is not supported; skipping tts_generate.",
+                _tts_provider,
             )
 
         # Register sub-agent tool (Phase 5E)

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -100,6 +100,15 @@ _WEB_TIMEOUT = 10.0       # seconds for all HTTP calls
 _CONTENT_LIMIT = 2000     # max chars returned to agent
 _SEARCH_RESULTS = 5       # default Brave results
 _IMAGE_TIMEOUT = 180.0
+_TTS_TIMEOUT = 180.0
+_TTS_CODECS = ("mp3", "wav", "pcm", "mulaw", "alaw")
+_TTS_CODEC_SUFFIX = {
+    "mp3": ".mp3",
+    "wav": ".wav",
+    "pcm": ".pcm",
+    "mulaw": ".ulaw",
+    "alaw": ".alaw",
+}
 
 
 async def _race_abort(coro, abort_signal):
@@ -2983,6 +2992,274 @@ def make_openai_image_generation_tool(
             "writes one generated image file under the workspace",
         ],
         scope_resolver=_make_openai_image_scope_resolver(workspace),
+    )
+
+
+def _make_xai_tts_scope_resolver(workspace: Path):
+    """Scope resolver for the xAI-backed TTS generation tool."""
+    import os.path
+
+    _workspace_resolved = workspace.resolve()
+
+    def _resolve(call: ToolCall) -> ScopeRequest:
+        raw = call.args.get("output_path") or "outputs"
+        p = Path(str(raw))
+        resolved = (workspace / p).resolve() if not p.is_absolute() else p.resolve()
+        try:
+            selector = str(resolved.parent.relative_to(_workspace_resolved))
+        except ValueError:
+            selector = os.path.normpath(str(resolved.parent))
+        return ScopeRequest(
+            tool_name=call.tool_name,
+            capabilities=call.capabilities,
+            requirements=[
+                ScopeRequirement(
+                    resource="path",
+                    action="write",
+                    selector=selector,
+                    tool_name=call.tool_name,
+                    capabilities=call.capabilities,
+                ),
+                ScopeRequirement(
+                    resource="network",
+                    action="connect",
+                    selector="api.x.ai",
+                    tool_name=call.tool_name,
+                    capabilities=call.capabilities,
+                ),
+            ],
+        )
+
+    return _resolve
+
+
+def make_xai_tts_tool(
+    workspace: Path,
+    *,
+    tool_name: str = "tts_generate",
+    default_voice_id: str = "eve",
+    default_language: str = "auto",
+    default_format: str = "mp3",
+    default_auth_mode: str = "oauth",
+    default_sample_rate: int | None = None,
+    default_bit_rate: int | None = None,
+) -> ToolDefinition:
+    """Build the canonical tts_generate tool backed by xAI TTS (OAuth-only).
+
+    No XAI_API_KEY fallback by design — mirrors the xai/<model> chat provider
+    so an OAuth-only path cannot silently spend API-key quota.
+    """
+
+    from loom.core.cognition.xai_auth import load_xai_oauth_credential
+
+    async def _xai_tts(call: ToolCall) -> ToolResult:
+        text = str(call.args.get("text", "")).strip()
+        if not text:
+            return ToolResult(
+                call_id=call.id,
+                tool_name=call.tool_name,
+                success=False,
+                error="Missing required argument: text",
+            )
+
+        auth_mode = str(call.args.get("auth_mode", default_auth_mode)).strip().lower()
+        if auth_mode != "oauth":
+            return ToolResult(
+                call_id=call.id,
+                tool_name=call.tool_name,
+                success=False,
+                error="auth_mode must be: oauth (xAI TTS is OAuth-only in Loom).",
+            )
+
+        credential = load_xai_oauth_credential()
+        if credential is None:
+            return ToolResult(
+                call_id=call.id,
+                tool_name=call.tool_name,
+                success=False,
+                error=(
+                    "No unexpired xAI OAuth token found. "
+                    "Run `loom auth xai` before using tts_generate."
+                ),
+            )
+
+        codec = str(call.args.get("format", default_format)).strip().lower() or default_format
+        if codec not in _TTS_CODEC_SUFFIX:
+            return ToolResult(
+                call_id=call.id,
+                tool_name=call.tool_name,
+                success=False,
+                error=f"format must be one of: {list(_TTS_CODECS)}",
+            )
+
+        raw_output = str(call.args.get("output_path", "")).strip()
+        suffix = _TTS_CODEC_SUFFIX[codec]
+        if raw_output:
+            output_path = _resolve_workspace_path(raw_output, workspace)
+        else:
+            output_path = workspace / "outputs" / f"tts-{uuid.uuid4().hex[:8]}{suffix}"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        voice_id = str(call.args.get("voice_id", default_voice_id)).strip() or default_voice_id
+        language = str(call.args.get("language", default_language)).strip() or default_language
+
+        def _coerce_positive_int(value: Any, fallback: int | None) -> int | None:
+            if isinstance(value, bool):
+                return fallback
+            if isinstance(value, (int, float)):
+                ivalue = int(value)
+                return ivalue if ivalue > 0 else fallback
+            return fallback
+
+        sample_rate = _coerce_positive_int(call.args.get("sample_rate"), default_sample_rate)
+        bit_rate = _coerce_positive_int(call.args.get("bit_rate"), default_bit_rate)
+
+        output_format: dict[str, Any] = {"codec": codec}
+        if sample_rate is not None:
+            output_format["sample_rate"] = sample_rate
+        if bit_rate is not None and codec == "mp3":
+            output_format["bit_rate"] = bit_rate
+
+        payload: dict[str, Any] = {
+            "text": text,
+            "voice_id": voice_id,
+            "language": language,
+            "output_format": output_format,
+        }
+        speed = call.args.get("speed")
+        if isinstance(speed, (int, float)) and not isinstance(speed, bool):
+            payload["speed"] = float(speed)
+
+        try:
+            async with httpx.AsyncClient(timeout=_TTS_TIMEOUT) as client:
+                resp = await client.post(
+                    "https://api.x.ai/v1/tts",
+                    headers={
+                        "Authorization": f"Bearer {credential.token}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                )
+                resp.raise_for_status()
+                audio_bytes = resp.content
+        except httpx.HTTPStatusError as exc:
+            body = exc.response.text[:500] if exc.response is not None else ""
+            return ToolResult(
+                call_id=call.id,
+                tool_name=call.tool_name,
+                success=False,
+                error=f"xAI TTS request failed with HTTP {exc.response.status_code}: {body}",
+            )
+        except Exception as exc:
+            return ToolResult(
+                call_id=call.id,
+                tool_name=call.tool_name,
+                success=False,
+                error=f"xAI TTS request failed: {type(exc).__name__}: {exc}",
+            )
+
+        if not audio_bytes:
+            return ToolResult(
+                call_id=call.id,
+                tool_name=call.tool_name,
+                success=False,
+                error="xAI TTS returned empty audio payload.",
+            )
+
+        output_path.write_bytes(audio_bytes)
+        try:
+            display_path = str(output_path.relative_to(workspace))
+        except ValueError:
+            display_path = str(output_path)
+        return ToolResult(
+            call_id=call.id,
+            tool_name=call.tool_name,
+            success=True,
+            output=json.dumps({
+                "path": display_path,
+                "provider": "xai",
+                "voice_id": voice_id,
+                "format": codec,
+                "bytes": len(audio_bytes),
+            }, ensure_ascii=False),
+        )
+
+    return ToolDefinition(
+        name=tool_name,
+        description=(
+            "Generate speech audio from text via xAI TTS (OAuth-only) and save "
+            "it to a workspace file. Defaults to MP3 with built-in voice `eve`."
+        ),
+        trust_level=TrustLevel.GUARDED,
+        capabilities=ToolCapability.NETWORK | ToolCapability.MUTATES,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "text": {"type": "string", "description": "Text to convert to speech."},
+                "output_path": {
+                    "type": "string",
+                    "description": (
+                        "Workspace-relative output path. "
+                        "Defaults to outputs/tts-<id>.<codec-ext>."
+                    ),
+                },
+                "voice_id": {
+                    "type": "string",
+                    "description": (
+                        "Built-in xAI voice (eve, ara, leo, rex, sal) "
+                        "or a custom voice id."
+                    ),
+                    "default": default_voice_id,
+                },
+                "language": {
+                    "type": "string",
+                    "description": "BCP-47 language code (e.g. en, zh, pt-BR) or `auto`.",
+                    "default": default_language,
+                },
+                "format": {
+                    "type": "string",
+                    "enum": list(_TTS_CODECS),
+                    "description": "Audio codec for the saved file.",
+                    "default": default_format,
+                },
+                "speed": {
+                    "type": "number",
+                    "description": "Speaking rate multiplier (xAI default applies when omitted).",
+                },
+                "sample_rate": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": (
+                        "Output sample rate in Hz. Omit to use xAI default "
+                        "(typically 24000)."
+                    ),
+                },
+                "bit_rate": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": (
+                        "Output bit rate in bps. Only applied for mp3; omit to "
+                        "use xAI default (typically 128000)."
+                    ),
+                },
+                "auth_mode": {
+                    "type": "string",
+                    "enum": ["oauth"],
+                    "default": default_auth_mode,
+                    "description": "xAI TTS is OAuth-only; XAI_API_KEY is intentionally ignored.",
+                },
+            },
+            "required": ["text"],
+            "additionalProperties": False,
+        },
+        executor=_xai_tts,
+        tags=["tts", "audio", "xai"],
+        impact_scope="network",
+        scope_descriptions=[
+            "connects to api.x.ai for xAI OAuth text-to-speech",
+            "writes one generated audio file under the workspace",
+        ],
+        scope_resolver=_make_xai_tts_scope_resolver(workspace),
     )
 
 

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -3002,7 +3002,11 @@ def _make_xai_tts_scope_resolver(workspace: Path):
     _workspace_resolved = workspace.resolve()
 
     def _resolve(call: ToolCall) -> ScopeRequest:
-        raw = call.args.get("output_path") or "outputs"
+        # When ``output_path`` is omitted the executor writes to
+        # ``outputs/tts-<id>.<codec>``. Mirror that here so the
+        # permission selector reflects the real mutation surface
+        # (``outputs``) instead of widening it to the workspace root.
+        raw = call.args.get("output_path") or "outputs/tts-default"
         p = Path(str(raw))
         resolved = (workspace / p).resolve() if not p.is_absolute() else p.resolve()
         try:

--- a/tests/test_xai_tts_tool.py
+++ b/tests/test_xai_tts_tool.py
@@ -347,6 +347,39 @@ async def test_tts_rejects_empty_audio_response(tmp_path, monkeypatch):
     assert "empty" in (result.error or "").lower()
 
 
+def test_tts_default_scope_selector_targets_outputs_subdir(tmp_path):
+    """When ``output_path`` is omitted the scope selector must point at
+    ``outputs`` (where the executor actually writes), not the workspace
+    root. Guards against widening write permission beyond what the
+    executor mutates. (Review feedback on PR #448.)"""
+    tool = make_xai_tts_tool(tmp_path)
+    call_no_path = ToolCall(
+        tool_name=tool.name,
+        args={"text": "hello"},
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+    call_with_path = ToolCall(
+        tool_name=tool.name,
+        args={"text": "hello", "output_path": "outputs/foo.mp3"},
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    no_path_selectors = {
+        (req.resource, req.action, req.selector)
+        for req in tool.scope_resolver(call_no_path).requirements
+    }
+    with_path_selectors = {
+        (req.resource, req.action, req.selector)
+        for req in tool.scope_resolver(call_with_path).requirements
+    }
+
+    assert ("path", "write", "outputs") in no_path_selectors
+    assert ("path", "write", ".") not in no_path_selectors
+    assert ("path", "write", "outputs") in with_path_selectors
+
+
 def test_tts_artifact_extractor_returns_audio_metadata():
     from loom.core.harness.middleware import (
         ToolResult,

--- a/tests/test_xai_tts_tool.py
+++ b/tests/test_xai_tts_tool.py
@@ -1,0 +1,382 @@
+import base64
+import json
+import time
+
+import httpx
+import pytest
+
+from loom.core.harness.middleware import ToolCall
+from loom.core.harness.permissions import TrustLevel
+from loom.platform.cli import tools as cli_tools
+from loom.platform.cli.tools import make_xai_tts_tool
+
+
+def _jwt(exp: int) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"exp": exp}).encode()
+    ).rstrip(b"=").decode()
+    return f"{header}.{payload}."
+
+
+class _FakeResponse:
+    def __init__(self, *, status_code: int = 200, content: bytes = b"", text: str = ""):
+        self.status_code = status_code
+        self.content = content
+        self.text = text or (content.decode("utf-8", "replace") if status_code >= 400 else "")
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            request = httpx.Request("POST", "https://api.x.ai/v1/tts")
+            response = httpx.Response(self.status_code, request=request, text=self.text)
+            raise httpx.HTTPStatusError("boom", request=request, response=response)
+        return None
+
+
+class _FakeAsyncClient:
+    """Minimal httpx.AsyncClient stand-in that records POST calls."""
+
+    last: "_FakeAsyncClient | None" = None
+    response_factory = staticmethod(lambda: _FakeResponse(content=b"audio-bytes"))
+
+    def __init__(self, *args, **kwargs):
+        self.requests: list[dict] = []
+        _FakeAsyncClient.last = self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, url, headers=None, json=None):
+        self.requests.append({"url": url, "headers": headers, "json": json})
+        return type(self).response_factory()
+
+
+def _save_oauth(tmp_path, monkeypatch, *, token: str | None = None) -> str:
+    from loom.core.cognition.xai_auth import DEFAULT_XAI_BASE_URL, save_xai_oauth_state
+
+    monkeypatch.setenv("LOOM_HOME", str(tmp_path / "loom-home"))
+    access = token or _jwt(int(time.time()) + 3600)
+    save_xai_oauth_state({
+        "tokens": {
+            "access_token": access,
+            "refresh_token": "refresh-secret",
+        },
+        "base_url": DEFAULT_XAI_BASE_URL,
+    })
+    return access
+
+
+@pytest.mark.asyncio
+async def test_tts_writes_audio_file_with_oauth_bearer(tmp_path, monkeypatch):
+    token = _save_oauth(tmp_path, monkeypatch)
+    _FakeAsyncClient.response_factory = lambda: _FakeResponse(content=b"audio-bytes")
+    monkeypatch.setattr(cli_tools.httpx, "AsyncClient", _FakeAsyncClient)
+
+    tool = make_xai_tts_tool(tmp_path)
+    call = ToolCall(
+        tool_name=tool.name,
+        args={"text": "hello world", "output_path": "out/hello.mp3"},
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    result = await tool.executor(call)
+
+    assert result.success, result.error
+    assert (tmp_path / "out" / "hello.mp3").read_bytes() == b"audio-bytes"
+    output = json.loads(result.output)
+    assert output["path"] == "out/hello.mp3"
+    assert output["provider"] == "xai"
+    assert output["voice_id"] == "eve"
+    assert output["format"] == "mp3"
+    assert output["bytes"] == len(b"audio-bytes")
+
+    req = _FakeAsyncClient.last.requests[0]
+    assert req["url"] == "https://api.x.ai/v1/tts"
+    assert req["headers"]["Authorization"] == f"Bearer {token}"
+    assert req["json"] == {
+        "text": "hello world",
+        "voice_id": "eve",
+        "language": "auto",
+        "output_format": {"codec": "mp3"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_tts_ignores_xai_api_key_when_no_oauth(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOOM_HOME", str(tmp_path / "loom-home"))
+    monkeypatch.setenv("XAI_API_KEY", "xai-api-key-that-must-not-be-used")
+    called: list[dict] = []
+
+    class _NoCallClient(_FakeAsyncClient):
+        async def post(self, url, headers=None, json=None):  # pragma: no cover - should not run
+            called.append({"url": url, "headers": headers, "json": json})
+            return _FakeResponse(content=b"audio-bytes")
+
+    monkeypatch.setattr(cli_tools.httpx, "AsyncClient", _NoCallClient)
+
+    tool = make_xai_tts_tool(tmp_path)
+    call = ToolCall(
+        tool_name=tool.name,
+        args={"text": "hello"},
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    result = await tool.executor(call)
+
+    assert not result.success
+    assert "loom auth xai" in (result.error or "")
+    assert called == []
+    assert "xai-api-key-that-must-not-be-used" not in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_tts_rejects_non_oauth_auth_mode(tmp_path, monkeypatch):
+    _save_oauth(tmp_path, monkeypatch)
+    monkeypatch.setattr(cli_tools.httpx, "AsyncClient", _FakeAsyncClient)
+
+    tool = make_xai_tts_tool(tmp_path)
+    call = ToolCall(
+        tool_name=tool.name,
+        args={"text": "hi", "auth_mode": "api_key"},
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    result = await tool.executor(call)
+
+    assert not result.success
+    assert "OAuth-only" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_tts_rejects_missing_text(tmp_path, monkeypatch):
+    _save_oauth(tmp_path, monkeypatch)
+    tool = make_xai_tts_tool(tmp_path)
+    call = ToolCall(
+        tool_name=tool.name,
+        args={"text": "   "},
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    result = await tool.executor(call)
+
+    assert not result.success
+    assert "text" in (result.error or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_tts_rejects_unsupported_codec(tmp_path, monkeypatch):
+    _save_oauth(tmp_path, monkeypatch)
+    monkeypatch.setattr(cli_tools.httpx, "AsyncClient", _FakeAsyncClient)
+
+    tool = make_xai_tts_tool(tmp_path)
+    call = ToolCall(
+        tool_name=tool.name,
+        args={"text": "hi", "format": "ogg"},
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    result = await tool.executor(call)
+
+    assert not result.success
+    assert "format" in (result.error or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_tts_passes_voice_language_format_and_speed(tmp_path, monkeypatch):
+    _save_oauth(tmp_path, monkeypatch)
+    _FakeAsyncClient.response_factory = lambda: _FakeResponse(content=b"wav-bytes")
+    monkeypatch.setattr(cli_tools.httpx, "AsyncClient", _FakeAsyncClient)
+
+    tool = make_xai_tts_tool(tmp_path)
+    call = ToolCall(
+        tool_name=tool.name,
+        args={
+            "text": "你好",
+            "voice_id": "ara",
+            "language": "zh",
+            "format": "wav",
+            "speed": 1.2,
+            "output_path": "renders/hi.wav",
+        },
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    result = await tool.executor(call)
+
+    assert result.success, result.error
+    req = _FakeAsyncClient.last.requests[0]
+    assert req["json"] == {
+        "text": "你好",
+        "voice_id": "ara",
+        "language": "zh",
+        "output_format": {"codec": "wav"},
+        "speed": 1.2,
+    }
+    output = json.loads(result.output)
+    assert output["voice_id"] == "ara"
+    assert output["format"] == "wav"
+    assert (tmp_path / "renders" / "hi.wav").read_bytes() == b"wav-bytes"
+
+
+@pytest.mark.asyncio
+async def test_tts_includes_sample_rate_and_bit_rate_when_provided(tmp_path, monkeypatch):
+    _save_oauth(tmp_path, monkeypatch)
+    _FakeAsyncClient.response_factory = lambda: _FakeResponse(content=b"mp3-bytes")
+    monkeypatch.setattr(cli_tools.httpx, "AsyncClient", _FakeAsyncClient)
+
+    tool = make_xai_tts_tool(
+        tmp_path,
+        default_sample_rate=24000,
+        default_bit_rate=128000,
+    )
+    call = ToolCall(
+        tool_name=tool.name,
+        args={"text": "hi", "sample_rate": 48000, "bit_rate": 192000},
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    result = await tool.executor(call)
+
+    assert result.success, result.error
+    req = _FakeAsyncClient.last.requests[0]
+    assert req["json"]["output_format"] == {
+        "codec": "mp3",
+        "sample_rate": 48000,
+        "bit_rate": 192000,
+    }
+
+
+@pytest.mark.asyncio
+async def test_tts_skips_bit_rate_for_non_mp3_codec(tmp_path, monkeypatch):
+    _save_oauth(tmp_path, monkeypatch)
+    _FakeAsyncClient.response_factory = lambda: _FakeResponse(content=b"wav-bytes")
+    monkeypatch.setattr(cli_tools.httpx, "AsyncClient", _FakeAsyncClient)
+
+    tool = make_xai_tts_tool(
+        tmp_path,
+        default_sample_rate=24000,
+        default_bit_rate=128000,
+    )
+    call = ToolCall(
+        tool_name=tool.name,
+        args={"text": "hi", "format": "wav"},
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    result = await tool.executor(call)
+
+    assert result.success, result.error
+    output_format = _FakeAsyncClient.last.requests[0]["json"]["output_format"]
+    assert output_format == {"codec": "wav", "sample_rate": 24000}
+    assert "bit_rate" not in output_format
+
+
+@pytest.mark.asyncio
+async def test_tts_defaults_output_path_uses_codec_extension(tmp_path, monkeypatch):
+    _save_oauth(tmp_path, monkeypatch)
+    _FakeAsyncClient.response_factory = lambda: _FakeResponse(content=b"pcm-bytes")
+    monkeypatch.setattr(cli_tools.httpx, "AsyncClient", _FakeAsyncClient)
+
+    tool = make_xai_tts_tool(tmp_path)
+    call = ToolCall(
+        tool_name=tool.name,
+        args={"text": "hi", "format": "pcm"},
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    result = await tool.executor(call)
+
+    assert result.success, result.error
+    output = json.loads(result.output)
+    assert output["path"].startswith("outputs/tts-")
+    assert output["path"].endswith(".pcm")
+
+
+@pytest.mark.asyncio
+async def test_tts_surfaces_http_error_body(tmp_path, monkeypatch):
+    _save_oauth(tmp_path, monkeypatch)
+    _FakeAsyncClient.response_factory = lambda: _FakeResponse(
+        status_code=429, text="rate limited"
+    )
+    monkeypatch.setattr(cli_tools.httpx, "AsyncClient", _FakeAsyncClient)
+
+    tool = make_xai_tts_tool(tmp_path)
+    call = ToolCall(
+        tool_name=tool.name,
+        args={"text": "hi"},
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    result = await tool.executor(call)
+
+    assert not result.success
+    assert "429" in (result.error or "")
+    assert "rate limited" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_tts_rejects_empty_audio_response(tmp_path, monkeypatch):
+    _save_oauth(tmp_path, monkeypatch)
+    _FakeAsyncClient.response_factory = lambda: _FakeResponse(content=b"")
+    monkeypatch.setattr(cli_tools.httpx, "AsyncClient", _FakeAsyncClient)
+
+    tool = make_xai_tts_tool(tmp_path)
+    call = ToolCall(
+        tool_name=tool.name,
+        args={"text": "hi"},
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+
+    result = await tool.executor(call)
+
+    assert not result.success
+    assert "empty" in (result.error or "").lower()
+
+
+def test_tts_artifact_extractor_returns_audio_metadata():
+    from loom.core.harness.middleware import (
+        ToolResult,
+        _ARTIFACT_EXTRACTORS,
+    )
+
+    extractor = _ARTIFACT_EXTRACTORS["tts_generate"]
+    call = ToolCall(
+        tool_name="tts_generate",
+        args={"text": "hello"},
+        trust_level=TrustLevel.GUARDED,
+        session_id="s1",
+    )
+    result = ToolResult(
+        call_id=call.id,
+        tool_name=call.tool_name,
+        success=True,
+        output=json.dumps({
+            "path": "outputs/tts-abc.mp3",
+            "provider": "xai",
+            "voice_id": "eve",
+            "format": "mp3",
+            "bytes": 1234,
+        }),
+    )
+
+    artifact = extractor(call, result)
+
+    assert artifact is not None
+    assert artifact["artifact_type"] == "audio"
+    assert artifact["size_bytes"] == 1234
+    assert artifact["location"] == "outputs/tts-abc.mp3"
+    assert artifact["digest"].startswith("sha256:")


### PR DESCRIPTION
## Summary
- New canonical `tts_generate` tool backed by xAI TTS, **OAuth-only** (no `XAI_API_KEY` fallback), mirroring the `image_generate` shape — config-gated, single provider for v1, room to add openai / elevenlabs / local TTS later without reshaping the tool.
- Uses the OAuth bearer from `load_xai_oauth_credential()` (the PR #447 helper) and POSTs to `https://api.x.ai/v1/tts`. Reference implementation: hermes-agent's `_generate_xai_tts` ([tools/tts_tool.py:969](https://github.com/NousResearch/hermes-agent/blob/v2026.5.16/tools/tts_tool.py#L969)) — same endpoint, same payload shape; Loom is stricter (OAuth-only, no API-key fallback).
- New `[tools.tts]` config block parallels `[tools.image]` (enabled / default_provider / per-provider sub-table); unsupported providers log a warning and skip registration.

## Review Notes
- **OAuth-only is enforced at two layers**: (a) the tool loads the bearer via `load_xai_oauth_credential()` which has no env-var fallback, and (b) the `auth_mode` schema only accepts `\"oauth\"` so future modes can extend without breaking. Tests assert that `XAI_API_KEY` present + no OAuth state → tool errors out and never makes a request.
- `output_format.bit_rate` is only sent for `codec=mp3` (matches hermes behavior; xAI ignores bit_rate for non-mp3 codecs). `sample_rate` is sent for all codecs when configured.
- Default output path uses the codec extension (`outputs/tts-<id>.mp3` / `.wav` / `.pcm` / `.ulaw` / `.alaw`).
- `_extract_tts_generate_artifact` registered in `_ARTIFACT_EXTRACTORS` → `artifact_type=\"audio\"`; digest is over `(path, bytes, voice_id, format)` since audio payload isn't retained on the result.
- `doc/33-CLI-命令.md` gets a `tts_generate` section alongside `image_generate` (parity).
- `loom.toml.example` updated (dual-write convention).

## Verification
- `python -m pytest tests/test_xai_tts_tool.py tests/test_session.py tests/test_xai_oauth_auth.py tests/test_openai_image_tool.py -q` — **70 passed**
- `python -m py_compile loom/platform/cli/tools.py loom/core/session.py loom/core/harness/middleware.py`
- `gitnexus detect_changes` — risk: low, affected_processes: 0
- `grep -rln \"tts_generate\\|make_xai_tts_tool\\|tools.tts\" doc/` — `doc/33-CLI-命令.md` updated in this PR

## Follow-ups (not in this PR)
- 15 000-char text guard (xAI's documented cap)
- `User-Agent: loom/<version>` header for xAI-side observability
- Additional providers (openai, elevenlabs, local) — drop into the same `[tools.tts]` shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)