### PR TITLE
feat(memory): route relational triples through semantic store (#451 phase A)

### DIFF
--- a/doc/11-Memory-Search.md
+++ b/doc/11-Memory-Search.md
@@ -44,6 +44,8 @@ LIMIT ?
 
 距離越小越相似，取 `1.0 - distance` 轉換為相似度分數（0–1）。
 
+> **#451 Phase A — Relational triples 走同一條路**：dreaming / `relate` tool / self-reflection 寫入的 `(subject, predicate, object)` 三元組會以 `key = "rel:{subject}::{predicate}"`、`value = "{subject} {predicate} {object}"` 鏡射到 `semantic_entries`，因此自動參與這兩階段瀑布。`recall` 回傳時透過 `_semantic_result_type()` 把 `rel:*` 鍵的命中標為 `type="relational"`，agent 看得到 kind 但不需要切換 verb。Legacy DB 升級後缺 embedding 的 `rel:*` 行，在 `LoomSession.start()` 由 `SemanticMemory.ensure_embeddings_for_prefix("rel:")` 補齊一次。
+
 ### SemanticMemory.upsert() 中的自動嵌入
 
 ```python

--- a/loom/core/memory/relational.py
+++ b/loom/core/memory/relational.py
@@ -18,10 +18,11 @@ Examples
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, UTC
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import aiosqlite
 
@@ -31,6 +32,11 @@ from loom.core.memory.ontology import (
     normalize_domain,
     normalize_temporal,
 )
+
+if TYPE_CHECKING:
+    from loom.core.memory.semantic import SemanticMemory
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -93,8 +99,18 @@ class RelationalMemory:
     Upserting with the same (subject, predicate) replaces the object.
     """
 
-    def __init__(self, db: aiosqlite.Connection) -> None:
+    def __init__(
+        self,
+        db: aiosqlite.Connection,
+        semantic: "SemanticMemory | None" = None,
+    ) -> None:
         self._db = db
+        # Issue #451 phase A: dual-write triples into the semantic store so
+        # ``recall`` can surface them. The legacy ``relational_entries``
+        # table remains the source of truth until phase B. When ``semantic``
+        # is None (e.g. ad-hoc scripts), dual-write is skipped — the next
+        # session startup will backfill via ``SQLiteStore.initialize``.
+        self._semantic = semantic
 
     async def upsert(self, entry: RelationalEntry) -> None:
         """Insert or update the (subject, predicate) entry."""
@@ -130,6 +146,19 @@ class RelationalMemory:
             ),
         )
         await self._db.commit()
+
+        # Issue #451 phase A: dual-write to semantic so recall can find this.
+        # Failure here must not block the relational write (semantic is the
+        # *new* path; relational remains the source of truth in phase A).
+        if self._semantic is not None:
+            try:
+                from loom.core.memory.relational_bridge import triple_to_semantic
+                await self._semantic.upsert(triple_to_semantic(entry))
+            except Exception as exc:
+                logger.warning(
+                    "Relational dual-write to semantic failed for (%s, %s): %s",
+                    entry.subject, entry.predicate, exc,
+                )
 
     async def get(self, subject: str, predicate: str) -> RelationalEntry | None:
         """Return the entry for (subject, predicate), or None."""
@@ -183,7 +212,22 @@ class RelationalMemory:
             (subject, predicate),
         )
         await self._db.commit()
-        return (cursor.rowcount or 0) > 0
+        deleted = (cursor.rowcount or 0) > 0
+
+        # Issue #451 phase A: mirror the delete in semantic so recall stops
+        # finding the triple. Safe to attempt even if the bridge row never
+        # existed — delete is idempotent.
+        if deleted and self._semantic is not None:
+            try:
+                from loom.core.memory.relational_bridge import make_rel_key
+                await self._semantic.delete(make_rel_key(subject, predicate))
+            except Exception as exc:
+                logger.warning(
+                    "Relational dual-delete in semantic failed for (%s, %s): %s",
+                    subject, predicate, exc,
+                )
+
+        return deleted
 
     # ------------------------------------------------------------------
 

--- a/loom/core/memory/relational_bridge.py
+++ b/loom/core/memory/relational_bridge.py
@@ -1,0 +1,92 @@
+"""
+Relational ↔ Semantic bridge (issue #451 phase A).
+
+Encodes (subject, predicate, object) triples as ``SemanticEntry`` rows so
+that ``recall`` — currently scoped to semantic + skill — can naturally
+surface relational facts written by dream cycle, ``relate`` tool, and
+self-reflection. Phase B will retire the standalone ``relational_entries``
+table once this routing is proven.
+
+Encoding rules:
+
+* ``key   = f"rel:{subject}::{predicate}"`` — preserves the original
+  ``(subject, predicate)`` uniqueness via the semantic ``key`` constraint.
+  The double-colon separator avoids ambiguity with subjects that already
+  contain single colons (e.g. ``minimax:tts:speech-2.6-hd``).
+* ``value = f"{subject} {predicate} {object}"`` — natural-language form
+  so BM25 and embedding tiers can match without special handling.
+* ``metadata`` carries the authoritative ``subject`` / ``predicate`` /
+  ``object`` triple for round-trip decoding. The key is for uniqueness
+  only and is *not* parsed back into a triple.
+"""
+
+from __future__ import annotations
+
+from loom.core.memory.relational import RelationalEntry
+from loom.core.memory.semantic import SemanticEntry
+
+
+REL_KEY_PREFIX = "rel:"
+REL_KEY_SEP = "::"
+
+
+def make_rel_key(subject: str, predicate: str) -> str:
+    return f"{REL_KEY_PREFIX}{subject}{REL_KEY_SEP}{predicate}"
+
+
+def is_rel_key(key: str) -> bool:
+    return key.startswith(REL_KEY_PREFIX)
+
+
+def triple_to_semantic(entry: RelationalEntry) -> SemanticEntry:
+    """Encode a ``RelationalEntry`` as a ``SemanticEntry`` for the semantic store."""
+    metadata = dict(entry.metadata)
+    metadata["subject"] = entry.subject
+    metadata["predicate"] = entry.predicate
+    metadata["object"] = entry.object
+    return SemanticEntry(
+        key=make_rel_key(entry.subject, entry.predicate),
+        value=f"{entry.subject} {entry.predicate} {entry.object}",
+        confidence=entry.confidence,
+        source=entry.source,
+        metadata=metadata,
+        id=entry.id,
+        created_at=entry.created_at,
+        updated_at=entry.updated_at,
+        domain=entry.domain,
+        temporal=entry.temporal,
+        last_accessed_at=entry.last_accessed_at,
+    )
+
+
+def semantic_to_triple(entry: SemanticEntry) -> RelationalEntry | None:
+    """Decode a ``SemanticEntry`` back to a ``RelationalEntry``.
+
+    Returns ``None`` if the entry is not a relational fact (key prefix
+    mismatch, or metadata missing required keys).
+    """
+    if not is_rel_key(entry.key):
+        return None
+    md = entry.metadata or {}
+    subject = md.get("subject")
+    predicate = md.get("predicate")
+    if not subject or not predicate:
+        return None
+    clean_md = {
+        k: v for k, v in md.items()
+        if k not in ("subject", "predicate", "object")
+    }
+    return RelationalEntry(
+        subject=subject,
+        predicate=predicate,
+        object=md.get("object", entry.value),
+        confidence=entry.confidence,
+        source=entry.source or "agent",
+        metadata=clean_md,
+        id=entry.id,
+        created_at=entry.created_at,
+        updated_at=entry.updated_at,
+        domain=entry.domain,
+        temporal=entry.temporal,
+        last_accessed_at=entry.last_accessed_at,
+    )

--- a/loom/core/memory/search.py
+++ b/loom/core/memory/search.py
@@ -44,6 +44,17 @@ def _sanitize_fts(query: str) -> str:
     return " ".join(f'"{t}"' for t in query.replace('"', " ").split() if t)
 
 
+def _semantic_result_type(key: str) -> str:
+    """Issue #451: tag rel:* keys as ``"relational"`` so callers see the kind.
+
+    Relational triples live in ``semantic_entries`` with key ``rel:{S}::{P}``
+    (see ``loom/core/memory/relational_bridge.py``). They surface through
+    the same BM25 / embedding paths as ordinary semantic facts; this helper
+    just relabels them for the agent-facing display.
+    """
+    return "relational" if key.startswith("rel:") else "semantic"
+
+
 def _axis_filter_sql(
     domain: str | None,
     temporal: str | None,
@@ -283,7 +294,7 @@ class MemorySearch:
             if score > 0.0:
                 results.append(
                     MemorySearchResult(
-                        type="semantic",
+                        type=_semantic_result_type(entry.key),
                         key=entry.key,
                         value=entry.value,
                         score=score,
@@ -316,7 +327,7 @@ class MemorySearch:
                 entries = await self._semantic.list_recent(limit)
             results.extend(
                 MemorySearchResult(
-                    type="semantic",
+                    type=_semantic_result_type(e.key),
                     key=e.key,
                     value=e.value,
                     score=0.0,
@@ -392,7 +403,7 @@ class MemorySearch:
             score = abs(r[11]) if r[11] else 0.0
             results.append(
                 MemorySearchResult(
-                    type="semantic",
+                    type=_semantic_result_type(entry.key),
                     key=entry.key,
                     value=entry.value,
                     score=score,

--- a/loom/core/memory/search.py
+++ b/loom/core/memory/search.py
@@ -243,8 +243,14 @@ class MemorySearch:
         return ranked
 
     async def _mark_accessed(self, results: list[MemorySearchResult]) -> None:
-        """Bump last_accessed_at for semantic hits (Memory Ontology v0.1)."""
-        keys = [r.key for r in results if r.type == "semantic"]
+        """Bump last_accessed_at for semantic + relational hits (Memory Ontology v0.1).
+
+        Issue #451 phase A: ``relational`` is a display label for ``rel:*``
+        keys that live in ``semantic_entries`` (see ``_semantic_result_type``).
+        Both kinds need their access timestamp refreshed; ``SemanticMemory.
+        mark_accessed`` handles the relational source-table mirror.
+        """
+        keys = [r.key for r in results if r.type in ("semantic", "relational")]
         if keys:
             await self._semantic.mark_accessed(keys)
 

--- a/loom/core/memory/semantic.py
+++ b/loom/core/memory/semantic.py
@@ -449,6 +449,81 @@ class SemanticMemory:
             results.append((_row_to_entry(r[:11]), float(score)))
         return results
 
+    async def ensure_embeddings_for_prefix(
+        self,
+        prefix: str,
+        *,
+        batch_size: int = 32,
+    ) -> int:
+        """Fill missing embeddings for rows whose ``key`` starts with ``prefix``.
+
+        Idempotent — only touches rows where ``embedding IS NULL``. Returns
+        the number of rows embedded. No-op when no embedding provider is
+        configured (callers should still be safe to invoke).
+
+        Added for issue #451 phase A so that legacy ``relational_entries``
+        rows backfilled into ``semantic_entries`` (without an embedding,
+        since ``SQLiteStore.initialize`` runs before the embedding provider
+        is plumbed) become visible through the embedding-tier recall path.
+        Without this, ``_search_semantic_embedding``'s
+        ``WHERE embedding IS NOT NULL`` filter excludes them, and recall's
+        short-circuit on non-empty embedding results means BM25 never sees
+        them either.
+        """
+        if self._embeddings is None:
+            return 0
+
+        cursor = await self._db.execute(
+            "SELECT key, value FROM semantic_entries "
+            "WHERE key LIKE ? AND embedding IS NULL",
+            (f"{prefix}%",),
+        )
+        rows = await cursor.fetchall()
+        if not rows:
+            return 0
+
+        embedded = 0
+        for i in range(0, len(rows), batch_size):
+            chunk = rows[i:i + batch_size]
+            texts = [f"{k} {v}" for k, v in chunk]
+            try:
+                vectors = await self._embeddings.embed(texts)
+            except Exception as exc:
+                logger.warning(
+                    "ensure_embeddings_for_prefix(%r) batch embed failed at "
+                    "offset %d (%d rows): %s — skipping remainder of this batch",
+                    prefix, i, len(chunk), exc,
+                )
+                if self._health:
+                    self._health.record_failure("embedding_write", str(exc))
+                continue
+
+            for (key, _value), vector in zip(chunk, vectors):
+                if vector is None:
+                    continue
+                try:
+                    await self._db.execute(
+                        "UPDATE semantic_entries SET embedding = ? WHERE key = ?",
+                        (json.dumps(vector), key),
+                    )
+                    embedded += 1
+                except Exception as exc:
+                    logger.warning(
+                        "ensure_embeddings_for_prefix(%r) write failed for "
+                        "key=%r: %s", prefix, key, exc,
+                    )
+            await self._db.commit()
+            if self._health:
+                self._health.record_success("embedding_write")
+
+        if embedded:
+            logger.info(
+                "Filled %d missing embeddings for prefix %r "
+                "(issue #451 phase A backfill).",
+                embedded, prefix,
+            )
+        return embedded
+
     async def list_by_prefix(self, prefix: str, limit: int = 10) -> list[SemanticEntry]:
         """Return entries whose key starts with *prefix*, newest first.
 
@@ -535,6 +610,16 @@ class SemanticMemory:
         decay cycle can distinguish facts that are still in active use from
         those drifting toward archived state. Silent no-op for empty keys
         list — recall hot path stays cheap.
+
+        Issue #451 phase A: when any ``rel:*`` keys are present, mirror the
+        timestamp into ``relational_entries`` as well. The bridged rows
+        share the same ``id`` across both tables (see
+        ``SQLiteStore._backfill_relational_into_semantic`` and
+        ``relational_bridge.triple_to_semantic``), so the mirror reduces to
+        an UPDATE..WHERE id IN (...). Without this, dream/relational
+        triples that are actively recalled still decay out of the
+        relational source-of-truth table. Phase B retires this mirror
+        when the relational table itself goes away.
         """
         if not keys:
             return
@@ -545,4 +630,17 @@ class SemanticMemory:
             f"WHERE key IN ({placeholders})",
             (now, *keys),
         )
+
+        # Mirror into relational_entries for any bridged rel:* keys.
+        rel_keys = [k for k in keys if k.startswith("rel:")]
+        if rel_keys:
+            rel_placeholders = ",".join("?" * len(rel_keys))
+            await self._db.execute(
+                f"UPDATE relational_entries SET last_accessed_at = ? "
+                f"WHERE id IN ("
+                f"  SELECT id FROM semantic_entries WHERE key IN ({rel_placeholders})"
+                f")",
+                (now, *rel_keys),
+            )
+
         await self._db.commit()

--- a/loom/core/memory/store.py
+++ b/loom/core/memory/store.py
@@ -277,6 +277,20 @@ class SQLiteStore:
                 except Exception:
                     pass
 
+            # Issue #451 phase A: backfill relational_entries → semantic_entries.
+            # Idempotent — INSERT OR IGNORE keyed on `rel:{subject}::{predicate}`.
+            # New relational writes dual-write directly via RelationalMemory.upsert,
+            # so this backfill is only load-bearing on first run and as a safety net
+            # for any process that wrote without plumbing semantic through.
+            try:
+                await self._backfill_relational_into_semantic(db)
+            except Exception as exc:
+                # Backfill failure must not block startup. Surface to logs.
+                import logging
+                logging.getLogger(__name__).warning(
+                    "Relational → semantic backfill failed: %s", exc,
+                )
+
             # Ensure FTS indexes are up-to-date with existing content (idempotent, fast)
             try:
                 await db.execute("INSERT INTO semantic_fts(semantic_fts) VALUES ('rebuild')")
@@ -300,6 +314,71 @@ class SQLiteStore:
             # instead of immediately raising `database is locked`.
             await db.execute("PRAGMA busy_timeout = 5000;")
             yield db
+
+    @staticmethod
+    async def _backfill_relational_into_semantic(db: aiosqlite.Connection) -> None:
+        """Copy every ``relational_entries`` row into ``semantic_entries`` with
+        a ``rel:{subject}::{predicate}`` key. Uses ``INSERT OR IGNORE`` so
+        re-runs are no-ops once the row exists.
+
+        Embeddings are *not* populated here — running provider calls inline
+        with startup would slow boot. Embedding maintenance fills them
+        opportunistically as recall traffic hits these keys.
+        """
+        # Build (subject, predicate, object, ...) → SemanticEntry-shaped rows.
+        cursor = await db.execute(
+            "SELECT id, subject, predicate, object, confidence, source, metadata, "
+            "created_at, updated_at, domain, temporal, last_accessed_at "
+            "FROM relational_entries"
+        )
+        rows = await cursor.fetchall()
+        if not rows:
+            return
+
+        inserted = 0
+        for (
+            rel_id, subject, predicate, obj, confidence, source, metadata_raw,
+            created_at, updated_at, domain, temporal, last_accessed_at,
+        ) in rows:
+            try:
+                md = json.loads(metadata_raw) if metadata_raw else {}
+            except Exception:
+                md = {}
+            md["subject"] = subject
+            md["predicate"] = predicate
+            md["object"] = obj
+            key = f"rel:{subject}::{predicate}"
+            value = f"{subject} {predicate} {obj}"
+            cur = await db.execute(
+                """
+                INSERT OR IGNORE INTO semantic_entries
+                    (id, key, value, confidence, source, metadata,
+                     created_at, updated_at, domain, temporal, last_accessed_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    rel_id,
+                    key,
+                    value,
+                    confidence,
+                    source,
+                    json.dumps(md, ensure_ascii=False),
+                    created_at,
+                    updated_at,
+                    domain or "knowledge",
+                    temporal or "recent",
+                    last_accessed_at,
+                ),
+            )
+            if cur.rowcount and cur.rowcount > 0:
+                inserted += 1
+        await db.commit()
+        if inserted:
+            import logging
+            logging.getLogger(__name__).info(
+                "Backfilled %d relational triples into semantic store "
+                "(issue #451 phase A).", inserted,
+            )
 
     @staticmethod
     def _dumps(obj: dict) -> str:

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1139,6 +1139,20 @@ class LoomSession:
         semantic = SemanticMemory(self._db, embedding_provider=emb_provider)
         procedural = ProceduralMemory(self._db)
         relational = RelationalMemory(self._db, semantic=semantic)
+        # Issue #451 phase A: backfill embeddings for `rel:*` mirror rows
+        # that were copied into semantic_entries by SQLiteStore.initialize()
+        # (which runs before the embedding provider is plumbed). Without
+        # this, the embedding tier filters them out and recall's short-
+        # circuit means BM25 never sees them. Idempotent — only acts on
+        # rows where embedding IS NULL.
+        if semantic.has_embeddings:
+            try:
+                await semantic.ensure_embeddings_for_prefix("rel:")
+            except Exception as exc:
+                logger.warning(
+                    "Relational embedding backfill failed (will retry next "
+                    "session start): %s", exc,
+                )
         # Issue #147 Phase C.1: ReflectionAPI / CounterFactualReflector
         # now take the MemoryFacade. They are constructed below, after
         # ``self._memory`` is built (search "Phase C.1: facade-aware

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1138,7 +1138,7 @@ class LoomSession:
         emb_provider = build_embedding_provider(_load_env(), _load_loom_config())
         semantic = SemanticMemory(self._db, embedding_provider=emb_provider)
         procedural = ProceduralMemory(self._db)
-        relational = RelationalMemory(self._db)
+        relational = RelationalMemory(self._db, semantic=semantic)
         # Issue #147 Phase C.1: ReflectionAPI / CounterFactualReflector
         # now take the MemoryFacade. They are constructed below, after
         # ``self._memory`` is built (search "Phase C.1: facade-aware

--- a/loom/platform/api/server.py
+++ b/loom/platform/api/server.py
@@ -149,6 +149,7 @@ def create_app(
         subject: str | None = Query(default=None),
         predicate: str | None = Query(default=None),
     ):
+        # Read path: semantic dual-write not needed; pass None for semantic.
         mem = RelationalMemory(app.state.db)
         entries = await mem.query(
             subject=subject or None,
@@ -168,7 +169,9 @@ def create_app(
 
     @app.post("/memory/relational", status_code=201, tags=["memory"])
     async def upsert_relational(body: RelationalBody):
-        mem = RelationalMemory(app.state.db)
+        # Issue #451 phase A: dual-write to semantic so recall can find it.
+        sem = SemanticMemory(app.state.db)
+        mem = RelationalMemory(app.state.db, semantic=sem)
         entry = RelationalEntry(
             subject=body.subject,
             predicate=body.predicate,
@@ -181,7 +184,9 @@ def create_app(
 
     @app.delete("/memory/relational", tags=["memory"])
     async def delete_relational(subject: str, predicate: str):
-        mem = RelationalMemory(app.state.db)
+        # Mirror delete into semantic so recall stops returning the triple.
+        sem = SemanticMemory(app.state.db)
+        mem = RelationalMemory(app.state.db, semantic=sem)
         deleted = await mem.delete(subject, predicate)
         if not deleted:
             raise HTTPException(status_code=404, detail="Entry not found")

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -2065,7 +2065,7 @@ async def _reflect(session_id: str | None, db: str) -> None:
         ep = EpisodicMemory(conn)
         pr = ProceduralMemory(conn)
         sem = SemanticMemory(conn)
-        rel = RelationalMemory(conn)
+        rel = RelationalMemory(conn, semantic=sem)
         facade = MemoryFacade(
             semantic=sem,
             procedural=pr,

--- a/tests/test_relational_into_semantic_migration.py
+++ b/tests/test_relational_into_semantic_migration.py
@@ -1,0 +1,291 @@
+"""
+Tests for issue #451 phase A — routing relational triples through the
+semantic store so ``recall`` can naturally surface them.
+
+Covers
+------
+* Backfill at ``SQLiteStore.initialize()`` copies existing
+  ``relational_entries`` rows into ``semantic_entries`` with
+  ``rel:{S}::{P}`` keys.
+* Backfill is idempotent (re-running ``initialize()`` does not duplicate).
+* ``RelationalMemory.upsert()`` dual-writes into the semantic store when
+  a SemanticMemory instance is plumbed in.
+* ``RelationalMemory.delete()`` mirrors deletion into semantic.
+* ``MemorySearch.recall()`` returns matching triples with
+  ``type="relational"`` and the relational ``key`` / ``value`` shape.
+* ``relational_bridge`` round-trips ``RelationalEntry`` ↔ ``SemanticEntry``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from loom.core.memory.procedural import ProceduralMemory
+from loom.core.memory.relational import RelationalEntry, RelationalMemory
+from loom.core.memory.relational_bridge import (
+    make_rel_key,
+    semantic_to_triple,
+    triple_to_semantic,
+)
+from loom.core.memory.search import MemorySearch
+from loom.core.memory.semantic import SemanticMemory
+from loom.core.memory.store import SQLiteStore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test.db")
+
+
+@pytest_asyncio.fixture
+async def fresh_store(tmp_db):
+    s = SQLiteStore(tmp_db)
+    await s.initialize()
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Bridge encoding/decoding
+# ---------------------------------------------------------------------------
+
+def test_bridge_round_trip_preserves_triple():
+    original = RelationalEntry(
+        subject="user",
+        predicate="likes_tts_voice",
+        object="xAI eve",
+        confidence=0.9,
+        source="agent",
+        metadata={"note": "told to me"},
+    )
+    sem = triple_to_semantic(original)
+
+    assert sem.key == "rel:user::likes_tts_voice"
+    assert sem.value == "user likes_tts_voice xAI eve"
+    assert sem.metadata["subject"] == "user"
+    assert sem.metadata["predicate"] == "likes_tts_voice"
+    assert sem.metadata["object"] == "xAI eve"
+    assert sem.metadata["note"] == "told to me"
+    assert sem.confidence == 0.9
+    assert sem.source == "agent"
+
+    decoded = semantic_to_triple(sem)
+    assert decoded is not None
+    assert decoded.subject == original.subject
+    assert decoded.predicate == original.predicate
+    assert decoded.object == original.object
+    assert decoded.confidence == original.confidence
+    assert decoded.source == original.source
+    assert "subject" not in decoded.metadata
+
+
+def test_bridge_handles_subject_with_colons():
+    """Subjects like ``openai:musk-trial:2026-05-15`` must round-trip cleanly."""
+    e = RelationalEntry(
+        subject="openai:musk-trial:2026-05-15",
+        predicate="関連到",
+        object="OpenAI IPO 進程",
+    )
+    sem = triple_to_semantic(e)
+    assert sem.key == "rel:openai:musk-trial:2026-05-15::関連到"
+    decoded = semantic_to_triple(sem)
+    assert decoded.subject == "openai:musk-trial:2026-05-15"
+    assert decoded.predicate == "関連到"
+
+
+def test_semantic_to_triple_rejects_non_relational_keys():
+    from loom.core.memory.semantic import SemanticEntry
+    e = SemanticEntry(key="user_pref:tts", value="something")
+    assert semantic_to_triple(e) is None
+
+
+# ---------------------------------------------------------------------------
+# Dual-write via RelationalMemory.upsert
+# ---------------------------------------------------------------------------
+
+async def test_upsert_dual_writes_into_semantic(tmp_db):
+    store = SQLiteStore(tmp_db)
+    await store.initialize()
+    async with store.connect() as db:
+        sem = SemanticMemory(db)
+        rel = RelationalMemory(db, semantic=sem)
+        await rel.upsert(RelationalEntry(
+            subject="user",
+            predicate="prefers_voice",
+            object="eve",
+        ))
+
+        # Relational table has the original row
+        triple = await rel.get("user", "prefers_voice")
+        assert triple is not None
+        assert triple.object == "eve"
+
+        # Semantic table has the bridge row
+        sem_entry = await sem.get("rel:user::prefers_voice")
+        assert sem_entry is not None
+        assert sem_entry.value == "user prefers_voice eve"
+        assert sem_entry.metadata["subject"] == "user"
+        assert sem_entry.metadata["predicate"] == "prefers_voice"
+        assert sem_entry.metadata["object"] == "eve"
+
+
+async def test_upsert_without_semantic_does_not_break(tmp_db):
+    """Backward-compat: passing semantic=None still works (no dual-write)."""
+    store = SQLiteStore(tmp_db)
+    await store.initialize()
+    async with store.connect() as db:
+        rel = RelationalMemory(db, semantic=None)
+        await rel.upsert(RelationalEntry(
+            subject="x", predicate="y", object="z",
+        ))
+        triple = await rel.get("x", "y")
+        assert triple is not None
+
+
+async def test_delete_mirrors_into_semantic(tmp_db):
+    store = SQLiteStore(tmp_db)
+    await store.initialize()
+    async with store.connect() as db:
+        sem = SemanticMemory(db)
+        rel = RelationalMemory(db, semantic=sem)
+        await rel.upsert(RelationalEntry(
+            subject="a", predicate="b", object="c",
+        ))
+        assert await sem.get("rel:a::b") is not None
+
+        deleted = await rel.delete("a", "b")
+        assert deleted is True
+        assert await sem.get("rel:a::b") is None
+
+
+# ---------------------------------------------------------------------------
+# Backfill in SQLiteStore.initialize()
+# ---------------------------------------------------------------------------
+
+async def _seed_legacy_relational_row(db: aiosqlite.Connection, **kwargs) -> None:
+    """Insert directly into ``relational_entries`` bypassing dual-write,
+    simulating a row that pre-dates phase A."""
+    import uuid
+    from datetime import UTC, datetime
+    now = datetime.now(UTC).isoformat()
+    await db.execute(
+        """
+        INSERT INTO relational_entries
+            (id, subject, predicate, object, confidence, source, metadata,
+             created_at, updated_at, domain, temporal, last_accessed_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            str(uuid.uuid4()),
+            kwargs["subject"],
+            kwargs["predicate"],
+            kwargs["object"],
+            kwargs.get("confidence", 1.0),
+            kwargs.get("source", "dreaming"),
+            json.dumps(kwargs.get("metadata", {})),
+            now,
+            now,
+            kwargs.get("domain", "knowledge"),
+            kwargs.get("temporal", "recent"),
+            None,
+        ),
+    )
+    await db.commit()
+
+
+async def test_backfill_copies_existing_triples_into_semantic(tmp_db):
+    # Pre-seed the relational table without dual-write, then re-initialize.
+    store = SQLiteStore(tmp_db)
+    await store.initialize()
+    async with store.connect() as db:
+        await _seed_legacy_relational_row(
+            db, subject="legacy", predicate="written_by", object="dream_cycle",
+        )
+
+    # Second initialize() should backfill the legacy row.
+    await store.initialize()
+    async with store.connect() as db:
+        sem = SemanticMemory(db)
+        entry = await sem.get("rel:legacy::written_by")
+        assert entry is not None
+        assert entry.value == "legacy written_by dream_cycle"
+        assert entry.metadata["subject"] == "legacy"
+        assert entry.metadata["predicate"] == "written_by"
+        assert entry.metadata["object"] == "dream_cycle"
+
+
+async def test_backfill_is_idempotent(tmp_db):
+    store = SQLiteStore(tmp_db)
+    await store.initialize()
+    async with store.connect() as db:
+        await _seed_legacy_relational_row(
+            db, subject="s", predicate="p", object="o",
+        )
+
+    # Run initialize multiple times — should still be exactly one row.
+    for _ in range(3):
+        await store.initialize()
+
+    async with store.connect() as db:
+        cur = await db.execute(
+            "SELECT COUNT(*) FROM semantic_entries WHERE key = ?",
+            ("rel:s::p",),
+        )
+        (count,) = await cur.fetchone()
+        assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# Recall surfacing
+# ---------------------------------------------------------------------------
+
+async def test_recall_returns_relational_triples_tagged_as_relational(tmp_db):
+    store = SQLiteStore(tmp_db)
+    await store.initialize()
+    async with store.connect() as db:
+        sem = SemanticMemory(db)
+        rel = RelationalMemory(db, semantic=sem)
+        proc = ProceduralMemory(db)
+        await rel.upsert(RelationalEntry(
+            subject="user",
+            predicate="likes_tts_voice",
+            object="xAI eve Chinese output sounds natural",
+        ))
+
+        search = MemorySearch(sem, proc)
+        results = await search.recall("likes_tts_voice", limit=5)
+
+        assert results, "recall returned nothing for a directly-indexed triple"
+        match = next(
+            (r for r in results if r.key == "rel:user::likes_tts_voice"), None,
+        )
+        assert match is not None
+        assert match.type == "relational"
+        assert "xAI eve" in match.value
+
+
+async def test_recall_does_not_relabel_ordinary_semantic_facts(tmp_db):
+    """Regression guard — ``type="semantic"`` must still apply to plain facts."""
+    from loom.core.memory.semantic import SemanticEntry
+
+    store = SQLiteStore(tmp_db)
+    await store.initialize()
+    async with store.connect() as db:
+        sem = SemanticMemory(db)
+        proc = ProceduralMemory(db)
+        await sem.upsert(SemanticEntry(
+            key="ordinary_fact",
+            value="Loom is harness-first and memory-native.",
+        ))
+        search = MemorySearch(sem, proc)
+        results = await search.recall("harness-first memory-native", limit=5)
+        assert results
+        ordinary = next(r for r in results if r.key == "ordinary_fact")
+        assert ordinary.type == "semantic"

--- a/tests/test_relational_into_semantic_migration.py
+++ b/tests/test_relational_into_semantic_migration.py
@@ -19,6 +19,7 @@ Covers
 from __future__ import annotations
 
 import json
+from unittest.mock import AsyncMock
 
 import aiosqlite
 import pytest
@@ -32,7 +33,7 @@ from loom.core.memory.relational_bridge import (
     triple_to_semantic,
 )
 from loom.core.memory.search import MemorySearch
-from loom.core.memory.semantic import SemanticMemory
+from loom.core.memory.semantic import SemanticEntry, SemanticMemory
 from loom.core.memory.store import SQLiteStore
 
 
@@ -273,8 +274,6 @@ async def test_recall_returns_relational_triples_tagged_as_relational(tmp_db):
 
 async def test_recall_does_not_relabel_ordinary_semantic_facts(tmp_db):
     """Regression guard — ``type="semantic"`` must still apply to plain facts."""
-    from loom.core.memory.semantic import SemanticEntry
-
     store = SQLiteStore(tmp_db)
     await store.initialize()
     async with store.connect() as db:
@@ -289,3 +288,156 @@ async def test_recall_does_not_relabel_ordinary_semantic_facts(tmp_db):
         assert results
         ordinary = next(r for r in results if r.key == "ordinary_fact")
         assert ordinary.type == "semantic"
+
+
+# ---------------------------------------------------------------------------
+# Review P1 regression — embedding backfill makes legacy rel:* rows visible
+# even when the embedding tier short-circuits the BM25 fallback.
+# ---------------------------------------------------------------------------
+
+async def test_ensure_embeddings_for_prefix_fills_missing_rows(tmp_db):
+    """``ensure_embeddings_for_prefix`` should only touch ``embedding IS NULL``."""
+    store = SQLiteStore(tmp_db)
+    await store.initialize()
+    async with store.connect() as db:
+        # Seed two legacy relational rows (no semantic dual-write, so they
+        # land in semantic_entries via the initialize() backfill only — and
+        # therefore have no embedding).
+        await _seed_legacy_relational_row(
+            db, subject="user", predicate="likes_tts_voice", object="xAI eve",
+        )
+        await _seed_legacy_relational_row(
+            db, subject="user", predicate="prefers_lang", object="zh-TW",
+        )
+
+    # Backfill table on second initialize().
+    await store.initialize()
+
+    # Now plumb a fake embedding provider and call the new ensure method.
+    async with store.connect() as db:
+        mock_provider = AsyncMock()
+        mock_provider.embed.return_value = [
+            [0.1, 0.2, 0.3],
+            [0.4, 0.5, 0.6],
+        ]
+        sem = SemanticMemory(db, embedding_provider=mock_provider)
+        n = await sem.ensure_embeddings_for_prefix("rel:")
+        assert n == 2
+
+        # Both rows now have embeddings.
+        pairs = await sem.list_with_embeddings(10)
+        rel_pairs = [(e, v) for (e, v) in pairs if e.key.startswith("rel:")]
+        assert len(rel_pairs) == 2
+        for _entry, vec in rel_pairs:
+            assert vec is not None
+
+        # Idempotent — second call is a no-op.
+        n2 = await sem.ensure_embeddings_for_prefix("rel:")
+        assert n2 == 0
+
+
+async def test_ensure_embeddings_no_op_without_provider(tmp_db):
+    store = SQLiteStore(tmp_db)
+    await store.initialize()
+    async with store.connect() as db:
+        sem = SemanticMemory(db, embedding_provider=None)
+        n = await sem.ensure_embeddings_for_prefix("rel:")
+        assert n == 0
+
+
+async def test_embedding_recall_finds_backfilled_rel_rows_after_ensure(tmp_db):
+    """Reviewer's manual repro: with embedding provider configured, recall
+    short-circuits on the embedding tier. Backfilled rel:* rows must end up
+    with embeddings or they're invisible. After ``ensure_embeddings_for_prefix``
+    they should surface alongside ordinary embedded semantic facts.
+    """
+    store = SQLiteStore(tmp_db)
+    await store.initialize()
+    async with store.connect() as db:
+        # Legacy relational row (no embedding yet).
+        await _seed_legacy_relational_row(
+            db, subject="user", predicate="likes_tts_voice",
+            object="xAI eve Chinese sounds natural",
+        )
+
+    await store.initialize()  # backfill into semantic_entries (no embedding)
+
+    async with store.connect() as db:
+        # Embedding provider returns deterministic vectors. We use the same
+        # vector for everything so cosine == 1.0; the goal is to confirm
+        # rel:* rows reach the embedding tier at all, not ranking fidelity.
+        provider = AsyncMock()
+        provider.embed.side_effect = lambda texts: [[1.0, 0.0, 0.0] for _ in texts]
+
+        sem = SemanticMemory(db, embedding_provider=provider)
+        proc = ProceduralMemory(db)
+
+        # Embed both the legacy rel:* row and a plain semantic fact.
+        await sem.ensure_embeddings_for_prefix("rel:")
+        await sem.upsert(SemanticEntry(key="ordinary", value="harness-first"))
+
+        # Reviewer's exact scenario: recall with a query that would short-
+        # circuit on the embedding tier.
+        search = MemorySearch(sem, proc)
+        results = await search.recall("likes_tts_voice", limit=10)
+        keys = {r.key for r in results}
+        assert "rel:user::likes_tts_voice" in keys, (
+            "backfilled relational row invisible to embedding-tier recall "
+            "— P1 regression"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Review P2 regression — recall must refresh last_accessed_at on both
+# semantic_entries and the relational source-of-truth row.
+# ---------------------------------------------------------------------------
+
+async def test_recall_refreshes_last_accessed_on_both_tables(tmp_db):
+    store = SQLiteStore(tmp_db)
+    await store.initialize()
+    async with store.connect() as db:
+        sem = SemanticMemory(db)
+        rel = RelationalMemory(db, semantic=sem)
+        proc = ProceduralMemory(db)
+        await rel.upsert(RelationalEntry(
+            subject="user",
+            predicate="likes_tts_voice",
+            object="xAI eve",
+        ))
+
+        # Both rows start with NULL last_accessed_at.
+        sem_row = await sem.get("rel:user::likes_tts_voice")
+        assert sem_row.last_accessed_at is None
+        rel_row = await rel.get("user", "likes_tts_voice")
+        assert rel_row.last_accessed_at is None
+
+        # Recall should bump both.
+        search = MemorySearch(sem, proc)
+        results = await search.recall("likes_tts_voice", limit=5)
+        assert any(r.type == "relational" for r in results)
+
+        sem_after = await sem.get("rel:user::likes_tts_voice")
+        rel_after = await rel.get("user", "likes_tts_voice")
+        assert sem_after.last_accessed_at is not None, (
+            "semantic row last_accessed_at not refreshed — P2 regression"
+        )
+        assert rel_after.last_accessed_at is not None, (
+            "relational source row last_accessed_at not mirrored "
+            "— would cause source/mirror decay drift"
+        )
+
+
+async def test_mark_accessed_does_not_touch_relational_when_no_rel_keys(tmp_db):
+    """Regression guard — non-rel:* keys must not trigger the relational
+    UPDATE branch (it would be wasted SQL on a hot recall path)."""
+    store = SQLiteStore(tmp_db)
+    await store.initialize()
+    async with store.connect() as db:
+        sem = SemanticMemory(db)
+        await sem.upsert(SemanticEntry(key="ordinary_fact", value="something"))
+        # The UPDATE returns silently regardless, but at least confirm no
+        # row in relational_entries exists for this key shape.
+        await sem.mark_accessed(["ordinary_fact"])
+        cur = await db.execute("SELECT COUNT(*) FROM relational_entries")
+        (count,) = await cur.fetchone()
+        assert count == 0


### PR DESCRIPTION
Closes the first half of #451 — relational triples become reachable via `recall` without a hand-typed `query_relations`.

## Summary

- **Problem (from #451):** asking 「你最近做夢怎樣」 returns nothing because `MemorySearch.recall` only touches semantic + skill. Auditing the live DB: 618 relational triples (499 dream + ~111 high-value agent-written + 8 user flags) all unreachable except `loom-self` (which `MemoryIndex` injects). High-signal entries like `user.likes_tts_voice`, `skill:code_weaver.pass_rate`, `sisi:user_relationship.vision` are dead storage.
- **Decision:** per #451 RFC comment, B 方案 — converge on `recall` as the single entry point. Relational triples live as `SemanticEntry` rows with key prefix `rel:{subject}::{predicate}`. Phase A is **additive**: `relational_entries` table remains source of truth; semantic gets a bridge copy. Phase B (later PR) cuts writers over and retires the table + `query_relations` tool.
- **Mechanism:**
  - `relational_bridge.py` — encode/decode (S,P,O) ↔ SemanticEntry. Key uses `::` separator to disambiguate subjects with single colons (`openai:musk-trial:2026-05-15`). Authoritative S/P/O round-trip via metadata.
  - `RelationalMemory` accepts optional `SemanticMemory`; `upsert` dual-writes, `delete` mirrors. Plumbed through all four instantiation sites.
  - `SQLiteStore.initialize` runs idempotent `INSERT OR IGNORE` backfill so legacy DBs migrate on first boot.
  - `MemorySearch` tags results with `type="relational"` when key starts with `rel:` so the agent sees the kind explicitly.

## Test plan

- [x] New `tests/test_relational_into_semantic_migration.py` (10 cases): bridge round-trip + edge cases (colons in subject, non-rel keys), dual-write, delete mirroring, backfill correctness, backfill idempotency, recall surfaces `type="relational"`, regression guard for ordinary semantic facts.
- [x] Full suite: **2066 passed**. The single failure on `master` (`test_doc_integrity.py::test_layer3_version_sync` — README changelog `v0.3.8.1` vs pyproject `0.3.8.0`) is pre-existing and unrelated.
- [ ] Manual smoke after merge: ask 絲絲「你最近做夢怎樣」on a session whose DB has run the backfill, confirm dream content actually surfaces in `recall` output.

## Doc drift (deferred to phase B)

14 doc files mention `RelationalMemory` / `query_relations` / `relational_entries`. All remain technically accurate after phase A (the table still exists, the tool still works). Updating them now creates churn that phase B's retirement would rewrite. Tracked here so they get cleaned up alongside the retirement PR:

- doc/SUMMARY.md, doc/03-目錄結構.md, doc/05-Trust-Level.md, doc/08-Memory-概述.md, doc/08b-Memory-Governance.md, doc/09-四種記憶詳解.md, doc/12-Memory-Index.md, doc/13-Cognition-概述.md, doc/16-Reflection-API.md, doc/19-Autonomy-概述.md, doc/29-Extensibility-概述.md, doc/31-Plugin-系統.md, doc/35b-Session-Lifecycle-詳解.md, doc/99-功能人工確認清單.md

## What phase B will do

- Cut over writers (`dream_cycle`, `relate` tool, `self_reflection`, `counter_factual`) to write `SemanticEntry` directly via the bridge.
- Retire `query_relations` tool — `recall` becomes the sole verb (per 絲絲: 「不需要記得『要去 query_relations 查那批』」).
- Drop `relational_entries` table + `RelationalMemory` class.
- Update the 14 docs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)