### PR TITLE
fix(cognition): revert forced Codex reasoning block, make opt-in only

### DIFF
--- a/loom.toml.example
+++ b/loom.toml.example
@@ -110,10 +110,14 @@ reminder_after_turns = 10
 # enabled          = true              # optional; explicit --model codex/... also registers it
 # base_url         = "https://chatgpt.com/backend-api/codex/responses"
 # default_model    = "gpt-5.5"         # bare model name — no "codex/" prefix here
-# reasoning_effort = "medium"          # minimal | low | medium | high (default: medium)
-#                                      # gpt-5.5 stalls the visible stream during reasoning at
-#                                      # "high"; "medium" is the default tradeoff. "low" if you
-#                                      # want shorter time-to-first-token at some quality cost.
+# reasoning_effort = "medium"          # OPT-IN — minimal | low | medium | high.
+#                                      # Leaving unset sends NO reasoning block, so the
+#                                      # ChatGPT.com Codex backend uses its tuned default
+#                                      # (fastest TTFT, no <think> in UI). Forcing a value
+#                                      # makes the backend allocate a parallel reasoning
+#                                      # summary stream — empirically 3× slower TTFT, and
+#                                      # minutes-long stalls in tool-heavy turns. Only set
+#                                      # this if you actively want visible reasoning.
 
 # [providers.xai_oauth]
 # enabled          = true              # optional; explicit --model xai/... also registers it

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -1068,12 +1068,16 @@ class CodexResponsesProvider(LLMProvider):
         self.model = model or (self.ROUTING_PREFIX + self.DEFAULT_MODEL)
         self._base_url = base_url or self.DEFAULT_BASE_URL
         self._timeout = timeout or self.DEFAULT_TIMEOUT
-        # Default to ``medium``: gpt-5.5 reasoning chains stall the visible
-        # text stream for tens of seconds at ``high``; ``medium`` keeps
-        # quality while shortening time-to-first-token noticeably. Users can
-        # override via ``[providers.codex].reasoning_effort``.
-        self._reasoning_effort = _normalize_reasoning_effort(
-            reasoning_effort or _RESPONSES_REASONING_DEFAULT_EFFORT
+        # Opt-in only. Forcing ``reasoning: {effort, summary: "auto"}`` into
+        # every request makes the ChatGPT.com Codex backend allocate a
+        # parallel summary stream, which empirically triples TTFT (1.7s →
+        # 5.8s in plain prompts, minutes in tool-heavy turns) and may
+        # downshift the model from its silent default reasoning path. When
+        # nothing is set we send no ``reasoning`` field at all so the
+        # backend uses its (faster, undocumented-but-tuned) default.
+        # Users can opt-in via ``[providers.codex].reasoning_effort``.
+        self._reasoning_effort = (
+            _normalize_reasoning_effort(reasoning_effort) if reasoning_effort else None
         )
 
     def _api_model(self) -> str:
@@ -1140,15 +1144,15 @@ class CodexResponsesProvider(LLMProvider):
             "input": input_items,
             "stream": True,
             "store": False,
-            # ``summary: auto`` makes the backend emit
-            # ``response.reasoning_summary_text.delta`` events during the
-            # otherwise-silent reasoning phase so users see the model is
-            # thinking instead of staring at an empty stream.
-            "reasoning": {
+        }
+        if self._reasoning_effort:
+            # Opt-in only — see __init__ comment. ``summary: auto`` makes
+            # the backend emit ``response.reasoning_summary_text.delta``
+            # events that the SSE handler renders as ``<think>…</think>``.
+            payload["reasoning"] = {
                 "effort": self._reasoning_effort,
                 "summary": "auto",
-            },
-        }
+            }
         if self.SUPPORTS_MAX_OUTPUT_TOKENS:
             payload["max_output_tokens"] = max_tokens
         if tools:

--- a/tests/test_codex_responses_provider.py
+++ b/tests/test_codex_responses_provider.py
@@ -395,7 +395,12 @@ async def test_codex_provider_keeps_max_output_incomplete_recoverable(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_codex_provider_payload_includes_reasoning_default_medium(monkeypatch, codex_home):
+async def test_codex_provider_omits_reasoning_block_by_default(monkeypatch, codex_home):
+    """Forcing ``reasoning: {effort, summary}`` empirically slows the
+    ChatGPT.com Codex backend (3x TTFT on plain prompts, minutes on
+    tool-heavy turns) and may force a different reasoning path than the
+    backend's tuned default. Send nothing unless user opts in.
+    """
     import httpx
 
     fake_client = _FakeAsyncClient([
@@ -408,8 +413,7 @@ async def test_codex_provider_payload_includes_reasoning_default_medium(monkeypa
 
     await provider.chat(messages=[{"role": "user", "content": "ping"}])
 
-    payload = fake_client.requests[0]["json"]
-    assert payload["reasoning"] == {"effort": "medium", "summary": "auto"}
+    assert "reasoning" not in fake_client.requests[0]["json"]
 
 
 @pytest.mark.asyncio
@@ -441,6 +445,7 @@ async def test_codex_provider_payload_falls_back_to_medium_on_invalid_effort(mon
         "",
     ])
     monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: fake_client)
+    # User explicitly opted in but typo'd the effort value.
     provider = CodexResponsesProvider(
         model="codex/gpt-5.5", reasoning_effort="ultra",
     )


### PR DESCRIPTION
## Problem
PR #455 set Codex's default \`reasoning_effort\` to \`"medium"\` and unconditionally sent \`reasoning: {effort, summary: "auto"}\` in every payload. End-to-end probing against the real ChatGPT.com Codex backend showed this is a significant regression:

| Variant | TTFT | total |
|---------|------|-------|
| vanilla (no \`reasoning\` block) | **1.70s** | 19.97s |
| effort=medium + summary=auto | 5.83s | 18.32s |
| effort=low + summary=auto | 3.32s | 20.23s |

In real chat (\`/tier 2\` → codex/gpt-5.5 with tools and Loom's full prompt stack), the slowdown ballooned to **3-minute silent stalls** after a tool result — DK had to \`/stop\` to escape. Forcing the backend to emit a parallel \`reasoning_summary\` stream also appears to push the model onto a different (slower, possibly weaker) reasoning path than its tuned default.

## Why we got here
- The "empty error" bug DK originally wanted fixed was actually solved by **#453** (SSE error surfacing), not #455.
- #455's \`<think>\` rendering was a nice-to-have. It only fires when the backend emits \`reasoning_summary_text.delta\`, which happens **only when we ask** via \`summary: auto\` — at significant cost.
- DK's real need: don't degrade model intelligence / speed. Visible reasoning is not required.

## Fix
Codex matches xAI now: \`reasoning\` block is **opt-in only**. Set \`[providers.codex].reasoning_effort\` in \`loom.toml\` to request visible reasoning. Default sends nothing → backend uses its tuned default → fast TTFT, no UI \`<think>\`.

Kept from #455 (harmless when not triggered):
- \`<think>\` SSE wrapper logic — only lights up when summary deltas arrive
- Class separation (\`XAIResponsesProvider\` no longer inherits from \`CodexResponsesProvider\`)
- \`reasoning_summary_part.done\` event handling
- Error-event surfacing from #453

## Verification
- \`pytest tests/test_codex_responses_provider.py tests/test_xai_responses_provider.py\` → 26 passed
- One Codex test rewritten: \`test_codex_provider_omits_reasoning_block_by_default\` replaces the previous \`payload_includes_reasoning_default_medium\` and inverts the assertion
- DK will test this branch locally with \`/tier 2\` to confirm "smooth as before"

## Diagnostic data
\`\`\`
Phase 1 (initial call, with tools): 2.00s total, 0 reasoning events
Phase 2 (after tool result):        2.00s total, 0 reasoning events
\`\`\`
Codex backend doesn't emit reasoning events for tool-flow turns even when asked, so \`<think>\` rendering wouldn't help anyway — but \`summary: auto\` still pays the latency cost. Best to omit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)