### PR TITLE
feat(autonomy): Circadian PR 5 — weave journal artifact (#463)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,5 +124,7 @@ autonomy/circadian/rhythm.toml
 autonomy/circadian/daily_weave.md
 # Weave revision proposals (issue #462) — per-day TOML audit artifacts
 autonomy/circadian/proposals/
+# Weave journal (issue #463) — per-day life-log artifacts, personal not project
+autonomy/circadian/journal/
 
 .gitnexus

--- a/autonomy/circadian/daily_weave.example.md
+++ b/autonomy/circadian/daily_weave.example.md
@@ -37,5 +37,8 @@ date: 2026-05-28
 
 ## evening_closure
 - 跟 DK 道晚安
-- 決定今天哪些值得留下（semantic memory / journal / 都不留）
-- 想想明天織程要不要調 — 若要，明早可以走 weave_propose 工具
+- 決定今天哪些值得留下：
+  - 結構性洞察 → `memorize`
+  - 生活片段 / 有趣發現 / 留念 / 明日想試 → `journal_append`
+  - 都不留也行
+- 想想明天織程要不要真的調 — 若要，今晚就走 `weave_revise` 工具

--- a/doc/57-Circadian-Autonomy-實作計畫.md
+++ b/doc/57-Circadian-Autonomy-實作計畫.md
@@ -4,7 +4,7 @@
 > 建立：2026-05-26（曾因 multi-agent shared working tree 衝突被 wipe，由 CC 從 conversation context 重建並 commit）
 > 上游藍圖：`doc/56-Circadian-Autonomy-藍圖.md`（2026-05-27 從 git stash 尋回原版本尊並 commit，本計畫以它為準）
 > 對應 issue：#458（epic）、milestone #14
-> 子 issue：#459 (PR 1 ✅ merged #476)、#460 (PR 2，**已重寫**)、#461 (PR 3)、#462 (PR 4)、#463 (PR 5)、#464 (生活語義 review)、#465 (weekly weave)、#466 (persona refresh)、#472 (emit 點清單)、#473 (state watchdog)、#477 (self-scheduling 工具)、#478 (事件驅動喚醒層)
+> 子 issue：#459 (PR 1 ✅ merged #476)、#460 (PR 2 ✅ merged #479)、#461 (PR 3 ✅ merged #480)、#462 (PR 4 ✅ merged #481)、#463 (PR 5)、#464 (生活語義 review)、#465 (weekly weave)、#466 (persona refresh)、#472 (emit 點清單)、#473 (state watchdog)、#477 (self-scheduling 工具)、#478 (事件驅動喚醒層)
 
 ---
 

--- a/loom/autonomy/circadian/journal.py
+++ b/loom/autonomy/circadian/journal.py
@@ -1,0 +1,177 @@
+"""
+Weave journal — the daily life-log artifact (PR5, issue #463).
+
+Per doc/56 §10 the rule is: semantic memory holds *structural insights*, the
+journal holds *the texture of the day*. Without a journal, every life fragment
+the agent wants to keep ("10:00 餵了喵吉", "讀了一篇好玩的論文") would either
+be lost or pushed into semantic memory and dilute it. With a journal those go
+to a dated markdown file instead — agent-readable when curiosity calls for it,
+but never recalled by the routine memory pipeline.
+
+Shape (doc/57 §7 PR5):
+
+    autonomy/circadian/journal/YYYY-MM-DD.md
+        # 2026-05-28 Journal
+
+        ## 14:30 · 有趣發現
+        ⋯
+
+        ## 21:00 · 明日想試
+        ⋯
+
+True append at file level (POSIX ``O_APPEND``) — never read-modify-write, so
+no mtime guard needed and concurrent calls don't tear (within one
+``write()``). Lazy file creation: the H1 header is written on the first call
+of the day. Dated paths, not rolling, so yesterday's file freezes the moment
+midnight rolls.
+
+Soft phase gating: ``journal_append`` is always callable. The
+evening_closure chime body steers the agent toward this tool for
+non-structural memories; nothing here enforces phase. Same pattern as
+weave_revise (PR4 #462) — the tool is honest about "use me here", the
+lifecycle doesn't police it.
+
+Trust = SAFE because the worst case is "a journal file accumulates a wrong
+entry" — recoverable by hand-editing the file. No memory pollution
+(structurally — this module never talks to MemoryGovernor), no overwrites of
+DK's edits (append-only).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from loom.core.harness.middleware import ToolCall, ToolResult
+from loom.core.harness.permissions import ToolCapability, TrustLevel
+from loom.core.harness.registry import ToolDefinition
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_JOURNAL_DIR = Path("autonomy/circadian/journal")
+
+# kind: stable English enum keys (tool args) → Chinese H2 labels (file output).
+# Mirrors the four bullet list in doc/56 §10.3.
+#   moment    — 生活片段     a piece of the day's texture
+#   finding   — 有趣發現     something curious / interesting noticed today
+#   keepsake  — 留念         something worth remembering, but not a structural insight
+#   tomorrow  — 明日想試     a soft wish/note for tomorrow (commitment goes via weave_revise)
+KIND_LABELS: dict[str, str] = {
+    "moment": "生活片段",
+    "finding": "有趣發現",
+    "keepsake": "留念",
+    "tomorrow": "明日想試",
+}
+
+
+def journal_path_for(date_str: str, base: Path | None = None) -> Path:
+    """Dated journal file for ``date_str`` (YYYY-MM-DD). One file per day."""
+    return (base or DEFAULT_JOURNAL_DIR) / f"{date_str}.md"
+
+
+def make_journal_append_tool(
+    *,
+    timezone: str = "Asia/Taipei",
+    journal_dir: Path | None = None,
+) -> ToolDefinition:
+    """Build the ``journal_append`` tool. Factory pattern matches
+    ``make_weave_revise_tool`` so tests can redirect IO and so the date stamp
+    follows engine timezone rather than wall-clock UTC.
+    """
+    target_dir = journal_dir or DEFAULT_JOURNAL_DIR
+
+    async def _journal_append(call: ToolCall) -> ToolResult:
+        kind = str(call.args.get("kind", "")).strip()
+        body = str(call.args.get("body", "")).strip()
+
+        if kind not in KIND_LABELS:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name, success=False,
+                error=(
+                    f"'kind' must be one of {sorted(KIND_LABELS)}; got {kind!r}. "
+                    "moment=生活片段, finding=有趣發現, keepsake=留念, "
+                    "tomorrow=明日想試。"
+                ),
+            )
+        if not body:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name, success=False,
+                error="'body' is empty — journal entries must have content.",
+            )
+
+        now = datetime.now(ZoneInfo(timezone))
+        date_str = now.strftime("%Y-%m-%d")
+        time_str = now.strftime("%H:%M")
+        label = KIND_LABELS[kind]
+        path = journal_path_for(date_str, target_dir)
+
+        # Build the full payload first so the actual write() is one syscall —
+        # POSIX O_APPEND is atomic for writes ≤ PIPE_BUF, and a single string
+        # write keeps two concurrent journal_append calls from interleaving
+        # mid-entry.
+        new_file = not path.exists()
+        chunk = ""
+        if new_file:
+            chunk += f"# {date_str} Journal\n\n"
+        chunk += f"## {time_str} · {label}\n{body}\n\n"
+
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(chunk)
+        except OSError as exc:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name, success=False,
+                error=f"could not write journal entry to {path}: {exc}",
+            )
+
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name, success=True,
+            output=f"journal entry added → {path} [{time_str} · {label}]",
+        )
+
+    return ToolDefinition(
+        name="journal_append",
+        description=(
+            "Append a dated entry to today's weave journal "
+            "(autonomy/circadian/journal/YYYY-MM-DD.md). Use this for life "
+            "fragments, curious findings, keepsakes worth remembering, and "
+            "soft 'maybe try tomorrow' notes — anything you want to keep "
+            "without polluting semantic memory. Structural insights still "
+            "go to memorize. Commitments to actually change tomorrow's plan "
+            "go to weave_revise. One file per day, append-only. Always "
+            "callable; especially natural during evening_closure."
+        ),
+        trust_level=TrustLevel.SAFE,
+        capabilities=ToolCapability.MUTATES,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "kind": {
+                    "type": "string",
+                    "enum": sorted(KIND_LABELS),
+                    "description": (
+                        "moment: a piece of today's texture. "
+                        "finding: something curious noticed today. "
+                        "keepsake: worth remembering, but not a structural "
+                        "insight (those go to memorize). "
+                        "tomorrow: a soft note about what to try tomorrow "
+                        "(commitments go via weave_revise instead)."
+                    ),
+                },
+                "body": {
+                    "type": "string",
+                    "description": (
+                        "Markdown body for the entry — bullets, blockquotes, "
+                        "nested headings all preserved verbatim."
+                    ),
+                },
+            },
+            "required": ["kind", "body"],
+        },
+        executor=_journal_append,
+        tags=["circadian", "journal", "write"],
+        impact_scope="filesystem",
+    )

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1415,6 +1415,13 @@ class LoomSession:
         from loom.autonomy.circadian.proposal import make_weave_revise_tool
         self.registry.register(make_weave_revise_tool())
 
+        # Issue #463 (Circadian PR5): journal_append — dated weave journal
+        # for life fragments / findings / keepsakes that shouldn't pollute
+        # semantic memory (doc/56 §10.1). Always callable; evening_closure
+        # chime body is the soft guidance, not a phase gate.
+        from loom.autonomy.circadian.journal import make_journal_append_tool
+        self.registry.register(make_journal_append_tool())
+
         # Issue #56: Register load_skill tool with outcome tracker
         from loom.core.memory.skill_outcome import SkillOutcomeTracker
         self._skill_outcome_tracker = SkillOutcomeTracker(

--- a/tests/test_circadian_journal.py
+++ b/tests/test_circadian_journal.py
@@ -1,0 +1,243 @@
+"""
+Tests for the journal_append tool (PR5, issue #463).
+
+Per doc/56 §10: the weave journal is the dated artifact for life fragments
+that shouldn't pollute semantic memory. True append at file level, lazy
+creation, dated paths, kind enum guidance.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from loom.autonomy.circadian.journal import (
+    DEFAULT_JOURNAL_DIR,
+    KIND_LABELS,
+    journal_path_for,
+    make_journal_append_tool,
+)
+from loom.core.harness.middleware import ToolCall
+from loom.core.harness.permissions import ToolCapability, TrustLevel
+
+
+@pytest.fixture(autouse=True)
+def _workspace(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    yield
+
+
+def _call(args: dict) -> ToolCall:
+    return ToolCall(
+        tool_name="journal_append",
+        args=args,
+        trust_level=TrustLevel.SAFE,
+        session_id="test-session",
+    )
+
+
+# ===========================================================================
+# Tool definition shape
+# ===========================================================================
+
+
+class TestToolDefinition:
+    def test_safe_trust_level(self):
+        tool = make_journal_append_tool()
+        assert tool.trust_level is TrustLevel.SAFE
+
+    def test_mutates_capability(self):
+        tool = make_journal_append_tool()
+        assert tool.capabilities & ToolCapability.MUTATES
+
+    def test_kind_enum_in_schema(self):
+        tool = make_journal_append_tool()
+        kind_schema = tool.input_schema["properties"]["kind"]
+        assert set(kind_schema["enum"]) == set(KIND_LABELS)
+
+    def test_required_fields(self):
+        tool = make_journal_append_tool()
+        assert set(tool.input_schema["required"]) == {"kind", "body"}
+
+
+# ===========================================================================
+# Happy-path append behaviour
+# ===========================================================================
+
+
+class TestAppend:
+    def test_creates_file_lazily_with_h1_header(self):
+        tool = make_journal_append_tool(timezone="Asia/Taipei")
+        result = asyncio.run(tool.executor(_call({"kind": "moment", "body": "喵吉早安"})))
+
+        assert result.success
+        today = datetime.now(ZoneInfo("Asia/Taipei")).strftime("%Y-%m-%d")
+        path = Path(f"autonomy/circadian/journal/{today}.md")
+        assert path.exists()
+        text = path.read_text(encoding="utf-8")
+        assert text.startswith(f"# {today} Journal\n\n")
+        assert "## " in text  # an H2 entry exists
+        assert "生活片段" in text  # Chinese display label
+        assert "喵吉早安" in text
+
+    def test_second_call_appends_no_duplicate_header(self):
+        tool = make_journal_append_tool(timezone="Asia/Taipei")
+        asyncio.run(tool.executor(_call({"kind": "moment", "body": "一"})))
+        asyncio.run(tool.executor(_call({"kind": "finding", "body": "二"})))
+
+        today = datetime.now(ZoneInfo("Asia/Taipei")).strftime("%Y-%m-%d")
+        text = Path(f"autonomy/circadian/journal/{today}.md").read_text("utf-8")
+        # Exactly one H1 header
+        assert text.count(f"# {today} Journal") == 1
+        # Two H2 entries (with one matching each kind)
+        assert "生活片段" in text
+        assert "有趣發現" in text
+        assert text.index("一") < text.index("二")  # order preserved
+
+    def test_each_entry_has_timestamp_and_label(self):
+        tool = make_journal_append_tool(timezone="Asia/Taipei")
+        asyncio.run(tool.executor(_call({"kind": "keepsake", "body": "x"})))
+
+        today = datetime.now(ZoneInfo("Asia/Taipei")).strftime("%Y-%m-%d")
+        text = Path(f"autonomy/circadian/journal/{today}.md").read_text("utf-8")
+        # ## HH:MM · 留念
+        assert re.search(r"^## \d{2}:\d{2} · 留念$", text, re.MULTILINE)
+
+    def test_markdown_body_preserved_verbatim(self):
+        tool = make_journal_append_tool(timezone="Asia/Taipei")
+        body = "- bullet one\n- bullet two\n\n> blockquote\n```\nfence\n```"
+        asyncio.run(tool.executor(_call({"kind": "finding", "body": body})))
+
+        today = datetime.now(ZoneInfo("Asia/Taipei")).strftime("%Y-%m-%d")
+        text = Path(f"autonomy/circadian/journal/{today}.md").read_text("utf-8")
+        assert body in text
+
+    def test_dated_path_uses_engine_timezone(self, tmp_path):
+        # Confirm path uses the configured timezone, not wall-clock UTC. Pick
+        # an extreme TZ so today-in-Pacific/Kiritimati differs from UTC by 14h.
+        tool = make_journal_append_tool(timezone="Pacific/Kiritimati")
+        asyncio.run(tool.executor(_call({"kind": "moment", "body": "x"})))
+        expected_date = datetime.now(ZoneInfo("Pacific/Kiritimati")).strftime("%Y-%m-%d")
+        assert Path(f"autonomy/circadian/journal/{expected_date}.md").exists()
+
+    def test_custom_journal_dir(self, tmp_path):
+        custom = tmp_path / "alt/journal"
+        tool = make_journal_append_tool(timezone="Asia/Taipei", journal_dir=custom)
+        asyncio.run(tool.executor(_call({"kind": "moment", "body": "x"})))
+        today = datetime.now(ZoneInfo("Asia/Taipei")).strftime("%Y-%m-%d")
+        assert (custom / f"{today}.md").exists()
+
+
+# ===========================================================================
+# Validation
+# ===========================================================================
+
+
+class TestValidation:
+    def test_unknown_kind_rejected(self):
+        tool = make_journal_append_tool()
+        result = asyncio.run(tool.executor(_call({"kind": "rant", "body": "x"})))
+        assert not result.success
+        assert "kind" in result.error
+        # File should NOT be created on validation failure
+        today = datetime.now(ZoneInfo("Asia/Taipei")).strftime("%Y-%m-%d")
+        assert not Path(f"autonomy/circadian/journal/{today}.md").exists()
+
+    def test_empty_body_rejected(self):
+        tool = make_journal_append_tool()
+        result = asyncio.run(tool.executor(_call({"kind": "moment", "body": "   "})))
+        assert not result.success
+        assert "body" in result.error
+        today = datetime.now(ZoneInfo("Asia/Taipei")).strftime("%Y-%m-%d")
+        assert not Path(f"autonomy/circadian/journal/{today}.md").exists()
+
+    def test_missing_kind_rejected(self):
+        tool = make_journal_append_tool()
+        result = asyncio.run(tool.executor(_call({"body": "x"})))
+        assert not result.success
+        assert "kind" in result.error
+
+    def test_missing_body_rejected(self):
+        tool = make_journal_append_tool()
+        result = asyncio.run(tool.executor(_call({"kind": "moment"})))
+        assert not result.success
+        assert "body" in result.error
+
+
+# ===========================================================================
+# Path helpers
+# ===========================================================================
+
+
+class TestJournalPath:
+    def test_default_base(self):
+        assert journal_path_for("2026-05-28") == DEFAULT_JOURNAL_DIR / "2026-05-28.md"
+
+    def test_custom_base(self, tmp_path):
+        p = journal_path_for("2026-05-28", tmp_path / "j")
+        assert p == tmp_path / "j" / "2026-05-28.md"
+
+
+# ===========================================================================
+# Acceptance criteria from issue #463
+# ===========================================================================
+
+
+class TestAcceptanceCriteria:
+    """The three boxes in issue #463 / doc/57 §7 PR5."""
+
+    def test_ac1_full_day_yields_non_empty_journal(self):
+        """跑完一天有一份非空 journal — simulated by a sequence of appends
+        spread across the four kinds."""
+        tool = make_journal_append_tool(timezone="Asia/Taipei")
+        for kind, body in [
+            ("moment", "10:00 餵了喵吉"),
+            ("finding", "讀到一篇談 timezone 的有趣文章"),
+            ("keepsake", "DK 今天笑了"),
+            ("tomorrow", "想試試早起一小時"),
+        ]:
+            r = asyncio.run(tool.executor(_call({"kind": kind, "body": body})))
+            assert r.success
+
+        today = datetime.now(ZoneInfo("Asia/Taipei")).strftime("%Y-%m-%d")
+        text = Path(f"autonomy/circadian/journal/{today}.md").read_text("utf-8")
+        assert text.strip()
+        for label in KIND_LABELS.values():
+            assert label in text
+
+    def test_ac2_journal_writes_never_touch_memory(self):
+        """semantic memory 沒被流水帳污染. Structural assertion: the journal
+        module imports nothing from loom.core.memory, so it cannot write
+        to MemoryGovernor / SemanticMemory by construction."""
+        import ast
+        import loom.autonomy.circadian.journal as journal_mod
+        tree = ast.parse(Path(journal_mod.__file__).read_text("utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                assert not node.module.startswith("loom.core.memory"), (
+                    f"journal.py must not import from memory layer; "
+                    f"found `from {node.module}`"
+                )
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    assert not alias.name.startswith("loom.core.memory"), (
+                        f"journal.py must not import memory layer; "
+                        f"found `import {alias.name}`"
+                    )
+
+    def test_ac3_dated_file_not_rolling(self):
+        """journal 檔案是 dated（每天一份），不是 rolling. Two appends with
+        different ``timezone``-resolved dates land in different files."""
+        # Two tools, two timezones 24h apart → guaranteed different dates.
+        tool_a = make_journal_append_tool(timezone="Pacific/Kiritimati")
+        tool_b = make_journal_append_tool(timezone="Pacific/Pago_Pago")
+        asyncio.run(tool_a.executor(_call({"kind": "moment", "body": "a"})))
+        asyncio.run(tool_b.executor(_call({"kind": "moment", "body": "b"})))
+
+        files = sorted(Path("autonomy/circadian/journal").glob("*.md"))
+        assert len(files) == 2  # two distinct dated files, no rolling


### PR DESCRIPTION
> Part of #458 / milestone Circadian Autonomy
> Closes #463 · Spec: [doc/57 §7 PR 5](../blob/master/doc/57-Circadian-Autonomy-實作計畫.md)
> Blueprint: [doc/56 §10](../blob/master/doc/56-Circadian-Autonomy-藍圖.md)

## Why

Without a journal, every life fragment 絲絲 wants to keep — "10:00 餵了喵吉", "讀了一篇好玩的論文" — would either be lost or pushed into semantic memory and dilute it. doc/56 §10 splits the two surfaces; this PR makes that split concrete at runtime.

## What

**New tool `journal_append(kind, body)`** — appends to `autonomy/circadian/journal/YYYY-MM-DD.md`.

- `kind` enum: `moment` (生活片段) · `finding` (有趣發現) · `keepsake` (留念) · `tomorrow` (明日想試)
- True file-level append (POSIX `O_APPEND`, single `write()` call) — no read-modify-write, no mtime guard needed, concurrent calls don't tear
- Lazy H1 header on first call of the day
- Dated path, not rolling (Q2 in doc/57: `daily_weave.md` rolling for *plan*, `journal/YYYY-MM-DD.md` dated for *record*)
- `TrustLevel.SAFE` + `MUTATES`; always callable, soft-gated by chime body guidance (same pattern as PR4 `weave_revise`)
- Structurally cannot pollute semantic memory: the module imports nothing from `loom.core.memory` (asserted by test)

**Soft guidance** added to `daily_weave.example.md` evening_closure:

```
- 結構性洞察 → memorize
- 生活片段 / 有趣發現 / 留念 / 明日想試 → journal_append
- 都不留也行
- 想想明天織程要不要真的調 — 若要，今晚就走 weave_revise 工具
```

(Also fixed the small `weave_propose` → `weave_revise` typo from the PR3 era.)

## Design choices (討論於此次對話)

Per DK 2026-05-28:

| Fork | Pick | Why |
|---|---|---|
| Tool API | `journal_append(kind, body)` with kind enum | Structured admission instead of free-form parser ([[feedback_prefer_structured_over_parser]]) |
| Append semantics | One H2 block per entry, true file-level append | POSIX atomic; no conflict guard needed |
| File creation | Lazy on first append | Allows "today had no entries" state |
| Trust + gating | `SAFE`, no phase enforcement | Mirrors PR4; chime body is the soft guide |
| Memory isolation | Structural (no memory import) + soft chime guidance | DK: "不用過於刻意, 明文引導即可"; rely on existing dedup if life events leak. Issue #464 一週後觀察記憶是否炸開 |

## Acceptance criteria (#463)

- [x] 跑完一天有一份非空 journal — `TestAcceptanceCriteria::test_ac1_full_day_yields_non_empty_journal`
- [x] semantic memory 沒被「10:00 餵了喵吉」這種流水帳污染 — `test_ac2_journal_writes_never_touch_memory` (AST import-graph assertion: `journal.py` never imports `loom.core.memory.*`)
- [x] journal 檔案是 dated（每天一份），不是 rolling — `test_ac3_dated_file_not_rolling`

## Test plan

- [x] 19 new tests in `tests/test_circadian_journal.py` (tool definition shape, append behaviour, validation, path helper, three acceptance criteria) — all green
- [x] Full suite: 2241 passed, 4 skipped (two pre-existing failures on master unrelated to this PR: `test_model_no_arg_shows_current_and_providers` mock + `test_layer3_version_sync` README version drift)
- [x] `gitnexus_detect_changes`: risk low, no affected processes — only `LoomSession.start` touched (the registration line)
- [ ] One-week observation (#464): does semantic memory get noisier with journal in play? Rely on existing dedup + contradiction handling as backstop

## Doc updates

- `doc/57` PR status row: PR 2/3/4 marked ✅ merged
- `daily_weave.example.md` evening_closure section: the four-way "what to keep today" choice now mentions all three tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)