### PR TITLE
fix(cognition): surface Responses SSE failures

### DIFF
--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -85,6 +85,69 @@ async def _http_status_detail(provider: str, exc: Any) -> str:
     return detail
 
 
+def _responses_sse_error_detail(provider: str, event_type: str, data: dict[str, Any]) -> str | None:
+    """Return a user-facing error detail for Responses SSE error events.
+
+    Some Responses-compatible backends report request failures inside the
+    event stream after HTTP 200. If we ignore those events, the harness sees
+    an empty successful turn and the operator gets no actionable error.
+    """
+    response = data.get("response")
+    response = response if isinstance(response, dict) else {}
+    status = str(response.get("status") or "").lower()
+    error = data.get("error") or response.get("error")
+    incomplete = response.get("incomplete_details")
+
+    if status == "incomplete" and isinstance(incomplete, dict):
+        reason = str(incomplete.get("reason") or "").strip()
+        # Preserve existing max-output handling: session.stream_turn can
+        # recover from max_tokens by injecting its reasoning-continuation
+        # reminder. Other incomplete reasons need to be visible.
+        if reason and reason != "max_output_tokens":
+            error = incomplete
+
+    failed_event = (
+        event_type in {"error", "response.failed"}
+        or event_type.endswith(".failed")
+        or status in {"failed", "cancelled"}
+        or error is not None
+    )
+    if not failed_event:
+        return None
+
+    parts: list[str] = []
+    if event_type:
+        parts.append(event_type)
+    if status:
+        parts.append(f"status={status}")
+
+    detail = ""
+    if isinstance(error, dict):
+        message = error.get("message") or error.get("detail") or error.get("reason")
+        code = error.get("code") or error.get("type")
+        if code and message:
+            detail = f"{code}: {message}"
+        elif message:
+            detail = str(message)
+        elif code:
+            detail = str(code)
+        else:
+            detail = json.dumps(error, ensure_ascii=False)
+    elif error:
+        detail = str(error)
+    elif isinstance(incomplete, dict):
+        detail = json.dumps(incomplete, ensure_ascii=False)
+    elif data.get("message"):
+        detail = str(data.get("message"))
+
+    context = " ".join(parts).strip()
+    if detail:
+        return f"{provider} response error ({context}): {detail[:1000]}"
+    if context:
+        return f"{provider} response error ({context})"
+    return f"{provider} response error"
+
+
 # ---------------------------------------------------------------------------
 # Retry helper
 # ---------------------------------------------------------------------------
@@ -1108,6 +1171,10 @@ class CodexResponsesProvider(LLMProvider):
                             except json.JSONDecodeError:
                                 continue
                             event_type = data.get("type", "")
+                            if detail := _responses_sse_error_detail(
+                                "Codex Responses", event_type, data,
+                            ):
+                                raise RuntimeError(detail)
                             delta = data.get("delta")
                             # OpenAI Responses SSE emits ``delta`` on multiple
                             # event types — only ``response.output_text.delta``
@@ -1364,6 +1431,10 @@ class XAIResponsesProvider(LLMProvider):
                             except json.JSONDecodeError:
                                 continue
                             event_type = data.get("type", "")
+                            if detail := _responses_sse_error_detail(
+                                "xAI Responses", event_type, data,
+                            ):
+                                raise RuntimeError(detail)
                             delta = data.get("delta")
                             # OpenAI Responses SSE emits ``delta`` on multiple
                             # event types — only ``response.output_text.delta``

--- a/tests/test_codex_responses_provider.py
+++ b/tests/test_codex_responses_provider.py
@@ -347,3 +347,48 @@ async def test_codex_provider_surfaces_backend_error_body(monkeypatch, codex_hom
     # the helper must call ``aread()`` before reading ``.text``, otherwise
     # this string from httpx leaks out and masks the real backend error.
     assert "without having called" not in message
+
+
+@pytest.mark.asyncio
+async def test_codex_provider_surfaces_sse_response_failed(monkeypatch, codex_home):
+    import httpx
+
+    fake_client = _FakeAsyncClient([
+        "event: response.failed",
+        (
+            'data: {"type":"response.failed","response":{"status":"failed",'
+            '"error":{"code":"context_length_exceeded",'
+            '"message":"input is too large"}}}'
+        ),
+        "",
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = CodexResponsesProvider(model="codex/gpt-5.5")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await provider.chat(messages=[{"role": "user", "content": "ping"}])
+
+    message = str(excinfo.value)
+    assert "Codex Responses response error" in message
+    assert "context_length_exceeded" in message
+    assert "input is too large" in message
+
+
+@pytest.mark.asyncio
+async def test_codex_provider_keeps_max_output_incomplete_recoverable(monkeypatch, codex_home):
+    import httpx
+
+    fake_client = _FakeAsyncClient([
+        "event: response.incomplete",
+        (
+            'data: {"type":"response.incomplete","response":{"status":"incomplete",'
+            '"incomplete_details":{"reason":"max_output_tokens"}}}'
+        ),
+        "",
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = CodexResponsesProvider(model="codex/gpt-5.5")
+
+    response = await provider.chat(messages=[{"role": "user", "content": "ping"}])
+
+    assert response.stop_reason == "max_tokens"

--- a/tests/test_xai_responses_provider.py
+++ b/tests/test_xai_responses_provider.py
@@ -325,6 +325,69 @@ async def test_xai_provider_surfaces_streaming_backend_error(tmp_path, monkeypat
 
 
 @pytest.mark.asyncio
+async def test_xai_provider_surfaces_sse_response_failed(tmp_path, monkeypatch):
+    import httpx
+
+    monkeypatch.setenv("LOOM_HOME", str(tmp_path / "loom-home"))
+    token = _jwt(int(time.time()) + 3600)
+    save_xai_oauth_state({
+        "tokens": {
+            "access_token": token,
+            "refresh_token": "refresh-secret",
+        },
+        "base_url": DEFAULT_XAI_BASE_URL,
+    })
+    fake_client = _FakeAsyncClient([
+        "event: response.failed",
+        (
+            'data: {"type":"response.failed","response":{"status":"failed",'
+            '"error":{"code":"context_length_exceeded",'
+            '"message":"input is too large"}}}'
+        ),
+        "",
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = XAIResponsesProvider(model="xai/grok-4.3")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await provider.chat(messages=[{"role": "user", "content": "ping"}])
+
+    message = str(excinfo.value)
+    assert "xAI Responses response error" in message
+    assert "context_length_exceeded" in message
+    assert "input is too large" in message
+
+
+@pytest.mark.asyncio
+async def test_xai_provider_keeps_max_output_incomplete_recoverable(tmp_path, monkeypatch):
+    import httpx
+
+    monkeypatch.setenv("LOOM_HOME", str(tmp_path / "loom-home"))
+    token = _jwt(int(time.time()) + 3600)
+    save_xai_oauth_state({
+        "tokens": {
+            "access_token": token,
+            "refresh_token": "refresh-secret",
+        },
+        "base_url": DEFAULT_XAI_BASE_URL,
+    })
+    fake_client = _FakeAsyncClient([
+        "event: response.incomplete",
+        (
+            'data: {"type":"response.incomplete","response":{"status":"incomplete",'
+            '"incomplete_details":{"reason":"max_output_tokens"}}}'
+        ),
+        "",
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = XAIResponsesProvider(model="xai/grok-4.3")
+
+    response = await provider.chat(messages=[{"role": "user", "content": "ping"}])
+
+    assert response.stop_reason == "max_tokens"
+
+
+@pytest.mark.asyncio
 async def test_xai_router_rejects_config_base_url_before_streaming(tmp_path, monkeypatch):
     import httpx
     from loom.core import session as session_module


### PR DESCRIPTION
## Summary
- surface Responses API `response.failed` / stream-embedded error events for Codex and xAI providers instead of silently ending with empty output
- preserve `max_output_tokens` incomplete handling so existing reasoning-continuation recovery still works
- add Codex and xAI provider regressions for SSE failure events and recoverable max-output incomplete events

## Verification
- `pytest -q tests/test_codex_responses_provider.py tests/test_xai_responses_provider.py` — 17 passed
- `python -m py_compile loom/core/cognition/providers.py`
- `git diff --check`
- `npx gitnexus analyze`
- `npx gitnexus detect-changes --scope staged --repo /private/tmp/Loom` — 3 files, 19 symbols, affected processes 0, risk low

## Notes
- Doc drift grep hit `doc/14-LLM-Router.md` for `CodexResponsesProvider`; not updated because this changes internal SSE error handling, not the documented router/provider contract.
- A wider local slice in the temp worktree is environment-sensitive: the repo-name assertions require a worktree ending in `Loom`, and router tests conflict with forcing a local provider via env. Provider-focused tests cover this patch directly.