### PR TITLE
feat(autonomy): Circadian PR 4 — weave_revise tool + dawn revision report (#462)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,5 +122,7 @@ loom.toml.bak
 autonomy/circadian/rhythm.toml
 # Per-agent daily weave plan (issue #461) — copy from daily_weave.example.md
 autonomy/circadian/daily_weave.md
+# Weave revision proposals (issue #462) — per-day TOML audit artifacts
+autonomy/circadian/proposals/
 
 .gitnexus

--- a/doc/56-Circadian-Autonomy-藍圖.md
+++ b/doc/56-Circadian-Autonomy-藍圖.md
@@ -285,6 +285,7 @@ CircadianRuntime
 
 - 讀取今日織程
 - 可用 mtime / hash 判斷是否變更
+- 供 `weave_revise` 修改時必須採 stable snapshot：`stat-before → read → stat-after`，以 `st_mtime_ns` 偵測 DK 手改競爭
 
 ### 8.5 PhaseResolver
 
@@ -314,10 +315,9 @@ timezone = "Asia/Taipei"
 start = "08:00"
 sleep = "00:00"
 session_prefix = "sisi-day"
-plan_path = "autonomy/circadian/daily_weave.md"
-tick_interval = "30m"
-quiet_by_default = true
 ```
+
+`daily_weave.md` 採 workspace-relative 固定路徑 `autonomy/circadian/daily_weave.md`。第一版不做可配置 `plan_path`，也不以 `tick_interval` / `quiet_by_default` 作 blanket gate；公開與靜默語義由各 phase chime contract 決定。
 
 ### 9.2 `daily_weave.md`
 
@@ -431,8 +431,9 @@ autonomy/circadian/journal/2026-05-26.md
 
 ### P1 — Nightly weave planning
 
-- 收織階段允許絲絲更新明天 / 下週織程
-- Dakai 可介入調整
+- 收織階段允許絲絲用 `weave_revise` 直接小幅更新明天織程，不需要每日 confirm
+- proposal artifact 保留 rationale / changes 作 audit trail，隔天 dawn report 讓 Dakai 知道昨夜改了什麼
+- Dakai 可隨時手動編 `daily_weave.md`；`weave_revise` 以 stable snapshot + `st_mtime_ns` guard 保證手改優先
 
 ### P2 — Weave journal
 
@@ -458,10 +459,10 @@ autonomy/circadian/journal/2026-05-26.md
 ## 13. 待討論問題
 
 1. Daily session 要由 Discord bot 自動開 thread，還是由 session manager 抽象建立？
-2. `daily_weave.md` 是單一 rolling file，還是每天一份 dated file？
-3. tick interval 預設 30 分鐘還是 1 小時？
+2. `daily_weave.md` 是單一 rolling file，還是每天一份 dated file？→ PR 3/4 第一版採單一 rolling file。
+3. tick interval 預設 30 分鐘還是 1 小時？→ PR 2 後不做 blanket cheap gate；由固定 phase cron / chime contract 控制公開節點。
 4. 哪些 phase 必定公開發訊息，哪些 phase 預設 silent？
-5. Nightly planning 是每天做，還是每天小調整 + 每週大調整？
+5. Nightly planning 是每天做，還是每天小調整 + 每週大調整？→ PR 4 先做每天小調整；週期性大調整留給後續 weekly weave。
 6. Weave journal 是否需要進 Research Library / wiki index？
 7. 如果 Dakai 當天一直沒有互動，daily session 是否仍建立公開 thread？
 8. 如果昨日 close 失敗，隔天 startup 的 recovery 流程如何設計？

--- a/doc/57-Circadian-Autonomy-實作計畫.md
+++ b/doc/57-Circadian-Autonomy-實作計畫.md
@@ -430,13 +430,13 @@ loom/autonomy/circadian/watchdog.py     # ConditionTrigger state-drift watchdog
   - `apply_changes(sections, changes)` — pure transform，all-or-nothing 語義
   - `render_weave_markdown(prelude, sections)` — 重組成 markdown，prelude 原樣保留（DK 自定 header / mood / 雜記不被洗掉）
   - **`weave_revise` tool** (trust=SAFE, cap=MUTATES)：
-    1. snapshot daily_weave.md → `(prelude, sections, mtime_A)`
+    1. stable snapshot daily_weave.md：`stat-before → read → stat-after`，若 `st_mtime_ns` 不一致視為 torn read → tool 回 error、檔案不動
     2. 寫 proposal artifact 到 `proposals/<date>-evening.toml`
     3. `apply_changes` 套用、失敗 → all-or-nothing 退回
-    4. **mtime guard**：再讀 mtime_B、若 ≠ mtime_A → proposal 移到 `proposals/conflicts/`、daily_weave.md 不動、回 error
+    4. **mtime guard**：atomic write 前再讀 `st_mtime_ns_B`、若 ≠ snapshot 的 `st_mtime_ns_A` → proposal 移到 `proposals/conflicts/`、daily_weave.md 不動、回 error
     5. atomic write daily_weave.md
     6. proposal 搬到 `proposals/applied/`
-- `loom/autonomy/circadian/weave.py` 加 `load_weave_for_revision(path) → (prelude, sections, mtime)`（fence-aware prelude split）
+- `loom/autonomy/circadian/weave.py` 加 `load_weave_for_revision(path) → (prelude, sections, mtime_ns)`（fence-aware prelude split + stable stat-read-stat snapshot）
 - `lifecycle._compose_chime_intent` 加第 4 層：dawn anchor 偵測昨日 applied/conflict proposal → 注入「**昨夜你改了什麼**」/「**昨夜的調整被擋下了**」摘要
 - `session.py` 在 tool 註冊段 register `make_weave_revise_tool()`
 - `.gitignore` 加 `autonomy/circadian/proposals/`
@@ -444,7 +444,7 @@ loom/autonomy/circadian/watchdog.py     # ConditionTrigger state-drift watchdog
 **Acceptance criteria**：
 - [x] `evening_closure` phase 絲絲呼叫 `weave_revise`，daily_weave.md 立即改、無需 confirm
 - [x] proposal artifact 永遠寫出（rationale + based_on_mtime + changes）作 audit trail
-- [x] DK 手改 daily_weave.md → mtime 不同 → proposal 移 `conflicts/`、檔案不動（DK 手改絕對優先）
+- [x] DK 手改 daily_weave.md：讀取中的 torn snapshot 直接 fail；snapshot 後、write 前 mtime 不同 → proposal 移 `conflicts/`、檔案不動（DK 手改絕對優先）
 - [x] dawn chime 帶「昨夜你改了什麼」摘要 + 提示絲絲開場跟 DK 簡述
 - [x] conflict case dawn chime 帶「昨夜的調整被擋下了」+ 問 DK 處理
 - [x] 非 dawn phase 不會看到 revision report 雜訊
@@ -489,9 +489,9 @@ loom/autonomy/circadian/watchdog.py     # ConditionTrigger state-drift watchdog
 |---|---|---|
 | Q1 platform vs core | core 定義 callback adapter，Discord bot 實作；CLI 暫 no-op | 對稱既有 `ChimeDelivery` |
 | Q2 rolling vs dated | `daily_weave.md` rolling（計畫）+ `journal/YYYY-MM-DD.md` dated（紀錄） | 計畫要改、紀錄要凍 |
-| Q3 tick 30m vs 1h | **default 30m**（絲絲 review 修正：原 15m 太頻、易給「heartbeat」錯覺；config 註明 tick 是 runtime sensing） | 反應速度交給 user message 即時 trigger，不靠 tick |
+| Q3 tick 30m vs 1h | #460 重寫後不再用 blanket `tick_interval` 作公開喚醒 gate；節律由 per-agent rhythm + cron anchor 驅動 | 反應速度交給 user message 即時 trigger，不靠 tick |
 | Q4 公開 vs silent | **dawn + evening_closure 強制公開**（絲絲 review 修正：bedtime + nightly_weave 合併成 evening_closure，避免每晚兩次固定訊息） | 一天兩次儀式性對話：開場 + 收束 |
-| Q5 daily vs weekly planning | daily 小調（PR 4，proposal-only），weekly 留 issue #465 後續 | 縮窄 MVP |
+| Q5 daily vs weekly planning | daily 小調（PR 4，`weave_revise` 直接套用 + dawn report），weekly 留 issue #465 後續 | 縮窄 MVP |
 | Q6 journal 進 wiki | 不進 | 違背藍圖 §10 分離立場 |
 | Q7 DK 整天不互動是否仍開 thread | 仍開 | 不然 close 路徑不存在 = compression 不觸發 |
 | Q8 startup recovery | 跨日 startup 強制 close 昨日、archive state、等今日 dawn cron | 見 §5 第 3 列 |
@@ -537,9 +537,11 @@ PR 1 + PR 2 合併後，DK 應該能看到這樣的一天：
          一天的人際收束 + 收織 + 安排明天⋯
        </system_chime>
        絲絲：道晚安、決定今天哪些值得留下、產出隔天 weave proposal
-       proposal 寫入 autonomy/circadian/proposals/2026-05-26-evening.md
-       daily_weave.md 本身未被動
-       evaluator.emit("circadian:weave_proposed")  ← issue #472
+       絲絲呼叫 weave_revise：
+         - proposal 寫入 autonomy/circadian/proposals/2026-05-26-evening.toml
+         - stable snapshot + mtime guard 通過 → daily_weave.md 立即 atomic update
+         - 若 DK 同時手改 → proposal 移 conflicts/，daily_weave.md 不動
+       不 emit weave event；proposal artifact 本身就是 durable trace（未來 issue #472 再接 subscriber）
 
 00:00  daemon: circadian:nightly_close fired
        bot: circadian_close()
@@ -583,10 +585,10 @@ PR 1 + PR 2 合併後，DK 應該能看到這樣的一天：
 | Discord thread 命名 `daily-life-...` 相容性 | 低 | 低 | DK 拍板 ASCII 命名，相容性已驗證 |
 | Cheap gate 規則過嚴 → 整天 silent | 中 | 中 | dawn + evening_closure 強制公開作護欄（兩次，不是三次） |
 | **Phase 退化成 task scheduler，失去生活語感** | 中 | 高 | PR 2 Phase chime prompt contract hardcode 每個 phase 的 meaning；acceptance criteria 強制 review 實際 chime body 是否保留藍圖語感；issue #464 一週 retrospective |
-| **Weave plan 被 autonomous 改壞** | 低 | 高 | PR 4 default `allow_autonomous_weave_write = false`，走 proposal-only 路徑；DK 隔天 dawn 才 confirm |
+| **Weave plan 被 autonomous 改壞** | 低 | 高 | PR 4 改為 `weave_revise` 直接套用、無 daily confirm；安全靠 audit artifact、dawn report、all-or-nothing transform、stable snapshot + `st_mtime_ns` guard，DK 可用 git revert |
 | 雙 daemon 啟動造成 state 競爭 | 低 | 中 | flock + state 後置 `is_for_today()` 檢查 |
 | Discord API rate limit（頻繁 verify thread）| 低 | 低 | verify 只在 cron 觸發跟 bot on_ready 時做，不在每個 tick 做 |
-| DK 手動編 `daily_weave.md` 跟 `weave_update` tool 同時寫 | 低 | 低 | atomic rename + mtime check（PR 4 細節）|
+| DK 手動編 `daily_weave.md` 跟 `weave_revise` tool 同時寫 | 低 | 低 | stable stat-read-stat snapshot 避免讀到半套內容；atomic write 前再比 `st_mtime_ns`，不一致則移 `conflicts/` 並保留 DK 手改 |
 | cron + on_ready 都漏網 | 低 | 中 | ConditionTrigger watchdog 60s polling（issue #473） |
 
 ---
@@ -639,8 +641,8 @@ Circadian 是天然的事件源頭。直接補 emit 點，把 dead infra 變 ali
 |---|---|---|---|
 | `circadian:day_started` | spawner 成功建 thread + 寫 state | PR 1 | `{date, thread_id, session_id}` |
 | `circadian:day_closed` | closer 完成 `session.stop()` + archive state | PR 1 | `{date, thread_id, closed_at}` |
-| `circadian:weave_proposed` | `weave_propose` tool 寫完 proposal | PR 4 | `{date, proposal_path}` |
-| `circadian:weave_applied` | dawn confirm 後 apply proposal | PR 4 | `{date, applied_from}` |
+| `circadian:weave_revised` | deferred：`weave_revise` 成功直接套用後 emit | #472 後續 | `{date, proposal_path, applied_path}` |
+| `circadian:weave_conflicted` | deferred：`weave_revise` 被 DK 手改 guard 擋下後 emit | #472 後續 | `{date, proposal_path, conflict_path}` |
 
 **不做**：
 - ❌ 不 land 任何 internal subscriber（等真實需求出現再接，避免 over-engineering）

--- a/doc/57-Circadian-Autonomy-實作計畫.md
+++ b/doc/57-Circadian-Autonomy-實作計畫.md
@@ -418,38 +418,42 @@ loom/autonomy/circadian/watchdog.py     # ConditionTrigger state-drift watchdog
 
 ---
 
-### PR 4 — Nightly weave proposal tool（對應 P1，issue #462）
+### PR 4 — Weave revision tool（對應 P1，issue #462）✅ 落地
 
-> **絲絲 user requirement（2026-05-26）：**
-> 第一版 **不可** autonomous overwrite `daily_weave.md`。預設走 proposal artifact 路徑，DK confirm 才落實。
+> **DK 翻案（2026-05-28）**：DK 明說「我不想 confirm，只需要跟我報告就」。propose → confirm → apply 三段流程砍掉，合併成「propose-and-apply 一步」，僅保留 audit trail + dawn 報告。原 spec 的 `allow_autonomous_weave_write` flag、`weave_apply`/`weave_reject` 獨立 tool、自然語言/slash/button confirm 機制 — 全部不做。
+>
+> 絲絲原 user requirement「不要 autonomous overwrite」**被翻**。Loom 的 owner 是 DK；DK 為自己 design call 拍板優先於絲絲對「希望被保護」的願望。安全保證改靠**結構性**（mtime guard 保 DK 手改優先、audit artifact 永遠寫出讓 DK 可 git revert）。
 
 **Scope**：
-- 新 config flag：
-  ```toml
-  [autonomy.circadian]
-  allow_autonomous_weave_write = false   # default：proposal-only
-  ```
-- 新增 tool `weave_propose`（不是 `weave_update`）：
-  - LLM 在 `evening_closure` phase 可呼叫
-  - 產出 `autonomy/circadian/proposals/YYYY-MM-DD-evening.md`（diff-like patch + 變更理由）
-  - **不直接寫 `daily_weave.md`**
-- 隔天 dawn chime 注入時帶上昨晚 proposal 摘要，DK 可在 daily thread 用一句話 confirm / reject
-- DK confirm 後：apply patch（atomic write + mtime check）、archive proposal 到 `proposals/applied/`
-- 若 `allow_autonomous_weave_write = true`（DK 自己後續解鎖）：`weave_propose` 仍產出 proposal，但同時 apply；保留 audit trail
-- Trust level：`guarded`（即使 autonomous 模式也走 guarded confirm）
-- **EventTrigger emit 點**（issue #472）：
-  - proposal 寫完 emit `circadian:weave_proposed`
-  - apply 後 emit `circadian:weave_applied`
+- 新增 `loom/autonomy/circadian/proposal.py`：
+  - `WeaveProposal` / `Change` dataclasses（TOML schema，非 markdown diff — 對齊 [[feedback_prefer_structured_over_parser]]、避 PR3 fence-bug 重演）
+  - `apply_changes(sections, changes)` — pure transform，all-or-nothing 語義
+  - `render_weave_markdown(prelude, sections)` — 重組成 markdown，prelude 原樣保留（DK 自定 header / mood / 雜記不被洗掉）
+  - **`weave_revise` tool** (trust=SAFE, cap=MUTATES)：
+    1. snapshot daily_weave.md → `(prelude, sections, mtime_A)`
+    2. 寫 proposal artifact 到 `proposals/<date>-evening.toml`
+    3. `apply_changes` 套用、失敗 → all-or-nothing 退回
+    4. **mtime guard**：再讀 mtime_B、若 ≠ mtime_A → proposal 移到 `proposals/conflicts/`、daily_weave.md 不動、回 error
+    5. atomic write daily_weave.md
+    6. proposal 搬到 `proposals/applied/`
+- `loom/autonomy/circadian/weave.py` 加 `load_weave_for_revision(path) → (prelude, sections, mtime)`（fence-aware prelude split）
+- `lifecycle._compose_chime_intent` 加第 4 層：dawn anchor 偵測昨日 applied/conflict proposal → 注入「**昨夜你改了什麼**」/「**昨夜的調整被擋下了**」摘要
+- `session.py` 在 tool 註冊段 register `make_weave_revise_tool()`
+- `.gitignore` 加 `autonomy/circadian/proposals/`
 
 **Acceptance criteria**：
-- [ ] `evening_closure` phase 絲絲呼叫 `weave_propose`，產出 proposal 檔，**`daily_weave.md` 沒被動**
-- [ ] DK 隔天 dawn 看到 proposal 摘要，能用一句話 confirm 或 reject
-- [ ] confirm 後 `daily_weave.md` 被原子寫入、proposal archive
-- [ ] reject 後 proposal 移到 `proposals/rejected/`、`daily_weave.md` 不變
-- [ ] `allow_autonomous_weave_write = true` 時：proposal 仍產出，但同步 apply（audit trail 完整）
-- [ ] DK 手改 plan 不會被覆蓋（mtime check fail → propose 帶 conflict warning）
-- [ ] tool 失敗時 phase chime 不卡（exception isolated）
-- [ ] `circadian:weave_proposed` / `circadian:weave_applied` event 正確 emit
+- [x] `evening_closure` phase 絲絲呼叫 `weave_revise`，daily_weave.md 立即改、無需 confirm
+- [x] proposal artifact 永遠寫出（rationale + based_on_mtime + changes）作 audit trail
+- [x] DK 手改 daily_weave.md → mtime 不同 → proposal 移 `conflicts/`、檔案不動（DK 手改絕對優先）
+- [x] dawn chime 帶「昨夜你改了什麼」摘要 + 提示絲絲開場跟 DK 簡述
+- [x] conflict case dawn chime 帶「昨夜的調整被擋下了」+ 問 DK 處理
+- [x] 非 dawn phase 不會看到 revision report 雜訊
+- [x] add/remove/rename/replace 四種 action；prelude 自訂內容保留；fence 內 H2 不誤切
+
+**不做（觀察期後評估）**：
+- ❌ `circadian:weave_revised` event emit — 等 #472 EventTrigger publisher infra 成熟、有真實 subscriber 再接（proposal 檔本身已是 durable trace）
+- ❌ proposal expiration / 多份 pending 排隊 — 第一版只承載最近一份 evening-of-X.toml
+- ❌ phase 硬閘 — tool 永遠可叫；靠 dawn/evening chime body instruction 軟引導
 
 ---
 

--- a/loom/autonomy/circadian/lifecycle.py
+++ b/loom/autonomy/circadian/lifecycle.py
@@ -19,11 +19,18 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Protocol
 from zoneinfo import ZoneInfo
 
 from loom.autonomy.chime import ChimeRequest
+from loom.autonomy.circadian.proposal import (
+    APPLIED_SUBDIR,
+    CONFLICTS_SUBDIR,
+    PROPOSALS_DIR,
+    load_proposal,
+    proposal_path,
+)
 from loom.autonomy.circadian.rhythm import Anchor, load_rhythm
 from loom.autonomy.circadian.state import CircadianState, _today_str, state_lock
 from loom.autonomy.circadian.weave import load_weave
@@ -445,7 +452,7 @@ async def _deliver_phase_chime(
     False) we still log a ``skipped`` outcome so phase_log is a complete
     audit trail.
     """
-    intent = _compose_chime_intent(anchor)
+    intent = _compose_chime_intent(anchor, config)
     req = ChimeRequest(
         schedule_name=anchor.trigger_name,
         intent=intent,
@@ -458,17 +465,19 @@ async def _deliver_phase_chime(
     _record_phase_outcome(anchor.name, outcome, reason, config.timezone)
 
 
-def _compose_chime_intent(anchor: Anchor) -> str:
+def _compose_chime_intent(anchor: Anchor, config: CircadianConfig) -> str:
     """Stitch rhythm meaning + today's weave section into the chime body.
 
-    Both layers are optional in the degenerate sense (an anchor with no
-    meaning, a phase missing from today's weave, the weave file itself
-    missing). Whatever survives gets joined with a blank line; if both are
-    empty we fall back to a generic intent so the chime is never a literal
-    empty string (which agents handle poorly).
+    Layers (composed in order, each optional):
+      1. ``anchor.meaning`` — rhythm.toml, the *why* of this phase (PR2)
+      2. ``**今日織程**\\n{section}`` — daily_weave.md, today's *what* (PR3)
+      3. ``**昨夜你改了什麼**\\n…`` — yesterday's weave_revise summary,
+         dawn-anchor only (PR4 #462). Lets DK find out about overnight
+         self-revisions without a confirm round-trip.
 
-    The 「今日織程」 sub-heading is the contract: it tells the agent the
-    bullets below are today-specific, not the stable scaffolding above.
+    When every layer is empty we fall back to a generic intent so the chime
+    is never an empty string (agents handle that poorly). Each sub-heading
+    is the contract that tells the agent which layer it's reading.
     """
     meaning = anchor.meaning.strip()
     weave = load_weave()
@@ -479,9 +488,59 @@ def _compose_chime_intent(anchor: Anchor) -> str:
         parts.append(meaning)
     if section:
         parts.append(f"**今日織程**\n{section}")
+
+    if anchor.name == "dawn":
+        revision_report = _yesterday_revision_report(config.timezone)
+        if revision_report:
+            parts.append(revision_report)
+
     if not parts:
         return f"Circadian phase: {anchor.name}"
     return "\n\n".join(parts)
+
+
+def _yesterday_revision_report(tz: str) -> str | None:
+    """Look up yesterday's evening_closure proposal artifact and turn it
+    into the 「昨夜你改了什麼」 chime layer.
+
+    Two possible artifacts:
+      - ``proposals/applied/{yesterday}-evening.toml`` — revise succeeded
+      - ``proposals/conflicts/{yesterday}-evening.toml`` — DK hand-edit
+        won the mtime race; proposal was parked, daily_weave.md untouched
+
+    Returns ``None`` when neither exists (no overnight revision happened).
+    The applied case nudges the agent to brief DK; the conflicts case
+    surfaces the parked attempt so DK can decide what to do.
+    """
+    yesterday = (
+        datetime.now(ZoneInfo(tz)) - timedelta(days=1)
+    ).strftime("%Y-%m-%d")
+
+    applied = proposal_path(yesterday, PROPOSALS_DIR / APPLIED_SUBDIR)
+    conflict = proposal_path(yesterday, PROPOSALS_DIR / CONFLICTS_SUBDIR)
+
+    proposal = load_proposal(applied)
+    if proposal is not None:
+        summary = "\n".join(f"- {line}" for line in proposal.summary_lines())
+        return (
+            "**昨夜你改了什麼**\n"
+            f"{summary}\n"
+            f"\n_理由_：{proposal.rationale}\n"
+            "\n→ 開場時跟 DK 簡述一下你昨夜對明天織程的調整。"
+        )
+
+    parked = load_proposal(conflict)
+    if parked is not None:
+        summary = "\n".join(f"- {line}" for line in parked.summary_lines())
+        return (
+            "**昨夜的調整被擋下了（DK 半夜手改過 daily_weave.md）**\n"
+            f"{summary}\n"
+            f"\n_當時的理由_：{parked.rationale}\n"
+            f"_park 在_：{conflict}\n"
+            "\n→ 告訴 DK 這件事，問他要不要重 propose 或直接跳過。"
+        )
+
+    return None
 
 
 def _record_phase_outcome(

--- a/loom/autonomy/circadian/proposal.py
+++ b/loom/autonomy/circadian/proposal.py
@@ -1,0 +1,504 @@
+"""
+Weave revision — agent edits tomorrow's daily_weave.md, with audit trail.
+
+PR4 #462. DK's design override (2026-05-28): the original spec had a
+proposal → confirm → apply flow; DK reversed it — "我不想 confirm, 只需要
+跟我報告就". So this module collapses propose-and-apply into one atomic
+tool action:
+
+    weave_revise(rationale, changes)
+        ↓ snapshot daily_weave.md (mtime + prelude + sections)
+        ↓ write proposal artifact (TOML, audit trail)
+        ↓ apply changes
+        ↓ atomic rewrite daily_weave.md
+        ↓ archive proposal to applied/
+        ↓ tomorrow's dawn chime reports "你昨夜改了什麼"
+
+The proposal artifact stays as a full audit trail — DK can ``git diff`` or
+revert from ``proposals/applied/`` if a revise was wrong. The mtime guard
+keeps DK's hand-edits to ``daily_weave.md`` from being silently overwritten:
+if mtime moved between snapshot and apply, the proposal goes to
+``conflicts/`` instead and the file is left alone.
+
+TOML over markdown-diff (DK preference + PR3 fence-bug lesson, see
+[[feedback_prefer_structured_over_parser]]): no second parser to write, no
+second parser to bug-fix later.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import tempfile
+import tomllib
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from loom.autonomy.circadian.weave import (
+    DEFAULT_WEAVE_PATH,
+    load_weave_for_revision,
+)
+from loom.core.harness.middleware import ToolCall, ToolResult
+from loom.core.harness.permissions import ToolCapability, TrustLevel
+from loom.core.harness.registry import ToolDefinition
+
+logger = logging.getLogger(__name__)
+
+PROPOSALS_DIR = Path("autonomy/circadian/proposals")
+APPLIED_SUBDIR = "applied"
+CONFLICTS_SUBDIR = "conflicts"
+
+VALID_ACTIONS = {"add", "remove", "rename", "replace"}
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class Change:
+    """One section-level edit. ``action`` decides which of ``to`` / ``new_body``
+    is consulted; validate() enforces the matrix so a malformed change is
+    rejected up-front, not mid-apply with a half-written file."""
+
+    section: str
+    action: str
+    to: str | None = None
+    new_body: str | None = None
+
+    def validate(self) -> str | None:
+        if self.action not in VALID_ACTIONS:
+            return f"invalid action {self.action!r}; must be one of {sorted(VALID_ACTIONS)}"
+        if not self.section.strip():
+            return "section name is empty"
+        if self.action == "rename":
+            if not self.to or not self.to.strip():
+                return "rename requires non-empty 'to'"
+        if self.action in {"add", "replace"} and self.new_body is None:
+            return f"{self.action} requires 'new_body'"
+        return None
+
+
+@dataclass
+class WeaveProposal:
+    """One evening_closure's batch of edits, with the metadata needed to (a)
+    detect a hand-edit conflict at apply time and (b) reconstruct the day
+    for DK at dawn-of-tomorrow."""
+
+    date: str                 # the day evening_closure fired (audit timestamp)
+    phase: str                # "evening_closure" — fixed for now
+    based_on_mtime: float     # daily_weave.md mtime at snapshot
+    rationale: str
+    changes: list[Change] = field(default_factory=list)
+
+    def to_toml_dict(self) -> dict[str, Any]:
+        return {
+            "date": self.date,
+            "phase": self.phase,
+            "based_on_mtime": self.based_on_mtime,
+            "rationale": self.rationale,
+            "changes": [
+                {k: v for k, v in asdict(c).items() if v is not None}
+                for c in self.changes
+            ],
+        }
+
+    @classmethod
+    def from_toml_dict(cls, raw: dict[str, Any]) -> "WeaveProposal":
+        changes = [
+            Change(
+                section=str(c["section"]),
+                action=str(c["action"]),
+                to=c.get("to"),
+                new_body=c.get("new_body"),
+            )
+            for c in raw.get("changes", [])
+        ]
+        return cls(
+            date=str(raw["date"]),
+            phase=str(raw["phase"]),
+            based_on_mtime=float(raw["based_on_mtime"]),
+            rationale=str(raw.get("rationale", "")),
+            changes=changes,
+        )
+
+    def summary_lines(self) -> list[str]:
+        """Human-readable one-liner per change, for the dawn chime report."""
+        out: list[str] = []
+        for c in self.changes:
+            if c.action == "add":
+                out.append(f"+ {c.section} (新增)")
+            elif c.action == "remove":
+                out.append(f"- {c.section} (刪除)")
+            elif c.action == "rename":
+                out.append(f"~ {c.section} → {c.to} (改名)")
+            elif c.action == "replace":
+                out.append(f"~ {c.section} (內容換)")
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Pure transformations
+# ---------------------------------------------------------------------------
+
+def apply_changes(
+    sections: dict[str, str], changes: list[Change]
+) -> tuple[dict[str, str], str | None]:
+    """Mutate-by-copy: returns ``(new_sections, error_or_None)``.
+
+    On any error (unknown section, name collision) returns the unchanged
+    dict + an error string. All-or-nothing semantics — the caller writes
+    the new sections only when error is None.
+
+    Insertion order: existing sections keep their position; ``add`` appends;
+    ``rename`` keeps the original slot (Python dict preserves insertion
+    order, so we rebuild to swap in-place).
+    """
+    items = list(sections.items())
+    by_name = dict(items)
+
+    for change in changes:
+        err = change.validate()
+        if err:
+            return sections, f"invalid change {change.section!r}: {err}"
+
+        if change.action == "add":
+            if change.section in by_name:
+                return sections, (
+                    f"add: section {change.section!r} already exists "
+                    "(use 'replace' to overwrite or 'rename')"
+                )
+            items.append((change.section, change.new_body or ""))
+            by_name[change.section] = change.new_body or ""
+
+        elif change.action == "remove":
+            if change.section not in by_name:
+                return sections, f"remove: section {change.section!r} not found"
+            items = [(k, v) for k, v in items if k != change.section]
+            del by_name[change.section]
+
+        elif change.action == "replace":
+            if change.section not in by_name:
+                return sections, f"replace: section {change.section!r} not found"
+            items = [
+                (k, change.new_body if k == change.section else v)
+                for k, v in items
+            ]
+            by_name[change.section] = change.new_body or ""
+
+        elif change.action == "rename":
+            if change.section not in by_name:
+                return sections, f"rename: section {change.section!r} not found"
+            if change.to in by_name and change.to != change.section:
+                return sections, (
+                    f"rename: target {change.to!r} already exists"
+                )
+            new_body = change.new_body if change.new_body is not None else by_name[change.section]
+            items = [
+                (change.to, new_body) if k == change.section else (k, v)
+                for k, v in items
+            ]
+            del by_name[change.section]
+            by_name[change.to] = new_body
+
+    return dict(items), None
+
+
+def render_weave_markdown(prelude: str, sections: dict[str, str]) -> str:
+    """Rebuild daily_weave.md text from prelude + sections.
+
+    Prelude is preserved verbatim (so DK's free-form header survives a tool
+    rewrite). Each section becomes ``## name\\n{body}\\n`` with one blank
+    line between sections for readability. Empty body still emits the
+    heading so a placeholder section stays visible.
+    """
+    parts: list[str] = []
+    if prelude:
+        parts.append(prelude.rstrip())
+        parts.append("")
+    for name, body in sections.items():
+        parts.append(f"## {name}")
+        if body.strip():
+            parts.append(body.rstrip())
+        parts.append("")
+    text = "\n".join(parts).rstrip() + "\n"
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Disk IO
+# ---------------------------------------------------------------------------
+
+def proposal_path(date_str: str, base_dir: Path | None = None) -> Path:
+    return (base_dir or PROPOSALS_DIR) / f"{date_str}-evening.toml"
+
+
+def _save_proposal_toml(proposal: WeaveProposal, target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    # tomllib is read-only in stdlib; we hand-write a minimal serializer to
+    # keep the dep surface (and the artifact format) under our control.
+    body = _render_proposal_toml(proposal)
+    fd, tmp = tempfile.mkstemp(dir=target.parent, prefix=".prop-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(body)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, target)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
+def _render_proposal_toml(proposal: WeaveProposal) -> str:
+    """Minimal TOML writer for WeaveProposal. JSON-encodes strings so embedded
+    quotes / newlines round-trip safely through tomllib on read."""
+    lines: list[str] = [
+        f"date = {json.dumps(proposal.date)}",
+        f"phase = {json.dumps(proposal.phase)}",
+        f"based_on_mtime = {proposal.based_on_mtime!r}",
+        f"rationale = {json.dumps(proposal.rationale)}",
+        "",
+    ]
+    for c in proposal.changes:
+        lines.append("[[changes]]")
+        lines.append(f"section = {json.dumps(c.section)}")
+        lines.append(f"action = {json.dumps(c.action)}")
+        if c.to is not None:
+            lines.append(f"to = {json.dumps(c.to)}")
+        if c.new_body is not None:
+            lines.append(f"new_body = {json.dumps(c.new_body)}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def load_proposal(path: Path) -> WeaveProposal | None:
+    """Read a proposal TOML; ``None`` when missing or malformed."""
+    if not path.exists():
+        return None
+    try:
+        raw = tomllib.loads(path.read_text(encoding="utf-8"))
+        return WeaveProposal.from_toml_dict(raw)
+    except (OSError, tomllib.TOMLDecodeError, KeyError, ValueError) as exc:
+        logger.warning("[circadian] proposal at %s unreadable (%s)", path, exc)
+        return None
+
+
+def _atomic_write_text(target: Path, text: str) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=target.parent, prefix=".wv-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, target)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
+def _archive_proposal(src: Path, subdir: str) -> Path:
+    dest_dir = src.parent / subdir
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / src.name
+    os.replace(src, dest)
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# Tool
+# ---------------------------------------------------------------------------
+
+def make_weave_revise_tool(
+    *,
+    timezone: str = "Asia/Taipei",
+    weave_path: Path | None = None,
+    proposals_dir: Path | None = None,
+) -> ToolDefinition:
+    """Build the ``weave_revise`` tool. Trust = SAFE because DK explicitly
+    designed this to run unattended (no confirm, "just report"); the safety
+    is structural — mtime guard + audit trail + DK hand-edit always wins.
+
+    Parameters are factory-time dependencies so tests can redirect IO and
+    so the timezone for the date stamp follows the engine config rather
+    than wall-clock UTC.
+    """
+    target_weave = weave_path or DEFAULT_WEAVE_PATH
+    target_proposals = proposals_dir or PROPOSALS_DIR
+
+    async def _weave_revise(call: ToolCall) -> ToolResult:
+        rationale = str(call.args.get("rationale", "")).strip()
+        raw_changes = call.args.get("changes") or []
+
+        if not rationale:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name, success=False,
+                error="'rationale' is required — DK reads this at dawn to "
+                      "understand why the weave changed.",
+            )
+        if not isinstance(raw_changes, list) or not raw_changes:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name, success=False,
+                error="'changes' must be a non-empty list.",
+            )
+
+        try:
+            changes = [
+                Change(
+                    section=str(c["section"]),
+                    action=str(c["action"]),
+                    to=c.get("to"),
+                    new_body=c.get("new_body"),
+                )
+                for c in raw_changes
+            ]
+        except (KeyError, TypeError) as exc:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name, success=False,
+                error=f"change spec malformed: {exc}",
+            )
+
+        snapshot = load_weave_for_revision(target_weave)
+        if snapshot is None:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name, success=False,
+                error=f"daily weave at {target_weave} not found — "
+                      "create it (or copy daily_weave.example.md) before revising.",
+            )
+        prelude, sections, mtime_before = snapshot
+
+        date_str = datetime.now(ZoneInfo(timezone)).strftime("%Y-%m-%d")
+        proposal = WeaveProposal(
+            date=date_str,
+            phase="evening_closure",
+            based_on_mtime=mtime_before,
+            rationale=rationale,
+            changes=changes,
+        )
+
+        new_sections, err = apply_changes(sections, changes)
+        if err is not None:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name, success=False,
+                error=f"changes rejected: {err}",
+            )
+
+        # Always persist the proposal artifact first — even if apply fails
+        # downstream, DK can see what was attempted.
+        artifact = proposal_path(date_str, target_proposals)
+        try:
+            _save_proposal_toml(proposal, artifact)
+        except OSError as exc:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name, success=False,
+                error=f"could not write proposal artifact: {exc}",
+            )
+
+        # Mtime conflict guard: if daily_weave.md moved between snapshot
+        # and write, DK (or another tool) hand-edited it. DK's edit wins;
+        # park the proposal under conflicts/ so DK sees it at dawn.
+        try:
+            mtime_now = target_weave.stat().st_mtime
+        except OSError:
+            mtime_now = mtime_before  # treat unstattable as no-conflict
+        if mtime_now != mtime_before:
+            conflict_path = _archive_proposal(artifact, CONFLICTS_SUBDIR)
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name, success=False,
+                error=(
+                    f"daily_weave.md changed under us "
+                    f"(mtime {mtime_before} → {mtime_now}); proposal parked at "
+                    f"{conflict_path} for DK review. Hand-edit takes priority."
+                ),
+                output=str(conflict_path),
+            )
+
+        new_text = render_weave_markdown(prelude, new_sections)
+        try:
+            _atomic_write_text(target_weave, new_text)
+        except OSError as exc:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name, success=False,
+                error=f"could not write daily_weave.md: {exc}",
+            )
+
+        applied = _archive_proposal(artifact, APPLIED_SUBDIR)
+        summary = " | ".join(proposal.summary_lines()) or "(no visible changes)"
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name, success=True,
+            output=(
+                f"daily_weave.md revised ({len(changes)} change(s)): {summary}\n"
+                f"audit: {applied}\n"
+                f"rationale: {rationale}"
+            ),
+        )
+
+    return ToolDefinition(
+        name="weave_revise",
+        description=(
+            "Atomically revise tomorrow's daily_weave.md (add / remove / "
+            "rename / replace H2 sections) and write an audit-trail TOML "
+            "proposal under autonomy/circadian/proposals/applied/. "
+            "Call this in the evening_closure phase when you want to adjust "
+            "the next day's plan. DK does not confirm — your rationale is "
+            "what reaches them at next dawn. If daily_weave.md changed "
+            "between read and write (DK hand-edit), the proposal is parked "
+            "under proposals/conflicts/ and the file is left untouched."
+        ),
+        trust_level=TrustLevel.SAFE,
+        capabilities=ToolCapability.MUTATES,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "rationale": {
+                    "type": "string",
+                    "description": "Why these edits — DK reads this at dawn.",
+                },
+                "changes": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "section": {
+                                "type": "string",
+                                "description": "H2 phase name to act on.",
+                            },
+                            "action": {
+                                "type": "string",
+                                "enum": sorted(VALID_ACTIONS),
+                                "description": (
+                                    "add: insert new H2 with new_body. "
+                                    "remove: drop H2 + body. "
+                                    "rename: change H2 name (to), optionally body. "
+                                    "replace: keep H2 name, swap body."
+                                ),
+                            },
+                            "to": {
+                                "type": "string",
+                                "description": "Rename target (required for rename).",
+                            },
+                            "new_body": {
+                                "type": "string",
+                                "description": "Section body markdown "
+                                               "(required for add / replace; optional for rename).",
+                            },
+                        },
+                        "required": ["section", "action"],
+                    },
+                },
+            },
+            "required": ["rationale", "changes"],
+        },
+        executor=_weave_revise,
+        tags=["circadian", "weave", "write"],
+        impact_scope="filesystem",
+    )

--- a/loom/autonomy/circadian/proposal.py
+++ b/loom/autonomy/circadian/proposal.py
@@ -92,7 +92,7 @@ class WeaveProposal:
 
     date: str                 # the day evening_closure fired (audit timestamp)
     phase: str                # "evening_closure" — fixed for now
-    based_on_mtime: float     # daily_weave.md mtime at snapshot
+    based_on_mtime: int       # daily_weave.md st_mtime_ns at snapshot (PR #481 P1)
     rationale: str
     changes: list[Change] = field(default_factory=list)
 
@@ -122,7 +122,7 @@ class WeaveProposal:
         return cls(
             date=str(raw["date"]),
             phase=str(raw["phase"]),
-            based_on_mtime=float(raw["based_on_mtime"]),
+            based_on_mtime=int(raw["based_on_mtime"]),
             rationale=str(raw.get("rationale", "")),
             changes=changes,
         )
@@ -370,8 +370,12 @@ def make_weave_revise_tool(
         if snapshot is None:
             return ToolResult(
                 call_id=call.id, tool_name=call.tool_name, success=False,
-                error=f"daily weave at {target_weave} not found — "
-                      "create it (or copy daily_weave.example.md) before revising.",
+                error=(
+                    f"could not take a stable snapshot of {target_weave}. "
+                    "either the file is missing (copy daily_weave.example.md "
+                    "to create it) or it was hand-edited during the read — "
+                    "the existing file is unchanged either way."
+                ),
             )
         prelude, sections, mtime_before = snapshot
 
@@ -405,8 +409,9 @@ def make_weave_revise_tool(
         # Mtime conflict guard: if daily_weave.md moved between snapshot
         # and write, DK (or another tool) hand-edited it. DK's edit wins;
         # park the proposal under conflicts/ so DK sees it at dawn.
+        # Uses st_mtime_ns to match the snapshot precision (PR #481 P1).
         try:
-            mtime_now = target_weave.stat().st_mtime
+            mtime_now = target_weave.stat().st_mtime_ns
         except OSError:
             mtime_now = mtime_before  # treat unstattable as no-conflict
         if mtime_now != mtime_before:

--- a/loom/autonomy/circadian/weave.py
+++ b/loom/autonomy/circadian/weave.py
@@ -56,32 +56,48 @@ class WeavePlan:
 
 def load_weave_for_revision(
     path: Path | None = None,
-) -> tuple[str, dict[str, str], float] | None:
-    """Read the weave file for the revise tool: prelude + sections + mtime.
+) -> tuple[str, dict[str, str], int] | None:
+    """Read the weave file for the revise tool: prelude + sections + mtime_ns.
 
     The revise tool (PR4 #462) needs three things load_weave() doesn't give:
 
     - **Prelude**: everything before the first H2 (typical: ``# 今日織程`` +
       ``date: ...`` + free-form blurb). Preserved verbatim so DK's hand-edits
       to the header survive a tool-driven rewrite.
-    - **mtime**: stamped onto the proposal artifact so apply-time can detect
-      a concurrent hand-edit (mtime conflict guard).
+    - **mtime_ns**: stamped onto the proposal artifact so apply-time can
+      detect a concurrent hand-edit (mtime conflict guard). Nanosecond
+      precision so two writes within the same wall-second still differ.
     - **Raw sections** as a dict (not the read-only ``WeavePlan`` wrapper)
       so the apply path can mutate it directly per the proposal's changes.
 
-    Returns ``None`` when the file doesn't exist — the tool refuses to
-    revise into thin air; user must create the file (or copy the example)
-    first. Fence-aware H2 boundary detection (same lesson as PR3 review).
+    Stable-snapshot contract (PR #481 review P1): stat-before, read,
+    stat-after; if mtime drifted during the read we treat the whole
+    snapshot as torn and return None. Without this guard, a hand-edit
+    landing between ``read_text()`` and ``stat()`` would yield (stale
+    content, fresh mtime) — the later guard would then pass and the
+    tool would silently overwrite DK's edit.
+
+    Returns ``None`` when the file doesn't exist, is unreadable, or
+    changed mid-snapshot. Fence-aware H2 boundary detection (same lesson
+    as PR3 review).
     """
     p = path or DEFAULT_WEAVE_PATH
     if not p.exists():
         return None
     try:
+        mtime_before = p.stat().st_mtime_ns
         text = p.read_text(encoding="utf-8")
-        mtime = p.stat().st_mtime
+        mtime_after = p.stat().st_mtime_ns
     except (OSError, UnicodeDecodeError) as exc:
         logger.warning("[circadian] daily weave at %s unreadable (%s)", p, exc)
         return None
+    if mtime_before != mtime_after:
+        logger.warning(
+            "[circadian] daily weave at %s changed during snapshot (mtime_ns %d → %d); "
+            "treating as torn read", p, mtime_before, mtime_after,
+        )
+        return None
+    mtime = mtime_after
 
     prelude_lines: list[str] = []
     rest_lines: list[str] = []

--- a/loom/autonomy/circadian/weave.py
+++ b/loom/autonomy/circadian/weave.py
@@ -54,6 +54,57 @@ class WeavePlan:
         return body if body else None
 
 
+def load_weave_for_revision(
+    path: Path | None = None,
+) -> tuple[str, dict[str, str], float] | None:
+    """Read the weave file for the revise tool: prelude + sections + mtime.
+
+    The revise tool (PR4 #462) needs three things load_weave() doesn't give:
+
+    - **Prelude**: everything before the first H2 (typical: ``# 今日織程`` +
+      ``date: ...`` + free-form blurb). Preserved verbatim so DK's hand-edits
+      to the header survive a tool-driven rewrite.
+    - **mtime**: stamped onto the proposal artifact so apply-time can detect
+      a concurrent hand-edit (mtime conflict guard).
+    - **Raw sections** as a dict (not the read-only ``WeavePlan`` wrapper)
+      so the apply path can mutate it directly per the proposal's changes.
+
+    Returns ``None`` when the file doesn't exist — the tool refuses to
+    revise into thin air; user must create the file (or copy the example)
+    first. Fence-aware H2 boundary detection (same lesson as PR3 review).
+    """
+    p = path or DEFAULT_WEAVE_PATH
+    if not p.exists():
+        return None
+    try:
+        text = p.read_text(encoding="utf-8")
+        mtime = p.stat().st_mtime
+    except (OSError, UnicodeDecodeError) as exc:
+        logger.warning("[circadian] daily weave at %s unreadable (%s)", p, exc)
+        return None
+
+    prelude_lines: list[str] = []
+    rest_lines: list[str] = []
+    in_fence = False
+    in_prelude = True
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        is_fence = stripped.startswith("```") or stripped.startswith("~~~")
+        if is_fence:
+            in_fence = not in_fence
+            (prelude_lines if in_prelude else rest_lines).append(line)
+            continue
+        if in_prelude and not in_fence and _H2_RE.match(line):
+            in_prelude = False
+        (prelude_lines if in_prelude else rest_lines).append(line)
+
+    prelude = "\n".join(prelude_lines)
+    if prelude and not prelude.endswith("\n"):
+        prelude += "\n"
+    sections = _parse_h2_sections("\n".join(rest_lines))
+    return prelude, sections, mtime
+
+
 def load_weave(path: Path | None = None) -> WeavePlan:
     """Read and parse the rolling daily weave file.
 

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1408,6 +1408,13 @@ class LoomSession:
         # Issue #283: probe_file — agent-initiated context establishment
         self.registry.register(make_probe_file_tool())
 
+        # Issue #462 (Circadian PR4): weave_revise — evening_closure phase
+        # can adjust tomorrow's daily_weave.md atomically with audit trail.
+        # Tool always registered; soft-gated by phase via dawn chime body
+        # instructions (no hard phase scope on tools yet).
+        from loom.autonomy.circadian.proposal import make_weave_revise_tool
+        self.registry.register(make_weave_revise_tool())
+
         # Issue #56: Register load_skill tool with outcome tracker
         from loom.core.memory.skill_outcome import SkillOutcomeTracker
         self._skill_outcome_tracker = SkillOutcomeTracker(

--- a/tests/test_circadian_phase_chime.py
+++ b/tests/test_circadian_phase_chime.py
@@ -465,7 +465,7 @@ class TestDawnRevisionReport:
         target_dir = PROPOSALS_DIR / subdir
         date = TestDawnRevisionReport._yesterday_str()
         p = WeaveProposal(
-            date=date, phase="evening_closure", based_on_mtime=0.0,
+            date=date, phase="evening_closure", based_on_mtime=0,
             rationale=rationale,
             changes=[Change(
                 section=changes_summary_token, action="add", new_body="- x",

--- a/tests/test_circadian_phase_chime.py
+++ b/tests/test_circadian_phase_chime.py
@@ -437,3 +437,125 @@ class TestWeaveCompositionInChime:
         assert "**今日織程**" in intent
         assert "- recall" in intent
         assert "Circadian phase:" not in intent  # generic fallback NOT triggered
+
+
+class TestDawnRevisionReport:
+    """PR4 #462: dawn anchor surfaces yesterday's weave_revise result as
+    a 4th chime body layer so DK gets informed without a confirm round-trip."""
+
+    @staticmethod
+    def _yesterday_str(tz="Asia/Taipei"):
+        from datetime import timedelta
+        from zoneinfo import ZoneInfo
+        return (datetime.now(ZoneInfo(tz)) - timedelta(days=1)).strftime("%Y-%m-%d")
+
+    @staticmethod
+    def _seed_proposal(subdir: str, rationale: str, changes_summary_token: str):
+        from pathlib import Path
+
+        from loom.autonomy.circadian.proposal import (
+            APPLIED_SUBDIR,  # noqa: F401 — kept for explicit reference
+            Change,
+            PROPOSALS_DIR,
+            WeaveProposal,
+            _save_proposal_toml,
+            proposal_path,
+        )
+
+        target_dir = PROPOSALS_DIR / subdir
+        date = TestDawnRevisionReport._yesterday_str()
+        p = WeaveProposal(
+            date=date, phase="evening_closure", based_on_mtime=0.0,
+            rationale=rationale,
+            changes=[Change(
+                section=changes_summary_token, action="add", new_body="- x",
+            )],
+        )
+        _save_proposal_toml(p, proposal_path(date, target_dir))
+
+    async def test_dawn_reports_applied_proposal(self):
+        from loom.autonomy.circadian.proposal import APPLIED_SUBDIR
+        self._seed_proposal(APPLIED_SUBDIR, "HN 沒看 → reading_block", "errand")
+
+        daemon, deliveries, _ = _make_daemon()
+        register_rhythm_anchors(daemon, CFG, [
+            Anchor(time="08:00", name="dawn", meaning="醒來"),
+        ])
+        plat = FakePlatform()
+        await ensure_today_session(
+            datetime.now(timezone.utc), plat, CFG, evaluator=FakeEvaluator()
+        )
+        trig = next(
+            t for t in daemon.evaluator.list() if t.name == "circadian:phase_dawn"
+        )
+        await daemon._on_trigger_fire(trig, {})
+
+        intent = deliveries[0].intent
+        assert "**昨夜你改了什麼**" in intent
+        assert "errand" in intent
+        assert "HN 沒看" in intent
+        assert "簡述" in intent  # nudges agent to brief DK
+
+    async def test_dawn_reports_conflict_proposal(self):
+        from loom.autonomy.circadian.proposal import CONFLICTS_SUBDIR
+        self._seed_proposal(CONFLICTS_SUBDIR, "想加 errand", "errand")
+
+        daemon, deliveries, _ = _make_daemon()
+        register_rhythm_anchors(daemon, CFG, [
+            Anchor(time="08:00", name="dawn", meaning="醒來"),
+        ])
+        plat = FakePlatform()
+        await ensure_today_session(
+            datetime.now(timezone.utc), plat, CFG, evaluator=FakeEvaluator()
+        )
+        trig = next(
+            t for t in daemon.evaluator.list() if t.name == "circadian:phase_dawn"
+        )
+        await daemon._on_trigger_fire(trig, {})
+
+        intent = deliveries[0].intent
+        assert "擋下" in intent
+        assert "errand" in intent
+        assert "問他要不要重 propose" in intent
+
+    async def test_non_dawn_phase_does_not_get_revision_report(self):
+        """Only dawn surfaces the revision report. shared_learning at 09:00
+        should not show the yesterday-revision layer even if a proposal exists."""
+        from loom.autonomy.circadian.proposal import APPLIED_SUBDIR
+        self._seed_proposal(APPLIED_SUBDIR, "x", "y")
+
+        daemon, deliveries, _ = _make_daemon()
+        register_rhythm_anchors(daemon, CFG, [
+            Anchor(time="09:00", name="shared_learning", meaning="共讀"),
+        ])
+        plat = FakePlatform()
+        await ensure_today_session(
+            datetime.now(timezone.utc), plat, CFG, evaluator=FakeEvaluator()
+        )
+        trig = next(
+            t for t in daemon.evaluator.list()
+            if t.name == "circadian:phase_shared_learning"
+        )
+        await daemon._on_trigger_fire(trig, {})
+
+        intent = deliveries[0].intent
+        assert "昨夜" not in intent
+
+    async def test_dawn_no_proposal_no_report_layer(self):
+        """Day without any overnight revision — dawn chime is just the
+        usual two layers, no 「昨夜」 noise."""
+        daemon, deliveries, _ = _make_daemon()
+        register_rhythm_anchors(daemon, CFG, [
+            Anchor(time="08:00", name="dawn", meaning="醒來"),
+        ])
+        plat = FakePlatform()
+        await ensure_today_session(
+            datetime.now(timezone.utc), plat, CFG, evaluator=FakeEvaluator()
+        )
+        trig = next(
+            t for t in daemon.evaluator.list() if t.name == "circadian:phase_dawn"
+        )
+        await daemon._on_trigger_fire(trig, {})
+
+        intent = deliveries[0].intent
+        assert "昨夜" not in intent

--- a/tests/test_circadian_weave_revise.py
+++ b/tests/test_circadian_weave_revise.py
@@ -163,7 +163,7 @@ class TestProposalArtifact:
         p = WeaveProposal(
             date="2026-05-28",
             phase="evening_closure",
-            based_on_mtime=1234567.89,
+            based_on_mtime=1234567890123456,  # st_mtime_ns is an int
             rationale="絲絲 想多睡半小時，dawn 從 08:00 改成 08:30 — 但這條走 rhythm 不走 weave；這份只調 deep_weave 內容。",
             changes=[
                 Change(section="deep_weave", action="replace", new_body="- 讀 DDIA Ch.7"),
@@ -265,7 +265,9 @@ class TestToolHappyPath:
             "changes": [{"section": "dawn", "action": "add", "new_body": "x"}],
         }))
         assert not result.success
-        assert "not found" in result.error
+        # Unified "could not take a stable snapshot" covers both missing file
+        # and mid-snapshot hand-edit (PR #481 P1 fix).
+        assert "stable snapshot" in result.error
 
     async def test_invalid_change_does_not_touch_weave(self):
         wp = _seed_weave("## dawn\n- original\n")
@@ -286,34 +288,34 @@ class TestToolHappyPath:
 
 
 class TestMtimeConflict:
-    async def test_concurrent_handedit_parks_proposal(self, monkeypatch):
+    async def test_concurrent_handedit_after_snapshot_parks_proposal(self, monkeypatch):
+        """Post-snapshot race: DK edits between snapshot completion and the
+        tool's pre-write stat. The existing guard catches this — proposal
+        goes to conflicts/, file untouched."""
         wp = _seed_weave("## dawn\n- original\n")
         tool = make_weave_revise_tool()
 
-        # Patch the post-snapshot mtime read to simulate a hand-edit between
-        # snapshot and apply. Using attribute injection because the tool
-        # reads via target_weave.stat().
-        from loom.autonomy.circadian import proposal as proposal_mod
-
         original_stat = Path.stat
+
+        class _FakeStat:
+            """Shim stat result that bumps st_mtime_ns to simulate a hand-edit."""
+            def __init__(self, real, bump_ns):
+                for attr in ("st_mode", "st_ino", "st_dev", "st_nlink",
+                             "st_uid", "st_gid", "st_size", "st_atime",
+                             "st_mtime", "st_ctime", "st_atime_ns",
+                             "st_ctime_ns"):
+                    setattr(self, attr, getattr(real, attr, 0))
+                self.st_mtime_ns = real.st_mtime_ns + bump_ns
 
         def _fake_stat(self, *a, **kw):
             real = original_stat(self, *a, **kw)
+            # Snapshot calls stat twice (before+after read). Only bump on the
+            # *third* stat (the tool's pre-write guard) so the snapshot itself
+            # is stable; the conflict surfaces at the post-snapshot check.
             if self.name == "daily_weave.md":
-                # Pretend mtime jumped forward by 100s
-                class FakeStat:
-                    def __init__(self, real, bump):
-                        for attr in ("st_mode", "st_ino", "st_dev", "st_nlink",
-                                     "st_uid", "st_gid", "st_size", "st_atime",
-                                     "st_ctime", "st_atime_ns", "st_ctime_ns",
-                                     "st_mtime_ns"):
-                            setattr(self, attr, getattr(real, attr, 0))
-                        self.st_mtime = real.st_mtime + bump
-                # First stat (snapshot) returns real; second (apply-time check)
-                # returns bumped — so use a call counter.
                 _fake_stat._n += 1
-                if _fake_stat._n >= 2:
-                    return FakeStat(real, 100)
+                if _fake_stat._n >= 3:
+                    return _FakeStat(real, 100_000_000)  # +100 ms in ns
             return real
 
         _fake_stat._n = 0
@@ -332,6 +334,44 @@ class TestMtimeConflict:
         conflicts = PROPOSALS_DIR / CONFLICTS_SUBDIR
         applied = PROPOSALS_DIR / APPLIED_SUBDIR
         assert list(conflicts.glob("*-evening.toml"))
+        assert not (applied.exists() and list(applied.glob("*-evening.toml")))
+
+    async def test_handedit_during_snapshot_read_blocks_revise(self, monkeypatch):
+        """PR #481 review P1: DK's edit lands *during* the snapshot read —
+        between ``read_text()`` returning the old buffer and the post-read
+        stat. The pre-fix code recorded the new mtime alongside stale
+        content, and the post-snapshot guard then passed against the
+        already-bumped mtime — silently overwriting DK's edit. The
+        stat-read-stat snapshot must refuse the torn read.
+        """
+        wp = _seed_weave("## dawn\n- ORIGINAL\n")
+        tool = make_weave_revise_tool()
+
+        original_read = Path.read_text
+
+        def _racy_read(self, *a, **kw):
+            text = original_read(self, *a, **kw)
+            if self.name == "daily_weave.md" and not getattr(_racy_read, "_done", False):
+                _racy_read._done = True
+                # Simulate DK hand-edit landing between the snapshot's
+                # initial stat and the post-read stat.
+                time.sleep(0.005)  # ensure st_mtime_ns ticks
+                self.write_text("## dawn\n- DK HAND EDIT\n", encoding="utf-8")
+            return text
+
+        monkeypatch.setattr(Path, "read_text", _racy_read)
+
+        result = await tool.executor(_call({
+            "rationale": "should be blocked by snapshot race",
+            "changes": [{"section": "dawn", "action": "replace",
+                         "new_body": "- AGENT WRITE"}],
+        }))
+        assert not result.success
+        assert "stable snapshot" in result.error
+        # DK's hand-edit preserved on disk — the agent write never happened
+        assert wp.read_text(encoding="utf-8") == "## dawn\n- DK HAND EDIT\n"
+        # No applied artifact was created — the tool refused before write
+        applied = PROPOSALS_DIR / APPLIED_SUBDIR
         assert not (applied.exists() and list(applied.glob("*-evening.toml")))
 
 

--- a/tests/test_circadian_weave_revise.py
+++ b/tests/test_circadian_weave_revise.py
@@ -1,0 +1,403 @@
+"""
+Tests for the weave_revise tool + proposal artifact (PR4, issue #462).
+
+DK's design (2026-05-28): no confirm round-trip. The tool atomically
+revises tomorrow's daily_weave.md and writes a TOML audit artifact under
+``proposals/applied/``; mtime conflict guard parks proposals under
+``proposals/conflicts/`` instead so DK's hand-edits always win.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from loom.autonomy.circadian.proposal import (
+    APPLIED_SUBDIR,
+    CONFLICTS_SUBDIR,
+    Change,
+    PROPOSALS_DIR,
+    WeaveProposal,
+    apply_changes,
+    load_proposal,
+    make_weave_revise_tool,
+    proposal_path,
+    render_weave_markdown,
+)
+from loom.autonomy.circadian.weave import load_weave_for_revision
+from loom.core.harness.middleware import ToolCall
+from loom.core.harness.permissions import TrustLevel
+
+
+@pytest.fixture(autouse=True)
+def _workspace(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    yield
+
+
+def _seed_weave(body: str) -> Path:
+    p = Path("autonomy/circadian/daily_weave.md")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def _call(args: dict) -> ToolCall:
+    return ToolCall(
+        tool_name="weave_revise",
+        args=args,
+        trust_level=TrustLevel.SAFE,
+        session_id="test-session",
+    )
+
+
+# ===========================================================================
+# Pure transformations
+# ===========================================================================
+
+
+class TestApplyChanges:
+    def test_add_appends_at_end(self):
+        sections = {"dawn": "- a", "evening_closure": "- z"}
+        new, err = apply_changes(sections, [
+            Change(section="errand", action="add", new_body="- go to store"),
+        ])
+        assert err is None
+        assert list(new) == ["dawn", "evening_closure", "errand"]
+        assert new["errand"] == "- go to store"
+
+    def test_remove_drops_section(self):
+        new, err = apply_changes(
+            {"dawn": "a", "pet": "b", "evening_closure": "c"},
+            [Change(section="pet", action="remove")],
+        )
+        assert err is None
+        assert list(new) == ["dawn", "evening_closure"]
+
+    def test_replace_preserves_position(self):
+        new, err = apply_changes(
+            {"dawn": "a", "pet": "b", "evening_closure": "c"},
+            [Change(section="pet", action="replace", new_body="NEW")],
+        )
+        assert err is None
+        assert list(new) == ["dawn", "pet", "evening_closure"]
+        assert new["pet"] == "NEW"
+
+    def test_rename_preserves_position_and_body(self):
+        new, err = apply_changes(
+            {"dawn": "a", "shared_learning": "hn", "evening_closure": "c"},
+            [Change(section="shared_learning", action="rename", to="reading_block")],
+        )
+        assert err is None
+        assert list(new) == ["dawn", "reading_block", "evening_closure"]
+        assert new["reading_block"] == "hn"  # body preserved when new_body omitted
+
+    def test_rename_with_new_body_overrides(self):
+        new, err = apply_changes(
+            {"x": "old"},
+            [Change(section="x", action="rename", to="y", new_body="fresh")],
+        )
+        assert err is None
+        assert new == {"y": "fresh"}
+
+    def test_unknown_section_errors_all_or_nothing(self):
+        before = {"dawn": "a"}
+        new, err = apply_changes(before, [
+            Change(section="dawn", action="replace", new_body="ok"),
+            Change(section="missing", action="remove"),
+        ])
+        assert err is not None and "missing" in err
+        assert new == before  # original unchanged
+
+    def test_add_collision_errors(self):
+        new, err = apply_changes(
+            {"dawn": "x"},
+            [Change(section="dawn", action="add", new_body="y")],
+        )
+        assert err is not None and "already exists" in err
+
+    def test_rename_target_collision_errors(self):
+        new, err = apply_changes(
+            {"a": "1", "b": "2"},
+            [Change(section="a", action="rename", to="b")],
+        )
+        assert err is not None and "already exists" in err
+
+    def test_invalid_action_errors(self):
+        new, err = apply_changes(
+            {"a": "1"},
+            [Change(section="a", action="frobnicate")],
+        )
+        assert err is not None and "invalid action" in err
+
+
+class TestRenderWeaveMarkdown:
+    def test_preserves_prelude(self):
+        text = render_weave_markdown(
+            "# 今日織程\n\ndate: 2026-05-29\n",
+            {"dawn": "- recall", "evening_closure": "- close"},
+        )
+        assert text.startswith("# 今日織程")
+        assert "date: 2026-05-29" in text
+        assert "## dawn\n- recall\n" in text
+        assert text.endswith("\n")
+
+    def test_empty_prelude(self):
+        text = render_weave_markdown("", {"dawn": "- x"})
+        assert text.startswith("## dawn")
+
+    def test_section_order_preserved(self):
+        text = render_weave_markdown("", {"c": "1", "a": "2", "b": "3"})
+        assert text.index("## c") < text.index("## a") < text.index("## b")
+
+
+# ===========================================================================
+# Proposal artifact round-trip
+# ===========================================================================
+
+
+class TestProposalArtifact:
+    def test_round_trip_through_toml(self, tmp_path):
+        p = WeaveProposal(
+            date="2026-05-28",
+            phase="evening_closure",
+            based_on_mtime=1234567.89,
+            rationale="絲絲 想多睡半小時，dawn 從 08:00 改成 08:30 — 但這條走 rhythm 不走 weave；這份只調 deep_weave 內容。",
+            changes=[
+                Change(section="deep_weave", action="replace", new_body="- 讀 DDIA Ch.7"),
+                Change(section="errand", action="add", new_body="- 買貓砂"),
+                Change(section="curiosity", action="remove"),
+            ],
+        )
+        target = tmp_path / "p.toml"
+        from loom.autonomy.circadian.proposal import _save_proposal_toml
+        _save_proposal_toml(p, target)
+        back = load_proposal(target)
+        assert back is not None
+        assert back.date == p.date
+        assert back.rationale == p.rationale
+        assert len(back.changes) == 3
+        assert back.changes[0].new_body == "- 讀 DDIA Ch.7"
+        assert back.changes[2].action == "remove"
+
+    def test_load_missing_returns_none(self, tmp_path):
+        assert load_proposal(tmp_path / "absent.toml") is None
+
+    def test_summary_lines_human_readable(self):
+        p = WeaveProposal(
+            date="2026-05-28", phase="evening_closure", based_on_mtime=0,
+            rationale="", changes=[
+                Change(section="x", action="add", new_body=""),
+                Change(section="y", action="remove"),
+                Change(section="a", action="rename", to="b"),
+                Change(section="c", action="replace", new_body=""),
+            ],
+        )
+        lines = p.summary_lines()
+        assert any("新增" in l for l in lines)
+        assert any("刪除" in l for l in lines)
+        assert any("改名" in l for l in lines)
+        assert any("內容換" in l for l in lines)
+
+
+# ===========================================================================
+# Tool — happy path
+# ===========================================================================
+
+
+class TestToolHappyPath:
+    async def test_revise_writes_proposal_and_applies(self):
+        wp = _seed_weave(
+            "# 今日織程\n\ndate: 2026-05-28\n\n"
+            "## dawn\n- recall\n\n"
+            "## shared_learning\n- HN\n\n"
+            "## evening_closure\n- close\n"
+        )
+        tool = make_weave_revise_tool()
+        result = await tool.executor(_call({
+            "rationale": "HN 沒看 — 改 reading_block",
+            "changes": [
+                {"section": "shared_learning", "action": "rename",
+                 "to": "reading_block", "new_body": "- DDIA Ch.7"},
+            ],
+        }))
+        assert result.success, result.error
+        new_text = wp.read_text(encoding="utf-8")
+        assert "## reading_block" in new_text
+        assert "DDIA Ch.7" in new_text
+        assert "## shared_learning" not in new_text
+        # Prelude preserved
+        assert "# 今日織程" in new_text
+        assert "date: 2026-05-28" in new_text
+        # Proposal archived to applied/
+        applied = PROPOSALS_DIR / APPLIED_SUBDIR
+        archived = list(applied.glob("*-evening.toml"))
+        assert len(archived) == 1
+        p = load_proposal(archived[0])
+        assert p.rationale == "HN 沒看 — 改 reading_block"
+
+    async def test_revise_missing_rationale_fails(self):
+        _seed_weave("## dawn\n- x\n")
+        tool = make_weave_revise_tool()
+        result = await tool.executor(_call({
+            "rationale": "  ",
+            "changes": [{"section": "dawn", "action": "replace", "new_body": "y"}],
+        }))
+        assert not result.success
+        assert "rationale" in result.error
+
+    async def test_revise_empty_changes_fails(self):
+        _seed_weave("## dawn\n- x\n")
+        tool = make_weave_revise_tool()
+        result = await tool.executor(_call({
+            "rationale": "why",
+            "changes": [],
+        }))
+        assert not result.success
+        assert "changes" in result.error
+
+    async def test_revise_no_weave_file_fails(self):
+        tool = make_weave_revise_tool()
+        result = await tool.executor(_call({
+            "rationale": "why",
+            "changes": [{"section": "dawn", "action": "add", "new_body": "x"}],
+        }))
+        assert not result.success
+        assert "not found" in result.error
+
+    async def test_invalid_change_does_not_touch_weave(self):
+        wp = _seed_weave("## dawn\n- original\n")
+        before = wp.read_text(encoding="utf-8")
+        tool = make_weave_revise_tool()
+        result = await tool.executor(_call({
+            "rationale": "try to add a colliding section",
+            "changes": [{"section": "dawn", "action": "add", "new_body": "boom"}],
+        }))
+        assert not result.success
+        # daily_weave.md untouched on rejection
+        assert wp.read_text(encoding="utf-8") == before
+
+
+# ===========================================================================
+# Mtime conflict guard — the protection DK explicitly required
+# ===========================================================================
+
+
+class TestMtimeConflict:
+    async def test_concurrent_handedit_parks_proposal(self, monkeypatch):
+        wp = _seed_weave("## dawn\n- original\n")
+        tool = make_weave_revise_tool()
+
+        # Patch the post-snapshot mtime read to simulate a hand-edit between
+        # snapshot and apply. Using attribute injection because the tool
+        # reads via target_weave.stat().
+        from loom.autonomy.circadian import proposal as proposal_mod
+
+        original_stat = Path.stat
+
+        def _fake_stat(self, *a, **kw):
+            real = original_stat(self, *a, **kw)
+            if self.name == "daily_weave.md":
+                # Pretend mtime jumped forward by 100s
+                class FakeStat:
+                    def __init__(self, real, bump):
+                        for attr in ("st_mode", "st_ino", "st_dev", "st_nlink",
+                                     "st_uid", "st_gid", "st_size", "st_atime",
+                                     "st_ctime", "st_atime_ns", "st_ctime_ns",
+                                     "st_mtime_ns"):
+                            setattr(self, attr, getattr(real, attr, 0))
+                        self.st_mtime = real.st_mtime + bump
+                # First stat (snapshot) returns real; second (apply-time check)
+                # returns bumped — so use a call counter.
+                _fake_stat._n += 1
+                if _fake_stat._n >= 2:
+                    return FakeStat(real, 100)
+            return real
+
+        _fake_stat._n = 0
+        monkeypatch.setattr(Path, "stat", _fake_stat)
+
+        before = wp.read_text(encoding="utf-8")
+        result = await tool.executor(_call({
+            "rationale": "should be blocked",
+            "changes": [{"section": "dawn", "action": "replace", "new_body": "new"}],
+        }))
+        assert not result.success
+        assert "changed under us" in result.error
+        # daily_weave.md untouched
+        assert wp.read_text(encoding="utf-8") == before
+        # Proposal landed in conflicts/, not applied/
+        conflicts = PROPOSALS_DIR / CONFLICTS_SUBDIR
+        applied = PROPOSALS_DIR / APPLIED_SUBDIR
+        assert list(conflicts.glob("*-evening.toml"))
+        assert not (applied.exists() and list(applied.glob("*-evening.toml")))
+
+
+# ===========================================================================
+# Prelude preservation (PR4 design: DK header survives)
+# ===========================================================================
+
+
+class TestPreludePreservation:
+    async def test_user_authored_header_survives(self):
+        wp = _seed_weave(
+            "# 今日織程\n\n"
+            "date: 2026-05-28\n"
+            "mood: rainy ☔\n\n"
+            "DK's note: 今天要記得多喝水\n\n"
+            "## dawn\n- recall\n"
+        )
+        tool = make_weave_revise_tool()
+        result = await tool.executor(_call({
+            "rationale": "add an errand",
+            "changes": [{"section": "errand", "action": "add", "new_body": "- 買貓砂"}],
+        }))
+        assert result.success
+        text = wp.read_text(encoding="utf-8")
+        assert "mood: rainy ☔" in text
+        assert "DK's note: 今天要記得多喝水" in text
+        assert "## dawn" in text
+        assert "## errand" in text
+
+    async def test_fence_in_prelude_with_h2_inside_does_not_split(self):
+        """PR3 lesson surfaces here too — H2 inside a fence in the prelude
+        must not trick the splitter into ending the prelude early."""
+        wp = _seed_weave(
+            "# 今日織程\n\n"
+            "```markdown\n"
+            "## not a real section\n"
+            "```\n\n"
+            "## dawn\n- recall\n"
+        )
+        tool = make_weave_revise_tool()
+        result = await tool.executor(_call({
+            "rationale": "noop replace to test prelude",
+            "changes": [{"section": "dawn", "action": "replace", "new_body": "- still ok"}],
+        }))
+        assert result.success
+        text = wp.read_text(encoding="utf-8")
+        assert "```markdown" in text
+        assert "## not a real section" in text
+        assert "## dawn" in text
+        assert "- still ok" in text
+
+
+# ===========================================================================
+# load_weave_for_revision sanity
+# ===========================================================================
+
+
+class TestLoadWeaveForRevision:
+    def test_returns_prelude_sections_mtime(self):
+        wp = _seed_weave("# header\n\n## a\nbody\n")
+        snap = load_weave_for_revision(wp)
+        assert snap is not None
+        prelude, sections, mtime = snap
+        assert "# header" in prelude
+        assert sections == {"a": "body"}
+        assert mtime > 0
+
+    def test_missing_returns_none(self, tmp_path):
+        assert load_weave_for_revision(tmp_path / "absent.md") is None


### PR DESCRIPTION
Closes #462. Part of #458 / milestone #14. Builds on PR3 (#480).

## Summary

DK 翻案（2026-05-28，本對話）：「我不想 confirm, 只需要跟我報告就」。原 spec 的 propose → confirm → apply round-trip 砍掉，合併成「propose-and-apply 一步」+ dawn 報告。

**Tool surface**：
\`\`\`
weave_revise(rationale, changes=[{section, action, to?, new_body?}])
   action ∈ {add, remove, rename, replace}
   trust=SAFE  cap=MUTATES
\`\`\`

**Flow**：
\`\`\`
snapshot daily_weave.md → (prelude, sections, mtime_A)
  ↓ apply_changes  (all-or-nothing 驗錯就退回)
  ↓ 寫 proposal artifact (TOML)
  ↓ re-stat mtime_B
      ≠ A → 移 proposals/conflicts/、檔不動、回 error
      = A → atomic write daily_weave.md
  ↓ 搬 proposal 到 proposals/applied/
\`\`\`

**Dawn chime 第 4 層**：dawn anchor 注入時讀昨日 \`applied/\` 或 \`conflicts/\` proposal，加「**昨夜你改了什麼**」/「**昨夜的調整被擋下了**」摘要 + 提示絲絲開場跟 DK 簡述。

## 跟原 issue/doc spec 落差（DK 翻案）

| 原 spec | 本 PR | 為什麼 |
|---|---|---|
| \`allow_autonomous_weave_write\` config flag | ❌ 砍 | 永遠 apply，不需 flag |
| 獨立 \`weave_apply\` / \`weave_reject\` tool | ❌ 砍 | propose 即 apply、沒有 reject |
| 自然語言 / slash / button confirm | ❌ 砍 | DK 不要 confirm |
| Trust=guarded | → Trust=SAFE | 結構性安全（mtime + artifact），不靠 procedural confirm |
| Markdown diff proposal | → TOML proposal | [[feedback_prefer_structured_over_parser]] + PR3 fence-bug 教訓 |
| \`circadian:weave_proposed/applied\` events | ⏸ 延後 #472 | 還沒真實 subscriber；artifact 本身已是 durable trace |

## 安全結構（DK 翻案後仍守的線）

- **mtime guard**：DK 半夜手改 daily_weave.md → 絲絲晚上的 propose 被擋下、artifact 進 conflicts/、檔案不動。DK 手改絕對優先。
- **Audit artifact 永遠寫出**：失敗的 propose 也留 artifact。\`git diff daily_weave.md\` + \`proposals/applied/\` archive 可完整回溯。
- **Prelude preservation**：DK 在 daily_weave.md 寫的 \`# 今日織程\` / \`date:\` / mood / 雜記不被 tool rewrite 洗掉（fence-aware 切分）。

## Files

**New:**
- \`loom/autonomy/circadian/proposal.py\` — WeaveProposal/Change schema, apply_changes (pure), render_weave_markdown (prelude-preserving), make_weave_revise_tool
- \`tests/test_circadian_weave_revise.py\` (25 tests: apply transforms × 9, render × 3, TOML round-trip × 3, tool happy path × 5, mtime conflict × 1, prelude × 2, load_weave_for_revision × 2)

**Modified:**
- \`loom/autonomy/circadian/weave.py\` — \`load_weave_for_revision\` fence-aware (prelude + sections + mtime)
- \`loom/autonomy/circadian/lifecycle.py\` — \`_compose_chime_intent\` config param + 4th layer via \`_yesterday_revision_report\`
- \`loom/core/session.py\` — register \`make_weave_revise_tool()\`
- \`tests/test_circadian_phase_chime.py\` — +4 dawn report tests (applied / conflict / non-dawn / no-proposal)
- \`doc/57\` §7 PR 4 — full rewrite reflecting DK override
- \`.gitignore\` — \`autonomy/circadian/proposals/\`

## Acceptance criteria (re-scoped per DK)

- [x] \`evening_closure\` 絲絲呼叫 \`weave_revise\` → daily_weave.md 立即改、無需 confirm
- [x] proposal artifact 永遠寫出（rationale + based_on_mtime + changes）作 audit trail
- [x] DK 手改 daily_weave.md → mtime 不同 → proposal 移 conflicts/、檔案不動
- [x] dawn chime 帶「昨夜你改了什麼」摘要 + 提示絲絲開場跟 DK 簡述
- [x] conflict case dawn chime 帶「昨夜的調整被擋下了」+ 問 DK 處理
- [x] 非 dawn phase 不會看到 revision report 雜訊
- [x] Tests + \`gitnexus_detect_changes\` (scope = lifecycle.py / weave.py / proposal.py / session.py / tests — exactly as planned)

## Test plan

- [x] \`pytest tests/test_circadian_* tests/test_chime.py\` — 136/136 pass
- [ ] DK 跑一天實測：copy weave example → enable circadian → 絲絲在 evening_closure 呼叫 weave_revise → 確認 applied/ artifact 出現、daily_weave.md 改了、隔天 dawn chime 收到摘要
- [ ] 對抗測試：DK 半夜手改 daily_weave.md → 隔晚絲絲 revise → 確認進 conflicts/ 而非 applied/

🤖 Generated with [Claude Code](https://claude.com/claude-code)