### PR TITLE
fix(discord): remove auto-deny on confirm timeout — wait for the operator

### DIFF
--- a/doc/36b-Discord-Bot-平台.md
+++ b/doc/36b-Discord-Bot-平台.md
@@ -161,7 +161,7 @@ class _ConfirmView(View):
     # ❌ Deny (N)    → ConfirmDecision.DENY（拒絕）
 ```
 
-BlastRadiusMiddleware 的 `_confirm_fn` 被 patch 成這個 Discord view，180s 超時自動視為 DENY。
+BlastRadiusMiddleware 的 `_confirm_fn` 被 patch 成這個 Discord view。**不設逾時、不 auto-deny**——按鈕一直亮著，confirm 阻塞直到你做決定（對齊 CLI 同樣阻塞等操作者）。理由：Circadian Autonomy 下絲絲可能在你睡覺/忙碌時自主行動，逾時 auto-deny 會餵給她一個「假性拒絕」，她可能據此繞路；寧可等你授權。`on_timeout`→DENY 仍保留為防禦性 fallback（只有顯式傳入有限 timeout 時才會觸發）。
 
 ### 整合方式
 

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -45,8 +45,12 @@ Streaming strategy
 Confirm flow
 ------------
 BlastRadiusMiddleware.confirm_fn is patched to send a four-button message
-(Allow / Lease / Auto / Deny) in the thread and await the button interaction
-(180s timeout → deny).  Lease and Auto decisions post a follow-up message
+(Allow / Lease / Auto / Deny) in the thread and await the button interaction.
+The confirm waits indefinitely for a human decision (no auto-deny on timeout)
+— under Circadian Autonomy the agent may act while the operator is asleep or
+away, and a timeout→deny would feed it a phantom refusal it then tries to
+route around. Waiting is the safer default (and mirrors the CLI, which also
+blocks on the operator). Lease and Auto decisions post a follow-up message
 showing the TTL or grant scope.
 """
 
@@ -112,7 +116,12 @@ if TYPE_CHECKING:
 class _ConfirmView(View):
     """Discord UI view with Allow / Lease / Auto / Deny buttons for tool confirmation."""
 
-    def __init__(self, timeout: float = 180.0) -> None:
+    def __init__(self, timeout: float | None = None) -> None:
+        # Default ``None`` = no auto-deny: the buttons stay live and the
+        # confirm blocks until the operator decides. See the module-level
+        # "Confirm flow" note for why timeout→deny is wrong under autonomy.
+        # A finite timeout may still be passed explicitly (then ``on_timeout``
+        # falls back to DENY as before).
         super().__init__(timeout=timeout)
         self._decision: ConfirmDecision | None = None
         self._done = asyncio.Event()
@@ -150,6 +159,8 @@ class _ConfirmView(View):
         )
 
     async def on_timeout(self) -> None:
+        # Only reachable when a finite timeout was passed explicitly; the
+        # default (None) never times out. Kept as a defensive fallback.
         self._decision = ConfirmDecision.DENY
         self._done.set()
 
@@ -1947,16 +1958,16 @@ class LoomDiscordBot:
             )[:120]
             trust = call.trust_level.plain
             color = "🟡" if trust == "GUARDED" else "🔴"
-            view = _ConfirmView(timeout=180.0)
+            view = _ConfirmView()  # no auto-deny — waits for your decision
 
             just_text = f"**Justification:** *{justification}*\n" if justification else ""
 
-            msg = await _safe_send(channel, 
+            msg = await _safe_send(channel,
                 f"{color} **{trust}** — tool confirmation required\n"
                 f"**`{call.tool_name}`**\n"
                 f"```\n{args_preview}\n```\n"
                 f"{just_text}"
-                f"*Timeout 3min → auto-deny*",
+                f"*Waiting for your decision — no timeout.*",
                 view=view,
             )
             self._active_confirmations[thread_id] = msg

--- a/tests/test_confirm_parity.py
+++ b/tests/test_confirm_parity.py
@@ -7,6 +7,13 @@ P3 refactor (Issue #347):
 
 TUI widget half of the parity suite was retired with the TUI subsystem
 itself; the Discord side documents the canonical confirm contract.
+
+Contract note (no auto-deny): the real view now defaults to NO timeout — the
+buttons stay live and the confirm blocks until the operator decides. Under
+Circadian Autonomy the agent may act while the operator is away, and a
+timeout→deny would be a phantom refusal it could route around. ``on_timeout``
+still maps to DENY but is only reachable when a finite timeout is passed
+explicitly; the default never fires it.
 """
 
 from __future__ import annotations
@@ -27,7 +34,7 @@ from loom.core.harness.scope import ConfirmDecision
 # =====================================================================
 
 class _ConfirmView:
-    def __init__(self, timeout: float = 60.0):
+    def __init__(self, timeout: float | None = None):
         self._decision: ConfirmDecision | None = None
         self._done = asyncio.Event()
         self.timeout = timeout
@@ -80,7 +87,7 @@ async def _make_confirm_fn(
         if channel is None:
             return ConfirmDecision.DENY
 
-        view = view_class(timeout=60.0)
+        view = view_class()  # no auto-deny — waits for the operator
         active_confirmations[thread_id] = view
 
         try:
@@ -147,7 +154,15 @@ class TestConfirmView:
         await view.deny_button(AsyncMock(), MagicMock())
         assert await view.wait_decision() == ConfirmDecision.DENY
 
-    async def test_timeout_falls_back_to_deny(self):
+    def test_default_view_has_no_timeout(self):
+        # Canonical contract: no auto-deny. The default view never times out,
+        # so a confirm blocks until the operator decides (autonomy-safe).
+        assert _ConfirmView().timeout is None
+
+    async def test_timeout_falls_back_to_deny_when_explicitly_set(self):
+        # Defensive fallback only: on_timeout still maps to DENY, but is
+        # reachable only when a finite timeout is passed explicitly — the
+        # default (None) never fires it.
         view = _ConfirmView(timeout=60.0)
         await view.on_timeout()
         assert await view.wait_decision() == ConfirmDecision.DENY

--- a/tests/test_confirm_parity.py
+++ b/tests/test_confirm_parity.py
@@ -272,3 +272,28 @@ class TestMakeConfirmFn:
             await confirm_fn(_make_call())
 
         assert 42 not in active
+
+    async def test_pending_confirm_cleared_on_cancellation(self):
+        # Since the default confirm now waits indefinitely (no auto-deny),
+        # turn cancellation is the primary escape hatch. Cancelling the
+        # awaiting task must propagate through ``wait_decision`` and run the
+        # ``finally`` cleanup so ``active_confirmations`` does not leak a
+        # stale, never-to-resolve entry. (#484 review P3.)
+        channel = MagicMock(send=AsyncMock())
+        active: dict = {}
+
+        confirm_fn = await _make_confirm_fn(
+            get_channel=lambda tid: channel,
+            thread_id=42,
+            active_confirmations=active,
+        )
+        task = asyncio.create_task(confirm_fn(_make_call()))
+        await asyncio.sleep(0)  # let the confirm register + reach wait_decision
+
+        assert active.get(42) is not None  # pending confirm is registered
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert 42 not in active  # finally cleanup ran on cancellation


### PR DESCRIPTION
## 為什麼

Discord 的 GUARDED-tool confirm（`_ConfirmView`）原本 180s 超時 → DENY。在 **Circadian Autonomy** 下，絲絲可能在操作者睡覺/忙碌時自主行動——超時 auto-deny 等於餵給她一個「假性拒絕」，她可能據此**繞路**找替代做法，而不是單純等待授權。

## 改了什麼

- `_ConfirmView` 預設 `timeout=None`：按鈕一直亮著，confirm **阻塞直到操作者決定**——對齊 CLI（CLI 本來就無逾時、阻塞等操作者）。
- `on_timeout`→DENY 保留為**防禦性 fallback**，只有顯式傳入有限 timeout 時才會觸發。
- confirm 訊息文字 `Timeout 3min → auto-deny` → `Waiting for your decision — no timeout.`
- doc/36b confirm flow 段落同步更新。

## 刻意不動

autonomy 的 notify 路徑（`ConfirmFlow`，60/300s）維持原樣——它本來就是 TIMEOUT→defer（不是 deny），不是假性拒絕的來源。

## ⚠️ 副作用（設計取捨）

自主回合現在可能在 confirm 上**無限阻塞**直到操作者回應（Deny 按鈕或 session cancel 可解除）。若日後想要安全網（例如 N 小時未回應就升級通知 / hold 而非拒絕），可作為後續步驟。

## 驗證

- `test_confirm_parity.py`：新增 `test_default_view_has_no_timeout`；舊的 timeout 測試改名標明是「顯式設定時的防禦 fallback」。
- 完整套件綠（2251 passed；3 個既有失敗為版本標記漂移 + /model mock，與本次無關）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)