### PR TITLE
fix(cognition): suppress function_call_arguments deltas from text stream

### DIFF
--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -1107,12 +1107,21 @@ class CodexResponsesProvider(LLMProvider):
                                 data = json.loads(raw)
                             except json.JSONDecodeError:
                                 continue
+                            event_type = data.get("type", "")
                             delta = data.get("delta")
-                            if isinstance(delta, str):
+                            # OpenAI Responses SSE emits ``delta`` on multiple
+                            # event types — only ``response.output_text.delta``
+                            # is user-facing text. ``response.function_call_arguments.delta``
+                            # streams the JSON args of an in-flight tool call
+                            # and must NOT leak into the assistant message;
+                            # the canonical args still arrive on
+                            # ``response.output_item.done`` so we can ignore
+                            # the streaming form entirely.
+                            if isinstance(delta, str) and event_type.endswith("output_text.delta"):
                                 full_content += delta
                                 yield (delta, None)
                             item = data.get("item")
-                            if isinstance(item, dict) and data.get("type", "").endswith("output_item.done"):
+                            if isinstance(item, dict) and event_type.endswith("output_item.done"):
                                 output_items.append(item)
                             response = data.get("response")
                             if isinstance(response, dict):
@@ -1354,12 +1363,21 @@ class XAIResponsesProvider(LLMProvider):
                                 data = json.loads(raw)
                             except json.JSONDecodeError:
                                 continue
+                            event_type = data.get("type", "")
                             delta = data.get("delta")
-                            if isinstance(delta, str):
+                            # OpenAI Responses SSE emits ``delta`` on multiple
+                            # event types — only ``response.output_text.delta``
+                            # is user-facing text. ``response.function_call_arguments.delta``
+                            # streams the JSON args of an in-flight tool call
+                            # and must NOT leak into the assistant message;
+                            # the canonical args still arrive on
+                            # ``response.output_item.done`` so we can ignore
+                            # the streaming form entirely.
+                            if isinstance(delta, str) and event_type.endswith("output_text.delta"):
                                 full_content += delta
                                 yield (delta, None)
                             item = data.get("item")
-                            if isinstance(item, dict) and data.get("type", "").endswith("output_item.done"):
+                            if isinstance(item, dict) and event_type.endswith("output_item.done"):
                                 output_items.append(item)
                             response = data.get("response")
                             if isinstance(response, dict):

--- a/tests/test_codex_responses_provider.py
+++ b/tests/test_codex_responses_provider.py
@@ -219,6 +219,48 @@ async def test_codex_provider_uses_output_text_for_assistant_history(monkeypatch
     assert input_items[2]["content"][0]["type"] == "input_text"
 
 
+@pytest.mark.asyncio
+async def test_codex_provider_does_not_leak_function_call_args_into_text(monkeypatch, codex_home):
+    """OpenAI Responses SSE emits ``delta`` on multiple event types.
+    ``response.function_call_arguments.delta`` carries the JSON args of
+    an in-flight tool call and must NOT bleed into the assistant text —
+    otherwise the user sees the JSON appear inline and then the tool
+    fires immediately after, which looks like a duplicated submission.
+    Regression test for the live-smoke observation on PR #448.
+    """
+    import httpx
+
+    fake_client = _FakeAsyncClient([
+        "event: response.output_text.delta",
+        'data: {"type":"response.output_text.delta","delta":"on it"}',
+        "",
+        "event: response.function_call_arguments.delta",
+        'data: {"type":"response.function_call_arguments.delta","delta":"{\\"path\\":"}',
+        "",
+        "event: response.function_call_arguments.delta",
+        'data: {"type":"response.function_call_arguments.delta","delta":"\\"README.md\\"}"}',
+        "",
+        "event: response.output_item.done",
+        'data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_1","name":"read_file","arguments":"{\\"path\\":\\"README.md\\"}"}}',
+        "",
+        "event: response.completed",
+        'data: {"type":"response.completed","response":{"status":"completed"}}',
+        "",
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = CodexResponsesProvider(model="codex/gpt-5.5")
+
+    response = await provider.chat(messages=[{"role": "user", "content": "read"}])
+
+    # Only the real output_text.delta becomes user-facing text.
+    assert response.text == "on it"
+    assert '"path"' not in (response.text or "")
+    # The tool call still arrives normally via output_item.done.
+    assert len(response.tool_uses) == 1
+    assert response.tool_uses[0].name == "read_file"
+    assert response.tool_uses[0].args == {"path": "README.md"}
+
+
 class _StreamDropResponse:
     """Simulates an SSE peer closing the connection mid-stream.
 

--- a/tests/test_xai_responses_provider.py
+++ b/tests/test_xai_responses_provider.py
@@ -189,6 +189,49 @@ async def test_xai_provider_uses_output_text_for_assistant_history(tmp_path, mon
     assert input_items[2]["content"][0]["type"] == "input_text"
 
 
+@pytest.mark.asyncio
+async def test_xai_provider_does_not_leak_function_call_args_into_text(tmp_path, monkeypatch):
+    """Mirror of the Codex regression — function_call_arguments.delta
+    must not bleed into assistant text."""
+    import httpx
+
+    monkeypatch.setenv("LOOM_HOME", str(tmp_path / "loom-home"))
+    token = _jwt(int(time.time()) + 3600)
+    save_xai_oauth_state({
+        "tokens": {
+            "access_token": token,
+            "refresh_token": "refresh-secret",
+        },
+        "base_url": DEFAULT_XAI_BASE_URL,
+    })
+    fake_client = _FakeAsyncClient([
+        "event: response.output_text.delta",
+        'data: {"type":"response.output_text.delta","delta":"thinking"}',
+        "",
+        "event: response.function_call_arguments.delta",
+        'data: {"type":"response.function_call_arguments.delta","delta":"{\\"q\\":"}',
+        "",
+        "event: response.function_call_arguments.delta",
+        'data: {"type":"response.function_call_arguments.delta","delta":"\\"loom\\"}"}',
+        "",
+        "event: response.output_item.done",
+        'data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_1","name":"search","arguments":"{\\"q\\":\\"loom\\"}"}}',
+        "",
+        "event: response.completed",
+        'data: {"type":"response.completed","response":{"status":"completed"}}',
+        "",
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = XAIResponsesProvider(model="xai/grok-4.3")
+
+    response = await provider.chat(messages=[{"role": "user", "content": "search loom"}])
+
+    assert response.text == "thinking"
+    assert '"q"' not in (response.text or "")
+    assert len(response.tool_uses) == 1
+    assert response.tool_uses[0].args == {"q": "loom"}
+
+
 class _XAIStreamDropResponse:
     """Simulates an SSE peer closing the connection mid-stream."""
 


### PR DESCRIPTION
## Summary
- OpenAI Responses SSE emits ``delta`` on multiple event types — only ``response.output_text.delta`` is user-facing text. ``response.function_call_arguments.delta`` carries the JSON args of an in-flight tool call and must NOT leak into the assistant message.
- The Codex / xAI providers' ``stream_chat`` blindly yielded any ``data[\"delta\"]`` as a text chunk, so the JSON args appeared inline in the reply right before the tool's structured invocation. From the user's POV: looks like the same tool call shows up twice — first as text, then as the actual tool run.
- Gate the text-yield path on ``event_type.endswith(\"output_text.delta\")``. The canonical args still arrive intact on ``response.output_item.done``, so we lose no information.

## Repro (from PR #448 live smoke test)
\`codex/gpt-5.5\` calling \`minimax__play_audio\` produced:
\`\`\`
哎呀播放器要絕對路徑，剛剛用相對路徑被它挑剔了～我換絕對路徑再播一次。{\"input_file_path\":\"/Users/...\",\"is_url\":false,\"justification\":\"...\"}{\"input_file_path\":\"/Users/...\",\"is_url\":false,\"justification\":\"...\"}
  [-] 前一次播放因相對路徑失敗...
      minimax__play_audio(input_file_path=\"/Users/...\", is_url=False)
  [ok] minimax__play_audio  7392ms  done
\`\`\`
The JSON appearing twice inline is two ``function_call_arguments.delta`` events leaking; the actual tool fired exactly once.

## Verification
- \`pytest tests/test_codex_responses_provider.py tests/test_xai_responses_provider.py\` — 13 passed (was 11, +2 new regression tests)
- \`pytest tests/test_codex_responses_provider.py tests/test_xai_responses_provider.py tests/test_xai_oauth_auth.py tests/test_session.py tests/test_cli_auth.py tests/test_xai_tts_tool.py\` — 79 passed, no regressions

## Regression test shape
Stream emits:
1. \`response.output_text.delta\` with \`delta=\"on it\"\`
2. \`response.function_call_arguments.delta\` × 2 (the leaky case)
3. \`response.output_item.done\` with the canonical \`function_call\` item
4. \`response.completed\`

Assertions: \`response.text == \"on it\"\` (no JSON in text), \`response.tool_uses[0].args == {\"path\": \"README.md\"}\` (canonical args still reconstructed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)