### PR TITLE
feat(autonomy): Circadian PR 1 — CircadianState + daily session lifecycle skeleton (#459)

### DIFF
--- a/loom.toml.example
+++ b/loom.toml.example
@@ -588,6 +588,19 @@ backend = "none"   # "none" | "srt"
 [autonomy]
 enabled  = false           # set true to activate daemon
 
+# ── Circadian Autonomy — daily-life rhythm (milestone #14, doc/57) ────────────
+# Opens one daily Discord thread at `start` and closes it at `sleep` (close runs
+# the existing memory-finalization path). The thread is opened in the channel
+# from DISCORD_CHANNEL_ID (.env) — per Loom convention environment/personal IDs
+# live in .env, behaviour lives here. Unlike the schedules below, `start`/`sleep`
+# are LOCAL wall-clock times in `timezone` (converted to UTC internally).
+[autonomy.circadian]
+enabled        = false          # opt-in
+timezone       = "Asia/Taipei"
+start          = "08:00"        # local wake → daily thread opens
+sleep          = "00:00"        # local sleep → daily thread closes (00:00 = end of day)
+session_prefix = "daily-life"   # thread name → daily-life-YYYY-MM-DD
+
 # Cron times are always UTC. Convert your local time before filling in.
 # Example: Asia/Taipei UTC+8 → subtract 8 h  (09:00 CST = 01:00 UTC)
 

--- a/loom/autonomy/circadian/__init__.py
+++ b/loom/autonomy/circadian/__init__.py
@@ -1,0 +1,24 @@
+"""
+Circadian Autonomy — the daily-life rhythm layer (milestone #14, epic #458).
+
+This package adds Loom's missing continuous life line on top of the existing
+autonomy primitives, without reinventing any of them:
+
+    wake → live → weave → sleep → remember → wake again
+
+It is *surgical addition*: triggers come from ``loom.autonomy.triggers``,
+delivery from ``loom.autonomy.chime`` + the Discord bot, scheduling from
+``AutonomyDaemon``. Circadian only supplies the daily-session bookkeeping
+(``CircadianState``), the idempotent lifecycle entry point
+(``ensure_today_session``), and the wiring that registers the dawn/sleep
+cron triggers with deterministic handlers.
+
+PR 1 scope (issue #459): state + lifecycle skeleton only. Phase chime, cheap
+gate, weave plan, journal land in later PRs (#460–#463).
+"""
+
+from __future__ import annotations
+
+from loom.autonomy.circadian.state import CircadianState
+
+__all__ = ["CircadianState"]

--- a/loom/autonomy/circadian/lifecycle.py
+++ b/loom/autonomy/circadian/lifecycle.py
@@ -203,6 +203,18 @@ async def ensure_today_session(
                     "[circadian] today's thread %s no longer exists — rebuilding",
                     state.thread_id,
                 )
+                # Best-effort finalize the orphaned session before replacing it.
+                # Without this the old thread's session stays loaded + registered
+                # until shutdown, so a stale discord_thread chime target would
+                # still pass deliver_chime() and the session would miss its
+                # session.stop() memory finalization (PR #476 review P1).
+                try:
+                    await platform.close_daily_session(state.thread_id)
+                except Exception:  # noqa: BLE001 — never block the rebuild
+                    logger.exception(
+                        "[circadian] closing orphaned session for thread %s failed",
+                        state.thread_id,
+                    )
             elif state is not None and not state.is_for_today(tz):
                 closed = await _close_and_archive(state, platform, config)
                 if closed is not None:

--- a/loom/autonomy/circadian/lifecycle.py
+++ b/loom/autonomy/circadian/lifecycle.py
@@ -1,0 +1,425 @@
+"""
+Circadian lifecycle — the idempotent daily-session entry point and its wiring.
+
+Everything that needs "make sure today's daily session exists" funnels through
+``ensure_today_session`` (doc/57 §5.1): dawn cron, bot ``on_ready`` catch-up,
+and (later) the state-drift watchdog. Calling it once or a thousand times has
+the same effect — a per-process async lock plus a cross-process ``state_lock``
+arbitrate so only one caller spawns.
+
+This module is platform-agnostic. The Discord-specific work (creating a thread,
+verifying it's alive, closing + stopping the session) lives behind the
+``CircadianPlatform`` protocol, which the bot implements. Triggers, delivery,
+and scheduling are all reused from the existing autonomy stack — circadian adds
+no new runtime (doc/57 §1.1, §6).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Protocol
+from zoneinfo import ZoneInfo
+
+from loom.autonomy.circadian.state import CircadianState, _today_str, state_lock
+from loom.autonomy.triggers import CronTrigger
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class CircadianConfig:
+    """Parsed ``[autonomy.circadian]`` block. Behaviour only — the channel id
+    comes from the ``DISCORD_CHANNEL_ID`` env var the bot already reads, not
+    from here (doc/57 §2, .env-vs-toml convention)."""
+
+    enabled: bool = False
+    timezone: str = "Asia/Taipei"
+    start: str = "08:00"
+    sleep: str = "00:00"
+    session_prefix: str = "daily-life"
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any] | None) -> "CircadianConfig":
+        raw = raw or {}
+        return cls(
+            enabled=bool(raw.get("enabled", False)),
+            timezone=str(raw.get("timezone", "Asia/Taipei")),
+            start=str(raw.get("start", "08:00")),
+            sleep=str(raw.get("sleep", "00:00")),
+            session_prefix=str(raw.get("session_prefix", "daily-life")),
+        )
+
+    def thread_name(self, tz_date: str) -> str:
+        return f"{self.session_prefix}-{tz_date}"
+
+
+# ---------------------------------------------------------------------------
+# Platform adapter
+# ---------------------------------------------------------------------------
+
+class CircadianPlatform(Protocol):
+    """The platform-side hooks circadian needs. The Discord bot supplies these;
+    the CLI can supply no-ops. Keeps the autonomy package free of any Discord
+    import (Platform → Cognition → Harness one-way rule, doc/57 §3.3)."""
+
+    def resolve_channel_id(self) -> int | None:
+        """Channel the daily thread is opened in (from ``DISCORD_CHANNEL_ID`` /
+        the bot's allowed channels). ``None`` ⇒ cannot spawn."""
+        ...
+
+    async def spawn_daily_thread(self, *, name: str, channel_id: int) -> tuple[int, str]:
+        """Create the daily thread and start its session. Returns
+        ``(thread_id, session_id)``. Raises on failure (caller logs + skips)."""
+        ...
+
+    async def verify_thread_alive(self, thread_id: int) -> bool:
+        """True if the thread still exists on the platform (not deleted)."""
+        ...
+
+    async def ensure_session_loaded(self, thread_id: int) -> None:
+        """Idempotently resume the in-memory session for an existing thread so
+        chimes / user messages have somewhere to land (bot-restart case)."""
+        ...
+
+    async def close_daily_session(self, thread_id: int) -> None:
+        """Close the thread's session, triggering ``session.stop()`` →
+        memory finalization / compression. Must be safe to call once."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Time helpers
+# ---------------------------------------------------------------------------
+
+def _parse_hhmm(hhmm: str) -> int:
+    h, m = (int(x) for x in hhmm.split(":"))
+    return h * 60 + m
+
+
+def is_in_active_hours(now_local: datetime, config: CircadianConfig) -> bool:
+    """Whether ``now_local`` falls inside [start, sleep). ``sleep="00:00"`` means
+    end-of-day (24:00); a sleep earlier than start wraps past midnight."""
+    start = _parse_hhmm(config.start)
+    sleep = _parse_hhmm(config.sleep) or 24 * 60  # 00:00 ⇒ 1440 (end of day)
+    now_min = now_local.hour * 60 + now_local.minute
+    if start < sleep:
+        return start <= now_min < sleep
+    return now_min >= start or now_min < sleep  # wraps midnight
+
+
+def local_hhmm_to_utc_cron(hhmm: str, tz: str) -> str:
+    """Convert a local ``HH:MM`` to a UTC 5-field cron the evaluator can match.
+
+    The evaluator fires crons against ``datetime.now(UTC)`` (``CronTrigger``'s
+    ``timezone`` field is not applied at match time), so we resolve the local
+    wall-clock time to UTC here. Computed once at registration; timezones with
+    DST could drift by an hour across a transition — acceptable for V1 since
+    the default zone (Asia/Taipei) has no DST. The date-string comparison in
+    ``CircadianState`` remains the source of truth for day boundaries (§5)."""
+    minutes = _parse_hhmm(hhmm)
+    local = datetime.now(ZoneInfo(tz)).replace(
+        hour=minutes // 60, minute=minutes % 60, second=0, microsecond=0
+    )
+    utc = local.astimezone(timezone.utc)
+    return f"{utc.minute} {utc.hour} * * *"
+
+
+# ---------------------------------------------------------------------------
+# In-process serialization
+# ---------------------------------------------------------------------------
+
+_inproc_lock: asyncio.Lock | None = None
+_inproc_lock_loop: Any = None
+
+
+def _get_inproc_lock() -> asyncio.Lock:
+    """An ``asyncio.Lock`` bound to the running loop. Rebuilt if the loop
+    changed (each pytest test gets a fresh loop) so we never acquire a lock
+    bound to a closed loop. Pairs with the cross-process ``state_lock``: this
+    one stops two coroutines in *this* process from both holding the blocking
+    fcntl lock across an ``await`` (which would deadlock the single thread)."""
+    global _inproc_lock, _inproc_lock_loop
+    loop = asyncio.get_running_loop()
+    if _inproc_lock is None or _inproc_lock_loop is not loop:
+        _inproc_lock = asyncio.Lock()
+        _inproc_lock_loop = loop
+    return _inproc_lock
+
+
+async def _emit(evaluator: Any, name: str, payload: dict[str, Any]) -> None:
+    """Fire a circadian lifecycle event, swallowing subscriber failures.
+
+    Always called *after* releasing the state lock so a subscriber's agent run
+    can't stall the lifecycle (doc/57 §13.1)."""
+    if evaluator is None:
+        return
+    try:
+        await evaluator.emit(name, dict(payload))
+    except Exception:  # noqa: BLE001 — a bad subscriber must not break the day
+        logger.exception("[circadian] emit %s failed", name)
+
+
+# ---------------------------------------------------------------------------
+# Core lifecycle
+# ---------------------------------------------------------------------------
+
+async def ensure_today_session(
+    now: datetime,
+    platform: CircadianPlatform,
+    config: CircadianConfig,
+    *,
+    evaluator: Any = None,
+) -> CircadianState | None:
+    """Guarantee today's daily session exists; return its state (or ``None`` if
+    spawning was impossible / handled by another holder). Idempotent.
+
+    Decision (doc/57 §5.1): if today's state is present and its thread is alive,
+    resume the session and return. If it's yesterday's leftover, recover it
+    first. Otherwise spawn a fresh thread + session and record state."""
+    tz = config.timezone
+    pending_emits: list[tuple[str, dict[str, Any]]] = []
+    spawned: CircadianState | None = None
+
+    async with _get_inproc_lock():
+        with state_lock(blocking=False) as acquired:
+            if not acquired:
+                # Another process is mid-spawn; let it win (idempotent outcome).
+                logger.info("[circadian] ensure: state lock held elsewhere — deferring")
+                return CircadianState.load()
+
+            state = CircadianState.load()
+            if state is not None and state.is_for_today(tz):
+                if await platform.verify_thread_alive(state.thread_id):
+                    await platform.ensure_session_loaded(state.thread_id)
+                    return state
+                logger.warning(
+                    "[circadian] today's thread %s no longer exists — rebuilding",
+                    state.thread_id,
+                )
+            elif state is not None and not state.is_for_today(tz):
+                closed = await _close_and_archive(state, platform, config)
+                if closed is not None:
+                    pending_emits.append(closed)
+
+            channel_id = platform.resolve_channel_id()
+            if channel_id is None:
+                logger.warning(
+                    "[circadian] no channel configured (DISCORD_CHANNEL_ID); "
+                    "cannot spawn daily session"
+                )
+                return None
+
+            name = config.thread_name(_today_str(tz))
+            try:
+                thread_id, session_id = await platform.spawn_daily_thread(
+                    name=name, channel_id=channel_id
+                )
+            except Exception:  # noqa: BLE001 — spawn IO failed; leave no state
+                logger.exception("[circadian] spawn_daily_thread failed for %s", name)
+                return None
+
+            spawned = CircadianState.new_for_today(
+                thread_id=thread_id,
+                session_id=session_id,
+                channel_id=channel_id,
+                now=now,
+                tz=tz,
+            )
+            spawned.append_phase("dawn", "spawned")
+            spawned.save_atomic()
+            pending_emits.append(
+                ("circadian:day_started", {
+                    "date": spawned.date,
+                    "thread_id": spawned.thread_id,
+                    "session_id": spawned.session_id,
+                })
+            )
+
+    for evt_name, payload in pending_emits:
+        await _emit(evaluator, evt_name, payload)
+    return spawned
+
+
+async def close_today(
+    platform: CircadianPlatform,
+    config: CircadianConfig,
+    *,
+    evaluator: Any = None,
+) -> None:
+    """Nightly close: stop today's session (→ memory finalization), stamp
+    ``closed_at``, and archive the state. No-op when there's no live state.
+
+    The heavy ``session.stop()`` runs *outside* the state lock so a long
+    compaction can't block a racing reader; only the small archive write is
+    serialized."""
+    state = CircadianState.load()
+    if state is None:
+        logger.info("[circadian] nightly close: no live state to close")
+        return
+    if state.closed_at is not None:
+        logger.info("[circadian] nightly close: %s already closed", state.date)
+        return
+
+    await platform.close_daily_session(state.thread_id)
+    closed_at = datetime.now(ZoneInfo(config.timezone)).isoformat()
+
+    async with _get_inproc_lock():
+        with state_lock() as acquired:
+            if not acquired:  # pragma: no cover — blocking lock yields True
+                return
+            fresh = CircadianState.load() or state
+            fresh.closed_at = closed_at
+            fresh.append_phase("nightly_close", "closed")
+            fresh.archive_and_reset()
+
+    await _emit(evaluator, "circadian:day_closed", {
+        "date": state.date,
+        "thread_id": state.thread_id,
+        "closed_at": closed_at,
+    })
+
+
+async def recover_on_startup(
+    platform: CircadianPlatform,
+    config: CircadianConfig,
+    *,
+    evaluator: Any = None,
+) -> None:
+    """Reconcile leftover state when the daemon (re)starts (doc/57 §5, rows 2–4).
+
+    - same-day, thread alive → resume the session (bot may have lost it)
+    - yesterday, not yet closed → force-close + archive (the missed nightly)
+    - yesterday, already closed → just archive away the stale record
+
+    Never spawns today — that's the dawn cron's job (or the bot ``on_ready``
+    catch-up if the daemon came up after dawn)."""
+    state = CircadianState.load()
+    if state is None:
+        return
+
+    if state.is_for_today(config.timezone):
+        if await platform.verify_thread_alive(state.thread_id):
+            await platform.ensure_session_loaded(state.thread_id)
+            logger.info("[circadian] startup: resumed today's session %s", state.session_id)
+        else:
+            logger.warning(
+                "[circadian] startup: today's thread %s gone; dawn/on_ready will rebuild",
+                state.thread_id,
+            )
+        return
+
+    logger.info("[circadian] startup: reconciling stale state from %s", state.date)
+    closed = await _close_and_archive(state, platform, config)
+    if closed is not None:
+        await _emit(evaluator, *closed)
+
+
+async def _close_and_archive(
+    state: CircadianState,
+    platform: CircadianPlatform,
+    config: CircadianConfig,
+) -> tuple[str, dict[str, Any]] | None:
+    """Close (if still open) and archive a stale day's state. Returns the
+    ``circadian:day_closed`` emit tuple when this call performed the close, else
+    ``None``. Shared by startup recovery and the defensive cross-day path in
+    ``ensure_today_session``."""
+    emit: tuple[str, dict[str, Any]] | None = None
+    if state.closed_at is None:
+        try:
+            await platform.close_daily_session(state.thread_id)
+        except Exception:  # noqa: BLE001 — best effort; still archive the record
+            logger.exception(
+                "[circadian] recovery close failed for thread %s", state.thread_id
+            )
+        state.closed_at = datetime.now(ZoneInfo(config.timezone)).isoformat()
+        emit = ("circadian:day_closed", {
+            "date": state.date,
+            "thread_id": state.thread_id,
+            "closed_at": state.closed_at,
+        })
+    state.archive_and_reset()
+    return emit
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+_DAWN_INTENT = (
+    "Circadian dawn: ensure today's daily-life session exists. Deterministic "
+    "spawn — not an agent run."
+)
+_CLOSE_INTENT = (
+    "Circadian nightly close: stop today's daily-life session and trigger "
+    "memory finalization. Deterministic — not an agent run."
+)
+
+
+def register_triggers(daemon: Any, platform: CircadianPlatform, config: CircadianConfig) -> None:
+    """Register the dawn-spawn and nightly-close cron triggers with deterministic
+    direct handlers (bypassing the LLM planner). Idempotent registration: the
+    evaluator keys triggers by name, so re-registering overwrites cleanly."""
+    evaluator = daemon.evaluator
+    dawn_cron = local_hhmm_to_utc_cron(config.start, config.timezone)
+    close_cron = local_hhmm_to_utc_cron(config.sleep, config.timezone)
+
+    async def _dawn_handler(_trigger: Any, _context: dict[str, Any]) -> None:
+        await ensure_today_session(
+            datetime.now(timezone.utc), platform, config, evaluator=evaluator
+        )
+
+    async def _close_handler(_trigger: Any, _context: dict[str, Any]) -> None:
+        await close_today(platform, config, evaluator=evaluator)
+
+    evaluator.register(CronTrigger(
+        name="circadian:dawn_spawn", intent=_DAWN_INTENT,
+        cron=dawn_cron, timezone=config.timezone, notify=False,
+    ))
+    daemon.register_direct_handler("circadian:dawn_spawn", _dawn_handler)
+
+    evaluator.register(CronTrigger(
+        name="circadian:nightly_close", intent=_CLOSE_INTENT,
+        cron=close_cron, timezone=config.timezone, notify=False,
+    ))
+    daemon.register_direct_handler("circadian:nightly_close", _close_handler)
+
+    logger.info(
+        "[circadian] registered dawn=%s close=%s (%s) for channel resolution at spawn",
+        dawn_cron, close_cron, config.timezone,
+    )
+
+
+async def setup_circadian(
+    daemon: Any, platform: CircadianPlatform, config: CircadianConfig
+) -> bool:
+    """One-shot wiring called from the bot+daemon assembly point *after the
+    Discord client is ready* (so adapter calls reach a live connection).
+
+    Three startup steps (doc/57 §5, §9 restart-verification block):
+
+    1. Register the dawn/close cron triggers.
+    2. Recover leftover state (resume same-day, force-close stale yesterday).
+    3. Catch-up spawn: if we came up during active hours, run the idempotent
+       ``ensure_today_session`` so a daemon/bot that started after dawn still
+       joins today's rhythm. ``ensure`` resumes when today's session is already
+       alive, so this never double-spawns. Outside active hours we don't spawn —
+       the dawn cron owns that.
+
+    Returns False (no-op) when circadian is disabled."""
+    if not config.enabled:
+        return False
+    register_triggers(daemon, platform, config)
+    await recover_on_startup(platform, config, evaluator=daemon.evaluator)
+    if is_in_active_hours(datetime.now(ZoneInfo(config.timezone)), config):
+        logger.info("[circadian] startup is within active hours — ensuring today's session")
+        await ensure_today_session(
+            datetime.now(timezone.utc), platform, config, evaluator=daemon.evaluator
+        )
+    return True

--- a/loom/autonomy/circadian/state.py
+++ b/loom/autonomy/circadian/state.py
@@ -1,0 +1,255 @@
+"""
+CircadianState — the single source of truth for "which daily session is today".
+
+The daily Discord thread id changes every day and must survive daemon / bot
+restarts, so it can't be hard-coded into ``loom.toml``. This module owns the
+``~/.loom/circadian/state.json`` file that records today's thread, plus the
+access discipline (atomic writes, corruption quarantine, cross-day detection)
+spelled out in doc/57 §4.
+
+Platform-internal, sibling to ``~/.loom/discord_threads.json`` — gitignored,
+never committed. Reads are lock-free; writes go through ``state_lock()`` so a
+daemon and a bot racing to spawn today's session can't corrupt the file.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import tempfile
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterator
+from zoneinfo import ZoneInfo
+
+logger = logging.getLogger(__name__)
+
+# Current on-disk schema version. Bumps require an explicit migration —
+# ``load()`` quarantines anything it doesn't recognise rather than guessing.
+STATE_VERSION = 1
+
+# Directory holding state + archive. Computed at call time (not import) so a
+# test can redirect it away from the real home dir via ``set_dir_for_test``.
+_DIR_OVERRIDE: Path | None = None
+
+
+def set_dir_for_test(path: Path | None) -> None:
+    """Redirect the circadian state dir (tests only). Pass ``None`` to reset."""
+    global _DIR_OVERRIDE
+    _DIR_OVERRIDE = path
+
+
+def _dir() -> Path:
+    if _DIR_OVERRIDE is not None:
+        return _DIR_OVERRIDE
+    return Path("~/.loom/circadian").expanduser()
+
+
+def state_path() -> Path:
+    """Absolute path of the state file (exposed for tests / introspection)."""
+    return _dir() / "state.json"
+
+
+def _lock_path() -> Path:
+    return _dir() / "state.json.lock"
+
+
+def _log_dir() -> Path:
+    return _dir() / "log"
+
+
+def _today_str(tz: str) -> str:
+    """Today's date (YYYY-MM-DD) in the configured timezone.
+
+    The date *string* — not a UTC instant — is the single source of truth for
+    "is this state today's?", so NTP corrections and DST edges resolve the same
+    way the daemon's wall-clock cron does (doc/57 §5, clock-skew row).
+    """
+    return datetime.now(ZoneInfo(tz)).strftime("%Y-%m-%d")
+
+
+@contextlib.contextmanager
+def state_lock(blocking: bool = True) -> Iterator[bool]:
+    """Process-level advisory lock guarding writes to ``state.json``.
+
+    Yields ``True`` when the lock is held, ``False`` when ``blocking=False``
+    and another holder has it. Uses ``fcntl`` on a sidecar lockfile so two
+    daemons (or a daemon + bot ``on_ready``) racing through
+    ``ensure_today_session`` serialise: the first writes, the rest observe a
+    held lock and bail. Degrades to a held no-op where ``fcntl`` is
+    unavailable (non-POSIX); Loom's runtime is POSIX.
+    """
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover — non-POSIX fallback
+        yield True
+        return
+
+    _dir().mkdir(parents=True, exist_ok=True)
+    fd = os.open(_lock_path(), os.O_CREAT | os.O_RDWR, 0o644)
+    acquired = False
+    try:
+        flags = fcntl.LOCK_EX | (0 if blocking else fcntl.LOCK_NB)
+        try:
+            fcntl.flock(fd, flags)
+            acquired = True
+        except OSError:
+            acquired = False  # non-blocking miss — someone else holds it
+        yield acquired
+    finally:
+        if acquired:
+            with contextlib.suppress(OSError):
+                fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+@dataclass
+class CircadianState:
+    """One day's daily-session bookkeeping. See doc/57 §4.2 for the schema."""
+
+    date: str
+    thread_id: int
+    session_id: str
+    channel_id: int
+    started_at: str
+    closed_at: str | None = None
+    version: int = STATE_VERSION
+    phase_log: list[dict[str, Any]] = field(default_factory=list)
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def new_for_today(
+        cls,
+        *,
+        thread_id: int,
+        session_id: str,
+        channel_id: int,
+        now: datetime,
+        tz: str,
+    ) -> "CircadianState":
+        """Build a fresh state for today's just-spawned session."""
+        return cls(
+            date=_today_str(tz),
+            thread_id=thread_id,
+            session_id=session_id,
+            channel_id=channel_id,
+            started_at=now.isoformat(),
+        )
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def load(cls) -> "CircadianState | None":
+        """Read today's state, or ``None`` when absent / unreadable.
+
+        A malformed or unknown-version file is quarantined to
+        ``state.json.broken-<ts>`` and treated as "no state" so the spawner
+        rebuilds from scratch (doc/57 §5, corruption row). Never raises.
+        """
+        sp = state_path()
+        if not sp.exists():
+            return None
+        try:
+            raw = json.loads(sp.read_text(encoding="utf-8"))
+            if raw.get("version") != STATE_VERSION:
+                raise ValueError(f"unknown version {raw.get('version')!r}")
+            return cls(
+                date=raw["date"],
+                thread_id=int(raw["thread_id"]),
+                session_id=str(raw["session_id"]),
+                channel_id=int(raw["channel_id"]),
+                started_at=raw["started_at"],
+                closed_at=raw.get("closed_at"),
+                version=int(raw["version"]),
+                phase_log=list(raw.get("phase_log", [])),
+            )
+        except Exception as exc:
+            cls._quarantine(exc)
+            return None
+
+    @staticmethod
+    def _quarantine(exc: Exception) -> None:
+        """Rename a corrupt state file aside so the next spawn rebuilds."""
+        sp = state_path()
+        ts = datetime.now().strftime("%Y%m%dT%H%M%S")
+        broken = sp.with_name(f"state.json.broken-{ts}")
+        try:
+            sp.replace(broken)
+            logger.warning(
+                "[circadian] state.json unreadable (%s); quarantined to %s",
+                exc, broken.name,
+            )
+        except OSError as move_exc:  # pragma: no cover — best effort
+            logger.warning(
+                "[circadian] state.json unreadable (%s) and quarantine failed: %s",
+                exc, move_exc,
+            )
+
+    def save_atomic(self) -> None:
+        """Write state via tempfile + ``os.replace`` so readers never see a
+        half-written file and a crash mid-write can't corrupt the live state.
+        Callers must hold ``state_lock()`` (writers are rare; readers don't)."""
+        d = _dir()
+        d.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(asdict(self), ensure_ascii=False, indent=2)
+        fd, tmp = tempfile.mkstemp(dir=d, prefix=".state-", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(payload)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, state_path())
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
+            raise
+
+    def archive_and_reset(self) -> None:
+        """Move today's record to ``log/YYYY-MM-DD.json`` and clear the live
+        state. Called at nightly close (and cross-day startup recovery) so
+        ``state.json`` never accumulates more than one day (doc/57 §4.3)."""
+        ld = _log_dir()
+        ld.mkdir(parents=True, exist_ok=True)
+        archive = ld / f"{self.date}.json"
+        try:
+            archive.write_text(
+                json.dumps(asdict(self), ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        except OSError as exc:  # pragma: no cover — best effort
+            logger.warning("[circadian] archive of %s failed: %s", self.date, exc)
+        with contextlib.suppress(FileNotFoundError):
+            state_path().unlink()
+
+    # ------------------------------------------------------------------
+    # Queries / mutations
+    # ------------------------------------------------------------------
+
+    def is_for_today(self, tz: str) -> bool:
+        """True when this state's date equals today's date in ``tz``."""
+        return self.date == _today_str(tz)
+
+    def append_phase(
+        self, phase: str, outcome: str, reason: str | None = None
+    ) -> None:
+        """Record one phase-trigger outcome (delivered / skipped / spawned…).
+
+        Mutates in place; the caller persists with ``save_atomic`` under lock.
+        The log is the audit trail for the anti-heartbeat gate and the
+        watchdog's missed-spawn counter (doc/57 §13.2)."""
+        entry: dict[str, Any] = {
+            "phase": phase,
+            "fired_at": datetime.now().isoformat(),
+            "outcome": outcome,
+        }
+        if reason is not None:
+            entry["reason"] = reason
+        self.phase_log.append(entry)

--- a/loom/autonomy/daemon.py
+++ b/loom/autonomy/daemon.py
@@ -166,6 +166,11 @@ class AutonomyDaemon:
         self._session = loom_session
         self._abort = AbortController()
         self._chime_delivery = chime_delivery
+        # Trigger name → deterministic async handler. When a fired trigger has
+        # a direct handler it bypasses the LLM ActionPlanner entirely — used by
+        # circadian lifecycle (dawn spawn / nightly close), where the action is
+        # a fixed bookkeeping step, not a planned agent run (doc/57 §7 PR 1).
+        self._direct_handlers: dict[str, Callable[..., Awaitable[None]]] = {}
 
         history = TriggerHistory(db) if db is not None else None
         # Issue #147 Phase C.2: pull semantic via the facade. ``_memory``
@@ -180,7 +185,26 @@ class AutonomyDaemon:
         self._planner_handle_orig = self._planner.handle
         self._evaluator._on_fire = self._on_trigger_fire
 
+    def register_direct_handler(
+        self, name: str, handler: Callable[..., Awaitable[None]]
+    ) -> None:
+        """Route fires of trigger ``name`` to ``handler`` instead of the planner.
+
+        The handler is invoked as ``await handler(trigger, context)``. Used for
+        deterministic triggers (circadian dawn/close) that must not be subject
+        to the planner's EXECUTE/SKIP/NOTIFY decision."""
+        self._direct_handlers[name] = handler
+
     async def _on_trigger_fire(self, trigger, context):
+        handler = self._direct_handlers.get(trigger.name)
+        if handler is not None:
+            try:
+                await handler(trigger, context)
+            except Exception:
+                logger.exception(
+                    "[autonomy] direct handler for trigger=%s raised", trigger.name
+                )
+            return
         plan = await self._planner.handle(trigger, context)
         await self._execute_plan(plan)
 

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -2582,10 +2582,12 @@ async def _discord_graceful_run(bot: "LoomDiscordBot", token: str) -> None:
 
 
 async def _setup_circadian_if_enabled(
-    bot: "LoomDiscordBot", daemon, config_path: str
+    bot: "LoomDiscordBot", daemon, config_path: str, channel_id: int
 ) -> None:
     """Read ``[autonomy.circadian]`` and wire the daily-life lifecycle onto the
-    daemon. Failures are logged but never block the daemon from starting."""
+    daemon. The daily thread opens in ``channel_id`` (the resolved notify
+    channel) so the target is deterministic rather than an arbitrary allowed
+    channel. Failures are logged but never block the daemon from starting."""
     import tomllib
     from pathlib import Path as _Path
 
@@ -2598,6 +2600,8 @@ async def _setup_circadian_if_enabled(
             with open(path, "rb") as f:
                 raw = tomllib.load(f).get("autonomy", {}).get("circadian", {})
         circ_cfg = CircadianConfig.from_dict(raw)
+        if channel_id:
+            bot._circadian_channel_id = channel_id
         if await setup_circadian(daemon, bot, circ_cfg):
             console.print(
                 f"[loom.muted]Circadian: [loom.success]on[/loom.success]  "
@@ -2670,7 +2674,7 @@ async def _discord_with_autonomy(
         # that the connection is live — registers dawn/close triggers, recovers
         # any leftover state, and catch-up-spawns if we came up inside active
         # hours. No-op unless [autonomy.circadian].enabled is true.
-        await _setup_circadian_if_enabled(bot, daemon, config_path)
+        await _setup_circadian_if_enabled(bot, daemon, config_path, notify_channel_id)
         console.print("[loom.muted]Autonomy daemon started.[/loom.muted]")
         _t = asyncio.ensure_future(daemon.start(poll_interval=float(interval)))
         _background_tasks.add(_t)

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -2581,6 +2581,33 @@ async def _discord_graceful_run(bot: "LoomDiscordBot", token: str) -> None:
             await bot._close_session(tid)
 
 
+async def _setup_circadian_if_enabled(
+    bot: "LoomDiscordBot", daemon, config_path: str
+) -> None:
+    """Read ``[autonomy.circadian]`` and wire the daily-life lifecycle onto the
+    daemon. Failures are logged but never block the daemon from starting."""
+    import tomllib
+    from pathlib import Path as _Path
+
+    from loom.autonomy.circadian.lifecycle import CircadianConfig, setup_circadian
+
+    try:
+        path = _Path(config_path)
+        raw: dict = {}
+        if path.exists():
+            with open(path, "rb") as f:
+                raw = tomllib.load(f).get("autonomy", {}).get("circadian", {})
+        circ_cfg = CircadianConfig.from_dict(raw)
+        if await setup_circadian(daemon, bot, circ_cfg):
+            console.print(
+                f"[loom.muted]Circadian: [loom.success]on[/loom.success]  "
+                f"start={circ_cfg.start} sleep={circ_cfg.sleep} "
+                f"{circ_cfg.timezone}[/loom.muted]"
+            )
+    except Exception as exc:  # noqa: BLE001 — circadian must not break startup
+        console.print(f"[loom.muted]Circadian: setup skipped ({exc})[/loom.muted]")
+
+
 async def _discord_with_autonomy(
     bot: "LoomDiscordBot",
     token: str,
@@ -2639,6 +2666,11 @@ async def _discord_with_autonomy(
         # Wait for the Discord connection before the daemon begins polling,
         # so notifications can be delivered from the first fire onwards.
         await bot._client.wait_until_ready()
+        # Circadian Autonomy (milestone #14): wire the daily-life lifecycle now
+        # that the connection is live — registers dawn/close triggers, recovers
+        # any leftover state, and catch-up-spawns if we came up inside active
+        # hours. No-op unless [autonomy.circadian].enabled is true.
+        await _setup_circadian_if_enabled(bot, daemon, config_path)
         console.print("[loom.muted]Autonomy daemon started.[/loom.muted]")
         _t = asyncio.ensure_future(daemon.start(poll_interval=float(interval)))
         _background_tasks.add(_t)

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -397,6 +397,14 @@ class LoomDiscordBot:
         self._model = model
         self._db_path = str(Path(db_path).expanduser())
         self._allowed_channels: set[int] = set(channel_ids or [])
+        # Insertion-ordered view of the same channels: membership checks use the
+        # set above, but circadian needs a *deterministic* "first channel" to
+        # open the daily thread in (a set's iteration order is arbitrary).
+        self._channel_list: list[int] = list(dict.fromkeys(channel_ids or []))
+        # Explicit channel for the circadian daily thread, set at autonomy
+        # wiring time to the resolved notify channel. Falls back to the first
+        # allowed channel when unset.
+        self._circadian_channel_id: int | None = None
         self._allowed_users: set[int] = set(allowed_user_ids or [])
 
         # thread_id → LoomSession (in-memory, cleared on restart)
@@ -759,9 +767,13 @@ class LoomDiscordBot:
     # ------------------------------------------------------------------
 
     def resolve_channel_id(self) -> int | None:
-        """The channel the daily thread is opened in: the bot's first allowed
-        channel (DISCORD_CHANNEL_ID / --channel). ``None`` ⇒ cannot spawn."""
-        return next(iter(self._allowed_channels), None)
+        """The channel the daily thread is opened in: the explicit circadian /
+        notify channel when set, else the *first* allowed channel
+        (DISCORD_CHANNEL_ID / --channel). Order is deterministic — never a
+        set's arbitrary iteration order. ``None`` ⇒ cannot spawn."""
+        if self._circadian_channel_id:
+            return self._circadian_channel_id
+        return self._channel_list[0] if self._channel_list else None
 
     async def spawn_daily_thread(
         self, *, name: str, channel_id: int

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -749,6 +749,67 @@ class LoomDiscordBot:
                 pass
 
     # ------------------------------------------------------------------
+    # Circadian platform adapter (milestone #14, issue #459)
+    #
+    # These five methods implement loom.autonomy.circadian.lifecycle's
+    # CircadianPlatform protocol. They reuse the existing thread/session
+    # machinery above — circadian adds no new session lifecycle, it just
+    # drives the daily one. Wired in from _discord_with_autonomy after the
+    # client is ready (so every call reaches a live connection).
+    # ------------------------------------------------------------------
+
+    def resolve_channel_id(self) -> int | None:
+        """The channel the daily thread is opened in: the bot's first allowed
+        channel (DISCORD_CHANNEL_ID / --channel). ``None`` ⇒ cannot spawn."""
+        return next(iter(self._allowed_channels), None)
+
+    async def spawn_daily_thread(
+        self, *, name: str, channel_id: int
+    ) -> tuple[int, str]:
+        """Create today's daily thread in ``channel_id`` and start its session.
+
+        Unlike ``_create_session_thread`` (which threads off a user message),
+        this opens a standalone public thread on the channel itself."""
+        channel = self._client.get_channel(channel_id)
+        if channel is None:
+            channel = await self._client.fetch_channel(channel_id)
+        if not isinstance(channel, discord.TextChannel):
+            raise RuntimeError(
+                f"circadian channel {channel_id} is not a text channel "
+                f"({type(channel).__name__}); cannot open daily thread"
+            )
+        thread = await channel.create_thread(
+            name=name,
+            type=discord.ChannelType.public_thread,
+            auto_archive_duration=_THREAD_ARCHIVE_MINUTES,
+        )
+        session = await self._start_session(thread.id, provisional_title=name)
+        return thread.id, session.session_id
+
+    async def verify_thread_alive(self, thread_id: int) -> bool:
+        """True if the thread still exists. A transient HTTP error is treated
+        as alive so a network blip never triggers a needless rebuild; only a
+        definitive 404 (deleted) returns False."""
+        if self._client.get_channel(thread_id) is not None:
+            return True
+        try:
+            return await self._client.fetch_channel(thread_id) is not None
+        except discord.NotFound:
+            return False
+        except discord.HTTPException:
+            return True
+
+    async def ensure_session_loaded(self, thread_id: int) -> None:
+        """Resume the in-memory session for an existing daily thread (bot
+        restarted, session map persisted). Idempotent."""
+        if thread_id not in self._sessions:
+            await self._start_session(thread_id)
+
+    async def close_daily_session(self, thread_id: int) -> None:
+        """Close + stop today's session → existing memory finalization path."""
+        await self._close_session(thread_id)
+
+    # ------------------------------------------------------------------
     # Chime delivery (issue #369)
     # ------------------------------------------------------------------
 

--- a/tests/test_circadian_lifecycle.py
+++ b/tests/test_circadian_lifecycle.py
@@ -1,0 +1,373 @@
+"""
+Tests for the circadian lifecycle (issue #459, doc/57 §5 robustness table).
+
+Exercises ``ensure_today_session`` idempotence + recovery, nightly ``close_today``,
+startup reconciliation, the dawn/close trigger wiring, and the daemon's
+direct-handler bypass — all against a fake ``CircadianPlatform`` so no Discord
+connection is needed. State IO is redirected to a tmp dir.
+
+Robustness rows covered here:
+  - daemon first start (no state)            → spawn
+  - daemon restart same-day (thread alive)   → no re-spawn, resume
+  - manual thread delete (thread gone)       → rebuild
+  - daemon restart cross-day (unclosed)      → recover + spawn
+  - cross-day startup, already closed        → archive only
+  - double-daemon spawn race                 → state lock arbitration (state test)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from loom.autonomy.circadian import state as st
+from loom.autonomy.circadian.state import CircadianState, state_lock
+from loom.autonomy.circadian.lifecycle import (
+    CircadianConfig,
+    close_today,
+    ensure_today_session,
+    is_in_active_hours,
+    local_hhmm_to_utc_cron,
+    recover_on_startup,
+    register_triggers,
+    setup_circadian,
+)
+
+TZ = "Asia/Taipei"
+CFG = CircadianConfig(enabled=True, timezone=TZ, start="08:00", sleep="00:00")
+# A config that is "active" at every wall-clock minute, for setup_circadian tests.
+CFG_ALWAYS = CircadianConfig(enabled=True, timezone=TZ, start="00:00", sleep="00:00")
+
+
+@pytest.fixture(autouse=True)
+def _circ_dir(tmp_path):
+    st.set_dir_for_test(tmp_path / "circadian")
+    yield
+    st.set_dir_for_test(None)
+
+
+class FakeEvaluator:
+    def __init__(self):
+        self.emitted: list[tuple[str, dict]] = []
+        self.registered: list = []
+
+    async def emit(self, name, payload):
+        self.emitted.append((name, dict(payload)))
+
+    def register(self, trigger):
+        self.registered.append(trigger)
+
+    def names(self):
+        return [t.name for t in self.registered]
+
+
+class FakePlatform:
+    """In-memory CircadianPlatform. Records every adapter call."""
+
+    def __init__(self, channel_id: int | None = 999):
+        self._channel_id = channel_id
+        self.threads: dict[int, bool] = {}     # thread_id → alive
+        self.loaded: list[int] = []
+        self.closed: list[int] = []
+        self.spawns: list[tuple[str, int]] = []
+        self._next = 1000
+        self.spawn_should_raise = False
+
+    def resolve_channel_id(self):
+        return self._channel_id
+
+    async def spawn_daily_thread(self, *, name, channel_id):
+        if self.spawn_should_raise:
+            raise RuntimeError("discord create_thread failed")
+        tid = self._next
+        self._next += 1
+        self.threads[tid] = True
+        self.spawns.append((name, channel_id))
+        return tid, f"session-{tid}"
+
+    async def verify_thread_alive(self, thread_id):
+        return self.threads.get(thread_id, False)
+
+    async def ensure_session_loaded(self, thread_id):
+        self.loaded.append(thread_id)
+
+    async def close_daily_session(self, thread_id):
+        self.closed.append(thread_id)
+        self.threads[thread_id] = False
+
+
+def _yesterday() -> str:
+    return (datetime.now(ZoneInfo(TZ)) - timedelta(days=1)).strftime("%Y-%m-%d")
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# ===========================================================================
+# ensure_today_session
+# ===========================================================================
+
+
+class TestEnsureSpawn:
+    async def test_first_run_spawns_and_writes_state(self):
+        plat, ev = FakePlatform(), FakeEvaluator()
+        state = await ensure_today_session(_now_utc(), plat, CFG, evaluator=ev)
+
+        assert state is not None
+        assert len(plat.spawns) == 1
+        assert plat.spawns[0][0].startswith("daily-life-")
+        persisted = CircadianState.load()
+        assert persisted is not None and persisted.thread_id == state.thread_id
+        assert ("circadian:day_started", {
+            "date": state.date,
+            "thread_id": state.thread_id,
+            "session_id": state.session_id,
+        }) in ev.emitted
+
+    async def test_idempotent_when_today_alive(self):
+        plat, ev = FakePlatform(), FakeEvaluator()
+        first = await ensure_today_session(_now_utc(), plat, CFG, evaluator=ev)
+        second = await ensure_today_session(_now_utc(), plat, CFG, evaluator=ev)
+
+        assert len(plat.spawns) == 1           # no second spawn
+        assert second is not None and second.thread_id == first.thread_id
+        assert plat.loaded == [first.thread_id]  # resumed, not rebuilt
+        # Only one day_started emitted.
+        assert sum(1 for n, _ in ev.emitted if n == "circadian:day_started") == 1
+
+    async def test_rebuilds_when_thread_deleted(self):
+        plat, ev = FakePlatform(), FakeEvaluator()
+        first = await ensure_today_session(_now_utc(), plat, CFG, evaluator=ev)
+        # Simulate manual thread deletion.
+        plat.threads[first.thread_id] = False
+
+        second = await ensure_today_session(_now_utc(), plat, CFG, evaluator=ev)
+        assert len(plat.spawns) == 2
+        assert second is not None and second.thread_id != first.thread_id
+
+    async def test_no_channel_means_no_spawn(self):
+        plat, ev = FakePlatform(channel_id=None), FakeEvaluator()
+        state = await ensure_today_session(_now_utc(), plat, CFG, evaluator=ev)
+        assert state is None
+        assert plat.spawns == []
+        assert CircadianState.load() is None
+
+    async def test_spawn_failure_leaves_no_state(self):
+        plat, ev = FakePlatform(), FakeEvaluator()
+        plat.spawn_should_raise = True
+        state = await ensure_today_session(_now_utc(), plat, CFG, evaluator=ev)
+        assert state is None
+        assert CircadianState.load() is None
+        assert ev.emitted == []
+
+    async def test_cross_day_recovers_then_spawns(self):
+        # Seed a stale, unclosed yesterday state.
+        stale = CircadianState(
+            date=_yesterday(), thread_id=7, session_id="old",
+            channel_id=999, started_at="2026-01-01T08:00:00+08:00",
+        )
+        with state_lock():
+            stale.save_atomic()
+        plat, ev = FakePlatform(), FakeEvaluator()
+        plat.threads[7] = True
+
+        state = await ensure_today_session(_now_utc(), plat, CFG, evaluator=ev)
+        assert 7 in plat.closed                 # yesterday closed
+        assert state is not None and state.date != _yesterday()
+        assert len(plat.spawns) == 1            # today spawned
+        names = [n for n, _ in ev.emitted]
+        assert "circadian:day_closed" in names  # recovery emitted close
+        assert "circadian:day_started" in names
+
+
+# ===========================================================================
+# close_today
+# ===========================================================================
+
+
+class TestCloseToday:
+    async def test_close_stops_session_and_archives(self):
+        plat, ev = FakePlatform(), FakeEvaluator()
+        state = await ensure_today_session(_now_utc(), plat, CFG, evaluator=ev)
+        ev.emitted.clear()
+
+        await close_today(plat, CFG, evaluator=ev)
+        assert plat.closed == [state.thread_id]
+        # Live state archived away.
+        assert CircadianState.load() is None
+        archive = st.state_path().parent / "log" / f"{state.date}.json"
+        assert archive.exists()
+        assert any(n == "circadian:day_closed" for n, _ in ev.emitted)
+
+    async def test_close_with_no_state_is_noop(self):
+        plat, ev = FakePlatform(), FakeEvaluator()
+        await close_today(plat, CFG, evaluator=ev)
+        assert plat.closed == []
+        assert ev.emitted == []
+
+
+# ===========================================================================
+# recover_on_startup
+# ===========================================================================
+
+
+class TestRecoverOnStartup:
+    async def test_same_day_alive_resumes(self):
+        plat, ev = FakePlatform(), FakeEvaluator()
+        state = await ensure_today_session(_now_utc(), plat, CFG, evaluator=ev)
+        plat.loaded.clear()
+
+        await recover_on_startup(plat, CFG, evaluator=ev)
+        assert plat.loaded == [state.thread_id]
+        assert plat.closed == []                # not closed — it's today's
+
+    async def test_cross_day_unclosed_force_closes(self):
+        stale = CircadianState(
+            date=_yesterday(), thread_id=7, session_id="old",
+            channel_id=999, started_at="2026-01-01T08:00:00+08:00",
+        )
+        with state_lock():
+            stale.save_atomic()
+        plat, ev = FakePlatform(), FakeEvaluator()
+        plat.threads[7] = True
+
+        await recover_on_startup(plat, CFG, evaluator=ev)
+        assert plat.closed == [7]
+        assert CircadianState.load() is None    # archived
+        assert plat.spawns == []                # recovery never spawns
+        assert any(n == "circadian:day_closed" for n, _ in ev.emitted)
+
+    async def test_cross_day_already_closed_archives_only(self):
+        stale = CircadianState(
+            date=_yesterday(), thread_id=7, session_id="old",
+            channel_id=999, started_at="2026-01-01T08:00:00+08:00",
+            closed_at="2026-01-01T23:59:00+08:00",
+        )
+        with state_lock():
+            stale.save_atomic()
+        plat, ev = FakePlatform(), FakeEvaluator()
+
+        await recover_on_startup(plat, CFG, evaluator=ev)
+        assert plat.closed == []                # already closed
+        assert ev.emitted == []                 # no duplicate close event
+        assert CircadianState.load() is None    # but still archived away
+
+    async def test_no_state_is_noop(self):
+        plat, ev = FakePlatform(), FakeEvaluator()
+        await recover_on_startup(plat, CFG, evaluator=ev)
+        assert plat.closed == [] and plat.spawns == []
+
+
+# ===========================================================================
+# Wiring — register_triggers + daemon direct-handler bypass
+# ===========================================================================
+
+
+def _make_daemon(session=None):
+    from loom.autonomy.daemon import AutonomyDaemon
+    from loom.notify.confirm import ConfirmFlow
+    from loom.notify.router import NotificationRouter
+
+    return AutonomyDaemon(
+        notify_router=NotificationRouter(),
+        confirm_flow=ConfirmFlow(send_fn=lambda n: None),
+        loom_session=session,
+    )
+
+
+class TestWiring:
+    def test_register_triggers_adds_dawn_and_close(self):
+        daemon = _make_daemon()
+        plat = FakePlatform()
+        register_triggers(daemon, plat, CFG)
+
+        names = {t.name for t in daemon.evaluator.list()}
+        assert "circadian:dawn_spawn" in names
+        assert "circadian:nightly_close" in names
+        assert "circadian:dawn_spawn" in daemon._direct_handlers
+        assert "circadian:nightly_close" in daemon._direct_handlers
+
+    async def test_dawn_fire_bypasses_planner_and_spawns(self):
+        daemon = _make_daemon()
+        plat = FakePlatform()
+        register_triggers(daemon, plat, CFG)
+
+        # Planner must NOT be consulted for a direct-handler trigger.
+        planner_called = False
+        orig = daemon._planner.handle
+
+        async def _spy(trigger, ctx):
+            nonlocal planner_called
+            planner_called = True
+            return await orig(trigger, ctx)
+
+        daemon._planner.handle = _spy
+
+        dawn = next(t for t in daemon.evaluator.list() if t.name == "circadian:dawn_spawn")
+        await daemon._on_trigger_fire(dawn, {"source": "cron"})
+
+        assert planner_called is False
+        assert len(plat.spawns) == 1
+
+    async def test_close_fire_bypasses_planner_and_closes(self):
+        daemon = _make_daemon()
+        plat = FakePlatform()
+        register_triggers(daemon, plat, CFG)
+        # First spawn today via dawn handler.
+        dawn = next(t for t in daemon.evaluator.list() if t.name == "circadian:dawn_spawn")
+        await daemon._on_trigger_fire(dawn, {})
+        assert len(plat.spawns) == 1
+
+        close = next(t for t in daemon.evaluator.list() if t.name == "circadian:nightly_close")
+        await daemon._on_trigger_fire(close, {})
+        assert len(plat.closed) == 1
+        assert CircadianState.load() is None
+
+    async def test_setup_disabled_is_noop(self):
+        daemon = _make_daemon()
+        plat = FakePlatform()
+        ok = await setup_circadian(daemon, plat, CircadianConfig(enabled=False))
+        assert ok is False
+        assert daemon.evaluator.list() == []
+
+    async def test_setup_enabled_registers_and_catches_up(self):
+        daemon = _make_daemon()
+        plat = FakePlatform()
+        ok = await setup_circadian(daemon, plat, CFG_ALWAYS)
+        assert ok is True
+        names = {t.name for t in daemon.evaluator.list()}
+        assert {"circadian:dawn_spawn", "circadian:nightly_close"} <= names
+        # CFG_ALWAYS is active at every minute → catch-up spawns today.
+        assert len(plat.spawns) == 1
+
+
+# ===========================================================================
+# Pure helpers
+# ===========================================================================
+
+
+class TestHelpers:
+    def test_active_hours_same_day_window(self):
+        cfg = CircadianConfig(timezone=TZ, start="08:00", sleep="00:00")
+        tz = ZoneInfo(TZ)
+        assert is_in_active_hours(datetime(2026, 5, 27, 8, 0, tzinfo=tz), cfg)
+        assert is_in_active_hours(datetime(2026, 5, 27, 23, 59, tzinfo=tz), cfg)
+        assert not is_in_active_hours(datetime(2026, 5, 27, 3, 0, tzinfo=tz), cfg)
+        assert not is_in_active_hours(datetime(2026, 5, 27, 7, 59, tzinfo=tz), cfg)
+
+    def test_active_hours_wraps_midnight(self):
+        # Night owl: 20:00 → 02:00 next day.
+        cfg = CircadianConfig(timezone=TZ, start="20:00", sleep="02:00")
+        tz = ZoneInfo(TZ)
+        assert is_in_active_hours(datetime(2026, 5, 27, 23, 0, tzinfo=tz), cfg)
+        assert is_in_active_hours(datetime(2026, 5, 27, 1, 0, tzinfo=tz), cfg)
+        assert not is_in_active_hours(datetime(2026, 5, 27, 12, 0, tzinfo=tz), cfg)
+
+    def test_utc_cron_conversion_taipei(self):
+        # Asia/Taipei is UTC+8, no DST.
+        assert local_hhmm_to_utc_cron("08:00", TZ) == "0 0 * * *"
+        assert local_hhmm_to_utc_cron("00:00", TZ) == "0 16 * * *"
+        assert local_hhmm_to_utc_cron("09:30", TZ) == "30 1 * * *"

--- a/tests/test_circadian_lifecycle.py
+++ b/tests/test_circadian_lifecycle.py
@@ -141,12 +141,16 @@ class TestEnsureSpawn:
     async def test_rebuilds_when_thread_deleted(self):
         plat, ev = FakePlatform(), FakeEvaluator()
         first = await ensure_today_session(_now_utc(), plat, CFG, evaluator=ev)
-        # Simulate manual thread deletion.
+        # Simulate genuine thread deletion (not a 24h TTL auto-archive, which
+        # verify_thread_alive still treats as alive).
         plat.threads[first.thread_id] = False
 
         second = await ensure_today_session(_now_utc(), plat, CFG, evaluator=ev)
         assert len(plat.spawns) == 2
         assert second is not None and second.thread_id != first.thread_id
+        # PR #476 review P1: the orphaned session must be finalized before the
+        # rebuild, not left loaded until shutdown.
+        assert first.thread_id in plat.closed
 
     async def test_no_channel_means_no_spawn(self):
         plat, ev = FakePlatform(channel_id=None), FakeEvaluator()
@@ -371,3 +375,32 @@ class TestHelpers:
         assert local_hhmm_to_utc_cron("08:00", TZ) == "0 0 * * *"
         assert local_hhmm_to_utc_cron("00:00", TZ) == "0 16 * * *"
         assert local_hhmm_to_utc_cron("09:30", TZ) == "30 1 * * *"
+
+
+# ===========================================================================
+# Bot adapter — deterministic channel resolution (PR #476 review P2)
+# ===========================================================================
+
+
+class TestBotChannelResolution:
+    def _stub_bot(self, *, channels, circadian=None):
+        from loom.platform.discord.bot import LoomDiscordBot
+
+        bot = LoomDiscordBot.__new__(LoomDiscordBot)
+        bot._allowed_channels = set(channels)
+        bot._channel_list = list(dict.fromkeys(channels))
+        bot._circadian_channel_id = circadian
+        return bot
+
+    def test_first_allowed_channel_is_deterministic(self):
+        # A set's iteration order is arbitrary; the ordered list is not.
+        bot = self._stub_bot(channels=[111, 222, 333])
+        assert bot.resolve_channel_id() == 111
+
+    def test_explicit_circadian_channel_wins(self):
+        bot = self._stub_bot(channels=[111, 222], circadian=999)
+        assert bot.resolve_channel_id() == 999
+
+    def test_none_when_no_channels(self):
+        bot = self._stub_bot(channels=[])
+        assert bot.resolve_channel_id() is None

--- a/tests/test_circadian_state.py
+++ b/tests/test_circadian_state.py
@@ -1,0 +1,146 @@
+"""
+Tests for CircadianState — the daily-session bookkeeping file (issue #459).
+
+Covers the access discipline doc/57 §4 requires: atomic save/load roundtrip,
+corruption + unknown-version quarantine, cross-day detection, archive+reset,
+phase logging, and the non-blocking state lock used to arbitrate spawns.
+
+All file IO is redirected away from the real ``~/.loom`` via
+``set_dir_for_test`` so the suite never touches the user's home dir.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from loom.autonomy.circadian import state as st
+from loom.autonomy.circadian.state import CircadianState, state_lock
+
+TZ = "Asia/Taipei"
+
+
+@pytest.fixture(autouse=True)
+def _circ_dir(tmp_path):
+    st.set_dir_for_test(tmp_path / "circadian")
+    yield
+    st.set_dir_for_test(None)
+
+
+def _today() -> str:
+    return datetime.now(ZoneInfo(TZ)).strftime("%Y-%m-%d")
+
+
+def _make(date: str | None = None) -> CircadianState:
+    return CircadianState(
+        date=date or _today(),
+        thread_id=12345,
+        session_id="daily-life-sess",
+        channel_id=999,
+        started_at=datetime.now(ZoneInfo(TZ)).isoformat(),
+    )
+
+
+class TestSaveLoad:
+    def test_roundtrip(self):
+        s = _make()
+        with state_lock():
+            s.save_atomic()
+        loaded = CircadianState.load()
+        assert loaded is not None
+        assert loaded.thread_id == 12345
+        assert loaded.session_id == "daily-life-sess"
+        assert loaded.channel_id == 999
+        assert loaded.version == 1
+        assert loaded.closed_at is None
+
+    def test_load_absent_returns_none(self):
+        assert CircadianState.load() is None
+
+    def test_save_leaves_no_temp_file(self):
+        with state_lock():
+            _make().save_atomic()
+        leftovers = list((st.state_path().parent).glob(".state-*.tmp"))
+        assert leftovers == []
+
+
+class TestQuarantine:
+    def test_corrupt_json_is_quarantined(self):
+        sp = st.state_path()
+        sp.parent.mkdir(parents=True, exist_ok=True)
+        sp.write_text("{ this is not json", encoding="utf-8")
+
+        assert CircadianState.load() is None
+        assert not sp.exists()
+        broken = list(sp.parent.glob("state.json.broken-*"))
+        assert len(broken) == 1
+
+    def test_unknown_version_is_quarantined(self):
+        sp = st.state_path()
+        sp.parent.mkdir(parents=True, exist_ok=True)
+        sp.write_text(json.dumps({"version": 99, "date": _today()}), encoding="utf-8")
+
+        assert CircadianState.load() is None
+        assert list(sp.parent.glob("state.json.broken-*"))
+
+
+class TestCrossDay:
+    def test_is_for_today_true(self):
+        assert _make().is_for_today(TZ) is True
+
+    def test_is_for_today_false_for_yesterday(self):
+        yesterday = (datetime.now(ZoneInfo(TZ)) - timedelta(days=1)).strftime("%Y-%m-%d")
+        assert _make(date=yesterday).is_for_today(TZ) is False
+
+
+class TestArchive:
+    def test_archive_and_reset(self):
+        s = _make()
+        with state_lock():
+            s.save_atomic()
+        s.archive_and_reset()
+
+        # Live state gone, archived copy present under log/<date>.json.
+        assert not st.state_path().exists()
+        archive = st.state_path().parent / "log" / f"{s.date}.json"
+        assert archive.exists()
+        data = json.loads(archive.read_text(encoding="utf-8"))
+        assert data["thread_id"] == 12345
+
+
+class TestPhaseLog:
+    def test_append_phase_records_outcome_and_reason(self):
+        s = _make()
+        s.append_phase("dawn", "spawned")
+        s.append_phase("tick", "skipped", reason="no_state_transition")
+        assert [e["phase"] for e in s.phase_log] == ["dawn", "tick"]
+        assert s.phase_log[0]["outcome"] == "spawned"
+        assert "reason" not in s.phase_log[0]
+        assert s.phase_log[1]["reason"] == "no_state_transition"
+        assert all("fired_at" in e for e in s.phase_log)
+
+    def test_phase_log_survives_roundtrip(self):
+        s = _make()
+        s.append_phase("dawn", "spawned")
+        with state_lock():
+            s.save_atomic()
+        loaded = CircadianState.load()
+        assert loaded is not None
+        assert loaded.phase_log[0]["phase"] == "dawn"
+
+
+class TestStateLock:
+    def test_nonblocking_miss_when_held(self):
+        # Holding the lock (blocking) makes a non-blocking acquire from a
+        # second fd in this process fail — the arbitration the spawn race
+        # relies on (doc/57 §5, double-daemon row).
+        with state_lock() as outer:
+            assert outer is True
+            with state_lock(blocking=False) as inner:
+                assert inner is False
+        # Released — a fresh non-blocking acquire now succeeds.
+        with state_lock(blocking=False) as after:
+            assert after is True


### PR DESCRIPTION
Closes #459 · Part of #458 / milestone #14 (Circadian Autonomy) · Spec: `doc/57` §7 PR 1

## What

The first slice of Circadian Autonomy: the daily-life **session lifecycle skeleton**. One daily Discord thread opens at `start`, closes at `sleep` (→ existing `session.stop()` → memory finalization), and survives daemon/bot restarts. Built as *surgical addition* on the existing autonomy stack — no new runtime, scheduler, or delivery mechanism (doc/57 §1.1, §6, §10).

## Changes

**New `loom/autonomy/circadian/`**
- `state.py` — `CircadianState` at `~/.loom/circadian/state.json`: atomic save (tempfile + `os.replace`), corruption + unknown-version quarantine, cross-day detection (date-string is source of truth), `archive_and_reset`, phase log, and an fcntl non-blocking spawn lock.
- `lifecycle.py` — idempotent `ensure_today_session()` (the single entry point all spawn paths funnel through), `recover_on_startup()` (resume same-day / force-close stale yesterday), `close_today()`, the `CircadianPlatform` protocol (keeps autonomy free of any Discord import), dawn/close cron registration with **deterministic handlers**, and `circadian:day_started` / `day_closed` event emit (the #472 emit points).

**Surgical edits**
- `daemon.py` — `register_direct_handler(name, handler)`: deterministic cron fires (dawn spawn / nightly close) bypass the LLM `ActionPlanner`. Backward-compatible (empty registry → existing triggers unchanged).
- `bot.py` — `LoomDiscordBot` implements `CircadianPlatform` (spawn standalone daily thread / verify alive / resume session / close). Reuses `_start_session` + `_close_session`; the bot's generic `on_ready` is untouched.
- `cli/main.py` — `_setup_circadian_if_enabled()` wires it from `_discord_with_autonomy` **after `wait_until_ready()`** so every adapter call reaches a live connection. This is where the doc's "`on_ready` 補開" lives (catch-up spawn folded into the idempotent `ensure`).
- `loom.toml.example` — `[autonomy.circadian]` block (channel via `DISCORD_CHANNEL_ID` env, per .env-vs-toml convention).

## Acceptance criteria (#459)

- [x] `enabled=true` + `DISCORD_CHANNEL_ID` → daily thread opens at dawn, closes at sleep
- [x] daemon restart same-day → no duplicate thread (`is_for_today` + thread verify)
- [x] daemon restart cross-day, yesterday unclosed → force-close + archive, no immediate spawn
- [x] bot restart same-day → today's session resumed
- [x] bot online after dawn (in active hours) → catch-up spawn via `setup_circadian`
- [x] manual thread delete → rebuild + warning
- [x] corrupt `state.json` → quarantine + rebuild
- [x] close triggers existing `session.stop()` path
- [x] thread named `daily-life-YYYY-MM-DD`
- [x] `loom.toml.example` dual-write
- [x] `circadian:day_started` / `day_closed` emitted (#472)
- [x] `gitnexus_impact` on `_close_session` + `deliver_chime` → LOW; `gitnexus_detect_changes` → low risk, expected symbols only

## Tests

31 new (`tests/test_circadian_state.py`, `tests/test_circadian_lifecycle.py`) covering doc/57 §5 robustness rows — spawn/idempotent-resume/rebuild/cross-day-recover, close, startup reconciliation, trigger wiring + planner-bypass, lock arbitration, active-hours + UTC-cron helpers. Full autonomy/chime/dream regression green.

## Notes for review
- Tests are flat `tests/test_circadian_*.py` (repo convention), not doc/57's `tests/autonomy/circadian/` (that path doesn't match the existing layout).
- Local `loom.toml` is gitignored, so only `loom.toml.example` is committed — dual-write spec satisfied.
- Heads-up: the **blueprint `doc/56` is missing from git and disk** (never committed; lost in the 2026-05-26 shared-tree wipe). doc/57 + epic #458 preserve the design, but doc/56 should be reconstructed at some point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)