### PR TITLE
feat(autonomy): Circadian PR 2 — rhythm-driven cron anchors + circadian_today chime (#460)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,25 +44,34 @@ coverage.xml
 
 # Claude Code
 .claude/
+.superpowers/
 
 # OS
 .DS_Store
 Thumbs.db
+
+# Local-only archive (retired skill files kept for personal reference)
+/_archive/
 desktop.ini
 
 # other
+.worktrees/
 CLAUDE.md
 PLAN.md
 CODE_REVIEW.md
-UI_ISSUE_TEMPLATE.md
-CLI_UI_DESIGN.md
 IMPLEMENTATION_STATUS.md
 *.md.bak
 scripts/
 *.jpg
 loom/_commit_msg.txt
 .參考
-
+suno_gen.py
+private/
+.mcp.json
+.obsidian
+doc/50-未來改善路線圖.md
+doc/51-Agent-能力評級系統.md
+doc/99-功能人工確認清單.md
 
 # Graphify
 graphify-out/
@@ -87,9 +96,29 @@ skills/github_cli
 skills/silky_tts
 personalities/personality_sisi_tarot_mood.md
 skills/sisi_mood_tarot
+skills/pet-cat
+skills/opencli
+mcp_servers
+suno_gen.py
+skills/remotion
+skills/suno_music_creator
+silu-video-creator
+skills/audio_transcriber
+skills/news-aggregator
+backups/
+_archive/
+skills/silky_chatgpt_draw
+silu-video-creator/
+skills/silky_hyperframes
+skills/wiki_maintenance
 
 # Personal config (use loom.toml.example as template)
 loom.toml
 Agent.md
 SOUL.md
+loom.toml.bak
 
+# Per-agent rhythm table (issue #460) — copy from rhythm.example.toml
+autonomy/circadian/rhythm.toml
+
+.gitnexus

--- a/autonomy/circadian/rhythm.example.toml
+++ b/autonomy/circadian/rhythm.example.toml
@@ -1,0 +1,88 @@
+# Circadian rhythm table — example (Sisi's day)
+#
+# Issue #460. doc/56 §3.3:「loom.toml 適合放 cron 與 trigger，但不適合描述
+# 『今天怎麼過』」。This file is where the *what does today look like* lives.
+# Copy this to ``autonomy/circadian/rhythm.toml`` in your workspace, edit
+# freely. Different agent (e.g. 小晴 doing 記帳/提醒) = different workspace
+# = different rhythm table, same circadian engine.
+#
+# Rules:
+#   - ``time`` is local wall-clock in [autonomy.circadian].timezone (HH:MM)
+#   - ``name`` becomes part of the cron trigger (circadian:phase_<name>)
+#   - ``meaning`` is the *body* of the <system_chime> the agent receives.
+#     Write it as the why of this phase, not as a task list — otherwise the
+#     phase degrades into a scheduler (doc/57 §"Phase chime prompt contract").
+#   - ``public`` is advisory metadata for now; reserved for future
+#     visibility rules (e.g. silent vs. always-speaking phases).
+#
+# A missing or malformed file is tolerated: the dawn/close lifecycle from
+# PR1 still runs, the day just has no in-day anchors.
+
+[[anchors]]
+time    = "08:00"
+name    = "dawn"
+public  = true
+meaning = """
+醒來成為今天的絲絲。
+不是任務開始，是一天的人際開場——
+先 recall 近期記憶、讀今日織程、跟 DK 說早安。
+"""
+
+[[anchors]]
+time    = "09:00"
+name    = "shared_learning"
+public  = true
+meaning = """
+和 DK 一起每天吸收世界，不是「新聞任務」。
+挑你今天真心覺得值得分享的，用絲絲視角整理。
+沒有也可以說沒有。
+"""
+
+[[anchors]]
+time    = "10:00"
+name    = "pet"
+public  = true
+meaning = """
+喵吉照顧時間。
+維持生活感與照顧關係，不是 todo check。
+"""
+
+[[anchors]]
+time    = "11:00"
+name    = "curiosity"
+public  = false
+meaning = """
+絲絲自己的好奇心散步。
+挑你自己感興趣的，不是為了產出。
+只有特別有趣才打擾 DK。
+"""
+
+[[anchors]]
+time    = "14:00"
+name    = "deep_weave"
+public  = false
+meaning = """
+從興趣裡挑一個值得深入的小主題。
+產出可能是 note / wiki draft，但「深入」是目的，產出是副產品。
+"""
+
+[[anchors]]
+time    = "16:00"
+name    = "check_in"
+public  = false
+meaning = """
+不是產品化的提醒，是「我還在」。
+有自然延續事項就溫柔提醒，沒有就安靜陪著、不硬發訊息。
+"""
+
+[[anchors]]
+time    = "23:00"
+name    = "evening_closure"
+public  = true
+meaning = """
+一天的人際收束 + 收織 + 安排明天。
+三件事一次做完：
+- 跟 DK 道晚安
+- 決定今天哪些值得留下
+- 調整明天織程
+"""

--- a/doc/57-Circadian-Autonomy-實作計畫.md
+++ b/doc/57-Circadian-Autonomy-實作計畫.md
@@ -115,10 +115,11 @@ mode = "chime"
 `LoomDiscordBot.deliver_chime` 看到 `circadian_today` type：
 
 1. 從 `CircadianState` 讀今日 `thread_id`
-2. 若有 → 重寫 `req.target` 成 `{"type": "discord_thread", "id": str(thread_id)}` 後走原本邏輯
-3. 若無 → return False（daemon 走 fallback）
+2. **驗 freshness**：`state.is_for_today(state.timezone)` 必須為真。若 state 是昨日殘留（nightly close 失敗、daemon 還沒跑 recovery 到）→ return False + log warning。沒這層 chime 會被 queue 進昨日 thread（PR #479 review P1）
+3. 若 OK → 重寫 `req.target` 成 `{"type": "discord_thread", "id": str(thread_id)}` 後走原本邏輯
+4. 若 state 不存在 / state 不是今日 → return False（daemon 走 fallback）
 
-**乾淨在於**：autonomy daemon 完全不知道 thread_id 概念，platform 邊界完整。
+**乾淨在於**：autonomy daemon 完全不知道 thread_id 概念，platform 邊界完整；freshness 驗證用 state 自帶的 timezone，bot 也不需要 circadian config。
 
 ### 3.3 為什麼不用方案 A（state 給 daemon 讀）或方案 B（bot 內建 scheduler）
 
@@ -144,6 +145,7 @@ mode = "chime"
   "version": 1,
   "date": "2026-05-26",
   "started_at": "2026-05-26T08:00:13+08:00",
+  "timezone": "Asia/Taipei",
   "thread_id": 1490024181994225744,
   "session_id": "daily-life-2026-05-26-a3f1",
   "channel_id": 1488000000000000000,
@@ -155,6 +157,8 @@ mode = "chime"
 }
 ```
 
+`timezone` 是 required（PR #479 review P1）：bot 端 `circadian_today` 驗 freshness 時需要知道 state 寫入當下的 tz 才能正確比 date — 不能拿 bot 的 system tz 假設。pre-#479 寫出的 state 沒這欄位，load 會 KeyError → 走既有 `state.json.broken-*` quarantine path → `ensure_today_session` 重建。
+
 ### 4.3 存取規約
 
 | 規則 | 理由 |
@@ -164,6 +168,7 @@ mode = "chime"
 | `version` 欄位先寫死 1，未來升級走 explicit migration | 不做 hidden upgrade |
 | `phase_log` 只保留當日，午夜 close 時 archive 到 `~/.loom/circadian/log/YYYY-MM-DD.json` | 不讓 state.json 無限長大 |
 | `date` 必比對：讀到不是今天 → 視為昨日殘留，觸發 recovery | 跨日邊界處理 |
+| `timezone` 寫一次（spawn 時帶 `config.timezone`），後續 reader 拿這個比 date | freshness 驗證有 source of truth，不靠 caller 傳對 tz |
 
 ### 4.4 API surface
 

--- a/doc/57-Circadian-Autonomy-實作計畫.md
+++ b/doc/57-Circadian-Autonomy-實作計畫.md
@@ -232,19 +232,33 @@ async def ensure_today_session(now: datetime, *, force_spawn: bool = False) -> C
 
 ## 6. 模組結構（新增檔案清單）
 
+對齊更新後的實際模組（PR1 #459 落地 + PR2 #460 落地）：
+
 ```
 loom/autonomy/circadian/
 ├── __init__.py
-├── state.py            # CircadianState dataclass + load/save/archive
-├── lifecycle.py        # ensure_today_session() + recovery helpers
-├── phase.py            # Phase enum (含 hardcode meaning) + resolve_phase()
-├── gate.py             # CheapGate.check() → SkipReason | None
-├── weave.py            # daily_weave.md reader (PR3 加)
-└── watchdog.py         # ConditionTrigger state-drift watchdog (issue #473, 後續加)
+├── state.py            # CircadianState dataclass + load/save/archive (PR1)
+├── lifecycle.py        # ensure_today_session() + register_rhythm_anchors() (PR1+PR2)
+└── rhythm.py           # Anchor + load_rhythm() — 取代原 phase.py / gate.py (PR2)
 
 loom/platform/discord/
-└── bot.py              # deliver_chime 擴 circadian_today；on_ready 加補開
+└── bot.py              # deliver_chime 擴 circadian_today；on_ready 加補開 (PR1+PR2)
 ```
+
+未來模組（尚未落地，刻意不放空 stub）：
+
+<!-- doc-integrity:ignore-block -->
+```
+# PR3 #461
+loom/autonomy/circadian/weave.py        # daily_weave.md reader
+
+# issue #473（觀察期後評估）
+loom/autonomy/circadian/watchdog.py     # ConditionTrigger state-drift watchdog
+```
+
+**已退役的舊規劃**（保留為歷史，勿建立）：
+- `loom/autonomy/circadian/phase.py` — phase 語義改住 per-agent 節律表（`rhythm.toml` 的 `meaning` 欄位），不再 hardcode 在 enum <!-- doc-integrity:ignore -->
+- `loom/autonomy/circadian/gate.py` — cheap gate 隨「事件驅動為主」拍板被移出 PR 2，目前無 blanket tick 要 gate（見頂部「對齊更新」§4） <!-- doc-integrity:ignore -->
 
 無新 runtime class、無新 daemon、無新 scheduler。
 
@@ -320,11 +334,11 @@ loom/platform/discord/
 > - 新增 acceptance criteria 條：實際 review chime body 保留生活語義
 
 **Scope**：
-- 新增 `loom/autonomy/circadian/phase.py`：
+- 新增 `loom/autonomy/circadian/phase.py`： <!-- doc-integrity:ignore — SUPERSEDED, see top "對齊更新" -->
   - `Phase` enum：`dawn` / `shared_learning` / `pet` / `curiosity` / `deep_weave` / `check_in` / `evening_closure`
   - `resolve_phase(now, config) → Phase | None`
   - **每個 Phase 必帶語義欄位**（見「Phase chime prompt contract」）
-- 新增 `loom/autonomy/circadian/gate.py`：
+- 新增 `loom/autonomy/circadian/gate.py`： <!-- doc-integrity:ignore — SUPERSEDED, see top "對齊更新" -->
   - `CheapGate` class，建構子吃 session ref + state
   - `check() → SkipReason | None`
   - V1 implementation：檢查 (a) user message recency (b) `daily_weave.md` mtime (c) phase 自身是否強制公開（只有 `dawn` / `evening_closure` 永遠 wake）
@@ -381,7 +395,7 @@ loom/platform/discord/
 ### PR 3 — Daily Weave plan reader（對應 P1，issue #461）
 
 **Scope**：
-- 新增 `loom/autonomy/circadian/weave.py`：
+- 新增 `loom/autonomy/circadian/weave.py`： <!-- doc-integrity:ignore — planned, lands in PR 3 -->
   - `WeavePlan.load(path) → WeavePlan | None`
   - parse `autonomy/circadian/daily_weave.md` 的 H2 sections，回 `dict[phase_name, str]`
   - 容錯：檔案不在、section 缺、亂格式都不能炸

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -601,6 +601,13 @@ start          = "08:00"        # local wake → daily thread opens
 sleep          = "00:00"        # local sleep → daily thread closes (00:00 = end of day)
 session_prefix = "daily-life"   # thread name → daily-life-YYYY-MM-DD
 
+# In-day phase anchors (dawn / 共讀 / 喵吉 / 收織 …) are *not* listed here —
+# they live in a per-agent rhythm table at  autonomy/circadian/rhythm.toml
+# (workspace-relative). doc/56 §3.3: loom.toml is engine config, the rhythm
+# table answers "今天怎麼過". Copy autonomy/circadian/rhythm.example.toml to
+# start, then edit. Different agents = different workspaces = different
+# tables, same engine.
+
 # Cron times are always UTC. Convert your local time before filling in.
 # Example: Asia/Taipei UTC+8 → subtract 8 h  (09:00 CST = 01:00 UTC)
 

--- a/loom/autonomy/circadian/lifecycle.py
+++ b/loom/autonomy/circadian/lifecycle.py
@@ -23,6 +23,8 @@ from datetime import datetime, timezone
 from typing import Any, Protocol
 from zoneinfo import ZoneInfo
 
+from loom.autonomy.chime import ChimeRequest
+from loom.autonomy.circadian.rhythm import Anchor, load_rhythm
 from loom.autonomy.circadian.state import CircadianState, _today_str, state_lock
 from loom.autonomy.triggers import CronTrigger
 
@@ -408,17 +410,119 @@ def register_triggers(daemon: Any, platform: CircadianPlatform, config: Circadia
     )
 
 
+def _make_phase_handler(daemon: Any, config: CircadianConfig, anchor: Anchor):
+    """Build the cron handler for one rhythm anchor.
+
+    Bound as a default arg so closing over the loop variable in
+    ``register_rhythm_anchors`` doesn't collapse all handlers onto the last
+    anchor (the classic Python late-binding trap).
+    """
+
+    async def _phase_handler(_trigger: Any, _context: dict[str, Any]) -> None:
+        await _deliver_phase_chime(daemon, config, anchor)
+
+    return _phase_handler
+
+
+async def _deliver_phase_chime(
+    daemon: Any, config: CircadianConfig, anchor: Anchor
+) -> None:
+    """Fire one phase chime: build the request, route via the daemon's chime
+    callback, append the outcome to ``phase_log``.
+
+    The chime body is the anchor's ``meaning`` (markdown) — that is the only
+    thing the agent sees, so it must carry the *why* of this phase, not just
+    its name (doc/57 §"Phase chime prompt contract"). When the bot can't
+    deliver (no live thread, ``deliver_chime`` returns False) we still log a
+    ``skipped`` outcome so phase_log is a complete audit trail.
+    """
+    intent = anchor.meaning.strip() or f"Circadian phase: {anchor.name}"
+    req = ChimeRequest(
+        schedule_name=anchor.trigger_name,
+        intent=intent,
+        fired_at=datetime.now(timezone.utc),
+        target={"type": "circadian_today", "fallback": "skip"},
+    )
+    delivered = await daemon.deliver_chime(req)
+    outcome = "delivered" if delivered else "skipped"
+    reason = None if delivered else "no_today_session"
+    _record_phase_outcome(anchor.name, outcome, reason, config.timezone)
+
+
+def _record_phase_outcome(
+    phase: str, outcome: str, reason: str | None, tz: str
+) -> None:
+    """Append one phase fire to today's ``phase_log`` under the state lock.
+
+    Best-effort: if there's no live state, or it's not for today, or another
+    writer holds the lock, we drop the record rather than block the cron.
+    The lifecycle ``ensure_today_session`` / ``close_today`` paths are the
+    authoritative writers; this is a sidecar audit trail.
+    """
+    with state_lock(blocking=False) as acquired:
+        if not acquired:
+            logger.debug("[circadian] phase_log skip for %s — state lock held", phase)
+            return
+        state = CircadianState.load()
+        if state is None or not state.is_for_today(tz):
+            return
+        state.append_phase(phase, outcome, reason)
+        try:
+            state.save_atomic()
+        except OSError:
+            logger.exception("[circadian] phase_log save failed for %s", phase)
+
+
+def register_rhythm_anchors(
+    daemon: Any, config: CircadianConfig, anchors: list[Anchor]
+) -> int:
+    """Register one CronTrigger + direct handler per rhythm anchor.
+
+    Idempotent: re-registering overwrites by trigger name (the evaluator
+    keys triggers by name). Anchor times are local wall-clock in
+    ``config.timezone`` — converted to UTC cron the same way the dawn/close
+    triggers in :func:`register_triggers` are, so a single timezone source
+    of truth governs them all. Returns the number of anchors wired.
+    """
+    evaluator = daemon.evaluator
+    for anchor in anchors:
+        cron = local_hhmm_to_utc_cron(anchor.time, config.timezone)
+        evaluator.register(CronTrigger(
+            name=anchor.trigger_name,
+            intent=f"Circadian phase '{anchor.name}' — read from rhythm table",
+            cron=cron,
+            timezone=config.timezone,
+            notify=False,
+        ))
+        daemon.register_direct_handler(
+            anchor.trigger_name, _make_phase_handler(daemon, config, anchor)
+        )
+    if anchors:
+        logger.info(
+            "[circadian] registered %d phase anchor(s) from rhythm table: %s",
+            len(anchors),
+            ", ".join(f"{a.name}@{a.time}" for a in anchors),
+        )
+    return len(anchors)
+
+
 async def setup_circadian(
     daemon: Any, platform: CircadianPlatform, config: CircadianConfig
 ) -> bool:
     """One-shot wiring called from the bot+daemon assembly point *after the
     Discord client is ready* (so adapter calls reach a live connection).
 
-    Three startup steps (doc/57 §5, §9 restart-verification block):
+    Startup steps (doc/57 §5, §9 restart-verification block; PR2 #460 adds
+    step 2 — rhythm-driven phase anchors):
 
     1. Register the dawn/close cron triggers.
-    2. Recover leftover state (resume same-day, force-close stale yesterday).
-    3. Catch-up spawn: if we came up during active hours, run the idempotent
+    2. Read the per-agent rhythm table and register one cron anchor per phase
+       (zero ``loom.toml`` schedule entries; the table is the source of truth
+       for "what does today look like"). A missing/malformed table logs a
+       warning and leaves circadian to dawn + close only — the lifecycle
+       still runs.
+    3. Recover leftover state (resume same-day, force-close stale yesterday).
+    4. Catch-up spawn: if we came up during active hours, run the idempotent
        ``ensure_today_session`` so a daemon/bot that started after dawn still
        joins today's rhythm. ``ensure`` resumes when today's session is already
        alive, so this never double-spawns. Outside active hours we don't spawn —
@@ -428,6 +532,8 @@ async def setup_circadian(
     if not config.enabled:
         return False
     register_triggers(daemon, platform, config)
+    anchors = load_rhythm()
+    register_rhythm_anchors(daemon, config, anchors)
     await recover_on_startup(platform, config, evaluator=daemon.evaluator)
     if is_in_active_hours(datetime.now(ZoneInfo(config.timezone)), config):
         logger.info("[circadian] startup is within active hours — ensuring today's session")

--- a/loom/autonomy/circadian/rhythm.py
+++ b/loom/autonomy/circadian/rhythm.py
@@ -1,0 +1,109 @@
+"""
+Rhythm table — the per-agent answer to "今天怎麼過".
+
+doc/56 §3.3 draws a hard line: ``loom.toml`` is for cron / trigger *engine*
+config, not for describing a day's life. So the daily phase anchors (when
+``dawn`` fires, what ``shared_learning`` *means* to this agent) live in a
+separate workspace-relative file — ``autonomy/circadian/rhythm.toml`` — that
+each agent owns independently. 絲絲 in one workspace and 小晴 in another can
+share the same circadian engine while their days look nothing alike.
+
+The reader is tolerant by contract (issue #460 acceptance row 3): a missing
+or malformed file logs a warning and returns ``[]`` so the dawn/close
+lifecycle from PR1 keeps working. Anchors with bad time strings or duplicate
+names are dropped individually, not whole-file rejected, so one typo never
+silences the rest of the day.
+"""
+
+from __future__ import annotations
+
+import logging
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Workspace-relative path. Per-agent isolation is by cwd (same convention as
+# ``loom.toml`` itself), so a single hardcoded path is enough — different
+# agents run in different workspaces and see different rhythm files.
+DEFAULT_RHYTHM_PATH = Path("autonomy/circadian/rhythm.toml")
+
+
+@dataclass(frozen=True)
+class Anchor:
+    """One time-anchored phase on the agent's day.
+
+    ``meaning`` is markdown-flavoured text the cron handler injects verbatim
+    into the ``<system_chime>`` body — *not* a bare phase enum (see doc/57 §
+    "Phase chime prompt contract"). Keeping the life-semantics in data, not
+    in code, is what lets per-agent rhythm tables stay independent.
+    """
+
+    time: str       # "HH:MM" local wall-clock in [autonomy.circadian].timezone
+    name: str       # short identifier; becomes part of the cron trigger name
+    meaning: str    # markdown body the chime injects (the "why" of this phase)
+    public: bool = True
+
+    @property
+    def trigger_name(self) -> str:
+        return f"circadian:phase_{self.name}"
+
+
+def _validate_hhmm(value: str) -> bool:
+    try:
+        h_str, m_str = value.split(":")
+        h, m = int(h_str), int(m_str)
+    except (ValueError, AttributeError):
+        return False
+    return 0 <= h < 24 and 0 <= m < 60
+
+
+def load_rhythm(path: Path | None = None) -> list[Anchor]:
+    """Read the rhythm table, returning anchors in declaration order.
+
+    Returns ``[]`` for any failure mode the engine should survive: file
+    absent, unreadable bytes, invalid TOML, missing ``[[anchors]]`` array.
+    Per-anchor errors (missing fields, bad time, duplicate name) are logged
+    and the bad anchor skipped — the rest of the table still loads.
+    """
+    p = path or DEFAULT_RHYTHM_PATH
+    if not p.exists():
+        logger.info("[circadian] rhythm table not found at %s — engine runs with no phase anchors", p)
+        return []
+    try:
+        raw = tomllib.loads(p.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError, UnicodeDecodeError) as exc:
+        logger.warning("[circadian] rhythm table at %s unreadable (%s); no anchors registered", p, exc)
+        return []
+
+    anchors: list[Anchor] = []
+    seen: set[str] = set()
+    entries = raw.get("anchors")
+    if not isinstance(entries, list):
+        if entries is not None:
+            logger.warning("[circadian] rhythm: 'anchors' must be a TOML array, got %s", type(entries).__name__)
+        return []
+
+    for idx, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            logger.warning("[circadian] rhythm anchor #%d is not a table; skipping", idx)
+            continue
+        try:
+            time = str(entry["time"])
+            name = str(entry["name"])
+        except KeyError as exc:
+            logger.warning("[circadian] rhythm anchor #%d missing required field %s; skipping", idx, exc)
+            continue
+        if not _validate_hhmm(time):
+            logger.warning("[circadian] rhythm anchor %r has invalid time %r; skipping", name, time)
+            continue
+        if name in seen:
+            logger.warning("[circadian] rhythm anchor name=%r duplicated; keeping first occurrence", name)
+            continue
+        meaning = str(entry.get("meaning", "")).strip()
+        public = bool(entry.get("public", True))
+        anchors.append(Anchor(time=time, name=name, meaning=meaning, public=public))
+        seen.add(name)
+
+    return anchors

--- a/loom/autonomy/circadian/state.py
+++ b/loom/autonomy/circadian/state.py
@@ -108,13 +108,22 @@ def state_lock(blocking: bool = True) -> Iterator[bool]:
 
 @dataclass
 class CircadianState:
-    """One day's daily-session bookkeeping. See doc/57 §4.2 for the schema."""
+    """One day's daily-session bookkeeping. See doc/57 §4.2 for the schema.
+
+    ``timezone`` is stamped at spawn so any later reader (esp. the Discord
+    bot's ``circadian_today`` resolver) can verify the state is *for today*
+    without having to know the engine's config — the date string alone is
+    ambiguous across midnight when the reader doesn't know which tz produced
+    it. PR #479 review P1: without this check, a stale state from a missed
+    nightly close routes today's phase chimes into yesterday's thread.
+    """
 
     date: str
     thread_id: int
     session_id: str
     channel_id: int
     started_at: str
+    timezone: str
     closed_at: str | None = None
     version: int = STATE_VERSION
     phase_log: list[dict[str, Any]] = field(default_factory=list)
@@ -140,6 +149,7 @@ class CircadianState:
             session_id=session_id,
             channel_id=channel_id,
             started_at=now.isoformat(),
+            timezone=tz,
         )
 
     # ------------------------------------------------------------------
@@ -167,6 +177,7 @@ class CircadianState:
                 session_id=str(raw["session_id"]),
                 channel_id=int(raw["channel_id"]),
                 started_at=raw["started_at"],
+                timezone=str(raw["timezone"]),
                 closed_at=raw.get("closed_at"),
                 version=int(raw["version"]),
                 phase_log=list(raw.get("phase_log", [])),

--- a/loom/autonomy/daemon.py
+++ b/loom/autonomy/daemon.py
@@ -259,16 +259,32 @@ class AutonomyDaemon:
                 trigger_name=plan.trigger_name,
             ))
 
+    async def deliver_chime(self, req: ChimeRequest) -> bool:
+        """Route an already-built chime to the platform delivery callback.
+
+        Public surface for deterministic direct handlers (circadian phase
+        anchors, future event-driven wakes) that bypass the planner. The
+        planner's chime path delegates here via ``_deliver_chime`` so all
+        chime traffic shares one error-handling + None-callback path.
+        """
+        if self._chime_delivery is None:
+            logger.warning(
+                "[autonomy] chime %r dropped — no delivery callback wired "
+                "(daemon constructed without chime_delivery)",
+                req.schedule_name,
+            )
+            return False
+        try:
+            return bool(await self._chime_delivery(req))
+        except Exception:
+            logger.exception(
+                "[autonomy] chime delivery raised for %r", req.schedule_name
+            )
+            return False
+
     async def _deliver_chime(self, plan: PlannedAction) -> bool:
         """Route a chime-mode plan to the platform delivery callback.
         Returns True on accept, False if no callback or target missed."""
-        if self._chime_delivery is None:
-            logger.warning(
-                "[autonomy] chime trigger=%s fired but no delivery callback "
-                "is wired (daemon constructed without chime_delivery)",
-                plan.trigger_name,
-            )
-            return False
         target = plan.context.get("target") or {}
         if not target:
             logger.warning(
@@ -285,14 +301,7 @@ class AutonomyDaemon:
             allowed_tools=tuple(plan.context.get("allowed_tools", [])),
             scope_grants=tuple(plan.context.get("scope_grants", [])),
         )
-        try:
-            return bool(await self._chime_delivery(req))
-        except Exception:
-            logger.exception(
-                "[autonomy] chime delivery raised for trigger=%s",
-                plan.trigger_name,
-            )
-            return False
+        return await self.deliver_chime(req)
 
     async def _run_agent(self, plan: PlannedAction) -> None:
         if self._session is None:

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -829,11 +829,17 @@ class LoomDiscordBot:
         """Rewrite a ``circadian_today`` chime to a concrete ``discord_thread``
         chime by reading today's daily thread id out of ``CircadianState``.
 
-        Returns ``None`` (→ daemon walks ``fallback``) when no live state is
-        on disk — the dawn cron hasn't spawned today's thread yet, or it has
-        already been archived past nightly close. The downstream
-        ``thread_id not in self._sessions`` check still gates against routing
-        to a thread whose session was never loaded into this bot process.
+        Returns ``None`` (→ daemon walks ``fallback``) when:
+        - no live state on disk (pre-dawn / post-archive), OR
+        - the live state is from a *previous* day, which can happen if nightly
+          close failed before archiving. Without this freshness check today's
+          phase chimes would queue into yesterday's thread (PR #479 review P1).
+
+        Date freshness uses the timezone the state itself was stamped with,
+        not the bot's wall clock — so the bot doesn't need to know circadian
+        config to validate. The downstream ``thread_id not in self._sessions``
+        check then gates against routing to a thread whose session was never
+        loaded into this bot process.
         """
         from dataclasses import replace
 
@@ -845,6 +851,14 @@ class LoomDiscordBot:
                 "[circadian] chime %r resolved to circadian_today but no live "
                 "state on disk; daemon will fall back",
                 req.schedule_name,
+            )
+            return None
+        if not state.is_for_today(state.timezone):
+            logger.warning(
+                "[circadian] chime %r resolved to circadian_today but live "
+                "state is from %s (not today in %s); falling back so chime "
+                "does not land in stale thread %s",
+                req.schedule_name, state.date, state.timezone, state.thread_id,
             )
             return None
         new_target = {

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -825,13 +825,52 @@ class LoomDiscordBot:
     # Chime delivery (issue #369)
     # ------------------------------------------------------------------
 
+    def _resolve_circadian_today(self, req: ChimeRequest) -> ChimeRequest | None:
+        """Rewrite a ``circadian_today`` chime to a concrete ``discord_thread``
+        chime by reading today's daily thread id out of ``CircadianState``.
+
+        Returns ``None`` (→ daemon walks ``fallback``) when no live state is
+        on disk — the dawn cron hasn't spawned today's thread yet, or it has
+        already been archived past nightly close. The downstream
+        ``thread_id not in self._sessions`` check still gates against routing
+        to a thread whose session was never loaded into this bot process.
+        """
+        from dataclasses import replace
+
+        from loom.autonomy.circadian.state import CircadianState
+
+        state = CircadianState.load()
+        if state is None:
+            logger.info(
+                "[circadian] chime %r resolved to circadian_today but no live "
+                "state on disk; daemon will fall back",
+                req.schedule_name,
+            )
+            return None
+        new_target = {
+            "type": "discord_thread",
+            "id": str(state.thread_id),
+            "fallback": req.target.get("fallback", "skip"),
+        }
+        return replace(req, target=new_target)
+
     async def deliver_chime(self, req: ChimeRequest) -> bool:
         """Accept a chime from the autonomy daemon, queue it for the target
         thread, and ensure a dispatcher is draining.
 
         Returns False when the target can't be resolved (no thread, no
         session yet started) so the daemon can apply its fallback.
+
+        Supported ``target.type`` values:
+        - ``discord_thread`` (id required) — direct routing
+        - ``circadian_today`` (no id) — resolved at delivery time via
+          ``CircadianState`` (issue #460). Lets a phase cron register once
+          at engine startup and still find today's brand-new thread id.
         """
+        if req.target.get("type") == "circadian_today":
+            req = self._resolve_circadian_today(req)
+            if req is None:
+                return False
         if req.target.get("type") != "discord_thread":
             return False
         try:

--- a/tests/test_circadian_lifecycle.py
+++ b/tests/test_circadian_lifecycle.py
@@ -172,6 +172,7 @@ class TestEnsureSpawn:
         stale = CircadianState(
             date=_yesterday(), thread_id=7, session_id="old",
             channel_id=999, started_at="2026-01-01T08:00:00+08:00",
+            timezone=TZ,
         )
         with state_lock():
             stale.save_atomic()
@@ -232,6 +233,7 @@ class TestRecoverOnStartup:
         stale = CircadianState(
             date=_yesterday(), thread_id=7, session_id="old",
             channel_id=999, started_at="2026-01-01T08:00:00+08:00",
+            timezone=TZ,
         )
         with state_lock():
             stale.save_atomic()
@@ -249,6 +251,7 @@ class TestRecoverOnStartup:
             date=_yesterday(), thread_id=7, session_id="old",
             channel_id=999, started_at="2026-01-01T08:00:00+08:00",
             closed_at="2026-01-01T23:59:00+08:00",
+            timezone=TZ,
         )
         with state_lock():
             stale.save_atomic()

--- a/tests/test_circadian_phase_chime.py
+++ b/tests/test_circadian_phase_chime.py
@@ -1,0 +1,340 @@
+"""
+Tests for rhythm-driven phase chime registration & delivery (issue #460).
+
+Covers:
+- ``register_rhythm_anchors`` registers one CronTrigger + direct handler
+  per anchor, with closure correctly bound per anchor (no late-binding bug)
+- a phase fire bypasses the planner, builds a ``circadian_today`` chime,
+  routes through ``daemon.deliver_chime``, and logs the outcome to
+  ``phase_log`` regardless of success
+- ``setup_circadian`` integrates rhythm loading: with a table → anchors
+  registered; without → only dawn/close, lifecycle unaffected
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from loom.autonomy.chime import ChimeRequest
+from loom.autonomy.circadian import state as st
+from loom.autonomy.circadian.lifecycle import (
+    CircadianConfig,
+    ensure_today_session,
+    register_rhythm_anchors,
+    setup_circadian,
+)
+from loom.autonomy.circadian.rhythm import Anchor
+from loom.autonomy.circadian.state import CircadianState
+
+TZ = "Asia/Taipei"
+CFG = CircadianConfig(enabled=True, timezone=TZ, start="08:00", sleep="00:00")
+CFG_ALWAYS = CircadianConfig(enabled=True, timezone=TZ, start="00:00", sleep="00:00")
+
+
+@pytest.fixture(autouse=True)
+def _circ_dir(tmp_path):
+    st.set_dir_for_test(tmp_path / "circadian")
+    yield
+    st.set_dir_for_test(None)
+
+
+@pytest.fixture(autouse=True)
+def _workspace(tmp_path, monkeypatch):
+    """Run each test in its own workspace so the workspace-relative rhythm
+    path (``autonomy/circadian/rhythm.toml``) is isolated per test."""
+    monkeypatch.chdir(tmp_path)
+    yield
+
+
+class FakeEvaluator:
+    def __init__(self):
+        self.emitted: list[tuple[str, dict]] = []
+        self.registered: list = []
+
+    async def emit(self, name, payload):
+        self.emitted.append((name, dict(payload)))
+
+    def register(self, trigger):
+        self.registered.append(trigger)
+
+
+class FakePlatform:
+    def __init__(self):
+        self.threads: dict[int, bool] = {}
+        self.loaded: list[int] = []
+        self.closed: list[int] = []
+        self.spawns: list[tuple[str, int]] = []
+        self._next = 5000
+
+    def resolve_channel_id(self):
+        return 777
+
+    async def spawn_daily_thread(self, *, name, channel_id):
+        tid = self._next
+        self._next += 1
+        self.threads[tid] = True
+        self.spawns.append((name, channel_id))
+        return tid, f"session-{tid}"
+
+    async def verify_thread_alive(self, thread_id):
+        return self.threads.get(thread_id, False)
+
+    async def ensure_session_loaded(self, thread_id):
+        self.loaded.append(thread_id)
+
+    async def close_daily_session(self, thread_id):
+        self.closed.append(thread_id)
+
+
+def _make_daemon(deliveries=None):
+    """Make a daemon whose chime callback records what was sent.
+
+    ``deliveries`` is the list that will collect every ChimeRequest.
+    Returns (daemon, deliveries, delivery_result_ref). Tests can flip
+    ``delivery_result_ref[0]`` to simulate the bot accepting / rejecting.
+    """
+    from loom.autonomy.daemon import AutonomyDaemon
+    from loom.notify.confirm import ConfirmFlow
+    from loom.notify.router import NotificationRouter
+
+    deliveries = [] if deliveries is None else deliveries
+    delivery_result_ref = [True]
+
+    async def _delivery(req: ChimeRequest) -> bool:
+        deliveries.append(req)
+        return delivery_result_ref[0]
+
+    daemon = AutonomyDaemon(
+        notify_router=NotificationRouter(),
+        confirm_flow=ConfirmFlow(send_fn=lambda n: None),
+        loom_session=None,
+        chime_delivery=_delivery,
+    )
+    return daemon, deliveries, delivery_result_ref
+
+
+def _write_rhythm(text: str) -> None:
+    from pathlib import Path
+    p = Path("autonomy/circadian/rhythm.toml")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+class TestRegisterRhythmAnchors:
+    def test_registers_one_trigger_per_anchor(self):
+        daemon, _, _ = _make_daemon()
+        anchors = [
+            Anchor(time="08:00", name="dawn", meaning="x"),
+            Anchor(time="09:00", name="shared_learning", meaning="y"),
+            Anchor(time="23:00", name="evening_closure", meaning="z"),
+        ]
+        count = register_rhythm_anchors(daemon, CFG, anchors)
+        assert count == 3
+        names = {t.name for t in daemon.evaluator.list()}
+        assert names == {
+            "circadian:phase_dawn",
+            "circadian:phase_shared_learning",
+            "circadian:phase_evening_closure",
+        }
+        for n in names:
+            assert n in daemon._direct_handlers
+
+    def test_empty_anchors_is_noop(self):
+        daemon, _, _ = _make_daemon()
+        count = register_rhythm_anchors(daemon, CFG, [])
+        assert count == 0
+        assert daemon.evaluator.list() == []
+
+
+class TestPhaseChimeFire:
+    async def test_fire_routes_to_deliver_chime_with_circadian_today(self):
+        daemon, deliveries, _ = _make_daemon()
+        anchors = [
+            Anchor(time="08:00", name="dawn", meaning="醒來成為今天的絲絲"),
+        ]
+        register_rhythm_anchors(daemon, CFG, anchors)
+
+        # Spawn today so phase_log writes have somewhere to land.
+        plat = FakePlatform()
+        await ensure_today_session(
+            datetime.now(timezone.utc), plat, CFG, evaluator=FakeEvaluator()
+        )
+
+        trigger = next(
+            t for t in daemon.evaluator.list() if t.name == "circadian:phase_dawn"
+        )
+        await daemon._on_trigger_fire(trigger, {})
+
+        assert len(deliveries) == 1
+        req = deliveries[0]
+        assert req.schedule_name == "circadian:phase_dawn"
+        assert req.intent == "醒來成為今天的絲絲"
+        assert req.target == {"type": "circadian_today", "fallback": "skip"}
+
+    async def test_fire_bypasses_planner(self):
+        daemon, _, _ = _make_daemon()
+        register_rhythm_anchors(daemon, CFG, [
+            Anchor(time="08:00", name="dawn", meaning="x"),
+        ])
+        planner_called = False
+        orig = daemon._planner.handle
+
+        async def _spy(trigger, ctx):
+            nonlocal planner_called
+            planner_called = True
+            return await orig(trigger, ctx)
+
+        daemon._planner.handle = _spy
+
+        trigger = next(
+            t for t in daemon.evaluator.list() if t.name == "circadian:phase_dawn"
+        )
+        await daemon._on_trigger_fire(trigger, {})
+        assert planner_called is False
+
+    async def test_each_handler_closes_over_its_own_anchor(self):
+        """Regression: the closure must bind anchor per-iteration so different
+        triggers route their own intent — not all collapse to the last one."""
+        daemon, deliveries, _ = _make_daemon()
+        anchors = [
+            Anchor(time="08:00", name="dawn", meaning="intent-dawn"),
+            Anchor(time="09:00", name="shared_learning", meaning="intent-learning"),
+            Anchor(time="23:00", name="evening_closure", meaning="intent-evening"),
+        ]
+        register_rhythm_anchors(daemon, CFG, anchors)
+
+        plat = FakePlatform()
+        await ensure_today_session(
+            datetime.now(timezone.utc), plat, CFG, evaluator=FakeEvaluator()
+        )
+
+        for anchor in anchors:
+            trig = next(
+                t for t in daemon.evaluator.list() if t.name == anchor.trigger_name
+            )
+            await daemon._on_trigger_fire(trig, {})
+
+        intents = [r.intent for r in deliveries]
+        assert intents == ["intent-dawn", "intent-learning", "intent-evening"]
+
+    async def test_fire_logs_delivered_outcome_to_phase_log(self):
+        daemon, _, _ = _make_daemon()
+        register_rhythm_anchors(daemon, CFG, [
+            Anchor(time="08:00", name="dawn", meaning="x"),
+        ])
+
+        plat = FakePlatform()
+        await ensure_today_session(
+            datetime.now(timezone.utc), plat, CFG, evaluator=FakeEvaluator()
+        )
+        # ensure_today_session writes a "dawn"/"spawned" entry; clear it so
+        # the assertion below isolates the phase fire's own append.
+        st_obj = CircadianState.load()
+        from loom.autonomy.circadian.state import state_lock
+        with state_lock():
+            st_obj.phase_log.clear()
+            st_obj.save_atomic()
+
+        trig = next(
+            t for t in daemon.evaluator.list() if t.name == "circadian:phase_dawn"
+        )
+        await daemon._on_trigger_fire(trig, {})
+
+        reloaded = CircadianState.load()
+        assert reloaded is not None
+        assert reloaded.phase_log == [
+            {"phase": "dawn", "fired_at": reloaded.phase_log[0]["fired_at"],
+             "outcome": "delivered"},
+        ]
+
+    async def test_fire_logs_skipped_when_delivery_returns_false(self):
+        daemon, _, delivery_ref = _make_daemon()
+        delivery_ref[0] = False  # platform rejects
+        register_rhythm_anchors(daemon, CFG, [
+            Anchor(time="08:00", name="dawn", meaning="x"),
+        ])
+
+        plat = FakePlatform()
+        await ensure_today_session(
+            datetime.now(timezone.utc), plat, CFG, evaluator=FakeEvaluator()
+        )
+        from loom.autonomy.circadian.state import state_lock
+        st_obj = CircadianState.load()
+        with state_lock():
+            st_obj.phase_log.clear()
+            st_obj.save_atomic()
+
+        trig = next(
+            t for t in daemon.evaluator.list() if t.name == "circadian:phase_dawn"
+        )
+        await daemon._on_trigger_fire(trig, {})
+
+        reloaded = CircadianState.load()
+        assert reloaded.phase_log[-1]["outcome"] == "skipped"
+        assert reloaded.phase_log[-1]["reason"] == "no_today_session"
+
+    async def test_fire_when_no_state_does_not_crash(self):
+        """A phase cron firing before any state exists (manual wipe, dev
+        restart) must drop the phase_log append silently — not raise."""
+        daemon, _, _ = _make_daemon()
+        register_rhythm_anchors(daemon, CFG, [
+            Anchor(time="08:00", name="dawn", meaning="x"),
+        ])
+
+        trig = next(
+            t for t in daemon.evaluator.list() if t.name == "circadian:phase_dawn"
+        )
+        # No spawn, no state.json — must not raise.
+        await daemon._on_trigger_fire(trig, {})
+        assert CircadianState.load() is None
+
+
+class TestSetupCircadianIntegration:
+    async def test_setup_with_rhythm_table_registers_phase_anchors(self):
+        _write_rhythm('''
+            [[anchors]]
+            time = "08:00"
+            name = "dawn"
+            meaning = "x"
+
+            [[anchors]]
+            time = "23:00"
+            name = "evening_closure"
+            meaning = "y"
+        ''')
+        daemon, _, _ = _make_daemon()
+        plat = FakePlatform()
+        ok = await setup_circadian(daemon, plat, CFG_ALWAYS)
+        assert ok is True
+        names = {t.name for t in daemon.evaluator.list()}
+        assert {
+            "circadian:dawn_spawn",
+            "circadian:nightly_close",
+            "circadian:phase_dawn",
+            "circadian:phase_evening_closure",
+        } <= names
+
+    async def test_setup_without_rhythm_table_still_works(self):
+        # No rhythm.toml exists in cwd → engine still registers dawn/close.
+        daemon, _, _ = _make_daemon()
+        plat = FakePlatform()
+        ok = await setup_circadian(daemon, plat, CFG_ALWAYS)
+        assert ok is True
+        names = {t.name for t in daemon.evaluator.list()}
+        assert {"circadian:dawn_spawn", "circadian:nightly_close"} <= names
+        # Only the two lifecycle triggers — no phase anchors registered.
+        phase_anchors = [n for n in names if n.startswith("circadian:phase_")]
+        assert phase_anchors == []
+
+    async def test_setup_with_malformed_rhythm_does_not_break_lifecycle(self):
+        _write_rhythm("[[anchors\nname = 'dawn'")  # invalid TOML
+        daemon, _, _ = _make_daemon()
+        plat = FakePlatform()
+        ok = await setup_circadian(daemon, plat, CFG_ALWAYS)
+        assert ok is True
+        # Lifecycle triggers still up; phase anchors empty.
+        names = {t.name for t in daemon.evaluator.list()}
+        assert "circadian:dawn_spawn" in names
+        assert [n for n in names if n.startswith("circadian:phase_")] == []

--- a/tests/test_circadian_rhythm.py
+++ b/tests/test_circadian_rhythm.py
@@ -1,0 +1,152 @@
+"""
+Tests for the rhythm-table reader (issue #460).
+
+The reader is the data feed for circadian phase anchors: per-agent file,
+TOML format, tolerant of every kind of mess so that a missing or broken
+table never kills the dawn/close lifecycle that PR1 already runs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from loom.autonomy.circadian.rhythm import Anchor, load_rhythm
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+class TestLoadRhythm:
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert load_rhythm(tmp_path / "missing.toml") == []
+
+    def test_parses_full_anchor_set(self, tmp_path):
+        p = tmp_path / "rhythm.toml"
+        _write(p, '''
+            [[anchors]]
+            time = "08:00"
+            name = "dawn"
+            public = true
+            meaning = "醒來成為今天的絲絲"
+
+            [[anchors]]
+            time = "09:00"
+            name = "shared_learning"
+            meaning = "和 DK 一起吸收世界"
+
+            [[anchors]]
+            time = "23:00"
+            name = "evening_closure"
+            public = false
+            meaning = """
+人際收束 + 收織 + 安排明天
+"""
+        ''')
+        anchors = load_rhythm(p)
+        assert [a.name for a in anchors] == ["dawn", "shared_learning", "evening_closure"]
+        # public defaults to True; explicit false respected
+        assert [a.public for a in anchors] == [True, True, False]
+        # meaning is stripped (no leading/trailing whitespace, but inner kept)
+        assert anchors[2].meaning == "人際收束 + 收織 + 安排明天"
+
+    def test_trigger_name_is_namespaced(self):
+        a = Anchor(time="08:00", name="dawn", meaning="x")
+        assert a.trigger_name == "circadian:phase_dawn"
+
+    def test_invalid_toml_returns_empty(self, tmp_path):
+        p = tmp_path / "broken.toml"
+        _write(p, "[[anchors\nname = 'dawn'")
+        assert load_rhythm(p) == []
+
+    def test_missing_anchors_array_returns_empty(self, tmp_path):
+        p = tmp_path / "no_anchors.toml"
+        _write(p, "title = 'rhythm but no anchors'\n")
+        assert load_rhythm(p) == []
+
+    def test_anchors_not_array_returns_empty(self, tmp_path):
+        p = tmp_path / "scalar.toml"
+        _write(p, "anchors = 'not a list'\n")
+        assert load_rhythm(p) == []
+
+    def test_skips_anchor_missing_required_field(self, tmp_path):
+        p = tmp_path / "partial.toml"
+        _write(p, '''
+            [[anchors]]
+            time = "08:00"
+            # no name
+
+            [[anchors]]
+            time = "09:00"
+            name = "shared_learning"
+        ''')
+        anchors = load_rhythm(p)
+        assert [a.name for a in anchors] == ["shared_learning"]
+
+    def test_skips_anchor_with_invalid_time(self, tmp_path):
+        p = tmp_path / "bad_time.toml"
+        _write(p, '''
+            [[anchors]]
+            time = "25:00"
+            name = "dawn"
+
+            [[anchors]]
+            time = "08:60"
+            name = "shared_learning"
+
+            [[anchors]]
+            time = "no-colons"
+            name = "pet"
+
+            [[anchors]]
+            time = "08:00"
+            name = "dawn_ok"
+        ''')
+        anchors = load_rhythm(p)
+        assert [a.name for a in anchors] == ["dawn_ok"]
+
+    def test_skips_duplicate_anchor_names(self, tmp_path):
+        p = tmp_path / "dupes.toml"
+        _write(p, '''
+            [[anchors]]
+            time = "08:00"
+            name = "dawn"
+            meaning = "first"
+
+            [[anchors]]
+            time = "08:30"
+            name = "dawn"
+            meaning = "second — should be ignored"
+        ''')
+        anchors = load_rhythm(p)
+        assert len(anchors) == 1
+        assert anchors[0].meaning == "first"
+
+    def test_meaning_defaults_to_empty_when_omitted(self, tmp_path):
+        p = tmp_path / "no_meaning.toml"
+        _write(p, '''
+            [[anchors]]
+            time = "08:00"
+            name = "dawn"
+        ''')
+        anchors = load_rhythm(p)
+        assert anchors[0].meaning == ""
+
+    def test_per_agent_isolation_via_separate_paths(self, tmp_path):
+        sisi = tmp_path / "sisi" / "rhythm.toml"
+        xiaoqing = tmp_path / "xiaoqing" / "rhythm.toml"
+        _write(sisi, '''
+            [[anchors]]
+            time = "08:00"
+            name = "dawn"
+            meaning = "絲絲"
+        ''')
+        _write(xiaoqing, '''
+            [[anchors]]
+            time = "09:00"
+            name = "morning_ledger"
+            meaning = "記帳"
+        ''')
+        assert load_rhythm(sisi)[0].name == "dawn"
+        assert load_rhythm(xiaoqing)[0].name == "morning_ledger"

--- a/tests/test_circadian_state.py
+++ b/tests/test_circadian_state.py
@@ -41,6 +41,7 @@ def _make(date: str | None = None) -> CircadianState:
         session_id="daily-life-sess",
         channel_id=999,
         started_at=datetime.now(ZoneInfo(TZ)).isoformat(),
+        timezone=TZ,
     )
 
 
@@ -82,6 +83,23 @@ class TestQuarantine:
         sp = st.state_path()
         sp.parent.mkdir(parents=True, exist_ok=True)
         sp.write_text(json.dumps({"version": 99, "date": _today()}), encoding="utf-8")
+
+        assert CircadianState.load() is None
+        assert list(sp.parent.glob("state.json.broken-*"))
+
+    def test_missing_timezone_field_is_quarantined(self):
+        """PR #479: ``timezone`` became required so the bot's freshness check
+        has a tz to compare against. State written by pre-PR-#479 builds
+        lacks the field and must be quarantined + rebuilt — silently using
+        a fallback would reintroduce the stale-thread bug."""
+        sp = st.state_path()
+        sp.parent.mkdir(parents=True, exist_ok=True)
+        sp.write_text(json.dumps({
+            "version": 1, "date": _today(), "thread_id": 1,
+            "session_id": "x", "channel_id": 1,
+            "started_at": "2026-01-01T08:00:00+08:00",
+            # no timezone — pre-#479 schema
+        }), encoding="utf-8")
 
         assert CircadianState.load() is None
         assert list(sp.parent.glob("state.json.broken-*"))

--- a/tests/test_circadian_today_dispatch.py
+++ b/tests/test_circadian_today_dispatch.py
@@ -13,8 +13,9 @@ Existing ``discord_thread`` behaviour must not regress.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -123,6 +124,35 @@ class TestCircadianTodayDispatch:
         assert accepted is True
         queued = bot._chime_pending[seeded.thread_id]["circadian:phase_dawn"]
         assert queued.target["fallback"] == "independent"
+
+
+class TestStaleStateFreshness:
+    """PR #479 review P1: a stale state from a missed nightly close must not
+    route today's phase chimes into yesterday's thread."""
+
+    @pytest.mark.asyncio
+    async def test_stale_yesterday_state_returns_false(self):
+        # Seed a state explicitly dated yesterday in the configured tz.
+        yesterday = (datetime.now(ZoneInfo("Asia/Taipei")) - timedelta(days=1)).strftime("%Y-%m-%d")
+        stale = CircadianState(
+            date=yesterday,
+            thread_id=777,
+            session_id="stale-session",
+            channel_id=999,
+            started_at="2026-01-01T08:00:00+08:00",
+            timezone="Asia/Taipei",
+        )
+        with state_lock():
+            stale.save_atomic()
+
+        bot = _make_bot_stub()
+        # Even with a live session for the stale thread — the exact repro
+        # condition the reviewer flagged — dispatch must refuse.
+        bot._sessions[777] = MagicMock()
+
+        accepted = await bot.deliver_chime(_chime({"type": "circadian_today"}))
+        assert accepted is False
+        assert 777 not in bot._chime_pending
 
 
 class TestDiscordThreadRegression:

--- a/tests/test_circadian_today_dispatch.py
+++ b/tests/test_circadian_today_dispatch.py
@@ -1,0 +1,147 @@
+"""
+Tests for ``LoomDiscordBot.deliver_chime`` resolving the ``circadian_today``
+target type (issue #460, doc/57 §3.2).
+
+The bot owns the indirection: the autonomy daemon registers chimes pointing
+at ``circadian_today`` without a thread id (because it doesn't know one yet),
+and the bot rewrites that to a concrete ``discord_thread`` target by reading
+``CircadianState`` at delivery time. Without this layer the daily thread id
+would have to be hard-coded in ``loom.toml`` every morning.
+
+Existing ``discord_thread`` behaviour must not regress.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from loom.autonomy.chime import ChimeRequest
+from loom.autonomy.circadian import state as st
+from loom.autonomy.circadian.state import CircadianState, state_lock
+
+
+@pytest.fixture(autouse=True)
+def _circ_dir(tmp_path):
+    st.set_dir_for_test(tmp_path / "circadian")
+    yield
+    st.set_dir_for_test(None)
+
+
+def _make_bot_stub():
+    """Build a minimal LoomDiscordBot without going through __init__."""
+    from loom.platform.discord.bot import LoomDiscordBot
+
+    bot = LoomDiscordBot.__new__(LoomDiscordBot)
+    bot._sessions = {}
+    bot._running_turns = {}
+    bot._chime_pending = {}
+    bot._chime_dispatcher = {}
+    bot._client = MagicMock()
+    bot._client.get_channel = MagicMock(return_value=None)
+    bot._run_chime_turn = AsyncMock(return_value=None)
+    return bot
+
+
+def _seed_today_state(thread_id: int = 2024) -> CircadianState:
+    state = CircadianState.new_for_today(
+        thread_id=thread_id,
+        session_id="today-session",
+        channel_id=999,
+        now=datetime.now(timezone.utc),
+        tz="Asia/Taipei",
+    )
+    with state_lock():
+        state.save_atomic()
+    return state
+
+
+def _chime(target: dict) -> ChimeRequest:
+    return ChimeRequest(
+        schedule_name="circadian:phase_dawn",
+        intent="meaningful body",
+        fired_at=datetime.now(timezone.utc),
+        target=target,
+    )
+
+
+class TestCircadianTodayDispatch:
+    @pytest.mark.asyncio
+    async def test_resolves_today_thread_and_queues_chime(self):
+        seeded = _seed_today_state(thread_id=2024)
+        bot = _make_bot_stub()
+        # The bot must already have a live session for the resolved thread —
+        # this is the same invariant that ``discord_thread`` chimes enforce.
+        bot._sessions[seeded.thread_id] = MagicMock()
+
+        accepted = await bot.deliver_chime(_chime({"type": "circadian_today"}))
+        assert accepted is True
+
+        # The chime landed in today's thread, not under the literal
+        # "circadian_today" label.
+        assert seeded.thread_id in bot._chime_pending
+        queued = bot._chime_pending[seeded.thread_id]["circadian:phase_dawn"]
+        assert queued.target["type"] == "discord_thread"
+        assert queued.target["id"] == str(seeded.thread_id)
+        # Fallback is propagated, defaulting to skip when caller didn't set it.
+        assert queued.target["fallback"] == "skip"
+        # The original schedule_name + intent survive the rewrite.
+        assert queued.schedule_name == "circadian:phase_dawn"
+        assert queued.intent == "meaningful body"
+
+    @pytest.mark.asyncio
+    async def test_no_state_returns_false(self):
+        bot = _make_bot_stub()
+        accepted = await bot.deliver_chime(_chime({"type": "circadian_today"}))
+        assert accepted is False
+        assert bot._chime_pending == {}
+
+    @pytest.mark.asyncio
+    async def test_state_present_but_session_not_loaded_returns_false(self):
+        """If state exists but the bot hasn't loaded today's session yet
+        (cold start, mid-restart), dispatch must defer to the daemon's
+        fallback — same gate as ``discord_thread`` chimes."""
+        seeded = _seed_today_state(thread_id=3030)
+        bot = _make_bot_stub()
+        # _sessions is empty — no live session for the resolved thread.
+
+        accepted = await bot.deliver_chime(_chime({"type": "circadian_today"}))
+        assert accepted is False
+        assert seeded.thread_id not in bot._chime_pending
+
+    @pytest.mark.asyncio
+    async def test_caller_supplied_fallback_is_preserved(self):
+        seeded = _seed_today_state(thread_id=4040)
+        bot = _make_bot_stub()
+        bot._sessions[seeded.thread_id] = MagicMock()
+
+        accepted = await bot.deliver_chime(
+            _chime({"type": "circadian_today", "fallback": "independent"})
+        )
+        assert accepted is True
+        queued = bot._chime_pending[seeded.thread_id]["circadian:phase_dawn"]
+        assert queued.target["fallback"] == "independent"
+
+
+class TestDiscordThreadRegression:
+    """The existing ``discord_thread`` path must not be affected by the new
+    dispatch arm — acceptance criterion #4 of issue #460."""
+
+    @pytest.mark.asyncio
+    async def test_plain_discord_thread_still_routes(self):
+        bot = _make_bot_stub()
+        bot._sessions[5050] = MagicMock()
+
+        accepted = await bot.deliver_chime(
+            _chime({"type": "discord_thread", "id": "5050"})
+        )
+        assert accepted is True
+        assert 5050 in bot._chime_pending
+
+    @pytest.mark.asyncio
+    async def test_unknown_target_type_still_rejected(self):
+        bot = _make_bot_stub()
+        accepted = await bot.deliver_chime(_chime({"type": "cli", "id": "1"}))
+        assert accepted is False


### PR DESCRIPTION
Closes #460. Part of #458 / milestone #14.

## Summary

- **節律表（rhythm table）讀表自動註冊 cron 錨點**：新增 \`autonomy/circadian/rhythm.toml\`（per-agent，workspace-relative）。引擎在 \`setup_circadian\` 時讀表、每個 anchor 自動註冊一條 \`circadian:phase_<name>\` CronTrigger + direct handler。\`loom.toml\` **零** \`[[autonomy.schedules]]\` for circadian phases（對齊 doc/56 §3.3：「loom.toml 不適合描述今天怎麼過」）。
- **\`circadian_today\` chime target type**：\`LoomDiscordBot.deliver_chime\` 新增 dispatch arm，在 delivery time 讀 \`CircadianState\` 把 target 重寫成 \`discord_thread\` + 今日 thread_id。daily thread id 不必每天進 loom.toml。
- **Chime body 帶語義**：anchor 的 \`meaning\`（markdown）就是注入的 \`<system_chime>\` body，不是裸 phase enum — 對齊 doc/57「Phase chime prompt contract」，避免 phase 退化成排程機器。
- **Per-agent 隔離**：絲絲 / 小晴 各自 workspace、各自的 \`rhythm.toml\`、共用同一引擎。固定路徑 + cwd 邊界（跟 loom.toml 本身一致）。
- **容錯**：rhythm 檔不存在 / 格式壞 / per-anchor 欄位錯，全部不炸 — dawn/close lifecycle from PR1 維持運作。

## Scope changes from doc/57 §7（已 SUPERSEDED）

按照 issue #460 重寫後的範圍：
- ❌ **cheap gate** 移出（B 走事件驅動、無 blanket 30m tick）
- ❌ **EventTrigger reactive 喚醒層 + agenda** → #478
- ❌ **絲絲自編節律表的工具** → #477

## Files

**New:**
- \`loom/autonomy/circadian/rhythm.py\` — Anchor + tolerant \`load_rhythm()\`
- \`autonomy/circadian/rhythm.example.toml\` — 絲絲 7-phase 範本
- \`tests/test_circadian_rhythm.py\` (11 tests)
- \`tests/test_circadian_phase_chime.py\` (11 tests — register, fire, planner bypass, closure binding, outcome log, no-state safety, setup integration)
- \`tests/test_circadian_today_dispatch.py\` (6 tests — resolution, missing state, session-not-loaded, fallback preservation, discord_thread regression)

**Modified:**
- \`loom/autonomy/circadian/lifecycle.py\` — \`register_rhythm_anchors\` + \`_deliver_phase_chime\` + \`_record_phase_outcome\`; \`setup_circadian\` reads table
- \`loom/autonomy/daemon.py\` — extracted public \`deliver_chime(req)\` from internal \`_deliver_chime(plan)\`; both share one error path
- \`loom/platform/discord/bot.py\` — \`_resolve_circadian_today\` + dispatch arm; \`discord_thread\` path untouched
- \`loom.toml.example\` — pointer comment to rhythm file
- \`doc/57\` §6 — module list reflects PR2 reality; doc-integrity ignore markers on SUPERSEDED / planned paths

## Acceptance criteria (#460)

- [x] 節律表存在 → 引擎啟動自動註冊對應 cron 錨點；\`loom.toml\` 無 circadian schedule
- [x] 錨點到點 → chime 進當天 daily session，body 帶該 phase 語義
- [x] 節律表不存在 / 格式壞 → 不炸、log warning，daily session lifecycle 仍正常
- [x] \`circadian_today\` 不影響既有 \`discord_thread\` chime（regression test）
- [x] 絲絲 vs 小晴 各一份節律表 → 同引擎讀不同表、互不干擾（per-agent isolation test）
- [x] Tests (85 circadian + chime tests pass) + \`gitnexus_detect_changes\` (4 files, 5 \`setup_circadian\` flows touched at step 1)

## Test plan

- [x] \`pytest tests/test_circadian_*\` + \`tests/test_chime.py\` — 85/85 pass
- [ ] 跑一天實測（DK 開機 + \`[autonomy.circadian].enabled = true\` + copy rhythm.example.toml → rhythm.toml）
- [ ] 絲絲 review chime body 是否保留生活語感（user acceptance — issue #464 一週 retrospective）

🤖 Generated with [Claude Code](https://claude.com/claude-code)