### PR TITLE
fix(cognition): stream reasoning summary + configurable effort

### DIFF
--- a/loom.toml.example
+++ b/loom.toml.example
@@ -107,14 +107,22 @@ reminder_after_turns = 10
 # default_model = "gpt-5.5"
 
 # [providers.codex]
-# enabled       = true                 # optional; explicit --model codex/... also registers it
-# base_url      = "https://chatgpt.com/backend-api/codex/responses"
-# default_model = "gpt-5.5"            # bare model name — no "codex/" prefix here
+# enabled          = true              # optional; explicit --model codex/... also registers it
+# base_url         = "https://chatgpt.com/backend-api/codex/responses"
+# default_model    = "gpt-5.5"         # bare model name — no "codex/" prefix here
+# reasoning_effort = "medium"          # minimal | low | medium | high (default: medium)
+#                                      # gpt-5.5 stalls the visible stream during reasoning at
+#                                      # "high"; "medium" is the default tradeoff. "low" if you
+#                                      # want shorter time-to-first-token at some quality cost.
 
 # [providers.xai_oauth]
-# enabled       = true                 # optional; explicit --model xai/... also registers it
-# base_url      = "https://api.x.ai/v1/responses"
-# default_model = "grok-4.3"           # bare model name — no "xai/" prefix here
+# enabled          = true              # optional; explicit --model xai/... also registers it
+# base_url         = "https://api.x.ai/v1/responses"
+# default_model    = "grok-4.3"        # bare model name — no "xai/" prefix here
+# reasoning_effort = "medium"          # OPT-IN — leave unset to preserve xAI's default behavior
+#                                      # (Grok-4.x already streams text during reasoning; setting
+#                                      # this also makes Loom render the <think> summary, but
+#                                      # adds a payload field xAI may not always accept).
 #
 # xAI is OAuth-only in Loom. Run `loom auth xai`; XAI_API_KEY is intentionally
 # not used by the xai/<model> provider.

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -85,6 +85,62 @@ async def _http_status_detail(provider: str, exc: Any) -> str:
     return detail
 
 
+_RESPONSES_REASONING_EFFORTS = ("minimal", "low", "medium", "high")
+_RESPONSES_REASONING_DEFAULT_EFFORT = "medium"
+
+
+class _ReasoningStreamWrapper:
+    """Wrap Responses SSE reasoning_summary deltas as ``<think>…</think>`` text.
+
+    The session-level consumer (``session.py``) already parses ``<think>``
+    tags out of the assistant text stream and surfaces them as
+    ``ThinkCollapsed`` UI events. Wrapping reasoning chunks in the same
+    protocol lets the user see *that the model is thinking* during the long
+    reasoning phase of o1-class / gpt-5.5 / grok-4 reasoning models —
+    instead of staring at an empty stream until output_text starts.
+
+    State: ``False`` until first reasoning delta seen; flipped back when
+    reasoning is done OR output_text starts OR stream ends. The caller is
+    responsible for calling ``flush()`` after the SSE loop exits to close
+    any dangling tag.
+    """
+
+    __slots__ = ("_open",)
+
+    def __init__(self) -> None:
+        self._open = False
+
+    def open_chunk(self, delta: str) -> str:
+        if not self._open:
+            self._open = True
+            return f"<think>{delta}"
+        return delta
+
+    def close(self) -> str:
+        if self._open:
+            self._open = False
+            return "</think>"
+        return ""
+
+    @property
+    def is_open(self) -> bool:
+        return self._open
+
+
+def _normalize_reasoning_effort(value: str | None) -> str:
+    """Coerce an optional config value into a valid Responses reasoning effort.
+
+    Falls back to ``medium`` for empty/None/invalid input rather than raising:
+    a typo in loom.toml should not block the whole chat path.
+    """
+    if not value:
+        return _RESPONSES_REASONING_DEFAULT_EFFORT
+    candidate = str(value).strip().lower()
+    if candidate in _RESPONSES_REASONING_EFFORTS:
+        return candidate
+    return _RESPONSES_REASONING_DEFAULT_EFFORT
+
+
 def _responses_sse_error_detail(provider: str, event_type: str, data: dict[str, Any]) -> str | None:
     """Return a user-facing error detail for Responses SSE error events.
 
@@ -1007,10 +1063,18 @@ class CodexResponsesProvider(LLMProvider):
         model: str = "",
         base_url: str = "",
         timeout: float = 0.0,
+        reasoning_effort: str | None = None,
     ) -> None:
         self.model = model or (self.ROUTING_PREFIX + self.DEFAULT_MODEL)
         self._base_url = base_url or self.DEFAULT_BASE_URL
         self._timeout = timeout or self.DEFAULT_TIMEOUT
+        # Default to ``medium``: gpt-5.5 reasoning chains stall the visible
+        # text stream for tens of seconds at ``high``; ``medium`` keeps
+        # quality while shortening time-to-first-token noticeably. Users can
+        # override via ``[providers.codex].reasoning_effort``.
+        self._reasoning_effort = _normalize_reasoning_effort(
+            reasoning_effort or _RESPONSES_REASONING_DEFAULT_EFFORT
+        )
 
     def _api_model(self) -> str:
         return self.model.removeprefix(self.ROUTING_PREFIX)
@@ -1076,6 +1140,14 @@ class CodexResponsesProvider(LLMProvider):
             "input": input_items,
             "stream": True,
             "store": False,
+            # ``summary: auto`` makes the backend emit
+            # ``response.reasoning_summary_text.delta`` events during the
+            # otherwise-silent reasoning phase so users see the model is
+            # thinking instead of staring at an empty stream.
+            "reasoning": {
+                "effort": self._reasoning_effort,
+                "summary": "auto",
+            },
         }
         if self.SUPPORTS_MAX_OUTPUT_TOKENS:
             payload["max_output_tokens"] = max_tokens
@@ -1134,6 +1206,7 @@ class CodexResponsesProvider(LLMProvider):
         input_tokens = 0
         output_tokens = 0
         response_status = "in_progress"
+        reasoning_wrapper = _ReasoningStreamWrapper()
 
         # SSE may already have yielded partial output; retrying mid-stream can
         # duplicate content or tool calls, so failures propagate to the caller.
@@ -1184,7 +1257,22 @@ class CodexResponsesProvider(LLMProvider):
                             # the canonical args still arrive on
                             # ``response.output_item.done`` so we can ignore
                             # the streaming form entirely.
-                            if isinstance(delta, str) and event_type.endswith("output_text.delta"):
+                            #
+                            # ``reasoning_summary_text.delta`` carries the
+                            # backend's reasoning summary — surface it wrapped
+                            # in ``<think>…</think>`` so session.stream_turn
+                            # renders it as a collapsed thinking block instead
+                            # of a silent stall.
+                            if isinstance(delta, str) and event_type.endswith("reasoning_summary_text.delta"):
+                                yield (reasoning_wrapper.open_chunk(delta), None)
+                            elif event_type.endswith("reasoning_summary_text.done"):
+                                closing = reasoning_wrapper.close()
+                                if closing:
+                                    yield (closing, None)
+                            elif isinstance(delta, str) and event_type.endswith("output_text.delta"):
+                                closing = reasoning_wrapper.close()
+                                if closing:
+                                    yield (closing, None)
                                 full_content += delta
                                 yield (delta, None)
                             item = data.get("item")
@@ -1205,6 +1293,12 @@ class CodexResponsesProvider(LLMProvider):
                     raise RuntimeError(
                         _stream_interrupt_detail("Codex Responses", exc)
                     ) from exc
+
+        # Close any reasoning tag the stream left dangling (e.g. abort signal,
+        # or backend that omitted the .done event).
+        closing = reasoning_wrapper.close()
+        if closing:
+            yield (closing, None)
 
         tool_uses: list[ToolUse] = []
         raw_tool_calls: list[dict[str, Any]] = []
@@ -1270,10 +1364,19 @@ class XAIResponsesProvider(LLMProvider):
         model: str = "",
         base_url: str = "",
         timeout: float = 0.0,
+        reasoning_effort: str | None = None,
     ) -> None:
         self.model = model or (self.ROUTING_PREFIX + self.DEFAULT_MODEL)
         self._base_url = base_url or self.DEFAULT_BASE_URL
         self._timeout = timeout or self.DEFAULT_TIMEOUT
+        # xAI Grok-4.x already streams text deltas during reasoning, so
+        # injecting ``reasoning.effort`` by default is unnecessary — and
+        # would risk a 400 if xAI's Responses-compat tightens later. Opt-in
+        # only: leave ``None`` to preserve the current working payload, or
+        # set ``[providers.xai_oauth].reasoning_effort`` to request a value.
+        self._reasoning_effort = (
+            _normalize_reasoning_effort(reasoning_effort) if reasoning_effort else None
+        )
 
     def _api_model(self) -> str:
         return self.model.removeprefix(self.ROUTING_PREFIX)
@@ -1341,6 +1444,14 @@ class XAIResponsesProvider(LLMProvider):
             "store": False,
             "max_output_tokens": max_tokens,
         }
+        if self._reasoning_effort:
+            # Opt-in only — see __init__ comment. ``summary: auto`` lets the
+            # backend stream reasoning summary so it can render via the same
+            # ``<think>…</think>`` path the Codex provider uses.
+            payload["reasoning"] = {
+                "effort": self._reasoning_effort,
+                "summary": "auto",
+            }
         if tools:
             payload["tools"] = self.format_tools(tools)
         return payload
@@ -1396,6 +1507,7 @@ class XAIResponsesProvider(LLMProvider):
         input_tokens = 0
         output_tokens = 0
         response_status = "in_progress"
+        reasoning_wrapper = _ReasoningStreamWrapper()
 
         async with httpx.AsyncClient(timeout=self._timeout) as client:
             async with client.stream(
@@ -1444,7 +1556,22 @@ class XAIResponsesProvider(LLMProvider):
                             # the canonical args still arrive on
                             # ``response.output_item.done`` so we can ignore
                             # the streaming form entirely.
-                            if isinstance(delta, str) and event_type.endswith("output_text.delta"):
+                            #
+                            # ``reasoning_summary_text.delta`` is no-op here
+                            # in xAI's default config (Grok streams text
+                            # deltas during reasoning anyway) but is wired so
+                            # opt-in ``reasoning_effort`` works symmetrically
+                            # with Codex.
+                            if isinstance(delta, str) and event_type.endswith("reasoning_summary_text.delta"):
+                                yield (reasoning_wrapper.open_chunk(delta), None)
+                            elif event_type.endswith("reasoning_summary_text.done"):
+                                closing = reasoning_wrapper.close()
+                                if closing:
+                                    yield (closing, None)
+                            elif isinstance(delta, str) and event_type.endswith("output_text.delta"):
+                                closing = reasoning_wrapper.close()
+                                if closing:
+                                    yield (closing, None)
                                 full_content += delta
                                 yield (delta, None)
                             item = data.get("item")
@@ -1465,6 +1592,10 @@ class XAIResponsesProvider(LLMProvider):
                     raise RuntimeError(
                         _stream_interrupt_detail("xAI Responses", exc)
                     ) from exc
+
+        closing = reasoning_wrapper.close()
+        if closing:
+            yield (closing, None)
 
         tool_uses: list[ToolUse] = []
         raw_tool_calls: list[dict[str, Any]] = []

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -1265,7 +1265,18 @@ class CodexResponsesProvider(LLMProvider):
                             # of a silent stall.
                             if isinstance(delta, str) and event_type.endswith("reasoning_summary_text.delta"):
                                 yield (reasoning_wrapper.open_chunk(delta), None)
-                            elif event_type.endswith("reasoning_summary_text.done"):
+                            elif (
+                                event_type.endswith("reasoning_summary_text.done")
+                                or event_type.endswith("reasoning_summary_part.done")
+                            ):
+                                # OpenAI Responses emits BOTH events at the
+                                # end of a summary part. ``part.done`` is the
+                                # outer wrapper and is the one we can rely on
+                                # to always arrive — ``text.done`` may be
+                                # omitted by some compat backends. Either
+                                # event closes the ``<think>`` tag so the UI
+                                # surfaces the block before ``output_text``
+                                # starts, which is the whole point of the fix.
                                 closing = reasoning_wrapper.close()
                                 if closing:
                                     yield (closing, None)
@@ -1564,7 +1575,18 @@ class XAIResponsesProvider(LLMProvider):
                             # with Codex.
                             if isinstance(delta, str) and event_type.endswith("reasoning_summary_text.delta"):
                                 yield (reasoning_wrapper.open_chunk(delta), None)
-                            elif event_type.endswith("reasoning_summary_text.done"):
+                            elif (
+                                event_type.endswith("reasoning_summary_text.done")
+                                or event_type.endswith("reasoning_summary_part.done")
+                            ):
+                                # OpenAI Responses emits BOTH events at the
+                                # end of a summary part. ``part.done`` is the
+                                # outer wrapper and is the one we can rely on
+                                # to always arrive — ``text.done`` may be
+                                # omitted by some compat backends. Either
+                                # event closes the ``<think>`` tag so the UI
+                                # surfaces the block before ``output_text``
+                                # starts, which is the whole point of the fix.
                                 closing = reasoning_wrapper.close()
                                 if closing:
                                     yield (closing, None)

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -622,6 +622,7 @@ def build_router(active_model: str | None = None) -> LLMRouter:
             CodexResponsesProvider(
                 model=codex_model,
                 base_url=codex_cfg.get("base_url", "") or CodexResponsesProvider.DEFAULT_BASE_URL,
+                reasoning_effort=codex_cfg.get("reasoning_effort") or None,
             ),
             default=codex_default or codex_requested,
             fallback=codex_default or codex_requested,
@@ -650,6 +651,7 @@ def build_router(active_model: str | None = None) -> LLMRouter:
             XAIResponsesProvider(
                 model=xai_model,
                 base_url=xai_base_url,
+                reasoning_effort=xai_cfg.get("reasoning_effort") or None,
             ),
             default=xai_default or xai_requested,
             fallback=xai_default or xai_requested,

--- a/tests/test_codex_responses_provider.py
+++ b/tests/test_codex_responses_provider.py
@@ -392,3 +392,142 @@ async def test_codex_provider_keeps_max_output_incomplete_recoverable(monkeypatc
     response = await provider.chat(messages=[{"role": "user", "content": "ping"}])
 
     assert response.stop_reason == "max_tokens"
+
+
+@pytest.mark.asyncio
+async def test_codex_provider_payload_includes_reasoning_default_medium(monkeypatch, codex_home):
+    import httpx
+
+    fake_client = _FakeAsyncClient([
+        "event: response.completed",
+        'data: {"type":"response.completed","response":{"status":"completed"}}',
+        "",
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = CodexResponsesProvider(model="codex/gpt-5.5")
+
+    await provider.chat(messages=[{"role": "user", "content": "ping"}])
+
+    payload = fake_client.requests[0]["json"]
+    assert payload["reasoning"] == {"effort": "medium", "summary": "auto"}
+
+
+@pytest.mark.asyncio
+async def test_codex_provider_payload_honors_configured_reasoning_effort(monkeypatch, codex_home):
+    import httpx
+
+    fake_client = _FakeAsyncClient([
+        "event: response.completed",
+        'data: {"type":"response.completed","response":{"status":"completed"}}',
+        "",
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = CodexResponsesProvider(
+        model="codex/gpt-5.5", reasoning_effort="low",
+    )
+
+    await provider.chat(messages=[{"role": "user", "content": "ping"}])
+
+    assert fake_client.requests[0]["json"]["reasoning"]["effort"] == "low"
+
+
+@pytest.mark.asyncio
+async def test_codex_provider_payload_falls_back_to_medium_on_invalid_effort(monkeypatch, codex_home):
+    import httpx
+
+    fake_client = _FakeAsyncClient([
+        "event: response.completed",
+        'data: {"type":"response.completed","response":{"status":"completed"}}',
+        "",
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = CodexResponsesProvider(
+        model="codex/gpt-5.5", reasoning_effort="ultra",
+    )
+
+    await provider.chat(messages=[{"role": "user", "content": "ping"}])
+
+    # Typo in loom.toml shouldn't block chat — falls back to medium.
+    assert fake_client.requests[0]["json"]["reasoning"]["effort"] == "medium"
+
+
+@pytest.mark.asyncio
+async def test_codex_provider_wraps_reasoning_summary_in_think_tags(monkeypatch, codex_home):
+    """Reasoning summary deltas must surface to the stream as ``<think>…</think>``.
+
+    Without this, gpt-5.5 stalls visibly during the reasoning phase since the
+    backend emits ``reasoning_summary_text.delta`` but no ``output_text.delta``
+    until reasoning completes — see PR #455.
+    """
+    import httpx
+
+    fake_client = _FakeAsyncClient([
+        "event: response.reasoning_summary_text.delta",
+        'data: {"type":"response.reasoning_summary_text.delta","delta":"Considering"}',
+        "",
+        "event: response.reasoning_summary_text.delta",
+        'data: {"type":"response.reasoning_summary_text.delta","delta":" options"}',
+        "",
+        "event: response.reasoning_summary_text.done",
+        'data: {"type":"response.reasoning_summary_text.done"}',
+        "",
+        "event: response.output_text.delta",
+        'data: {"type":"response.output_text.delta","delta":"answer"}',
+        "",
+        "event: response.completed",
+        'data: {"type":"response.completed","response":{"status":"completed"}}',
+        "",
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = CodexResponsesProvider(model="codex/gpt-5.5")
+
+    chunks: list[str] = []
+    async for delta, final in provider.stream_chat(
+        messages=[{"role": "user", "content": "ping"}],
+    ):
+        if final is None and delta:
+            chunks.append(delta)
+
+    joined = "".join(chunks)
+    # ``<think>`` opens on first reasoning delta, closes on .done event.
+    assert "<think>Considering options</think>" in joined
+    # Output text comes after, NOT inside the think tags.
+    assert joined.endswith("answer")
+    # Final assistant text must not include the reasoning summary.
+    final_response = await provider.chat(messages=[{"role": "user", "content": "ping"}])
+    assert "Considering" not in (final_response.text or "")
+
+
+@pytest.mark.asyncio
+async def test_codex_provider_closes_dangling_think_tag_when_output_starts_without_done(
+    monkeypatch, codex_home,
+):
+    """If the backend omits ``.done`` and jumps straight to output_text, the
+    wrapper must still close the ``<think>`` tag so the UI doesn't bleed
+    reasoning into the answer.
+    """
+    import httpx
+
+    fake_client = _FakeAsyncClient([
+        "event: response.reasoning_summary_text.delta",
+        'data: {"type":"response.reasoning_summary_text.delta","delta":"thinking"}',
+        "",
+        "event: response.output_text.delta",
+        'data: {"type":"response.output_text.delta","delta":"answer"}',
+        "",
+        "event: response.completed",
+        'data: {"type":"response.completed","response":{"status":"completed"}}',
+        "",
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = CodexResponsesProvider(model="codex/gpt-5.5")
+
+    chunks: list[str] = []
+    async for delta, final in provider.stream_chat(
+        messages=[{"role": "user", "content": "ping"}],
+    ):
+        if final is None and delta:
+            chunks.append(delta)
+
+    joined = "".join(chunks)
+    assert "<think>thinking</think>answer" in joined

--- a/tests/test_codex_responses_provider.py
+++ b/tests/test_codex_responses_provider.py
@@ -455,18 +455,72 @@ async def test_codex_provider_payload_falls_back_to_medium_on_invalid_effort(mon
 async def test_codex_provider_wraps_reasoning_summary_in_think_tags(monkeypatch, codex_home):
     """Reasoning summary deltas must surface to the stream as ``<think>…</think>``.
 
-    Without this, gpt-5.5 stalls visibly during the reasoning phase since the
-    backend emits ``reasoning_summary_text.delta`` but no ``output_text.delta``
-    until reasoning completes — see PR #455.
+    Uses the official OpenAI Responses event sequence — ``part.done`` is the
+    real end-of-summary signal. Without this, gpt-5.5 stalls visibly during
+    the reasoning phase since the backend emits ``reasoning_summary_text.delta``
+    but no ``output_text.delta`` until reasoning completes — see PR #455.
     """
     import httpx
 
     fake_client = _FakeAsyncClient([
+        "event: response.reasoning_summary_part.added",
+        'data: {"type":"response.reasoning_summary_part.added"}',
+        "",
         "event: response.reasoning_summary_text.delta",
         'data: {"type":"response.reasoning_summary_text.delta","delta":"Considering"}',
         "",
         "event: response.reasoning_summary_text.delta",
         'data: {"type":"response.reasoning_summary_text.delta","delta":" options"}',
+        "",
+        "event: response.reasoning_summary_part.done",
+        'data: {"type":"response.reasoning_summary_part.done"}',
+        "",
+        "event: response.output_text.delta",
+        'data: {"type":"response.output_text.delta","delta":"answer"}',
+        "",
+        "event: response.completed",
+        'data: {"type":"response.completed","response":{"status":"completed"}}',
+        "",
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = CodexResponsesProvider(model="codex/gpt-5.5")
+
+    chunks: list[str] = []
+    async for delta, final in provider.stream_chat(
+        messages=[{"role": "user", "content": "ping"}],
+    ):
+        if final is None and delta:
+            chunks.append(delta)
+
+    joined = "".join(chunks)
+    assert "<think>Considering options</think>" in joined
+    assert joined.endswith("answer")
+
+    # Stream-order invariant: ``</think>`` must arrive BEFORE the first
+    # ``output_text`` delta, otherwise the UI sees the answer first and
+    # only learns about the thinking block retroactively — defeating the
+    # purpose of streaming the summary.
+    close_idx = next(i for i, c in enumerate(chunks) if "</think>" in c)
+    answer_idx = next(i for i, c in enumerate(chunks) if c == "answer")
+    assert close_idx < answer_idx, (
+        f"</think> at chunk {close_idx} must come before 'answer' at chunk {answer_idx}"
+    )
+
+    # Final assistant text must not include the reasoning summary.
+    final_response = await provider.chat(messages=[{"role": "user", "content": "ping"}])
+    assert "Considering" not in (final_response.text or "")
+
+
+@pytest.mark.asyncio
+async def test_codex_provider_closes_think_on_text_done_event_too(monkeypatch, codex_home):
+    """Some compat backends emit ``reasoning_summary_text.done`` but not
+    ``reasoning_summary_part.done``. Either should close the tag.
+    """
+    import httpx
+
+    fake_client = _FakeAsyncClient([
+        "event: response.reasoning_summary_text.delta",
+        'data: {"type":"response.reasoning_summary_text.delta","delta":"thinking"}',
         "",
         "event: response.reasoning_summary_text.done",
         'data: {"type":"response.reasoning_summary_text.done"}',
@@ -489,13 +543,11 @@ async def test_codex_provider_wraps_reasoning_summary_in_think_tags(monkeypatch,
             chunks.append(delta)
 
     joined = "".join(chunks)
-    # ``<think>`` opens on first reasoning delta, closes on .done event.
-    assert "<think>Considering options</think>" in joined
-    # Output text comes after, NOT inside the think tags.
-    assert joined.endswith("answer")
-    # Final assistant text must not include the reasoning summary.
-    final_response = await provider.chat(messages=[{"role": "user", "content": "ping"}])
-    assert "Considering" not in (final_response.text or "")
+    assert "<think>thinking</think>" in joined
+    # Close must precede answer.
+    close_idx = next(i for i, c in enumerate(chunks) if "</think>" in c)
+    answer_idx = next(i for i, c in enumerate(chunks) if c == "answer")
+    assert close_idx < answer_idx
 
 
 @pytest.mark.asyncio

--- a/tests/test_xai_responses_provider.py
+++ b/tests/test_xai_responses_provider.py
@@ -428,3 +428,100 @@ async def test_xai_router_rejects_config_base_url_before_streaming(tmp_path, mon
     req = fake_client.requests[0]
     assert req["url"] == "https://api.x.ai/v1/responses"
     assert req["headers"]["Authorization"] == f"Bearer {token}"
+
+
+@pytest.mark.asyncio
+async def test_xai_provider_omits_reasoning_block_by_default(tmp_path, monkeypatch):
+    """xAI Grok-4.3 already streams text during reasoning; injecting the
+    ``reasoning`` field by default risks a 400 if compat tightens and gains
+    nothing visible. Preserve the working payload — opt-in only via config.
+    """
+    import httpx
+
+    monkeypatch.setenv("LOOM_HOME", str(tmp_path / "loom-home"))
+    token = _jwt(int(time.time()) + 3600)
+    save_xai_oauth_state({
+        "tokens": {"access_token": token, "refresh_token": "refresh-secret"},
+        "base_url": DEFAULT_XAI_BASE_URL,
+    })
+    fake_client = _FakeAsyncClient([
+        "event: response.completed",
+        'data: {"type":"response.completed","response":{"status":"completed"}}',
+        "",
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = XAIResponsesProvider(model="xai/grok-4.3")
+
+    await provider.chat(messages=[{"role": "user", "content": "ping"}])
+
+    assert "reasoning" not in fake_client.requests[0]["json"]
+
+
+@pytest.mark.asyncio
+async def test_xai_provider_payload_includes_reasoning_when_configured(tmp_path, monkeypatch):
+    import httpx
+
+    monkeypatch.setenv("LOOM_HOME", str(tmp_path / "loom-home"))
+    token = _jwt(int(time.time()) + 3600)
+    save_xai_oauth_state({
+        "tokens": {"access_token": token, "refresh_token": "refresh-secret"},
+        "base_url": DEFAULT_XAI_BASE_URL,
+    })
+    fake_client = _FakeAsyncClient([
+        "event: response.completed",
+        'data: {"type":"response.completed","response":{"status":"completed"}}',
+        "",
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = XAIResponsesProvider(
+        model="xai/grok-4.3", reasoning_effort="high",
+    )
+
+    await provider.chat(messages=[{"role": "user", "content": "ping"}])
+
+    assert fake_client.requests[0]["json"]["reasoning"] == {
+        "effort": "high",
+        "summary": "auto",
+    }
+
+
+@pytest.mark.asyncio
+async def test_xai_provider_wraps_reasoning_summary_in_think_tags(tmp_path, monkeypatch):
+    """If xAI ever does emit reasoning_summary deltas, surface them via the
+    same ``<think>…</think>`` protocol Codex uses.
+    """
+    import httpx
+
+    monkeypatch.setenv("LOOM_HOME", str(tmp_path / "loom-home"))
+    token = _jwt(int(time.time()) + 3600)
+    save_xai_oauth_state({
+        "tokens": {"access_token": token, "refresh_token": "refresh-secret"},
+        "base_url": DEFAULT_XAI_BASE_URL,
+    })
+    fake_client = _FakeAsyncClient([
+        "event: response.reasoning_summary_text.delta",
+        'data: {"type":"response.reasoning_summary_text.delta","delta":"weighing"}',
+        "",
+        "event: response.reasoning_summary_text.done",
+        'data: {"type":"response.reasoning_summary_text.done"}',
+        "",
+        "event: response.output_text.delta",
+        'data: {"type":"response.output_text.delta","delta":"reply"}',
+        "",
+        "event: response.completed",
+        'data: {"type":"response.completed","response":{"status":"completed"}}',
+        "",
+    ])
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    provider = XAIResponsesProvider(model="xai/grok-4.3")
+
+    chunks: list[str] = []
+    async for delta, final in provider.stream_chat(
+        messages=[{"role": "user", "content": "ping"}],
+    ):
+        if final is None and delta:
+            chunks.append(delta)
+
+    joined = "".join(chunks)
+    assert "<think>weighing</think>" in joined
+    assert joined.endswith("reply")

--- a/tests/test_xai_responses_provider.py
+++ b/tests/test_xai_responses_provider.py
@@ -502,8 +502,8 @@ async def test_xai_provider_wraps_reasoning_summary_in_think_tags(tmp_path, monk
         "event: response.reasoning_summary_text.delta",
         'data: {"type":"response.reasoning_summary_text.delta","delta":"weighing"}',
         "",
-        "event: response.reasoning_summary_text.done",
-        'data: {"type":"response.reasoning_summary_text.done"}',
+        "event: response.reasoning_summary_part.done",
+        'data: {"type":"response.reasoning_summary_part.done"}',
         "",
         "event: response.output_text.delta",
         'data: {"type":"response.output_text.delta","delta":"reply"}',
@@ -525,3 +525,7 @@ async def test_xai_provider_wraps_reasoning_summary_in_think_tags(tmp_path, monk
     joined = "".join(chunks)
     assert "<think>weighing</think>" in joined
     assert joined.endswith("reply")
+    # Stream-order invariant: close-think before output text.
+    close_idx = next(i for i, c in enumerate(chunks) if "</think>" in c)
+    reply_idx = next(i for i, c in enumerate(chunks) if c == "reply")
+    assert close_idx < reply_idx


### PR DESCRIPTION
## Problem
gpt-5.5 via the Codex Responses provider stalls for 90+ seconds before any visible output — DK had to hit \`/stop\` to coax a partial response out. Root cause: SSE parser only forwarded \`response.output_text.delta\`. Reasoning-class models (gpt-5.5, o1, grok-4) emit \`response.reasoning_summary_text.delta\` events during the reasoning phase, which we silently dropped — leaving the user looking at an empty stream while the model burned tokens.

## Approach
**Codex provider** (default fix):
- Payload adds \`reasoning: {effort: "medium", summary: "auto"}\`. \`"medium"\` is the default quality / TTFT tradeoff; configurable via \`[providers.codex].reasoning_effort\` in \`loom.toml\` — invalid values fall back to medium instead of 400'ing.
- SSE parser handles \`reasoning_summary_text.delta\` / \`.done\` and wraps the chunks in \`<think>…</think>\` so the existing \`session.stream_turn\` tag protocol renders them as a \`ThinkCollapsed\` event in the UI.
- Open \`<think>\` tags are closed defensively on abort or missing \`.done\` event.

**xAI provider** (opt-in only — Grok-4.3 runs smoothly today):
- Same \`<think>\` wrapping logic — harmless when backend doesn't emit reasoning events.
- \`reasoning\` block is **not** injected by default. Grok-4.x already streams text deltas during reasoning (no observable stall), and forcing the field risks a 400 if xAI's compat tightens. Users can opt-in via \`[providers.xai_oauth].reasoning_effort\`.

## Phases (all done)
- ✅ Phase 1 — provider changes (\`ba0d5f8\`)
- ✅ Phase 2 — 8 regression tests, 25 passing (\`e6e487f\`)
- ✅ Phase 3 — \`loom.toml.example\` dual-write (\`75d0fd8\`)

## Verification
- \`pytest tests/test_codex_responses_provider.py tests/test_xai_responses_provider.py\` — **25 passed** (17 baseline + 8 new)
- \`gitnexus detect-changes --scope compare --base-ref master\` — 38 changed symbols across 5 files, **0 affected processes, risk LOW**
- gitnexus impact upstream on \`CodexResponsesProvider.stream_chat\` / \`XAIResponsesProvider.stream_chat\` — LOW, no direct callers in graph (dynamic dispatch via \`LLMProvider\`)

## Doc drift check
- \`doc/14-LLM-Router.md\` mentions \`CodexResponsesProvider\` only in a router-registration example — no SSE / reasoning detail to drift.
- \`doc/37-loom-toml-參考.md\` has no per-provider config section — \`loom.toml.example\` is the canonical reference.
- No doc update needed in this PR.

## Out of scope
- Surfacing reasoning content into \`raw_message["reasoning_summary"]\` for context preservation across turns. The Responses API has \`previous_response_id\` for that and Loom currently re-sends full message history anyway, so the chain doesn't break — but if we ever want to log reasoning summaries for analysis, that's a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)