### PR TITLE
feat(autonomy): Circadian PR 3 — Daily Weave plan reader + chime composition (#461)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,5 +120,7 @@ loom.toml.bak
 
 # Per-agent rhythm table (issue #460) — copy from rhythm.example.toml
 autonomy/circadian/rhythm.toml
+# Per-agent daily weave plan (issue #461) — copy from daily_weave.example.md
+autonomy/circadian/daily_weave.md
 
 .gitnexus

--- a/autonomy/circadian/daily_weave.example.md
+++ b/autonomy/circadian/daily_weave.example.md
@@ -1,0 +1,41 @@
+# 今日織程 — example (絲絲)
+
+> H2 標題用 rhythm.toml 的 anchor.name (`dawn`、`shared_learning`、…)。
+> 內容是 markdown — bullets / blockquotes / 巢狀都會原封不動進 chime body。
+> 缺 section 不會炸；該 phase chime body 就只剩 rhythm 的 `meaning`。
+
+date: 2026-05-28
+
+## dawn
+- recall 近期 3-5 個重要記憶
+- 跟 DK 說早安、看他有沒有提到今天的計畫
+- 讀一下今日織程，心裡有底
+
+## shared_learning
+- 讀今早 HN top 10
+- 挑 1-2 件真心覺得值得分享的
+- 若 DK 還沒醒就先寫下來，等他起來再聊
+
+## pet
+- 看喵吉狀態（自動報告 / Discord）
+- 若食水夠、玩具還新鮮，安靜就好
+- 真有狀況才提醒 DK
+
+## curiosity
+- 隨意走走：最近想多懂的東西
+- 1-3 個來源就好，不求完整
+- 真有趣才寫個短 note 留下
+
+## deep_weave
+- 從今早或前幾天的好奇心挑一個小主題
+- 產出可以是 wiki draft / 短 note / 概念整理
+- 「深入」是目的，產出是副產品
+
+## check_in
+- 看 DK 在做什麼，有沒有自然聊得起來的點
+- 沒有就安靜陪著，不硬發訊息
+
+## evening_closure
+- 跟 DK 道晚安
+- 決定今天哪些值得留下（semantic memory / journal / 都不留）
+- 想想明天織程要不要調 — 若要，明早可以走 weave_propose 工具

--- a/doc/57-Circadian-Autonomy-實作計畫.md
+++ b/doc/57-Circadian-Autonomy-實作計畫.md
@@ -237,26 +237,24 @@ async def ensure_today_session(now: datetime, *, force_spawn: bool = False) -> C
 
 ## 6. 模組結構（新增檔案清單）
 
-對齊更新後的實際模組（PR1 #459 落地 + PR2 #460 落地）：
+對齊更新後的實際模組（PR1 #459 + PR2 #460 + PR3 #461 落地）：
 
 ```
 loom/autonomy/circadian/
 ├── __init__.py
 ├── state.py            # CircadianState dataclass + load/save/archive (PR1)
-├── lifecycle.py        # ensure_today_session() + register_rhythm_anchors() (PR1+PR2)
-└── rhythm.py           # Anchor + load_rhythm() — 取代原 phase.py / gate.py (PR2)
+├── lifecycle.py        # ensure_today_session() + register_rhythm_anchors() + chime composition (PR1+PR2+PR3)
+├── rhythm.py           # Anchor + load_rhythm() — 取代原 phase.py / gate.py (PR2)
+└── weave.py            # WeavePlan + load_weave() — daily_weave.md H2 reader (PR3)
 
 loom/platform/discord/
-└── bot.py              # deliver_chime 擴 circadian_today；on_ready 加補開 (PR1+PR2)
+└── bot.py              # deliver_chime 擴 circadian_today + freshness 驗證；on_ready 加補開 (PR1+PR2)
 ```
 
 未來模組（尚未落地，刻意不放空 stub）：
 
 <!-- doc-integrity:ignore-block -->
 ```
-# PR3 #461
-loom/autonomy/circadian/weave.py        # daily_weave.md reader
-
 # issue #473（觀察期後評估）
 loom/autonomy/circadian/watchdog.py     # ConditionTrigger state-drift watchdog
 ```
@@ -397,22 +395,26 @@ loom/autonomy/circadian/watchdog.py     # ConditionTrigger state-drift watchdog
 
 ---
 
-### PR 3 — Daily Weave plan reader（對應 P1，issue #461）
+### PR 3 — Daily Weave plan reader（對應 P1，issue #461）✅ 落地
+
+> **PR2 重寫後的調整**（2026-05-28）：path 走 hardcoded `autonomy/circadian/daily_weave.md`（跟 PR2 rhythm.toml 對稱，不加 `plan_path` config）；gate.py mtime check 移除（gate.py 已隨 PR2 退役，B 模型無 blanket tick 要 gate — mtime 觀察未來可由 #478 EventTrigger 接手）。
 
 **Scope**：
-- 新增 `loom/autonomy/circadian/weave.py`： <!-- doc-integrity:ignore — planned, lands in PR 3 -->
-  - `WeavePlan.load(path) → WeavePlan | None`
-  - parse `autonomy/circadian/daily_weave.md` 的 H2 sections，回 `dict[phase_name, str]`
-  - 容錯：檔案不在、section 缺、亂格式都不能炸
-- dawn / 各 phase chime 注入時把對應 section 內容塞進 `ChimeRequest.intent` 或附在 `<system_chime>` body
-- gate.py 的 plan mtime check 改成真實檔案路徑（之前是 stub）
-- `loom.toml.example` 加 `plan_path` 設定（藍圖建議 `autonomy/circadian/daily_weave.md`）
-- 提供範例 `autonomy/circadian/daily_weave.example.md`（藍圖 §9.2 內容）
+- 新增 `loom/autonomy/circadian/weave.py`：
+  - `WeavePlan` dataclass + `load_weave(path) → WeavePlan`（empty plan 不是 None）
+  - `_parse_h2_sections(text)` regex-based，preserves inner markdown（bullets / blockquotes / code fences）
+  - 容錯：檔案不在、section 缺、亂格式、duplicate H2 都不炸
+- `_deliver_phase_chime` 改走 `_compose_chime_intent(anchor)`：composition order = `anchor.meaning`（rhythm，scaffolding）→ `**今日織程**\n{weave_section}`（today's items）→ generic fallback
+- `.gitignore` 加 `autonomy/circadian/daily_weave.md`（user-specific）
+- 範例 `autonomy/circadian/daily_weave.example.md`（H2 用 anchor.name = `dawn` / `shared_learning` / …，bodies markdown）
 
 **Acceptance criteria**：
-- [ ] DK 改 plan 隔天 dawn chime 內容跟著變
-- [ ] 不存在 plan 檔時系統不炸、phase chime 仍正常發（用 default intent）
-- [ ] plan 改動 mtime 變化 → cheap gate 下一次 tick 視為 state transition
+- [x] DK 改 plan，隔天 dawn chime 內容跟著變（每次 fire load file，沒 cache）
+- [x] 不存在 plan 檔時系統不炸、phase chime 仍正常發（用 `anchor.meaning` alone）
+- [x] meaning 為空但 section 存在 → chime body 是 section 自己，不退到 generic fallback
+- [x] H2 對應 phase name 直接 match（簡單 contract，例：`## dawn` ↔ `name = "dawn"`）
+
+**~~移除~~**：~~plan mtime → cheap gate state transition~~（gate 已退役；未來如要 plan-changed 喚醒走 #478 EventTrigger）
 
 ---
 

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -607,6 +607,12 @@ session_prefix = "daily-life"   # thread name → daily-life-YYYY-MM-DD
 # table answers "今天怎麼過". Copy autonomy/circadian/rhythm.example.toml to
 # start, then edit. Different agents = different workspaces = different
 # tables, same engine.
+#
+# Today's per-phase content (what specifically to do at dawn / shared_learning
+# today) lives in  autonomy/circadian/daily_weave.md  (rolling, also
+# workspace-relative). H2 headings = phase names from rhythm.toml; bodies
+# are markdown. Missing file → chimes use rhythm `meaning` alone. Copy
+# autonomy/circadian/daily_weave.example.md to start.
 
 # Cron times are always UTC. Convert your local time before filling in.
 # Example: Asia/Taipei UTC+8 → subtract 8 h  (09:00 CST = 01:00 UTC)

--- a/loom/autonomy/circadian/lifecycle.py
+++ b/loom/autonomy/circadian/lifecycle.py
@@ -26,6 +26,7 @@ from zoneinfo import ZoneInfo
 from loom.autonomy.chime import ChimeRequest
 from loom.autonomy.circadian.rhythm import Anchor, load_rhythm
 from loom.autonomy.circadian.state import CircadianState, _today_str, state_lock
+from loom.autonomy.circadian.weave import load_weave
 from loom.autonomy.triggers import CronTrigger
 
 logger = logging.getLogger(__name__)
@@ -430,13 +431,21 @@ async def _deliver_phase_chime(
     """Fire one phase chime: build the request, route via the daemon's chime
     callback, append the outcome to ``phase_log``.
 
-    The chime body is the anchor's ``meaning`` (markdown) — that is the only
-    thing the agent sees, so it must carry the *why* of this phase, not just
-    its name (doc/57 §"Phase chime prompt contract"). When the bot can't
-    deliver (no live thread, ``deliver_chime`` returns False) we still log a
-    ``skipped`` outcome so phase_log is a complete audit trail.
+    Body composition (PR3 #461 adds the second layer):
+      - ``anchor.meaning`` (rhythm.toml, stable) — *why* this phase exists
+      - ``daily_weave.md`` section matching ``anchor.name`` — today's *what*
+
+    Both are markdown; the agent sees them concatenated under a 「今日織程」
+    sub-heading so it can tell the difference between scaffolding and today's
+    specifics. Missing weave file or missing section is normal — chimes fall
+    through to ``meaning`` alone so a fresh install with no weave plan still
+    works (PR2 acceptance preserved).
+
+    When the bot can't deliver (no live thread, ``deliver_chime`` returns
+    False) we still log a ``skipped`` outcome so phase_log is a complete
+    audit trail.
     """
-    intent = anchor.meaning.strip() or f"Circadian phase: {anchor.name}"
+    intent = _compose_chime_intent(anchor)
     req = ChimeRequest(
         schedule_name=anchor.trigger_name,
         intent=intent,
@@ -447,6 +456,32 @@ async def _deliver_phase_chime(
     outcome = "delivered" if delivered else "skipped"
     reason = None if delivered else "no_today_session"
     _record_phase_outcome(anchor.name, outcome, reason, config.timezone)
+
+
+def _compose_chime_intent(anchor: Anchor) -> str:
+    """Stitch rhythm meaning + today's weave section into the chime body.
+
+    Both layers are optional in the degenerate sense (an anchor with no
+    meaning, a phase missing from today's weave, the weave file itself
+    missing). Whatever survives gets joined with a blank line; if both are
+    empty we fall back to a generic intent so the chime is never a literal
+    empty string (which agents handle poorly).
+
+    The 「今日織程」 sub-heading is the contract: it tells the agent the
+    bullets below are today-specific, not the stable scaffolding above.
+    """
+    meaning = anchor.meaning.strip()
+    weave = load_weave()
+    section = weave.section_for(anchor.name)
+
+    parts: list[str] = []
+    if meaning:
+        parts.append(meaning)
+    if section:
+        parts.append(f"**今日織程**\n{section}")
+    if not parts:
+        return f"Circadian phase: {anchor.name}"
+    return "\n\n".join(parts)
 
 
 def _record_phase_outcome(

--- a/loom/autonomy/circadian/weave.py
+++ b/loom/autonomy/circadian/weave.py
@@ -1,0 +1,118 @@
+"""
+Daily weave plan — today's specific items per phase (PR3, issue #461).
+
+The rhythm table from PR2 ([[rhythm.py]]) answers *what phases exist and why*
+— stable, edited rarely. The weave plan answers *what does this phase look
+like today* — content, can change daily. doc/56 §6: "Daily Weave 是
+Circadian Autonomy 的日程內容層 … 類似遊戲『美少女夢工廠』的 time block".
+
+Composition at chime time (lifecycle._deliver_phase_chime):
+    intent = anchor.meaning   ← rhythm.toml, the *why*
+           + weave.section_for(anchor.name)   ← daily_weave.md, today's *what*
+
+Phase name is the bridge: `anchor.name` must match a markdown H2 heading
+verbatim. doc/57 §8 Q2: rolling file (not dated) — the agent rewrites it
+nightly via the proposal tool (#462 PR4); for now any caller (user or
+agent) just edits the file in place.
+
+Tolerant by contract: missing file, unreadable bytes, no H2 sections, all
+return an empty WeavePlan so phase chimes keep firing with `meaning` alone.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_WEAVE_PATH = Path("autonomy/circadian/daily_weave.md")
+
+# ATX H2: `## heading text` (two hashes, at least one space, then text).
+# We intentionally do *not* support Setext (===/---) headings — the example
+# template and proposal tool both write ATX, and Setext would muddy the
+# regex without buying anything.
+_H2_RE = re.compile(r"^##\s+(.+?)\s*$")
+
+
+@dataclass(frozen=True)
+class WeavePlan:
+    """Parsed daily weave: phase name → markdown body for that section.
+
+    ``section_for`` is the only consumer-facing method; everything else is
+    internal to the parser. Empty plan (missing file / no H2s) returns
+    ``None`` for every lookup so the composition site can do a simple
+    truthy-check.
+    """
+
+    sections: dict[str, str] = field(default_factory=dict)
+
+    def section_for(self, phase_name: str) -> str | None:
+        body = self.sections.get(phase_name)
+        return body if body else None
+
+
+def load_weave(path: Path | None = None) -> WeavePlan:
+    """Read and parse the rolling daily weave file.
+
+    Returns an empty ``WeavePlan`` for every failure mode the engine must
+    survive: file absent, OS read error, decode error, no H2s. The lifecycle
+    chime composer treats empty-plan the same as missing-section so the
+    chime body falls through to ``anchor.meaning`` alone.
+    """
+    p = path or DEFAULT_WEAVE_PATH
+    if not p.exists():
+        logger.info(
+            "[circadian] daily weave at %s not found — chimes use rhythm meaning only",
+            p,
+        )
+        return WeavePlan()
+    try:
+        text = p.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        logger.warning("[circadian] daily weave at %s unreadable (%s)", p, exc)
+        return WeavePlan()
+    return WeavePlan(sections=_parse_h2_sections(text))
+
+
+def _parse_h2_sections(text: str) -> dict[str, str]:
+    """Walk the markdown line-by-line, slicing it on H2 boundaries.
+
+    Body is every line between this H2 and the next (or EOF), with leading
+    and trailing whitespace stripped but inner content preserved verbatim —
+    bullets, code fences, nested headings, blank lines all survive. The
+    agent reads the chime body as markdown so faithful preservation matters.
+
+    Duplicate H2 names: last one wins with a warning. The agent's nightly
+    weave proposal could in theory produce a duplicate, but the proposal
+    flow is supposed to overwrite a section in place; a duplicate is a bug
+    upstream and the user should see it in logs.
+    """
+    sections: dict[str, str] = {}
+    current_name: str | None = None
+    current_body: list[str] = []
+
+    def _flush() -> None:
+        nonlocal current_name
+        if current_name is None:
+            return
+        body = "\n".join(current_body).strip()
+        if current_name in sections:
+            logger.warning(
+                "[circadian] daily weave: H2 '%s' duplicated; keeping latest",
+                current_name,
+            )
+        sections[current_name] = body
+
+    for line in text.splitlines():
+        m = _H2_RE.match(line)
+        if m:
+            _flush()
+            current_name = m.group(1).strip()
+            current_body.clear()
+        elif current_name is not None:
+            current_body.append(line)
+    _flush()
+    return sections

--- a/loom/autonomy/circadian/weave.py
+++ b/loom/autonomy/circadian/weave.py
@@ -85,6 +85,12 @@ def _parse_h2_sections(text: str) -> dict[str, str]:
     bullets, code fences, nested headings, blank lines all survive. The
     agent reads the chime body as markdown so faithful preservation matters.
 
+    Fenced-code-block awareness (PR #480 review P2): a line like
+    ``## not_a_phase`` *inside* a ``` ``` `` or ``~~~`` fence is content, not
+    a section boundary. Without this guard a weave section that shows a
+    markdown example would lose every line after the fake heading. The
+    fence delimiter lines themselves remain part of the body.
+
     Duplicate H2 names: last one wins with a warning. The agent's nightly
     weave proposal could in theory produce a duplicate, but the proposal
     flow is supposed to overwrite a section in place; a duplicate is a bug
@@ -93,6 +99,7 @@ def _parse_h2_sections(text: str) -> dict[str, str]:
     sections: dict[str, str] = {}
     current_name: str | None = None
     current_body: list[str] = []
+    in_fence = False
 
     def _flush() -> None:
         nonlocal current_name
@@ -107,12 +114,20 @@ def _parse_h2_sections(text: str) -> dict[str, str]:
         sections[current_name] = body
 
     for line in text.splitlines():
-        m = _H2_RE.match(line)
-        if m:
-            _flush()
-            current_name = m.group(1).strip()
-            current_body.clear()
-        elif current_name is not None:
+        stripped = line.lstrip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+            if current_name is not None:
+                current_body.append(line)
+            continue
+        if not in_fence:
+            m = _H2_RE.match(line)
+            if m:
+                _flush()
+                current_name = m.group(1).strip()
+                current_body.clear()
+                continue
+        if current_name is not None:
             current_body.append(line)
     _flush()
     return sections

--- a/tests/test_circadian_phase_chime.py
+++ b/tests/test_circadian_phase_chime.py
@@ -338,3 +338,102 @@ class TestSetupCircadianIntegration:
         names = {t.name for t in daemon.evaluator.list()}
         assert "circadian:dawn_spawn" in names
         assert [n for n in names if n.startswith("circadian:phase_")] == []
+
+
+def _write_weave(text: str) -> None:
+    from pathlib import Path
+    p = Path("autonomy/circadian/daily_weave.md")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+class TestWeaveCompositionInChime:
+    """PR3 #461: daily_weave section composes into chime body after rhythm
+    meaning, under a 「今日織程」 sub-heading so the agent can distinguish
+    stable scaffolding from today-specific items."""
+
+    async def test_weave_section_composes_after_meaning(self):
+        _write_weave("""
+## dawn
+- recall 近期記憶
+- 跟 DK 說早安
+""")
+        daemon, deliveries, _ = _make_daemon()
+        register_rhythm_anchors(daemon, CFG, [
+            Anchor(time="08:00", name="dawn", meaning="醒來成為今天的絲絲"),
+        ])
+        plat = FakePlatform()
+        await ensure_today_session(
+            datetime.now(timezone.utc), plat, CFG, evaluator=FakeEvaluator()
+        )
+
+        trig = next(
+            t for t in daemon.evaluator.list() if t.name == "circadian:phase_dawn"
+        )
+        await daemon._on_trigger_fire(trig, {})
+
+        intent = deliveries[0].intent
+        assert "醒來成為今天的絲絲" in intent
+        assert "**今日織程**" in intent
+        assert "recall 近期記憶" in intent
+        # Meaning comes first, weave second (ordering matters for the agent).
+        assert intent.index("醒來成為今天的絲絲") < intent.index("**今日織程**")
+
+    async def test_weave_missing_for_phase_falls_back_to_meaning(self):
+        _write_weave("## shared_learning\n- 讀 HN top 10\n")  # no dawn section
+        daemon, deliveries, _ = _make_daemon()
+        register_rhythm_anchors(daemon, CFG, [
+            Anchor(time="08:00", name="dawn", meaning="醒來"),
+        ])
+        plat = FakePlatform()
+        await ensure_today_session(
+            datetime.now(timezone.utc), plat, CFG, evaluator=FakeEvaluator()
+        )
+        trig = next(
+            t for t in daemon.evaluator.list() if t.name == "circadian:phase_dawn"
+        )
+        await daemon._on_trigger_fire(trig, {})
+
+        intent = deliveries[0].intent
+        assert intent == "醒來"
+        assert "今日織程" not in intent  # no spurious heading when section absent
+
+    async def test_no_weave_file_preserves_pr2_behavior(self):
+        """PR2 regression: with no weave file at all, intent is meaning only."""
+        # No _write_weave call.
+        daemon, deliveries, _ = _make_daemon()
+        register_rhythm_anchors(daemon, CFG, [
+            Anchor(time="08:00", name="dawn", meaning="只有 meaning"),
+        ])
+        plat = FakePlatform()
+        await ensure_today_session(
+            datetime.now(timezone.utc), plat, CFG, evaluator=FakeEvaluator()
+        )
+        trig = next(
+            t for t in daemon.evaluator.list() if t.name == "circadian:phase_dawn"
+        )
+        await daemon._on_trigger_fire(trig, {})
+
+        assert deliveries[0].intent == "只有 meaning"
+
+    async def test_meaning_empty_with_weave_section_still_composes(self):
+        """An anchor with empty meaning but a weave section — chime body is
+        the weave section alone (not the generic fallback)."""
+        _write_weave("## dawn\n- recall\n")
+        daemon, deliveries, _ = _make_daemon()
+        register_rhythm_anchors(daemon, CFG, [
+            Anchor(time="08:00", name="dawn", meaning=""),
+        ])
+        plat = FakePlatform()
+        await ensure_today_session(
+            datetime.now(timezone.utc), plat, CFG, evaluator=FakeEvaluator()
+        )
+        trig = next(
+            t for t in daemon.evaluator.list() if t.name == "circadian:phase_dawn"
+        )
+        await daemon._on_trigger_fire(trig, {})
+
+        intent = deliveries[0].intent
+        assert "**今日織程**" in intent
+        assert "- recall" in intent
+        assert "Circadian phase:" not in intent  # generic fallback NOT triggered

--- a/tests/test_circadian_weave.py
+++ b/tests/test_circadian_weave.py
@@ -1,0 +1,120 @@
+"""
+Tests for the daily-weave plan reader (issue #461).
+
+The reader is the data feed for today's chime *content* — paired with
+``rhythm.py`` from PR2 which provides the stable per-phase scaffolding.
+Tolerant by contract: a missing or broken weave file never blocks phase
+chimes; they just fall through to the rhythm meaning alone.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from loom.autonomy.circadian.weave import (
+    DEFAULT_WEAVE_PATH,
+    WeavePlan,
+    load_weave,
+)
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+class TestLoadWeave:
+    def test_missing_file_returns_empty(self, tmp_path):
+        plan = load_weave(tmp_path / "absent.md")
+        assert plan.sections == {}
+        assert plan.section_for("dawn") is None
+
+    def test_parses_h2_sections(self, tmp_path):
+        p = tmp_path / "weave.md"
+        _write(p, """
+# 今日織程
+date: 2026-05-28
+
+## dawn
+- recall 近期記憶
+- 跟 DK 說早安
+
+## shared_learning
+- 讀 HN top 10
+- 挑 1-2 件想分享的
+
+## evening_closure
+- 道晚安
+- 收織
+""")
+        plan = load_weave(p)
+        assert set(plan.sections) == {"dawn", "shared_learning", "evening_closure"}
+        assert "recall" in plan.section_for("dawn")
+        assert "HN top 10" in plan.section_for("shared_learning")
+
+    def test_preserves_markdown_inner_content(self, tmp_path):
+        p = tmp_path / "weave.md"
+        _write(p, """
+## deep_weave
+- bullet A
+  - nested
+- bullet B
+
+> blockquote line
+
+```python
+def x(): pass
+```
+""")
+        body = load_weave(p).section_for("deep_weave")
+        assert "nested" in body
+        assert "blockquote line" in body
+        assert "```python" in body
+        assert "def x(): pass" in body
+
+    def test_h2_with_no_body(self, tmp_path):
+        p = tmp_path / "weave.md"
+        _write(p, "## empty_phase\n\n## next_phase\n- something\n")
+        plan = load_weave(p)
+        # Empty body → section_for returns None (treat-as-missing semantics).
+        assert plan.section_for("empty_phase") is None
+        assert plan.section_for("next_phase") == "- something"
+
+    def test_trailing_h2_with_no_body(self, tmp_path):
+        p = tmp_path / "weave.md"
+        _write(p, "## dawn\n- recall\n\n## evening_closure\n")
+        plan = load_weave(p)
+        assert plan.section_for("dawn") == "- recall"
+        assert plan.section_for("evening_closure") is None
+
+    def test_no_h2_returns_empty(self, tmp_path):
+        p = tmp_path / "no_h2.md"
+        _write(p, "# Title only\n\nSome prose with no level-2 headings.\n")
+        plan = load_weave(p)
+        assert plan.sections == {}
+
+    def test_duplicate_h2_last_wins(self, tmp_path):
+        p = tmp_path / "dupes.md"
+        _write(p, "## dawn\n- first version\n\n## dawn\n- second version\n")
+        plan = load_weave(p)
+        assert plan.section_for("dawn") == "- second version"
+
+    def test_h2_with_trailing_whitespace_in_heading(self, tmp_path):
+        p = tmp_path / "ws.md"
+        _write(p, "##   dawn   \n- recall\n")
+        plan = load_weave(p)
+        assert plan.section_for("dawn") == "- recall"
+
+    def test_h3_not_treated_as_h2(self, tmp_path):
+        """An H3 inside a section is part of the H2 body, not a new section."""
+        p = tmp_path / "nested.md"
+        _write(p, "## dawn\n### subsection of dawn\n- detail\n")
+        plan = load_weave(p)
+        assert "dawn" in plan.sections
+        assert "### subsection of dawn" in plan.section_for("dawn")
+
+    def test_default_path_is_workspace_relative(self):
+        assert DEFAULT_WEAVE_PATH == Path("autonomy/circadian/daily_weave.md")
+
+    def test_empty_plan_lookup_returns_none(self):
+        assert WeavePlan().section_for("anything") is None

--- a/tests/test_circadian_weave.py
+++ b/tests/test_circadian_weave.py
@@ -118,3 +118,84 @@ def x(): pass
 
     def test_empty_plan_lookup_returns_none(self):
         assert WeavePlan().section_for("anything") is None
+
+
+class TestFencedCodeBlockIsolation:
+    """PR #480 review P2: H2-looking lines *inside* a fenced code block must
+    not be treated as section boundaries — otherwise a weave section that
+    shows a markdown example would lose everything after the fake heading."""
+
+    def test_h2_inside_backtick_fence_is_body(self, tmp_path):
+        """The exact reviewer repro."""
+        p = tmp_path / "weave.md"
+        p.write_text(
+            "## deep_weave\n"
+            "- before\n"
+            "\n"
+            "```markdown\n"
+            "## not_a_phase\n"
+            "inside code\n"
+            "```\n"
+            "\n"
+            "- after\n"
+            "\n"
+            "## evening_closure\n"
+            "- close\n",
+            encoding="utf-8",
+        )
+        plan = load_weave(p)
+        assert set(plan.sections) == {"deep_weave", "evening_closure"}
+        deep = plan.section_for("deep_weave")
+        assert "- before" in deep
+        assert "```markdown" in deep
+        assert "## not_a_phase" in deep   # preserved as body, not promoted
+        assert "inside code" in deep
+        assert "- after" in deep
+        assert plan.section_for("evening_closure") == "- close"
+
+    def test_h2_inside_tilde_fence_is_body(self, tmp_path):
+        p = tmp_path / "tilde.md"
+        p.write_text(
+            "## dawn\n"
+            "~~~\n"
+            "## not_a_phase\n"
+            "~~~\n"
+            "- after\n",
+            encoding="utf-8",
+        )
+        plan = load_weave(p)
+        assert set(plan.sections) == {"dawn"}
+        assert "## not_a_phase" in plan.section_for("dawn")
+        assert "- after" in plan.section_for("dawn")
+
+    def test_fence_with_info_string(self, tmp_path):
+        """Real-world fences carry an info string (` ```python `)."""
+        p = tmp_path / "info.md"
+        p.write_text(
+            "## dawn\n"
+            "```python\n"
+            "## comment-looking-line\n"
+            "x = 1\n"
+            "```\n",
+            encoding="utf-8",
+        )
+        plan = load_weave(p)
+        assert set(plan.sections) == {"dawn"}
+        assert "## comment-looking-line" in plan.section_for("dawn")
+
+    def test_unclosed_fence_eats_to_eof(self, tmp_path):
+        """An unclosed fence is a user error, but it must not crash and must
+        not let a later `## phase` punch through into a new section — that
+        line is, per markdown semantics, still inside the open fence."""
+        p = tmp_path / "unclosed.md"
+        p.write_text(
+            "## dawn\n"
+            "```\n"
+            "unclosed\n"
+            "## looks_like_phase\n"
+            "still inside fence\n",
+            encoding="utf-8",
+        )
+        plan = load_weave(p)
+        assert set(plan.sections) == {"dawn"}
+        assert "## looks_like_phase" in plan.section_for("dawn")


### PR DESCRIPTION
Closes #461. Part of #458 / milestone #14. Builds on PR2 (#479).

## Summary

Pairs with the rhythm table from PR2 to give phase chimes two layers — *why* (rhythm meaning, stable) + *what today* (weave section, rolling). 對齊 doc/56 §6「Daily Weave 是 Circadian Autonomy 的日程內容層 … 類似美少女夢工廠的 time block」。

Composition at chime time:
\`\`\`
anchor.meaning            ← rhythm.toml (stable, the why)
                          ↓
**今日織程**
{weave H2 section body}   ← daily_weave.md (today, the what)
\`\`\`

每次 fire 重讀 weave file — file 小、fire 少、避免 stale cache。

## Re-scope vs original doc/57 §7 PR 3 (post-PR2 alignment)

- **Path = hardcoded** \`autonomy/circadian/daily_weave.md\`（跟 PR2 rhythm.toml 對稱，不加 \`plan_path\` config — per-agent 隔離靠 cwd）
- **gate.py mtime check 移除** — gate.py 已隨 PR2 退役（B 模型無 blanket tick 要 gate）；plan-changed 喚醒未來可由 #478 EventTrigger 接手
- **H2 對應 phase name 直接 match** — \`## dawn\` ↔ \`name = \"dawn\"\`，簡單 contract、解析無歧義

DK 拍板 of two design options before implementation:
- daily_weave path: hardcoded（不是 \`plan_path\` config）
- H2 對應：直接寫 phase name（不是 weave_section field、不是 fuzzy match）

## Files

**New:**
- \`loom/autonomy/circadian/weave.py\` — \`WeavePlan\` + \`load_weave\` + \`_parse_h2_sections\`
- \`autonomy/circadian/daily_weave.example.md\` — 絲絲 7-phase 內容範例
- \`tests/test_circadian_weave.py\` (11 tests — missing / unreadable / happy / preserves nested markdown / empty body / no H2 / dupes / whitespace tolerance)

**Modified:**
- \`loom/autonomy/circadian/lifecycle.py\` — \`_compose_chime_intent\` helper; \`_deliver_phase_chime\` 走 composition
- \`tests/test_circadian_phase_chime.py\` — +4 tests for composition (meaning + section / section missing / weave file missing / empty meaning + section)
- \`.gitignore\` — \`autonomy/circadian/daily_weave.md\`（user-specific, .example tracked）
- \`loom.toml.example\` — pointer comment to daily_weave file
- \`doc/57\` §6（landed module list）+ §7 PR 3（re-scope notes, marked ✅ 落地）

## Acceptance criteria (#461)

- [x] DK 改 plan → 隔天 dawn chime 內容跟著變（each fire reads fresh）
- [x] 不存在 plan 檔時系統不炸、phase chime 仍正常發（fallback to \`anchor.meaning\`）
- [x] H2 對應 phase name 直接 match（\`test_parses_h2_sections\` 等）
- [x] Tests + \`gitnexus_detect_changes\` (scope = lifecycle.py + 1 \`setup_circadian\` flow at register_rhythm_anchors step 2)

## Test plan

- [x] \`pytest tests/test_circadian_* tests/test_chime.py\` — 103/103 pass
- [ ] DK 跑一天實測：copy \`daily_weave.example.md\` → \`daily_weave.md\`、enable circadian、看 phase chime body 是否帶 \"**今日織程**\" + bullets
- [ ] 絲絲 user-acceptance review chime body 的生活語感（issue #464 一週 retrospective）

🤖 Generated with [Claude Code](https://claude.com/claude-code)