### PR TITLE
fix(codex): omit unsupported max_output_tokens

### DIFF
--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -44,6 +44,18 @@ from .forensics import get_forensics
 logger = logging.getLogger(__name__)
 
 
+def _stream_interrupt_detail(provider: str, exc: BaseException) -> str:
+    """Format a streaming-transport error.
+
+    Some httpx exceptions (notably ``RemoteProtocolError`` raised when an
+    SSE peer closes mid-stream) carry an empty ``str(exc)``. Fall back
+    to the exception class name so the user never sees the bare
+    ``turn aborted with error: `` with nothing after the colon.
+    """
+    detail = str(exc).strip() or type(exc).__name__
+    return f"{provider} stream interrupted: {detail}"
+
+
 async def _http_status_detail(provider: str, exc: Any) -> str:
     """Format an HTTPStatusError into a human-readable detail string.
 
@@ -1079,39 +1091,44 @@ class CodexResponsesProvider(LLMProvider):
                     raise RuntimeError(await _http_status_detail("Codex Responses", exc)) from exc
                 event: str | None = None
                 data_lines: list[str] = []
-                async for line in resp.aiter_lines():
-                    if abort_signal is not None and abort_signal.is_set():
-                        break
-                    if line.startswith("event: "):
-                        event = line[7:]
-                    elif line.startswith("data: "):
-                        data_lines.append(line[6:])
-                    elif line == "" and event:
-                        raw = "\n".join(data_lines)
-                        event = None
-                        data_lines = []
-                        try:
-                            data = json.loads(raw)
-                        except json.JSONDecodeError:
-                            continue
-                        delta = data.get("delta")
-                        if isinstance(delta, str):
-                            full_content += delta
-                            yield (delta, None)
-                        item = data.get("item")
-                        if isinstance(item, dict) and data.get("type", "").endswith("output_item.done"):
-                            output_items.append(item)
-                        response = data.get("response")
-                        if isinstance(response, dict):
-                            response_status = str(response.get("status") or response_status)
-                            usage = response.get("usage") or {}
-                            if isinstance(usage, dict):
-                                input_tokens = int(
-                                    usage.get("input_tokens") or usage.get("prompt_tokens") or input_tokens
-                                )
-                                output_tokens = int(
-                                    usage.get("output_tokens") or usage.get("completion_tokens") or output_tokens
-                                )
+                try:
+                    async for line in resp.aiter_lines():
+                        if abort_signal is not None and abort_signal.is_set():
+                            break
+                        if line.startswith("event: "):
+                            event = line[7:]
+                        elif line.startswith("data: "):
+                            data_lines.append(line[6:])
+                        elif line == "" and event:
+                            raw = "\n".join(data_lines)
+                            event = None
+                            data_lines = []
+                            try:
+                                data = json.loads(raw)
+                            except json.JSONDecodeError:
+                                continue
+                            delta = data.get("delta")
+                            if isinstance(delta, str):
+                                full_content += delta
+                                yield (delta, None)
+                            item = data.get("item")
+                            if isinstance(item, dict) and data.get("type", "").endswith("output_item.done"):
+                                output_items.append(item)
+                            response = data.get("response")
+                            if isinstance(response, dict):
+                                response_status = str(response.get("status") or response_status)
+                                usage = response.get("usage") or {}
+                                if isinstance(usage, dict):
+                                    input_tokens = int(
+                                        usage.get("input_tokens") or usage.get("prompt_tokens") or input_tokens
+                                    )
+                                    output_tokens = int(
+                                        usage.get("output_tokens") or usage.get("completion_tokens") or output_tokens
+                                    )
+                except httpx.HTTPError as exc:
+                    raise RuntimeError(
+                        _stream_interrupt_detail("Codex Responses", exc)
+                    ) from exc
 
         tool_uses: list[ToolUse] = []
         raw_tool_calls: list[dict[str, Any]] = []
@@ -1321,39 +1338,44 @@ class XAIResponsesProvider(LLMProvider):
                     raise RuntimeError(await _http_status_detail("xAI Responses", exc)) from exc
                 event: str | None = None
                 data_lines: list[str] = []
-                async for line in resp.aiter_lines():
-                    if abort_signal is not None and abort_signal.is_set():
-                        break
-                    if line.startswith("event: "):
-                        event = line[7:]
-                    elif line.startswith("data: "):
-                        data_lines.append(line[6:])
-                    elif line == "" and event:
-                        raw = "\n".join(data_lines)
-                        event = None
-                        data_lines = []
-                        try:
-                            data = json.loads(raw)
-                        except json.JSONDecodeError:
-                            continue
-                        delta = data.get("delta")
-                        if isinstance(delta, str):
-                            full_content += delta
-                            yield (delta, None)
-                        item = data.get("item")
-                        if isinstance(item, dict) and data.get("type", "").endswith("output_item.done"):
-                            output_items.append(item)
-                        response = data.get("response")
-                        if isinstance(response, dict):
-                            response_status = str(response.get("status") or response_status)
-                            usage = response.get("usage") or {}
-                            if isinstance(usage, dict):
-                                input_tokens = int(
-                                    usage.get("input_tokens") or usage.get("prompt_tokens") or input_tokens
-                                )
-                                output_tokens = int(
-                                    usage.get("output_tokens") or usage.get("completion_tokens") or output_tokens
-                                )
+                try:
+                    async for line in resp.aiter_lines():
+                        if abort_signal is not None and abort_signal.is_set():
+                            break
+                        if line.startswith("event: "):
+                            event = line[7:]
+                        elif line.startswith("data: "):
+                            data_lines.append(line[6:])
+                        elif line == "" and event:
+                            raw = "\n".join(data_lines)
+                            event = None
+                            data_lines = []
+                            try:
+                                data = json.loads(raw)
+                            except json.JSONDecodeError:
+                                continue
+                            delta = data.get("delta")
+                            if isinstance(delta, str):
+                                full_content += delta
+                                yield (delta, None)
+                            item = data.get("item")
+                            if isinstance(item, dict) and data.get("type", "").endswith("output_item.done"):
+                                output_items.append(item)
+                            response = data.get("response")
+                            if isinstance(response, dict):
+                                response_status = str(response.get("status") or response_status)
+                                usage = response.get("usage") or {}
+                                if isinstance(usage, dict):
+                                    input_tokens = int(
+                                        usage.get("input_tokens") or usage.get("prompt_tokens") or input_tokens
+                                    )
+                                    output_tokens = int(
+                                        usage.get("output_tokens") or usage.get("completion_tokens") or output_tokens
+                                    )
+                except httpx.HTTPError as exc:
+                    raise RuntimeError(
+                        _stream_interrupt_detail("xAI Responses", exc)
+                    ) from exc
 
         tool_uses: list[ToolUse] = []
         raw_tool_calls: list[dict[str, Any]] = []

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -979,7 +979,7 @@ class CodexResponsesProvider(LLMProvider):
                 if content:
                     input_items.append({
                         "role": "assistant",
-                        "content": [{"type": "input_text", "text": str(content)}],
+                        "content": [{"type": "output_text", "text": str(content)}],
                     })
                 for tc in msg.get("tool_calls", []) or []:
                     fn = tc.get("function", {}) if isinstance(tc, dict) else {}
@@ -1224,7 +1224,7 @@ class XAIResponsesProvider(LLMProvider):
                 if content:
                     input_items.append({
                         "role": "assistant",
-                        "content": [{"type": "input_text", "text": str(content)}],
+                        "content": [{"type": "output_text", "text": str(content)}],
                     })
                 for tc in msg.get("tool_calls", []) or []:
                     fn = tc.get("function", {}) if isinstance(tc, dict) else {}

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -896,6 +896,7 @@ class CodexResponsesProvider(LLMProvider):
     DEFAULT_MODEL = "gpt-5.5"
     DEFAULT_BASE_URL = "https://chatgpt.com/backend-api/codex/responses"
     DEFAULT_TIMEOUT = 180.0
+    SUPPORTS_MAX_OUTPUT_TOKENS = False
 
     def __init__(
         self,
@@ -971,8 +972,9 @@ class CodexResponsesProvider(LLMProvider):
             "input": input_items,
             "stream": True,
             "store": False,
-            "max_output_tokens": max_tokens,
         }
+        if self.SUPPORTS_MAX_OUTPUT_TOKENS:
+            payload["max_output_tokens"] = max_tokens
         if tools:
             payload["tools"] = self.format_tools(tools)
         return payload
@@ -1139,6 +1141,7 @@ class XAIResponsesProvider(CodexResponsesProvider):
     DEFAULT_MODEL = "grok-4.3"
     DEFAULT_BASE_URL = "https://api.x.ai/v1/responses"
     DEFAULT_TIMEOUT = 180.0
+    SUPPORTS_MAX_OUTPUT_TOKENS = True
 
     def _load_bearer_token(self) -> str:
         from loom.core.cognition.xai_auth import load_xai_oauth_credential

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -44,6 +44,18 @@ from .forensics import get_forensics
 logger = logging.getLogger(__name__)
 
 
+def _http_status_detail(provider: str, exc: Any) -> str:
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", "unknown")
+    body = ""
+    if response is not None:
+        body = str(getattr(response, "text", "") or "").strip()
+    detail = f"{provider} request failed with HTTP {status_code}"
+    if body:
+        detail += f": {body[:1000]}"
+    return detail
+
+
 # ---------------------------------------------------------------------------
 # Retry helper
 # ---------------------------------------------------------------------------
@@ -1044,7 +1056,10 @@ class CodexResponsesProvider(LLMProvider):
                 },
                 json=payload,
             ) as resp:
-                resp.raise_for_status()
+                try:
+                    resp.raise_for_status()
+                except httpx.HTTPStatusError as exc:
+                    raise RuntimeError(_http_status_detail("Codex Responses", exc)) from exc
                 event: str | None = None
                 data_lines: list[str] = []
                 async for line in resp.aiter_lines():
@@ -1126,14 +1141,12 @@ class CodexResponsesProvider(LLMProvider):
         }
 
 
-class XAIResponsesProvider(CodexResponsesProvider):
+class XAIResponsesProvider(LLMProvider):
     """
     xAI Grok OAuth chat via xAI's Responses API.
 
     Routing prefix: ``xai/``. This provider intentionally has no
     ``XAI_API_KEY`` fallback; selecting ``xai/...`` means OAuth only.
-    Coupled to ``CodexResponsesProvider``'s Responses SSE shape; revisit if
-    xAI diverges from that protocol.
     """
 
     name = "xai"
@@ -1141,7 +1154,19 @@ class XAIResponsesProvider(CodexResponsesProvider):
     DEFAULT_MODEL = "grok-4.3"
     DEFAULT_BASE_URL = "https://api.x.ai/v1/responses"
     DEFAULT_TIMEOUT = 180.0
-    SUPPORTS_MAX_OUTPUT_TOKENS = True
+
+    def __init__(
+        self,
+        model: str = "",
+        base_url: str = "",
+        timeout: float = 0.0,
+    ) -> None:
+        self.model = model or (self.ROUTING_PREFIX + self.DEFAULT_MODEL)
+        self._base_url = base_url or self.DEFAULT_BASE_URL
+        self._timeout = timeout or self.DEFAULT_TIMEOUT
+
+    def _api_model(self) -> str:
+        return self.model.removeprefix(self.ROUTING_PREFIX)
 
     def _load_bearer_token(self) -> str:
         from loom.core.cognition.xai_auth import load_xai_oauth_credential
@@ -1153,6 +1178,209 @@ class XAIResponsesProvider(CodexResponsesProvider):
                 "before using an OAuth model such as `xai/grok-4.3`."
             )
         return credential.token
+
+    def _build_payload(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        max_tokens: int,
+    ) -> dict[str, Any]:
+        instructions: list[str] = []
+        input_items: list[dict[str, Any]] = []
+        for msg in messages:
+            role = msg.get("role")
+            content = msg.get("content", "")
+            if role == "system":
+                if content:
+                    instructions.append(str(content))
+                continue
+            if role == "tool":
+                call_id = msg.get("tool_call_id")
+                if call_id:
+                    input_items.append({
+                        "type": "function_call_output",
+                        "call_id": call_id,
+                        "output": str(content),
+                    })
+                continue
+            if role == "assistant":
+                if content:
+                    input_items.append({
+                        "role": "assistant",
+                        "content": [{"type": "input_text", "text": str(content)}],
+                    })
+                for tc in msg.get("tool_calls", []) or []:
+                    fn = tc.get("function", {}) if isinstance(tc, dict) else {}
+                    input_items.append({
+                        "type": "function_call",
+                        "call_id": tc.get("id") or str(uuid.uuid4()),
+                        "name": fn.get("name", ""),
+                        "arguments": fn.get("arguments", "{}"),
+                    })
+                continue
+            input_items.append({
+                "role": "user" if role != "assistant" else "assistant",
+                "content": [{"type": "input_text", "text": str(content)}],
+            })
+
+        payload: dict[str, Any] = {
+            "model": self._api_model(),
+            "instructions": "\n\n".join(instructions) or "You are a helpful assistant.",
+            "input": input_items,
+            "stream": True,
+            "store": False,
+            "max_output_tokens": max_tokens,
+        }
+        if tools:
+            payload["tools"] = self.format_tools(tools)
+        return payload
+
+    def format_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        formatted: list[dict[str, Any]] = []
+        for tool in tools:
+            formatted.append({
+                "type": "function",
+                "name": tool.get("name", ""),
+                "description": tool.get("description", ""),
+                "parameters": tool.get("parameters") or tool.get("input_schema") or {},
+            })
+        return formatted
+
+    async def chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        max_tokens: int = 8096,
+    ) -> LLMResponse:
+        text_parts: list[str] = []
+        final: LLMResponse | None = None
+        async for chunk, resp in self.stream_chat(
+            messages=messages,
+            tools=tools,
+            max_tokens=max_tokens,
+        ):
+            if resp is not None:
+                final = resp
+            elif chunk:
+                text_parts.append(chunk)
+        return final or LLMResponse(
+            text="".join(text_parts) or None,
+            tool_uses=[],
+            stop_reason="end_turn",
+        )
+
+    async def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        max_tokens: int = 8096,
+        *,
+        abort_signal: Any = None,
+    ) -> AsyncIterator[tuple[str, LLMResponse | None]]:
+        import httpx
+
+        bearer = self._load_bearer_token()
+        payload = self._build_payload(messages, tools, max_tokens)
+        full_content = ""
+        output_items: list[dict[str, Any]] = []
+        input_tokens = 0
+        output_tokens = 0
+        response_status = "in_progress"
+
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            async with client.stream(
+                "POST",
+                self._base_url,
+                headers={
+                    "Authorization": f"Bearer {bearer}",
+                    "Content-Type": "application/json",
+                    "Accept": "text/event-stream",
+                },
+                json=payload,
+            ) as resp:
+                try:
+                    resp.raise_for_status()
+                except httpx.HTTPStatusError as exc:
+                    raise RuntimeError(_http_status_detail("xAI Responses", exc)) from exc
+                event: str | None = None
+                data_lines: list[str] = []
+                async for line in resp.aiter_lines():
+                    if abort_signal is not None and abort_signal.is_set():
+                        break
+                    if line.startswith("event: "):
+                        event = line[7:]
+                    elif line.startswith("data: "):
+                        data_lines.append(line[6:])
+                    elif line == "" and event:
+                        raw = "\n".join(data_lines)
+                        event = None
+                        data_lines = []
+                        try:
+                            data = json.loads(raw)
+                        except json.JSONDecodeError:
+                            continue
+                        delta = data.get("delta")
+                        if isinstance(delta, str):
+                            full_content += delta
+                            yield (delta, None)
+                        item = data.get("item")
+                        if isinstance(item, dict) and data.get("type", "").endswith("output_item.done"):
+                            output_items.append(item)
+                        response = data.get("response")
+                        if isinstance(response, dict):
+                            response_status = str(response.get("status") or response_status)
+                            usage = response.get("usage") or {}
+                            if isinstance(usage, dict):
+                                input_tokens = int(
+                                    usage.get("input_tokens") or usage.get("prompt_tokens") or input_tokens
+                                )
+                                output_tokens = int(
+                                    usage.get("output_tokens") or usage.get("completion_tokens") or output_tokens
+                                )
+
+        tool_uses: list[ToolUse] = []
+        raw_tool_calls: list[dict[str, Any]] = []
+        for item in output_items:
+            if item.get("type") != "function_call":
+                continue
+            args_raw = item.get("arguments") or "{}"
+            try:
+                args = json.loads(args_raw)
+            except (json.JSONDecodeError, ValueError):
+                args = {"_raw": args_raw}
+            call_id = item.get("call_id") or item.get("id") or str(uuid.uuid4())
+            name = item.get("name") or ""
+            tool_uses.append(ToolUse(id=call_id, name=name, args=args))
+            raw_tool_calls.append({
+                "id": call_id,
+                "type": "function",
+                "function": {"name": name, "arguments": args_raw},
+            })
+
+        stop_reason = "tool_use" if tool_uses else "end_turn"
+        if response_status == "incomplete":
+            stop_reason = "max_tokens"
+
+        raw_message: dict[str, Any] = {"role": "assistant", "content": full_content}
+        if raw_tool_calls:
+            raw_message["tool_calls"] = raw_tool_calls
+        yield ("", LLMResponse(
+            text=full_content or None,
+            tool_uses=tool_uses,
+            stop_reason=stop_reason,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            raw_message=raw_message,
+        ))
+
+    def format_tool_result(
+        self, tool_use_id: str, content: str, success: bool = True
+    ) -> dict[str, Any]:
+        return {
+            "role": "tool",
+            "tool_call_id": tool_use_id,
+            "content": content if success else f"Error: {content}",
+        }
 
 
 class LMStudioProvider(_OpenAICompatibleBase):

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -44,12 +44,29 @@ from .forensics import get_forensics
 logger = logging.getLogger(__name__)
 
 
-def _http_status_detail(provider: str, exc: Any) -> str:
+async def _http_status_detail(provider: str, exc: Any) -> str:
+    """Format an HTTPStatusError into a human-readable detail string.
+
+    Works for both regular and streaming responses. Streaming responses
+    raised through ``client.stream(...).__aenter__()`` haven't loaded
+    their body yet, so accessing ``.text`` would raise
+    ``httpx.ResponseNotRead``. We call ``aread()`` first and swallow any
+    read failure so the caller always gets *some* detail.
+    """
     response = getattr(exc, "response", None)
     status_code = getattr(response, "status_code", "unknown")
     body = ""
     if response is not None:
-        body = str(getattr(response, "text", "") or "").strip()
+        aread = getattr(response, "aread", None)
+        if callable(aread):
+            try:
+                await aread()
+            except Exception:
+                pass
+        try:
+            body = str(getattr(response, "text", "") or "").strip()
+        except Exception:
+            body = ""
     detail = f"{provider} request failed with HTTP {status_code}"
     if body:
         detail += f": {body[:1000]}"
@@ -1059,7 +1076,7 @@ class CodexResponsesProvider(LLMProvider):
                 try:
                     resp.raise_for_status()
                 except httpx.HTTPStatusError as exc:
-                    raise RuntimeError(_http_status_detail("Codex Responses", exc)) from exc
+                    raise RuntimeError(await _http_status_detail("Codex Responses", exc)) from exc
                 event: str | None = None
                 data_lines: list[str] = []
                 async for line in resp.aiter_lines():
@@ -1301,7 +1318,7 @@ class XAIResponsesProvider(LLMProvider):
                 try:
                     resp.raise_for_status()
                 except httpx.HTTPStatusError as exc:
-                    raise RuntimeError(_http_status_detail("xAI Responses", exc)) from exc
+                    raise RuntimeError(await _http_status_detail("xAI Responses", exc)) from exc
                 event: str | None = None
                 data_lines: list[str] = []
                 async for line in resp.aiter_lines():

--- a/tests/test_codex_responses_provider.py
+++ b/tests/test_codex_responses_provider.py
@@ -191,6 +191,35 @@ async def test_codex_provider_normalizes_tool_call(monkeypatch, codex_home):
 
 
 @pytest.mark.asyncio
+async def test_codex_provider_uses_output_text_for_assistant_history(monkeypatch, codex_home):
+    """Codex Responses backend rejects ``input_text`` in assistant slots
+    with HTTP 400 ``Supported values are: 'output_text' and 'refusal'``.
+    History replay must use ``output_text`` for the assistant role and
+    ``input_text`` for the user role."""
+    import httpx
+
+    fake_client = _FakeAsyncClient([
+        "event: response.completed",
+        'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":0,"output_tokens":0}}}',
+        "",
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = CodexResponsesProvider(model="codex/gpt-5.5")
+
+    await provider.chat(messages=[
+        {"role": "user", "content": "first user"},
+        {"role": "assistant", "content": "first reply"},
+        {"role": "user", "content": "second user"},
+    ])
+
+    input_items = fake_client.requests[0]["json"]["input"]
+    assert [item["role"] for item in input_items] == ["user", "assistant", "user"]
+    assert input_items[0]["content"][0]["type"] == "input_text"
+    assert input_items[1]["content"][0]["type"] == "output_text"
+    assert input_items[2]["content"][0]["type"] == "input_text"
+
+
+@pytest.mark.asyncio
 async def test_codex_provider_surfaces_backend_error_body(monkeypatch, codex_home):
     import httpx
 

--- a/tests/test_codex_responses_provider.py
+++ b/tests/test_codex_responses_provider.py
@@ -53,6 +53,49 @@ class _FakeAsyncClient:
         return _Ctx()
 
 
+class _ErrorStreamResponse:
+    status_code = 400
+    text = '{"detail":"Unsupported parameter: max_output_tokens"}'
+
+    def raise_for_status(self):
+        import httpx
+
+        request = httpx.Request("POST", "https://chatgpt.com/backend-api/codex/responses")
+        response = httpx.Response(400, text=self.text, request=request)
+        raise httpx.HTTPStatusError(
+            "Client error '400 Bad Request' for url",
+            request=request,
+            response=response,
+        )
+
+    async def aiter_lines(self):
+        if False:
+            yield ""
+
+
+class _FakeErrorAsyncClient:
+    def __init__(self):
+        self.requests = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def stream(self, method, url, headers=None, json=None):
+        self.requests.append({"method": method, "url": url, "headers": headers, "json": json})
+
+        class _Ctx:
+            async def __aenter__(self_inner):
+                return _ErrorStreamResponse()
+
+            async def __aexit__(self_inner, *exc):
+                return False
+
+        return _Ctx()
+
+
 @pytest.fixture
 def codex_home(tmp_path, monkeypatch):
     home = tmp_path / "codex"
@@ -123,3 +166,15 @@ async def test_codex_provider_normalizes_tool_call(monkeypatch, codex_home):
     assert response.tool_uses[0].args == {"path": "README.md"}
     assert response.raw_message["tool_calls"][0]["function"]["name"] == "read_file"
     assert fake_client.requests[0]["json"]["tools"][0]["type"] == "function"
+
+
+@pytest.mark.asyncio
+async def test_codex_provider_surfaces_backend_error_body(monkeypatch, codex_home):
+    import httpx
+
+    fake_client = _FakeErrorAsyncClient()
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = CodexResponsesProvider(model="codex/gpt-5.5")
+
+    with pytest.raises(RuntimeError, match="Unsupported parameter: max_output_tokens"):
+        await provider.chat(messages=[{"role": "user", "content": "ping"}])

--- a/tests/test_codex_responses_provider.py
+++ b/tests/test_codex_responses_provider.py
@@ -90,6 +90,7 @@ async def test_codex_provider_streams_text(monkeypatch, codex_home):
     assert req["json"]["model"] == "gpt-5.5"
     assert req["json"]["store"] is False
     assert req["json"]["stream"] is True
+    assert "max_output_tokens" not in req["json"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_codex_responses_provider.py
+++ b/tests/test_codex_responses_provider.py
@@ -54,18 +54,40 @@ class _FakeAsyncClient:
 
 
 class _ErrorStreamResponse:
+    """Mock that mirrors httpx streaming-response semantics.
+
+    A streaming response raises ``httpx.ResponseNotRead`` when ``.text``
+    is accessed before ``aread()``. ``raise_for_status()`` itself does
+    *not* read the body, so the exception carries this same streaming
+    response — accessing its ``.text`` blindly is the bug PR #449's
+    original handler had.
+    """
+
     status_code = 400
-    text = '{"detail":"Unsupported parameter: max_output_tokens"}'
+    _body = '{"detail":"Unsupported parameter: max_output_tokens"}'
+
+    def __init__(self):
+        self._read = False
+
+    async def aread(self):
+        self._read = True
+
+    @property
+    def text(self):
+        if not self._read:
+            import httpx
+
+            raise httpx.ResponseNotRead()
+        return self._body
 
     def raise_for_status(self):
         import httpx
 
         request = httpx.Request("POST", "https://chatgpt.com/backend-api/codex/responses")
-        response = httpx.Response(400, text=self.text, request=request)
         raise httpx.HTTPStatusError(
             "Client error '400 Bad Request' for url",
             request=request,
-            response=response,
+            response=self,
         )
 
     async def aiter_lines(self):
@@ -176,5 +198,13 @@ async def test_codex_provider_surfaces_backend_error_body(monkeypatch, codex_hom
     monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
     provider = CodexResponsesProvider(model="codex/gpt-5.5")
 
-    with pytest.raises(RuntimeError, match="Unsupported parameter: max_output_tokens"):
+    with pytest.raises(RuntimeError) as excinfo:
         await provider.chat(messages=[{"role": "user", "content": "ping"}])
+
+    message = str(excinfo.value)
+    assert "Unsupported parameter: max_output_tokens" in message
+    assert "HTTP 400" in message
+    # Guard against regression of the `.text` on streaming-response bug —
+    # the helper must call ``aread()`` before reading ``.text``, otherwise
+    # this string from httpx leaks out and masks the real backend error.
+    assert "without having called" not in message

--- a/tests/test_codex_responses_provider.py
+++ b/tests/test_codex_responses_provider.py
@@ -219,6 +219,74 @@ async def test_codex_provider_uses_output_text_for_assistant_history(monkeypatch
     assert input_items[2]["content"][0]["type"] == "input_text"
 
 
+class _StreamDropResponse:
+    """Simulates an SSE peer closing the connection mid-stream.
+
+    httpx raises ``RemoteProtocolError`` from ``aiter_lines`` when h11
+    sees a premature peer close. Some of those instances carry an empty
+    ``str(exc)`` — previously that surfaced as a bare
+    ``turn aborted with error: `` with nothing after the colon.
+    """
+
+    status_code = 200
+
+    def raise_for_status(self):
+        return None
+
+    async def aiter_lines(self):
+        import httpx
+
+        # Yield a partial event, then raise — mirrors a real peer-close.
+        yield "event: response.output_text.delta"
+        yield 'data: {"type":"response.output_text.delta","delta":"par"}'
+        yield ""
+        raise httpx.RemoteProtocolError("")
+
+
+class _StreamDropAsyncClient:
+    def __init__(self):
+        self.requests = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def stream(self, method, url, headers=None, json=None):
+        self.requests.append({"method": method, "url": url, "headers": headers, "json": json})
+
+        class _Ctx:
+            async def __aenter__(self_inner):
+                return _StreamDropResponse()
+
+            async def __aexit__(self_inner, *exc):
+                return False
+
+        return _Ctx()
+
+
+@pytest.mark.asyncio
+async def test_codex_provider_raises_meaningful_error_on_stream_drop(monkeypatch, codex_home):
+    """Mid-stream RemoteProtocolError with empty message must not surface
+    as ``turn aborted with error: `` (empty after colon)."""
+    import httpx
+
+    fake_client = _StreamDropAsyncClient()
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = CodexResponsesProvider(model="codex/gpt-5.5")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await provider.chat(messages=[{"role": "user", "content": "ping"}])
+
+    message = str(excinfo.value)
+    assert "Codex Responses stream interrupted" in message
+    # Falls back to the exception class name when the underlying message
+    # is empty — never leaves the user with a bare colon.
+    assert "RemoteProtocolError" in message
+    assert message.strip().endswith("RemoteProtocolError")
+
+
 @pytest.mark.asyncio
 async def test_codex_provider_surfaces_backend_error_body(monkeypatch, codex_home):
     import httpx

--- a/tests/test_xai_responses_provider.py
+++ b/tests/test_xai_responses_provider.py
@@ -189,6 +189,73 @@ async def test_xai_provider_uses_output_text_for_assistant_history(tmp_path, mon
     assert input_items[2]["content"][0]["type"] == "input_text"
 
 
+class _XAIStreamDropResponse:
+    """Simulates an SSE peer closing the connection mid-stream."""
+
+    status_code = 200
+
+    def raise_for_status(self):
+        return None
+
+    async def aiter_lines(self):
+        import httpx
+
+        yield "event: response.output_text.delta"
+        yield 'data: {"type":"response.output_text.delta","delta":"par"}'
+        yield ""
+        raise httpx.RemoteProtocolError("")
+
+
+class _XAIStreamDropAsyncClient:
+    def __init__(self, *args, **kwargs):
+        self.requests = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def stream(self, method, url, headers=None, json=None):
+        self.requests.append({"method": method, "url": url, "headers": headers, "json": json})
+
+        class _Ctx:
+            async def __aenter__(self_inner):
+                return _XAIStreamDropResponse()
+
+            async def __aexit__(self_inner, *exc):
+                return False
+
+        return _Ctx()
+
+
+@pytest.mark.asyncio
+async def test_xai_provider_raises_meaningful_error_on_stream_drop(tmp_path, monkeypatch):
+    """Mid-stream RemoteProtocolError with empty message must not surface
+    as ``turn aborted with error: `` (empty after colon)."""
+    import httpx
+
+    monkeypatch.setenv("LOOM_HOME", str(tmp_path / "loom-home"))
+    token = _jwt(int(time.time()) + 3600)
+    save_xai_oauth_state({
+        "tokens": {
+            "access_token": token,
+            "refresh_token": "refresh-secret",
+        },
+        "base_url": DEFAULT_XAI_BASE_URL,
+    })
+    monkeypatch.setattr(httpx, "AsyncClient", _XAIStreamDropAsyncClient)
+    provider = XAIResponsesProvider(model="xai/grok-4.3")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await provider.chat(messages=[{"role": "user", "content": "ping"}])
+
+    message = str(excinfo.value)
+    assert "xAI Responses stream interrupted" in message
+    assert "RemoteProtocolError" in message
+    assert message.strip().endswith("RemoteProtocolError")
+
+
 @pytest.mark.asyncio
 async def test_xai_provider_surfaces_streaming_backend_error(tmp_path, monkeypatch):
     import httpx

--- a/tests/test_xai_responses_provider.py
+++ b/tests/test_xai_responses_provider.py
@@ -88,6 +88,7 @@ async def test_xai_provider_streams_with_oauth_token_not_api_key(tmp_path, monke
     assert req["headers"]["Authorization"] == f"Bearer {token}"
     assert "xai-api-key-that-must-not-be-used" not in json.dumps(req)
     assert req["json"]["model"] == "grok-4.3"
+    assert req["json"]["max_output_tokens"] == 8096
 
 
 @pytest.mark.asyncio

--- a/tests/test_xai_responses_provider.py
+++ b/tests/test_xai_responses_provider.py
@@ -4,7 +4,7 @@ import time
 
 import pytest
 
-from loom.core.cognition.providers import XAIResponsesProvider
+from loom.core.cognition.providers import CodexResponsesProvider, XAIResponsesProvider
 from loom.core.cognition.xai_auth import DEFAULT_XAI_BASE_URL, save_xai_oauth_state
 
 
@@ -14,6 +14,10 @@ def _jwt(exp: int) -> str:
         json.dumps({"exp": exp}).encode()
     ).rstrip(b"=").decode()
     return f"{header}.{payload}."
+
+
+def test_xai_provider_does_not_inherit_codex_provider():
+    assert not issubclass(XAIResponsesProvider, CodexResponsesProvider)
 
 
 class _StreamResponse:

--- a/tests/test_xai_responses_provider.py
+++ b/tests/test_xai_responses_provider.py
@@ -154,6 +154,42 @@ class _XAIErrorAsyncClient:
 
 
 @pytest.mark.asyncio
+async def test_xai_provider_uses_output_text_for_assistant_history(tmp_path, monkeypatch):
+    """Mirrors the Codex Responses contract — assistant content must be
+    ``output_text``, user content ``input_text``."""
+    import httpx
+
+    monkeypatch.setenv("LOOM_HOME", str(tmp_path / "loom-home"))
+    token = _jwt(int(time.time()) + 3600)
+    save_xai_oauth_state({
+        "tokens": {
+            "access_token": token,
+            "refresh_token": "refresh-secret",
+        },
+        "base_url": DEFAULT_XAI_BASE_URL,
+    })
+    fake_client = _FakeAsyncClient([
+        "event: response.completed",
+        'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":0,"output_tokens":0}}}',
+        "",
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = XAIResponsesProvider(model="xai/grok-4.3")
+
+    await provider.chat(messages=[
+        {"role": "user", "content": "first user"},
+        {"role": "assistant", "content": "first reply"},
+        {"role": "user", "content": "second user"},
+    ])
+
+    input_items = fake_client.requests[0]["json"]["input"]
+    assert [item["role"] for item in input_items] == ["user", "assistant", "user"]
+    assert input_items[0]["content"][0]["type"] == "input_text"
+    assert input_items[1]["content"][0]["type"] == "output_text"
+    assert input_items[2]["content"][0]["type"] == "input_text"
+
+
+@pytest.mark.asyncio
 async def test_xai_provider_surfaces_streaming_backend_error(tmp_path, monkeypatch):
     import httpx
 

--- a/tests/test_xai_responses_provider.py
+++ b/tests/test_xai_responses_provider.py
@@ -95,6 +95,89 @@ async def test_xai_provider_streams_with_oauth_token_not_api_key(tmp_path, monke
     assert req["json"]["max_output_tokens"] == 8096
 
 
+class _XAIErrorStreamResponse:
+    """Streaming-aware mock that mirrors httpx.ResponseNotRead semantics."""
+
+    status_code = 401
+    _body = '{"detail":"invalid bearer token"}'
+
+    def __init__(self):
+        self._read = False
+
+    async def aread(self):
+        self._read = True
+
+    @property
+    def text(self):
+        if not self._read:
+            import httpx
+
+            raise httpx.ResponseNotRead()
+        return self._body
+
+    def raise_for_status(self):
+        import httpx
+
+        request = httpx.Request("POST", "https://api.x.ai/v1/responses")
+        raise httpx.HTTPStatusError(
+            "Client error '401 Unauthorized' for url",
+            request=request,
+            response=self,
+        )
+
+    async def aiter_lines(self):
+        if False:
+            yield ""
+
+
+class _XAIErrorAsyncClient:
+    def __init__(self, *args, **kwargs):
+        self.requests = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def stream(self, method, url, headers=None, json=None):
+        self.requests.append({"method": method, "url": url, "headers": headers, "json": json})
+
+        class _Ctx:
+            async def __aenter__(self_inner):
+                return _XAIErrorStreamResponse()
+
+            async def __aexit__(self_inner, *exc):
+                return False
+
+        return _Ctx()
+
+
+@pytest.mark.asyncio
+async def test_xai_provider_surfaces_streaming_backend_error(tmp_path, monkeypatch):
+    import httpx
+
+    monkeypatch.setenv("LOOM_HOME", str(tmp_path / "loom-home"))
+    token = _jwt(int(time.time()) + 3600)
+    save_xai_oauth_state({
+        "tokens": {
+            "access_token": token,
+            "refresh_token": "refresh-secret",
+        },
+        "base_url": DEFAULT_XAI_BASE_URL,
+    })
+    monkeypatch.setattr(httpx, "AsyncClient", _XAIErrorAsyncClient)
+    provider = XAIResponsesProvider(model="xai/grok-4.3")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await provider.chat(messages=[{"role": "user", "content": "ping"}])
+
+    message = str(excinfo.value)
+    assert "401" in message
+    assert "invalid bearer token" in message
+    assert "without having called" not in message
+
+
 @pytest.mark.asyncio
 async def test_xai_router_rejects_config_base_url_before_streaming(tmp_path, monkeypatch):
     import httpx


### PR DESCRIPTION
## Summary
- stop sending `max_output_tokens` to the ChatGPT Codex Responses backend, which now rejects it with HTTP 400
- keep `max_output_tokens` enabled for the xAI Responses subclass so the newly merged xAI provider keeps its API shape
- add regression assertions for both provider payload contracts

## Verification
- `pytest -q tests/test_codex_responses_provider.py::test_codex_provider_streams_text tests/test_xai_responses_provider.py::test_xai_provider_streams_with_oauth_token_not_api_key` — red/green verified
- authenticated Codex backend probe with `codex/gpt-5.5` now returns HTTP 200 and confirms the request omits `max_output_tokens`
- `pytest -q tests/test_codex_responses_provider.py tests/test_xai_responses_provider.py tests/test_session.py::TestBuildRouter` — 7 passed
- `python -m py_compile loom/core/cognition/providers.py tests/test_codex_responses_provider.py tests/test_xai_responses_provider.py`
- `git diff --check`
- `npx gitnexus detect-changes --scope staged` — risk low, affected processes 0

Root cause: `https://chatgpt.com/backend-api/codex/responses` now returns `{"detail":"Unsupported parameter: max_output_tokens"}` for the previous payload.