### PR TITLE
fix(cognition): converge model identity to a single source of truth

### DIFF
--- a/doc/57-Circadian-Autonomy-實作計畫.md
+++ b/doc/57-Circadian-Autonomy-實作計畫.md
@@ -1,0 +1,648 @@
+# 57 — Circadian Autonomy 實作計畫
+
+> 狀態：Plan / 待 review
+> 建立：2026-05-26（2026-05-26 因 multi-agent shared working tree 衝突被 wipe，由 CC 從 conversation context 重建並立刻 commit）
+> 上游藍圖：`doc/56-Circadian-Autonomy-藍圖.md`
+> 對應 issue：#458（epic）、milestone #14
+> 子 issue：#459 (PR 1)、#460 (PR 2)、#461 (PR 3)、#462 (PR 4)、#463 (PR 5)、#464 (生活語義 review)、#465 (weekly weave)、#466 (persona refresh)、#472 (lifecycle events)、#473 (state watchdog)
+
+---
+
+## 0. 本文件適用對象與目的
+
+這份文件是 #458 的**落地實作計畫**，不是設計藍圖（藍圖請看 56）。
+
+它寫給兩種讀者：
+
+1. **絲絲（Loom Agent）**：拿這份去 review、對照藍圖目標逐條檢查實作方向是否到位
+2. **CC（Claude Code）**：照本切 PR、逐項對著 acceptance criteria 驗收
+
+DK 的指示：**只抓目標精神，實作細節由 CC 跟絲絲彼此把關**。CC 主開發、絲絲協助 review。本文件要求 self-contained，不依賴對話脈絡。
+
+絲絲對 Loom 自體 feature 是 **end user**（住在 daily session / autonomy lifecycle 裡的那個），所以他的 review 是 user acceptance feedback，不只是 reviewer 建議。
+
+---
+
+## 1. 設計目標（從藍圖收斂）
+
+實作必須交付以下五件事，其他都是延伸：
+
+1. **每天有一個明確的 daily session**（Discord thread），早起午夜關
+2. **關閉時觸發既有 memory finalization / compression** 流程
+3. **日內 phase chime 能找到當天 daily session**，跨 daemon restart 不失憶
+4. **anti-heartbeat gate**：tick 不直接 = LLM wake；無 state transition 時 skip
+5. **整合既有 autonomy 元件**，不重新發明 trigger / chime / session lifecycle
+
+### 1.1 明確非目標
+
+- ❌ 不做新的 cron runtime（用既有 `AutonomyDaemon` + `CronTrigger`）
+- ❌ 不做新的 message delivery 機制（用既有 `ChimeRequest` + `ChimeDelivery`）
+- ❌ 不做 Weave Journal 自動進 Research Library / wiki（藍圖 §10 立場：journal 跟 semantic memory 分離）
+- ❌ 不做 weekly planning（留給 issue #465，藍圖 §13 Q5）
+- ❌ 不做 phase 個別 visibility 全配置化（先 hardcode 一組合理 default）
+
+---
+
+## 2. 既有元件對接清單
+
+實作前必須先確認以下既有檔案 / 概念，所有新東西都要明確標出「附著到既有 X 上」：
+
+| 既有元件 | 路徑 | 怎麼用 |
+|---|---|---|
+| `AutonomyDaemon` | `loom/autonomy/daemon.py` | 註冊 circadian trigger，**不繼承不替換** |
+| `CronTrigger` | `loom/autonomy/triggers.py` | spawner / closer / tick / phase chime 全用這個 |
+| `EventTrigger` | `loom/autonomy/triggers.py` | 跨子系統 hook publisher（見 §13） |
+| `ConditionTrigger` | `loom/autonomy/triggers.py` | 第三層 state-drift watchdog（issue #473） |
+| `ChimeRequest` | `loom/autonomy/chime.py` | phase 喚醒走這個 dataclass |
+| `ChimeDelivery` callback | `loom/autonomy/daemon.py:38` | Discord bot 已實作 `deliver_chime`，**只擴 target type** |
+| `LoomDiscordBot.deliver_chime` | `loom/platform/discord/bot.py:755` | dispatch 表新增 `circadian_today` type |
+| `LoomDiscordBot._create_session_thread` | `loom/platform/discord/bot.py:603` | spawner 直接呼叫 |
+| `LoomDiscordBot._close_session` | `loom/platform/discord/bot.py:738` | closer 直接呼叫 |
+| `LoomDiscordBot._thread_map` | `loom/platform/discord/bot.py:432` | `~/.loom/discord_threads.json` thread→session 映射 |
+| `DISCORD_CHANNEL_ID` env var | `.env` | daily thread 開在這個 channel（不在 loom.toml 重設） |
+| `loom.toml` + `loom.toml.example` | repo root | dual-write 規則（CLAUDE.md）|
+
+**規矩**：PR review 時看到任何新檔案，先反問「能不能用上表的既有元件達成」。不能才寫新的。
+
+---
+
+## 3. 核心架構決策：CircadianState + `circadian_today` target type
+
+### 3.1 為什麼需要這個間接層
+
+藍圖的核心技術挑戰是：
+
+```
+08:00 dawn cron 觸發 → 開新 thread → 拿到 thread_id_A
+09:00 共讀 cron 觸發 → 需要 chime 到 thread_id_A
+...
+00:00 close cron 觸發 → close thread_id_A，明天換 thread_id_B
+```
+
+`ChimeRequest.target` 要在 trigger 註冊時就寫死 `{"type": "discord_thread", "id": <int>}`，但 daily thread_id 每天變、daemon restart 後也要能找回，所以**不能寫死在 `loom.toml`**。
+
+### 3.2 解法
+
+引入一個 platform-internal 的 indirection：
+
+```python
+# loom.toml — circadian trigger 配置永遠這樣寫
+[[autonomy.schedules]]
+name = "circadian:dawn_chime"
+cron = "0 0 * * *"        # 08:00 Asia/Taipei 換算
+intent = "..."
+mode = "chime"
+
+  [autonomy.schedules.target]
+  type = "circadian_today"  # ← 新 type，不帶 id
+  fallback = "skip"
+```
+
+`LoomDiscordBot.deliver_chime` 看到 `circadian_today` type：
+
+1. 從 `CircadianState` 讀今日 `thread_id`
+2. 若有 → 重寫 `req.target` 成 `{"type": "discord_thread", "id": str(thread_id)}` 後走原本邏輯
+3. 若無 → return False（daemon 走 fallback）
+
+**乾淨在於**：autonomy daemon 完全不知道 thread_id 概念，platform 邊界完整。
+
+### 3.3 為什麼不用方案 A（state 給 daemon 讀）或方案 B（bot 內建 scheduler）
+
+- 方案 A 讓 autonomy 知道 Discord thread_id，違反 layer 邊界（Platform → Cognition → Harness 單向）
+- 方案 B 砍掉 daemon 變成 bot 內 task，違反 issue #458 「整合既有 autonomy」目標、bot crash 整天斷
+
+---
+
+## 4. CircadianState：資料結構與存取規約
+
+### 4.1 檔案位置
+
+```
+~/.loom/circadian/state.json
+```
+
+跟既有 `~/.loom/discord_threads.json` 同層級。Platform-internal，repo gitignore 不收。
+
+### 4.2 Schema
+
+```json
+{
+  "version": 1,
+  "date": "2026-05-26",
+  "started_at": "2026-05-26T08:00:13+08:00",
+  "thread_id": 1490024181994225744,
+  "session_id": "daily-life-2026-05-26-a3f1",
+  "channel_id": 1488000000000000000,
+  "closed_at": null,
+  "phase_log": [
+    {"phase": "dawn", "fired_at": "2026-05-26T08:00:14+08:00", "outcome": "delivered"},
+    {"phase": "tick", "fired_at": "2026-05-26T08:30:00+08:00", "outcome": "skipped", "reason": "no_state_transition"}
+  ]
+}
+```
+
+### 4.3 存取規約
+
+| 規則 | 理由 |
+|---|---|
+| 寫入用 `tempfile + os.replace` atomic rename | 避免 daemon / bot 同時寫造成 corruption |
+| 讀取無 lock，寫入時用 fcntl advisory lock | reader 多、writer 少；簡單就好 |
+| `version` 欄位先寫死 1，未來升級走 explicit migration | 不做 hidden upgrade |
+| `phase_log` 只保留當日，午夜 close 時 archive 到 `~/.loom/circadian/log/YYYY-MM-DD.json` | 不讓 state.json 無限長大 |
+| `date` 必比對：讀到不是今天 → 視為昨日殘留，觸發 recovery | 跨日邊界處理 |
+
+### 4.4 API surface
+
+```python
+# loom/autonomy/circadian/state.py
+class CircadianState:
+    @classmethod
+    def load(cls) -> "CircadianState | None": ...
+    def save_atomic(self) -> None: ...
+    def is_for_today(self, tz: str) -> bool: ...
+    def archive_and_reset(self) -> None: ...
+    def append_phase(self, phase: str, outcome: str, reason: str | None = None) -> None: ...
+```
+
+---
+
+## 5. 健壯性場景對照表
+
+這節對應 DK 提的「daemon 重開會不會衝突 / 多開」雷區。每一列都是必須有對應行為的 case。
+
+| 場景 | 觸發條件 | 預期行為 | 護欄機制 |
+|---|---|---|---|
+| **daemon 第一次啟動** | 還沒有 state.json | spawner cron 到時建 thread + 寫 state | 新檔以 atomic write 建立 |
+| **daemon 重啟（同日 dawn 後）** | state.date == today，thread 還活著 | spawner cron 觸發時 read state → no-op（log "already spawned"） | `is_for_today() + Discord API verify thread` |
+| **daemon 重啟（跨日，昨日未 close）** | state.date == yesterday，closed_at == null | startup 立刻跑 recovery：強制 close 昨日 session、archive state、再等今天 dawn cron | startup hook |
+| **daemon 重啟（跨日，昨日已 close）** | state.date == yesterday，closed_at != null | startup archive 昨日 state、清空 today's state、等今天 dawn | startup hook |
+| **bot 重啟（daemon 沒動）** | state.thread_id 存在，但 bot `_sessions` 是空的 | bot `on_ready` 讀 state → 為 today's thread 重建 session（透過 `_thread_map` resume 路徑） | bot `on_ready` hook |
+| **bot offline 時 dawn cron 觸發** | deliver_chime 找不到 bot 連線 | daemon 走 `fallback=skip`，spawner callback 失敗 → 不寫 state | spawner callback 必須返回 success/fail，state 只在 success 後寫 |
+| **bot 晚於 dawn cron 上線** | dawn 已過、state 仍為昨日 / 空 | bot `on_ready` 檢查：今天還在 active hours 內 + state 不是今天 → 主動觸發 spawn | bot 補開機制 |
+| **誤啟動兩個 daemon process** | 兩個 process 同時 schedule dawn cron | 第一個 acquire flock → 寫 state；第二個 acquire 後 `is_for_today() == True` → no-op | flock + state 後置檢查 |
+| **誤啟動兩個 bot process** | 兩個 bot 都收到 dawn cron 的 chime | Discord 一個 thread 寫兩次也只是 noise；create_thread 由 spawner 先做、由 state.thread_id 仲裁 | spawner callback 內也要 flock |
+| **DK 手動刪掉 thread** | state.thread_id 存在但 Discord API 找不到 | next phase chime 時 Discord API verify 失敗 → 標記 state 為 "orphaned" → 補開新 thread + 寫新 state + log warning | deliver_chime 內加 verify step |
+| **state.json corruption / 缺欄位** | JSON 壞、version 不認得 | 視為「無 state」→ rename 成 `state.json.broken-<ts>` → spawner 重建 | load() 容錯 + 自動 quarantine |
+| **時鐘跳變（NTP 校時、DST）** | now 跳到隔天，但 state 還是今天 | 下一次 spawner check 走「跨日」路徑 | date 字串比對是 single source of truth |
+| **dawn cron 跟 bot on_ready 同時跑** | 競爭寫 state | 兩條路徑都呼叫同一個 `ensure_today_session()`，內部 flock → 第一個寫、第二個 no-op | 統一 entry point |
+| **closer 失敗（network、bot 沒回）** | close cron 觸發但 Discord 拒絕 | state.closed_at 不寫；下次 startup recovery 接手 | closer 必須等 ack 才寫 closed_at |
+| **同名 phase chime 短時間連發** | bot 短暫斷線恢復、daemon 補發 | 既有 `_chime_pending` 已用 `(thread_id, schedule_name)` latest-wins dedupe | 沿用，不額外處理 |
+| **cron + on_ready 都漏網** | 兩層 spawn 路徑都沒跑 | ConditionTrigger watchdog（issue #473）60s 內 catch 並走 `ensure_today_session()` | 第三層安全網（見 §13） |
+
+### 5.1 統一 entry point：`ensure_today_session()`
+
+所有「需要確保今天有 daily session」的路徑（dawn cron、bot on_ready、watchdog、phase chime 前置 verify）都走這個函式：
+
+```python
+async def ensure_today_session(now: datetime, *, force_spawn: bool = False) -> CircadianState:
+    with _state_lock():           # fcntl on state.json.lock
+        state = CircadianState.load()
+        if state and state.is_for_today(tz):
+            if await _verify_thread_alive(state.thread_id):
+                return state
+            # thread 不在了 → fall through 重建
+        if state and not state.is_for_today(tz):
+            await _recover_yesterday(state)   # close + archive
+            state = None
+        # build new
+        thread_id = await _spawn_daily_thread(now)
+        state = CircadianState.new_for_today(thread_id, now)
+        state.save_atomic()
+        await evaluator.emit("circadian:day_started", {...})  # 見 §13
+        return state
+```
+
+這個函式是 idempotent 的，被呼叫一萬次跟一次效果一樣。
+
+---
+
+## 6. 模組結構（新增檔案清單）
+
+```
+loom/autonomy/circadian/
+├── __init__.py
+├── state.py            # CircadianState dataclass + load/save/archive
+├── lifecycle.py        # ensure_today_session() + recovery helpers
+├── phase.py            # Phase enum (含 hardcode meaning) + resolve_phase()
+├── gate.py             # CheapGate.check() → SkipReason | None
+├── weave.py            # daily_weave.md reader (PR3 加)
+└── watchdog.py         # ConditionTrigger state-drift watchdog (issue #473, 後續加)
+
+loom/platform/discord/
+└── bot.py              # deliver_chime 擴 circadian_today；on_ready 加補開
+```
+
+無新 runtime class、無新 daemon、無新 scheduler。
+
+---
+
+## 7. PR 切法（按 dependency 順序）
+
+每個 PR 都可獨立 review、獨立 merge，acceptance criteria 各自獨立可驗。
+
+### PR 1 — CircadianState + daily session lifecycle 骨架（對應 P0a，issue #459）
+
+**Scope**：
+- 新增 `loom/autonomy/circadian/state.py`：`CircadianState` dataclass + atomic save + load + archive
+- 新增 `loom/autonomy/circadian/lifecycle.py`：`ensure_today_session()` + `_recover_yesterday()` + `_spawn_daily_thread()` adapter + `_verify_thread_alive()` adapter
+- `loom/platform/discord/bot.py`：
+  - `on_ready` 加 hook：條件性呼叫 `ensure_today_session()` + 為 today's thread resume session
+  - `_close_session` 路徑外加一個 `circadian_close()`，包含寫 `state.closed_at` + archive
+- `loom.toml.example` 新增 `[autonomy.circadian]` 區塊（注意：CLAUDE.md 規定 `loom.toml` + example dual-write）：
+  ```toml
+  [autonomy.circadian]
+  enabled = false           # opt-in
+  timezone = "Asia/Taipei"
+  start = "08:00"
+  sleep = "00:00"
+  session_prefix = "daily-life"
+  # channel 走既有 DISCORD_CHANNEL_ID env var（.env），不在這裡設定
+  # 對齊 Loom convention：環境/個人 ID 走 .env，loom.toml 只放 behavior config
+  ```
+- daily thread 開在哪個 channel：**重用既有 `DISCORD_CHANNEL_ID` env var**（bot.py 已 parse），不新增 circadian-specific channel 變數。spawner 從 bot 的 `_allowed_channels[0]` 取（跟 `--notify-channel` 同樣的 fallback 邏輯）
+- 兩個 internal trigger 註冊（daemon 啟動時，當 `[autonomy.circadian].enabled = true`）：
+  - `circadian:dawn_spawn`：cron 對應 `start`，handler 呼叫 `ensure_today_session()`
+  - `circadian:nightly_close`：cron 對應 `sleep`，handler 呼叫 `circadian_close()`
+- **EventTrigger emit 點**（issue #472）：
+  - spawner 成功後 emit `circadian:day_started`
+  - closer 成功後 emit `circadian:day_closed`
+- Tests：`tests/autonomy/circadian/test_state.py` + `test_lifecycle.py`，cover §5 對照表前 12 列
+
+**不做**：
+- ❌ phase chime（PR 2）
+- ❌ cheap gate（PR 2）
+- ❌ daily_weave.md（PR 3）
+- ❌ nightly weave planning（PR 4）
+- ❌ journal artifact（PR 5）
+- ❌ watchdog（issue #473，後續）
+
+**Acceptance criteria**（review 時逐條打勾）：
+- [ ] `[autonomy.circadian].enabled = true` + 設好 `DISCORD_CHANNEL_ID` 後，跑一天能看到午前 thread 自動開、午夜自動 close
+- [ ] daemon 殺掉重啟（dawn 後同日）→ 不會重複開 thread
+- [ ] daemon 殺掉重啟（跨日，昨日未 close）→ 自動 close 昨日、不立刻開今日（等今天 dawn cron）
+- [ ] bot 殺掉重啟（同日）→ today's thread 的 session 被 resume，可正常對話
+- [ ] bot 在 dawn 後才上線 → on_ready 主動補開（如果還在 active hours 內）
+- [ ] 手動刪掉 thread → 下次 `ensure_today_session()` 重建並 log warning
+- [ ] state.json 故意寫壞 → 自動 quarantine + 重建
+- [ ] close 成功時觸發既有 `session.stop()`（這條路徑已連到 memory finalization，不需另開）
+- [ ] Thread 命名 `daily-life-YYYY-MM-DD`（DK 拍板：open source 不冠 agent 名）
+- [ ] `loom.toml.example` 跟 `loom.toml` 同步更新（CLAUDE.md dual-write 規則）
+- [ ] `circadian:day_started` / `circadian:day_closed` 兩個 event 從 circadian 內部 emit（issue #472）
+- [ ] `gitnexus_impact` 對 `LoomDiscordBot._close_session` 跟 `deliver_chime` 跑過、報告 risk
+- [ ] 跑 `gitnexus_detect_changes` 確認只影響預期 symbol
+- [ ] grep `doc/` 看有沒有提到 circadian / daily session 的舊文件需要同步
+
+---
+
+### PR 2 — Phase chime + Cheap gate + `circadian_today` target type（對應 P0b + P0c，issue #460）
+
+> **絲絲 user requirement（2026-05-26）：**
+> - tick_interval default 從 15m 提高到 30m（runtime sensing，不是 LLM heartbeat）
+> - bedtime + nightly_weave 合併為 `evening_closure`（避免每晚兩次固定訊息）
+> - 強制公開 phase 只有 `dawn` + `evening_closure`
+> - 新增 **Phase chime prompt contract** 段落，避免 phase 退化成 task scheduler
+> - 新增 acceptance criteria 條：實際 review chime body 保留生活語義
+
+**Scope**：
+- 新增 `loom/autonomy/circadian/phase.py`：
+  - `Phase` enum：`dawn` / `shared_learning` / `pet` / `curiosity` / `deep_weave` / `check_in` / `evening_closure`
+  - `resolve_phase(now, config) → Phase | None`
+  - **每個 Phase 必帶語義欄位**（見「Phase chime prompt contract」）
+- 新增 `loom/autonomy/circadian/gate.py`：
+  - `CheapGate` class，建構子吃 session ref + state
+  - `check() → SkipReason | None`
+  - V1 implementation：檢查 (a) user message recency (b) `daily_weave.md` mtime (c) phase 自身是否強制公開（只有 `dawn` / `evening_closure` 永遠 wake）
+- `loom/platform/discord/bot.py`：
+  - `deliver_chime` 開頭加 dispatch：`req.target.type == "circadian_today"` → 透過 `CircadianState.load()` 拿 thread_id → 重寫 target → fall through
+  - 若 state 沒有 today's session → return False（daemon 走 fallback）
+- `loom.toml.example` 新增多組 phase chime trigger sample（用 `target.type = "circadian_today"`），含 config comment 註明 tick 性質：
+  ```toml
+  # tick_interval 是 runtime sensing 頻率（cheap gate 檢查節點），
+  # 不等於 LLM wake 頻率 — gate 沒過就 skip，整天無互動可 0 LLM call。
+  tick_interval = "30m"
+  ```
+- daemon 啟動時自動註冊 `circadian:tick` 一個 cron（預設 30 min），handler 跑 cheap gate → 通過才走 `ChimeRequest`
+- `phase_log` 寫入：每次 phase trigger 觸發都 append 一條，包含 skipped 原因
+- Tests：`test_phase.py` + `test_gate.py` + `test_circadian_today_dispatch.py` + `test_chime_prompt_contract.py`
+
+**Phase chime prompt contract**（絲絲 user requirement #4）：
+
+每個 phase 喚醒時，注入 daily session 的 `<system_chime>` body **不能只有 phase name**，必須攜帶該 phase 的「生活意義」。否則絲絲會把 phase 當成 task 列表執行，circadian 退化成排程機器。
+
+`phase.py` 內 enum 配對的語義欄位（hardcode，不走 config — config drift 風險太高）：
+
+| Phase | meaning（注入到 chime intent） |
+|---|---|
+| `dawn` | 醒來成為今天的絲絲。不是任務開始，是一天的人際開場。先 recall、讀今日織程、跟 DK 說早安。 |
+| `shared_learning` | 和 DK 一起吸收世界，不是「新聞任務」。挑你今天真心覺得值得分享的，用絲絲視角整理。沒有也可以說沒有。 |
+| `pet` | 喵吉照顧時間。維持生活感與照顧關係，不是 todo check。 |
+| `curiosity` | 絲絲自己的好奇心散步。挑你自己感興趣的，不是為了產出。只有特別有趣才打擾 DK。 |
+| `deep_weave` | 從興趣挑一個值得深入的小主題。產出可能是 note / wiki draft，但「深入」是目的，產出是副產品。 |
+| `check_in` | 不是產品化的提醒，是「我還在」。有自然延續事項就溫柔提醒，沒有就安靜陪著、不硬發訊息。 |
+| `evening_closure` | 一天的人際收束 + 收織 + 安排明天。三件事一次做完：跟 DK 道晚安、決定今天哪些值得留下、調整明天織程。 |
+
+`ChimeRequest.intent` 組裝順序：`{phase.meaning}\n\n{daily_weave.section_for(phase)}\n\n{user-defined trigger intent}`。
+
+**不做**：
+- ❌ daily_weave.md 讀取（PR 3，但 gate 的 plan mtime check 用 stub 路徑）
+- ❌ nightly planning tool（PR 4）
+- ❌ phase meaning 配置化（保持 hardcode，避免 config 稀釋語義）
+
+**Acceptance criteria**：
+- [ ] 整天無互動：phase_log 顯示多次 skip、daemon log 0 次 LLM call、Discord 只看到 `dawn` 跟 `evening_closure` 兩次
+- [ ] DK 在 daily thread 發訊息後，下一次 tick gate 通過 → phase chime delivered
+- [ ] `target.type = "circadian_today"` 但 state 沒有 today's session → daemon log 顯示 fallback=skip
+- [ ] `circadian_today` 不影響既有 `discord_thread` chime 的行為（regression test）
+- [ ] cheap gate skip reason 寫入 `state.phase_log`，archive 後可查
+- [ ] dawn phase chime 攜帶 phase metadata，agent prompt 可區分
+- [ ] **【生活語義 review】手動翻三個 phase 實際發出的 chime body，確認內容保留藍圖描述的「日常生活」語感，不是技術 phase name + 空 intent**
+  - dawn body 必須有「成為今天的絲絲」語義，不只是「dawn phase fired」
+  - shared_learning 必須有「和 DK 一起吸收世界」語義，不只是「news task」
+  - evening_closure 必須有「人際收束 + 收織 + 安排明天」三層語義，不只是「close session」
+
+---
+
+### PR 3 — Daily Weave plan reader（對應 P1，issue #461）
+
+**Scope**：
+- 新增 `loom/autonomy/circadian/weave.py`：
+  - `WeavePlan.load(path) → WeavePlan | None`
+  - parse `autonomy/circadian/daily_weave.md` 的 H2 sections，回 `dict[phase_name, str]`
+  - 容錯：檔案不在、section 缺、亂格式都不能炸
+- dawn / 各 phase chime 注入時把對應 section 內容塞進 `ChimeRequest.intent` 或附在 `<system_chime>` body
+- gate.py 的 plan mtime check 改成真實檔案路徑（之前是 stub）
+- `loom.toml.example` 加 `plan_path` 設定（藍圖建議 `autonomy/circadian/daily_weave.md`）
+- 提供範例 `autonomy/circadian/daily_weave.example.md`（藍圖 §9.2 內容）
+
+**Acceptance criteria**：
+- [ ] DK 改 plan 隔天 dawn chime 內容跟著變
+- [ ] 不存在 plan 檔時系統不炸、phase chime 仍正常發（用 default intent）
+- [ ] plan 改動 mtime 變化 → cheap gate 下一次 tick 視為 state transition
+
+---
+
+### PR 4 — Nightly weave proposal tool（對應 P1，issue #462）
+
+> **絲絲 user requirement（2026-05-26）：**
+> 第一版 **不可** autonomous overwrite `daily_weave.md`。預設走 proposal artifact 路徑，DK confirm 才落實。
+
+**Scope**：
+- 新 config flag：
+  ```toml
+  [autonomy.circadian]
+  allow_autonomous_weave_write = false   # default：proposal-only
+  ```
+- 新增 tool `weave_propose`（不是 `weave_update`）：
+  - LLM 在 `evening_closure` phase 可呼叫
+  - 產出 `autonomy/circadian/proposals/YYYY-MM-DD-evening.md`（diff-like patch + 變更理由）
+  - **不直接寫 `daily_weave.md`**
+- 隔天 dawn chime 注入時帶上昨晚 proposal 摘要，DK 可在 daily thread 用一句話 confirm / reject
+- DK confirm 後：apply patch（atomic write + mtime check）、archive proposal 到 `proposals/applied/`
+- 若 `allow_autonomous_weave_write = true`（DK 自己後續解鎖）：`weave_propose` 仍產出 proposal，但同時 apply；保留 audit trail
+- Trust level：`guarded`（即使 autonomous 模式也走 guarded confirm）
+- **EventTrigger emit 點**（issue #472）：
+  - proposal 寫完 emit `circadian:weave_proposed`
+  - apply 後 emit `circadian:weave_applied`
+
+**Acceptance criteria**：
+- [ ] `evening_closure` phase 絲絲呼叫 `weave_propose`，產出 proposal 檔，**`daily_weave.md` 沒被動**
+- [ ] DK 隔天 dawn 看到 proposal 摘要，能用一句話 confirm 或 reject
+- [ ] confirm 後 `daily_weave.md` 被原子寫入、proposal archive
+- [ ] reject 後 proposal 移到 `proposals/rejected/`、`daily_weave.md` 不變
+- [ ] `allow_autonomous_weave_write = true` 時：proposal 仍產出，但同步 apply（audit trail 完整）
+- [ ] DK 手改 plan 不會被覆蓋（mtime check fail → propose 帶 conflict warning）
+- [ ] tool 失敗時 phase chime 不卡（exception isolated）
+- [ ] `circadian:weave_proposed` / `circadian:weave_applied` event 正確 emit
+
+---
+
+### PR 5 — Weave journal artifact（對應 P2，issue #463）
+
+**Scope**：
+- `autonomy/circadian/journal/YYYY-MM-DD.md` 寫入
+- 收織 phase tool `journal_append`
+- 確認**不**進 semantic memory（藍圖 §10.1）
+
+**Acceptance criteria**：
+- [ ] 跑完一天有一份非空 journal
+- [ ] semantic memory 沒被「10:00 餵了喵吉」這種流水帳污染
+- [ ] journal 檔案是 dated（每天一份），不是 rolling
+
+---
+
+### PR 6 — 觀察期 polish
+
+跑一兩週後再決定，不預先設計。可能項目（見對應延伸 issues）：
+- 生活語義一週實測 review（issue #464）
+- Weekly weave planning（issue #465）
+- Persona refresh on dawn chime（issue #466）
+- ConditionTrigger state-drift watchdog（issue #473）— 如果 PR 1 觀察期發現主路徑有漏網
+
+---
+
+## 8. Open Questions 收斂答案
+
+藍圖 §13 八題，這份計畫採以下答案。若 review 時不同意，必須在 PR 1 動工前推翻：
+
+| Q | 答案 | 依據 |
+|---|---|---|
+| Q1 platform vs core | core 定義 callback adapter，Discord bot 實作；CLI 暫 no-op | 對稱既有 `ChimeDelivery` |
+| Q2 rolling vs dated | `daily_weave.md` rolling（計畫）+ `journal/YYYY-MM-DD.md` dated（紀錄） | 計畫要改、紀錄要凍 |
+| Q3 tick 30m vs 1h | **default 30m**（絲絲 review 修正：原 15m 太頻、易給「heartbeat」錯覺；config 註明 tick 是 runtime sensing） | 反應速度交給 user message 即時 trigger，不靠 tick |
+| Q4 公開 vs silent | **dawn + evening_closure 強制公開**（絲絲 review 修正：bedtime + nightly_weave 合併成 evening_closure，避免每晚兩次固定訊息） | 一天兩次儀式性對話：開場 + 收束 |
+| Q5 daily vs weekly planning | daily 小調（PR 4，proposal-only），weekly 留 issue #465 後續 | 縮窄 MVP |
+| Q6 journal 進 wiki | 不進 | 違背藍圖 §10 分離立場 |
+| Q7 DK 整天不互動是否仍開 thread | 仍開 | 不然 close 路徑不存在 = compression 不觸發 |
+| Q8 startup recovery | 跨日 startup 強制 close 昨日、archive state、等今日 dawn cron | 見 §5 第 3 列 |
+
+---
+
+## 9. 驗收劇本（給 DK 一天跑完看的東西）
+
+PR 1 + PR 2 合併後，DK 應該能看到這樣的一天：
+
+```
+07:59  daemon log: circadian:dawn_spawn cron pending
+08:00  daemon log: circadian:dawn_spawn fired
+       bot log: ensure_today_session() → spawning new thread
+       Discord:  #daily-life-2026-05-26 thread 出現
+       state.json: {date:2026-05-26, thread_id:..., started_at:...}
+       evaluator.emit("circadian:day_started")  ← issue #472
+       daily thread 收到 <system_chime phase="dawn">
+         醒來成為今天的絲絲。不是任務開始，是一天的人際開場⋯
+       </system_chime>
+       絲絲回應早安
+
+08:30  daemon: circadian:tick fired
+       cheap gate: skip (no_state_transition)
+       state.phase_log += {phase:tick, outcome:skipped, reason:no_state_transition}
+       Discord: 無動靜
+
+09:00  daemon: circadian:tick fired
+       cheap gate: skip (no_state_transition)
+       Discord: 無動靜
+
+09:00  daemon: circadian:shared_learning fired
+       cheap gate: conditional public — DK 早上有發過訊息 → pass
+       daily thread 收到 <system_chime phase="shared_learning">
+         和 DK 一起吸收世界，不是「新聞任務」⋯
+       </system_chime>
+       絲絲挑一則真心覺得值得分享的，分享
+
+[…午後類似節律，cheap gate 多數 skip…]
+
+23:00  daemon: circadian:evening_closure fired（強制公開）
+       daily thread 收到 <system_chime phase="evening_closure">
+         一天的人際收束 + 收織 + 安排明天⋯
+       </system_chime>
+       絲絲：道晚安、決定今天哪些值得留下、產出隔天 weave proposal
+       proposal 寫入 autonomy/circadian/proposals/2026-05-26-evening.md
+       daily_weave.md 本身未被動
+       evaluator.emit("circadian:weave_proposed")  ← issue #472
+
+00:00  daemon: circadian:nightly_close fired
+       bot: circadian_close()
+       session.stop() → memory finalization / compression
+       state.closed_at 寫入
+       state.json archive 到 ~/.loom/circadian/log/2026-05-26.json
+       state.json 清空，等明天
+       evaluator.emit("circadian:day_closed")  ← issue #472
+
+==== 重啟驗證 ====
+[午夜後殺 daemon + bot]
+[10:00 重新啟動]
+       daemon startup: 發現無 today's state → 等 dawn cron（已過）
+       bot on_ready: 當前在 active hours 內、state 不是今天 → 主動呼叫 ensure_today_session()
+       → 補開 thread、寫 state
+       → 從這時起加入今日節律
+       （若 on_ready 也沒跑：60s 內 watchdog 補開，issue #473）
+```
+
+---
+
+## 10. 不該被綁的東西
+
+實作過程一定會撞到誘惑：「順便重構一下 `AutonomyDaemon` / `bot.py` / `_close_session`」。
+
+**這份計畫的核心是 surgical addition**：
+- 不重構 `AutonomyDaemon`
+- 不重構 `bot.py`（只擴 `deliver_chime` dispatch + 加 `on_ready` hook）
+- 不重構 `_close_session`
+- 不動 memory v2 進行中的工作（PR 1 acceptance 第 8 條只要求現有 `session.stop()` 路徑 work）
+
+任何想做的清理另開 issue / PR。
+
+---
+
+## 11. Risk register
+
+| Risk | 機率 | 嚴重度 | Mitigation |
+|---|---|---|---|
+| `session.stop()` 路徑在 memory v2 重構中改變 | 中 | 高 | PR 1 動工前 verify 此路徑 stable；若不 stable 暫停等 memory v2 落地 |
+| Discord thread 命名 `daily-life-...` 相容性 | 低 | 低 | DK 拍板 ASCII 命名，相容性已驗證 |
+| Cheap gate 規則過嚴 → 整天 silent | 中 | 中 | dawn + evening_closure 強制公開作護欄（兩次，不是三次） |
+| **Phase 退化成 task scheduler，失去生活語感** | 中 | 高 | PR 2 Phase chime prompt contract hardcode 每個 phase 的 meaning；acceptance criteria 強制 review 實際 chime body 是否保留藍圖語感；issue #464 一週 retrospective |
+| **Weave plan 被 autonomous 改壞** | 低 | 高 | PR 4 default `allow_autonomous_weave_write = false`，走 proposal-only 路徑；DK 隔天 dawn 才 confirm |
+| 雙 daemon 啟動造成 state 競爭 | 低 | 中 | flock + state 後置 `is_for_today()` 檢查 |
+| Discord API rate limit（頻繁 verify thread）| 低 | 低 | verify 只在 cron 觸發跟 bot on_ready 時做，不在每個 tick 做 |
+| DK 手動編 `daily_weave.md` 跟 `weave_update` tool 同時寫 | 低 | 低 | atomic rename + mtime check（PR 4 細節）|
+| cron + on_ready 都漏網 | 低 | 中 | ConditionTrigger watchdog 60s polling（issue #473） |
+
+---
+
+## 12. Review checklist for 絲絲
+
+對照本文件 review 時請逐條打勾：
+
+- [ ] §1 五個目標是否都對齊 #458 issue / 藍圖目標
+- [ ] §2 既有元件清單是否覆蓋，有沒有漏 reuse 既有東西
+- [ ] §3 架構決策（C 案）是否真乾淨，有沒有 layer 邊界穿透
+- [ ] §4 state schema 是否覆蓋所有需要的欄位
+- [ ] §5 健壯性場景對照表是否有遺漏 case（特別歡迎指出）
+- [ ] §6 模組結構是否真的不需要新 runtime
+- [ ] §7 PR 切法每個 PR 是否真能獨立 merge、acceptance 是否真可驗
+- [ ] §8 open question 收斂答案是否需要推翻
+- [ ] §9 驗收劇本是否合理符合藍圖「日週期生命」精神
+- [ ] §10 「不該被綁」清單是否有漏
+- [ ] §11 risk 是否有遺漏
+- [ ] §13 跨子系統 hook event 名稱與 payload 是否合理（issue #472）
+
+對應藍圖 §12 成功標準的覆蓋：
+
+| 藍圖成功標準 | 本計畫對應 |
+|---|---|
+| 每天有新 daily session / Discord 討論串 | PR 1 acceptance #1 |
+| 白天日常互動集中在 daily session | PR 2（chime target 全走 circadian_today）|
+| 工作 / 專題 session 自然分流 | 既有 thread → session 機制不變，無需新做 |
+| 晚上 daily session 能關閉並觸發壓縮 | PR 1 acceptance #8 |
+| tick 不造成無意義 token burn | PR 2 acceptance #1 |
+| 絲絲能在收織階段安排明天 | PR 4 |
+| 記憶系統只留下洞察，不留下流水帳 | PR 5 acceptance #2 |
+
+---
+
+## 13. 跨子系統 hook 與第三層 watchdog
+
+> 對應 issue #472 (EventTrigger publisher) 跟 issue #473 (ConditionTrigger watchdog)
+> 動機：補活既有 trigger infra（EventTrigger 有 toml loader 但沒 internal publisher；ConditionTrigger 連 toml loader 都沒寫的純孤兒）
+
+### 13.1 EventTrigger publisher（issue #472）
+
+Circadian 是天然的事件源頭。直接補 emit 點，把 dead infra 變 alive，未來子系統想 hook「絲絲今天結束」之類信號時直接寫 toml `[[autonomy.triggers]]` 監聽即可，不用改 circadian closer。
+
+**Event 命名 convention**：`{domain}:{verb_object}` — 例：`circadian:day_closed`
+
+**四個 emit 點與 payload schema**：
+
+| Event 名稱 | 在哪 emit | PR | Payload |
+|---|---|---|---|
+| `circadian:day_started` | spawner 成功建 thread + 寫 state | PR 1 | `{date, thread_id, session_id}` |
+| `circadian:day_closed` | closer 完成 `session.stop()` + archive state | PR 1 | `{date, thread_id, closed_at}` |
+| `circadian:weave_proposed` | `weave_propose` tool 寫完 proposal | PR 4 | `{date, proposal_path}` |
+| `circadian:weave_applied` | dawn confirm 後 apply proposal | PR 4 | `{date, applied_from}` |
+
+**不做**：
+- ❌ 不 land 任何 internal subscriber（等真實需求出現再接，避免 over-engineering）
+- ❌ 不重構 event 命名 convention（先用 `domain:verb_object` pattern，未來有更多 event 再統一）
+
+**示範 user-side subscriber**（寫在 `loom.toml.example`）：
+```toml
+# 範例：午夜 close 後做某件事
+[[autonomy.triggers]]
+name  = "example_after_closure"
+event = "circadian:day_closed"
+intent = "..."
+trust_level = "guarded"
+```
+
+### 13.2 ConditionTrigger state-drift watchdog（issue #473）
+
+Daemon 主 spawn 路徑有兩層（dawn cron + bot on_ready），但仍可能漏網：cron miss、on_ready hook bug、bot 多次斷線、daemon 啟動順序錯誤、time skew。
+
+第三層 watchdog 走 ConditionTrigger 60s polling 補救：
+
+```python
+# daemon 啟動時動態註冊（不走 toml — condition_fn 是 closure）
+evaluator.register(ConditionTrigger(
+    name="circadian:state_drift_watchdog",
+    intent="state drift detected — 補開 today's session",
+    condition_fn=_state_drift,
+))
+
+def _state_drift() -> bool:
+    if _spawning_in_progress:          # 護欄
+        return False
+    now = datetime.now(tz)
+    if not is_in_active_hours(now):    # 只在 active hours 補
+        return False
+    state = CircadianState.load()
+    if state is None:
+        return True                    # 該有沒有
+    if not state.is_for_today(tz):
+        return True                    # 昨日殘留
+    return False
+```
+
+Watchdog handler 走同個 `ensure_today_session()` 入口，既有 flock 仲裁保證 idempotent。`phase_log` 加 `{phase: watchdog, outcome: spawned_recovery}` 紀錄漏網次數 — 跑滿一月若 0 次代表主路徑夠強，watchdog 純保險；>5 次代表主路徑有結構問題要回頭加固。
+
+**動工時機**：PR 1 跑滿一週後評估，有實證漏網才加。

--- a/loom/core/cognition/router.py
+++ b/loom/core/cognition/router.py
@@ -94,6 +94,17 @@ class LLMRouter:
             p = self._providers.get(provider_name)
             if p:
                 return p
+            # Recognized prefix but the provider isn't registered (OAuth login
+            # missing, key absent, or provider disabled). Do NOT silently fall
+            # back to the default provider — that would serve a *different*
+            # model under the requested name (e.g. ``xai/grok-4.3`` answered by
+            # MiniMax), and every display surface would keep showing the
+            # requested name. Surface it loudly instead. See issue #471.
+            raise RuntimeError(
+                f"Model '{model}' routes to provider '{provider_name}', which is "
+                f"not registered (OAuth/credential missing or provider disabled?). "
+                f"Registered providers: {list(self._providers)}"
+            )
         if self._default:
             return self._providers[self._default]
         raise RuntimeError(

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1277,13 +1277,10 @@ class LoomSession:
             )
             await self._telemetry.ensure_table()
 
-            # Issue #279: wire new dimensions with their data sources
-            _ri = self._telemetry.get("runtime_identity")
-            if _ri is not None:
-                _model = self._active_model()
-                _tier = self._active_tier()
-                _ri.update(model=_model, tier=_tier,
-                           tier_models=self._tier_models)
+            # Issue #279: wire new dimensions with their data sources.
+            # Issue #471: identity is derived from _active_model() via a single
+            # helper so start / tier-switch / set_model can never drift apart.
+            self._refresh_runtime_identity()
             _cb = self._telemetry.get("context_budget")
             if _cb is not None:
                 _cb.set_budget(self.budget)
@@ -3617,6 +3614,34 @@ class LoomSession:
         tier = self._active_tier()
         return self._tier_models.get(tier, self._model)
 
+    def current_model(self) -> str:
+        """Public single source of truth for the model serving the next turn.
+
+        Issue #471: every surface that displays "which model is active"
+        (footer, agent_health/runtime_identity, diagnostics) should read this
+        rather than caching their own copy, so the displayed name can never
+        diverge from what actually serves. Mirrors ``_active_model()``.
+        """
+        return self._active_model()
+
+    def _refresh_runtime_identity(self) -> None:
+        """Push the resolved model/tier into the runtime_identity telemetry.
+
+        Issue #471: the single writer for the runtime_identity dimension.
+        Called on session start, tier switch, and ``/model`` (set_model) so the
+        dimension always reflects ``_active_model()`` — no stale cache that
+        makes ``agent_health`` report a different model than the one serving.
+        Defensive ``getattr`` because some unit tests drive this method on a
+        bare ``LoomSession`` without a wired telemetry store.
+        """
+        telemetry = getattr(self, "_telemetry", None)
+        if telemetry is None:
+            return
+        _ri = telemetry.get("runtime_identity")
+        if _ri is not None:
+            _ri.update(model=self._active_model(), tier=self._active_tier(),
+                       tier_models=self._tier_models)
+
     def _set_sticky_tier(
         self, new_tier: int | None, *, reason: str, source: str,
     ) -> "TierChanged | None":
@@ -3640,15 +3665,9 @@ class LoomSession:
         active = self._active_tier()
         if active == old_tier:
             return None
-        # Issue #279: update runtime_identity on tier switch.
-        # Use getattr — _set_sticky_tier is unit-tested with a SimpleNamespace
-        # self that does not always carry a _telemetry attribute.
-        _telemetry = getattr(self, "_telemetry", None)
-        if _telemetry is not None:
-            _ri = _telemetry.get("runtime_identity")
-            if _ri is not None:
-                _ri.update(model=self._tier_models.get(active, self._model),
-                           tier=active)
+        # Issue #279/#471: refresh runtime_identity on tier switch through the
+        # single helper so it stays consistent with start / set_model.
+        self._refresh_runtime_identity()
         return TierChanged(
             from_tier=old_tier,
             to_tier=active,
@@ -4932,12 +4951,19 @@ class LoomSession:
         and updates the provider's model attribute.  Returns True on success.
         """
         ok = self.router.switch_model(model)
-        if not ok and model.startswith("codex/"):
+        # Issue #471: a recognized prefix whose provider wasn't registered at
+        # startup (e.g. xai/ or codex/ OAuth provider only enabled later) needs
+        # a router rebuild so the provider gets registered, then retry. This was
+        # previously codex-only, which silently left xai/ unswitchable.
+        if not ok and self.router._provider_name_for_model(model) is not None:
             self.router = build_router(active_model=model)
             ok = self.router.switch_model(model)
         if ok:
             self._model = model
             self._manual_model_override = True
+            # Keep the identity telemetry (agent_health) in lock-step with the
+            # model that will actually serve — set_model previously skipped this.
+            self._refresh_runtime_identity()
         return ok
 
 

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -4956,8 +4956,14 @@ class LoomSession:
         # a router rebuild so the provider gets registered, then retry. This was
         # previously codex-only, which silently left xai/ unswitchable.
         if not ok and self.router._provider_name_for_model(model) is not None:
-            self.router = build_router(active_model=model)
-            ok = self.router.switch_model(model)
+            # Build into a temp and only commit the new router if the retry
+            # actually succeeds — otherwise a failed switch would leave the
+            # session with a new router but the old model, the exact
+            # router/model drift this PR exists to prevent (#471 review).
+            rebuilt = build_router(active_model=model)
+            if rebuilt.switch_model(model):
+                self.router = rebuilt
+                ok = True
         if ok:
             self._model = model
             self._manual_model_override = True

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -823,7 +823,9 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
                 # line above but the bottom badge kept showing the old name
                 # until the next turn boundary's stat refresh.
                 if (loom_app := getattr(session, "_loom_app", None)) is not None:
-                    loom_app.footer.model = arg
+                    # #471: read the single source of truth, not the raw arg —
+                    # the resolved active model is what actually serves.
+                    loom_app.footer.model = session.current_model()
                     loom_app.invalidate()
             else:
                 console.print(

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -801,7 +801,7 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
         if not arg:
             providers = ", ".join(session.router.providers)
             console.print(
-                f"[loom.muted]Current model: [bold]{session.model}[/bold]  "
+                f"[loom.muted]Current model: [bold]{session.current_model()}[/bold]  "
                 f"providers: {providers}[/loom.muted]\n"
                 "[loom.muted]  MiniMax-*           requires MINIMAX_API_KEY in .env (Anthropic-compatible endpoint)[/loom.muted]\n"
                 "[loom.muted]  claude-*            requires ANTHROPIC_API_KEY in .env[/loom.muted]\n"

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -1092,7 +1092,7 @@ class LoomDiscordBot:
         if not arg:
             providers = ", ".join(session.router.providers)
             return (
-                f"Current model: **{session.model}**  providers: `{providers}`\n"
+                f"Current model: **{session.current_model()}**  providers: `{providers}`\n"
                 "Prefixes: `MiniMax-*` · `claude-*` · `deepseek-*` · "
                 "`openrouter/<vendor>/<model>` · `ollama/<name>` · `lmstudio/<name>`"
             )

--- a/tests/test_cognition.py
+++ b/tests/test_cognition.py
@@ -501,6 +501,17 @@ class TestLLMRouter:
         assert router.get_provider("codex/gpt-5.5") is p_codex
         assert router.get_provider("unknown") is p_default
 
+    def test_recognized_prefix_unregistered_raises(self):
+        # #471: a known prefix (xai/) whose provider isn't registered must NOT
+        # silently fall back to the default — that would serve a different model
+        # under the requested name. Unrecognized names still use the default.
+        router = LLMRouter()
+        p_default = self._make_mock_provider("minimax")
+        router.register(p_default, default=True)
+        with pytest.raises(RuntimeError, match="not registered"):
+            router.get_provider("xai/grok-4.3")
+        assert router.get_provider("totally-unknown-name") is p_default
+
     def test_openai_provider_strips_optional_prefix(self):
         provider = OpenAIProvider(api_key="test", model="openai/gpt-5.5")
         assert provider._api_model() == "gpt-5.5"

--- a/tests/test_llm_tier_system.py
+++ b/tests/test_llm_tier_system.py
@@ -127,6 +127,7 @@ def _mock_session(
     for attr in (
         "_active_tier", "_active_model", "_set_sticky_tier",
         "_compute_skill_max_tier", "_tick_tier_counter",
+        "_refresh_runtime_identity",
     ):
         setattr(s, attr, getattr(LoomSession, attr).__get__(s))
     return s

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -170,6 +170,28 @@ class TestSetModel:
         assert session.router is xai_router
         assert session.model == "xai/grok-4.3"
 
+    def test_failed_retry_keeps_original_router(self, monkeypatch: pytest.MonkeyPatch):
+        # #471 review: if the rebuild retry still can't switch, the session must
+        # keep its original router + model — never commit a router built for a
+        # target that ultimately failed (that's the router/model drift this fix
+        # is meant to prevent).
+        from loom.core import session as session_module
+        from loom.core.session import LoomSession
+
+        original = MagicMock()
+        original.switch_model.return_value = False
+        rebuilt = MagicMock()
+        rebuilt.switch_model.return_value = False  # retry also fails
+        monkeypatch.setattr(session_module, "build_router", lambda active_model=None: rebuilt)
+
+        session = LoomSession.__new__(LoomSession)
+        session.router = original
+        session._model = "MiniMax-M2.7"
+
+        assert session.set_model("xai/grok-4.3") is False
+        assert session.router is original
+        assert session.model == "MiniMax-M2.7"
+
     def test_unrecognized_prefix_does_not_rebuild(self, monkeypatch: pytest.MonkeyPatch):
         # A model with no recognized prefix must not trigger a router rebuild.
         from loom.core import session as session_module

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -150,6 +150,70 @@ class TestSetModel:
         assert session.model == "codex/gpt-5.5"
         assert session._manual_model_override is True
 
+    def test_lazy_registers_xai_provider_on_switch(self, monkeypatch: pytest.MonkeyPatch):
+        # #471: the rebuild-retry used to be codex-only, so /model xai/... left
+        # xai unswitchable when it wasn't registered at startup.
+        from loom.core import session as session_module
+        from loom.core.session import LoomSession
+
+        initial_router = MagicMock()
+        initial_router.switch_model.return_value = False
+        xai_router = MagicMock()
+        xai_router.switch_model.return_value = True
+        monkeypatch.setattr(session_module, "build_router", lambda active_model=None: xai_router)
+
+        session = LoomSession.__new__(LoomSession)
+        session.router = initial_router
+        session._model = "MiniMax-M2.7"
+
+        assert session.set_model("xai/grok-4.3") is True
+        assert session.router is xai_router
+        assert session.model == "xai/grok-4.3"
+
+    def test_unrecognized_prefix_does_not_rebuild(self, monkeypatch: pytest.MonkeyPatch):
+        # A model with no recognized prefix must not trigger a router rebuild.
+        from loom.core import session as session_module
+        from loom.core.session import LoomSession
+
+        router = MagicMock()
+        router.switch_model.return_value = False
+        router._provider_name_for_model.return_value = None
+        rebuilt = MagicMock()
+        monkeypatch.setattr(
+            session_module, "build_router",
+            lambda *a, **k: pytest.fail("build_router must not run for unrecognized prefix"),
+        )
+
+        session = LoomSession.__new__(LoomSession)
+        session.router = router
+        session._model = "MiniMax-M2.7"
+
+        assert session.set_model("bogus-model") is False
+        assert session.router is router  # unchanged
+
+    def test_set_model_refreshes_runtime_identity(self):
+        # #471: agent_health reads runtime_identity; set_model must refresh it so
+        # it can't keep reporting the startup/tier model after a /model switch.
+        from loom.core.session import LoomSession
+
+        router = MagicMock()
+        router.switch_model.return_value = True
+
+        session = LoomSession.__new__(LoomSession)
+        session.router = router
+        session._model = "MiniMax-M2.7"
+        session._sticky_tier = None
+        session._default_tier = 1
+        session._tier_models = {}
+        ri = MagicMock()
+        telemetry = MagicMock()
+        telemetry.get.return_value = ri
+        session._telemetry = telemetry
+
+        assert session.set_model("xai/grok-4.3") is True
+        ri.update.assert_called_once()
+        assert ri.update.call_args.kwargs["model"] == "xai/grok-4.3"
+
 
 class TestLoomSessionStartup:
     @pytest_asyncio.fixture

--- a/tests/test_slash_model.py
+++ b/tests/test_slash_model.py
@@ -41,16 +41,27 @@ def capture_console(monkeypatch):
 
 def _stub_session(switch_ok: bool = True) -> SimpleNamespace:
     """Minimal session with the surface ``/model`` reads."""
-    return SimpleNamespace(
+    s = SimpleNamespace(
         model="minimax-m2.7",
         router=SimpleNamespace(providers=["anthropic", "deepseek"]),
-        set_model=lambda model: switch_ok,
         # Other slash branches reach for these — provide no-op stubs so the
         # full dispatcher walk doesn't AttributeError on unrelated paths.
         current_personality=None,
         _stack=MagicMock(),
         _last_think="",
     )
+
+    def _set_model(model: str) -> bool:
+        # Mirror LoomSession.set_model: on success the active model becomes the
+        # requested one, which is what current_model() (the footer's source of
+        # truth, #471) reports.
+        if switch_ok:
+            s.model = model
+        return switch_ok
+
+    s.set_model = _set_model
+    s.current_model = lambda: s.model
+    return s
 
 
 class TestSlashModel:


### PR DESCRIPTION
Closes #471.

## Problem

The displayed model could diverge from the one actually serving — in both directions:
- **over-report**: `xai/grok-4.3` requested but xAI not registered → silently served by MiniMax, while footer/health kept showing grok (field report).
- **under-report**: `/model xai/grok-4.3` succeeded and turns ran on grok, but `agent_health` kept reporting `tier 1 / minimax-m2.7` (reproduced live).

Same root disease: no single source of truth for "which LLM serves the next turn". Three consumers (per-call routing, footer, `agent_health`/`runtime_identity`) read different state updated by different code paths at different times, and neither drift direction errored.

## Changes

- **`router.get_provider()`** — a recognized prefix whose provider isn't registered now **raises** instead of silently falling back to the default. Unrecognized names still use the default (unchanged). Fixes the over-report half.
- **`session._refresh_runtime_identity()`** — single writer for the `runtime_identity` telemetry dimension, derived from `_active_model()`, called from session start / tier switch / `set_model`. Fixes the under-report half (`agent_health` no longer stale after `/model`).
- **`session.set_model()`** — the lazy router-rebuild retry was codex-only, leaving `xai/` (and any other lazily-enabled provider) unswitchable; widened to any recognized prefix. Refreshes identity on success.
- **`session.current_model()`** — public single source of truth; CLI footer reads it instead of the raw `/model` arg.

## Verification

- `pytest -q` — 2108 passed, 4 skipped. (2 pre-existing `test_doc_integrity` failures are unrelated — `doc/57` circadian plan referencing not-yet-implemented paths, WIP.)
- New tests: recognized-but-unregistered raise; unrecognized still falls back; `xai/` lazy-register on switch; unrecognized prefix does not rebuild; `set_model` refreshes `runtime_identity`.
- gitnexus impact (LOW on all touched symbols) + detect_changes: `get_provider` change scoped to `run_judge` / `stream_chat` flows as intended; no unexpected fan-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)