### PR TITLE
refactor(session): converge session.py — extract stateless helpers + TierManager

### DIFF
--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -33,51 +33,9 @@ from datetime import datetime, UTC
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
-from dotenv import dotenv_values
 from rich.console import Console
 from rich.panel import Panel
 from rich.rule import Rule
-
-_OUTCOME_MARKERS: dict[str, str] = {
-    "✓": "fulfilled",
-    "◐": "partial",
-    "⚠": "unfulfilled",
-    "↪": "pivoted",
-    "🛑": "aborted",
-}
-
-
-def _clean_envelope_metadata_line(text: str, *, max_len: int = 140) -> str:
-    line = " ".join(str(text or "").strip().split())
-    if len(line) <= max_len:
-        return line
-    return line[: max_len - 1] + "…"
-
-
-def _iter_nonempty_lines(text: str):
-    for line in str(text or "").splitlines():
-        line = line.strip()
-        if line:
-            yield line
-
-
-def _extract_envelope_intent_marker(text: str) -> str:
-    for line in _iter_nonempty_lines(text):
-        if line.startswith("▸"):
-            return _clean_envelope_metadata_line(line.removeprefix("▸"))
-    return ""
-
-
-def _extract_envelope_outcome_marker(text: str) -> tuple[str, str]:
-    for line in _iter_nonempty_lines(text):
-        marker = line[0]
-        outcome = _OUTCOME_MARKERS.get(marker)
-        if outcome is None:
-            continue
-        summary = _clean_envelope_metadata_line(line[1:].lstrip("\ufe0f"))
-        return outcome, summary
-    return "", ""
-
 
 from loom.core.config import load_loom_config as _load_loom_config  # re-exported for tests/diagnostic/cli
 from loom.core.diagnostic import DiagnosticReport, StartupDiagnostic
@@ -168,6 +126,26 @@ from loom.core.memory.search import MemorySearch
 from loom.core.memory.semantic import SemanticEntry, SemanticMemory
 from loom.core.memory.session_log import SessionLog
 from loom.core.memory.store import SQLiteStore
+
+# Stateless helpers extracted to a sibling module (see session_support.py).
+# Re-exported here so historical import paths
+# (``from loom.core.session import _load_env`` etc.) keep working.
+from loom.core.session_support import (  # noqa: F401  (re-export)
+    _OUTCOME_MARKERS,
+    _DEFAULT_OUTPUT_MAX_TOKENS,
+    _MAX_REASONING_CONTINUATIONS,
+    _build_jobs_inject_message,
+    _clean_envelope_metadata_line,
+    _extract_envelope_intent_marker,
+    _extract_envelope_outcome_marker,
+    _find_partial_tag_suffix,
+    _format_scope_panel,
+    _format_scope_summary_plain,
+    _iter_nonempty_lines,
+    _load_env,
+    _parse_skill_frontmatter,
+    _resolve_output_max_tokens,
+)
 
 console = Console(highlight=False)
 logger = logging.getLogger(__name__)
@@ -322,194 +300,8 @@ async def compress_session(
 
 
 # ---------------------------------------------------------------------------
-# Think-block filter helpers
-# ---------------------------------------------------------------------------
-
-
-def _find_partial_tag_suffix(text: str, tag: str) -> int:
-    """Return the length of the longest suffix of *text* that is a prefix of *tag*.
-
-    Used to detect `<think>` / `</think>` tags split across streaming chunks so
-    we can hold the partial tag in a lookahead buffer instead of emitting it.
-    """
-    for n in range(min(len(tag) - 1, len(text)), 0, -1):
-        if text[-n:] == tag[:n]:
-            return n
-    return 0
-
-
-# ---------------------------------------------------------------------------
 # Router factory
 # ---------------------------------------------------------------------------
-
-
-# Issue #181: per-model output cap. Different providers have very different
-# output ceilings (MiniMax-M2.7 ~64K, Claude Sonnet 4.6 ~64K, smaller local
-# models often 4-8K) so a single hardcoded value was either wasteful or
-# clipping long tool-loop turns. Resolved once at session start.
-_DEFAULT_OUTPUT_MAX_TOKENS = 8192
-
-# Issue #271: max consecutive max_tokens-with-zero-tools recoveries within a
-# single stream_turn() before falling through to TurnDropped. Two attempts
-# is empirically enough for deep-reasoning prompts (10-question deductive
-# quizzes) without risking unbounded loops on pathologically long inputs.
-_MAX_REASONING_CONTINUATIONS = 2
-
-
-def _resolve_output_max_tokens(
-    cfg: dict, model: str, router: "LLMRouter | None" = None,
-) -> int:
-    """Return the output-token cap for *model*.
-
-    Precedence (Issue #272):
-      1. ``[cognition.output_max_tokens_overrides][<model>]`` — explicit
-         user override, case-sensitive (intentional: user typed it).
-      2. ``[cognition].output_max_tokens`` — global user-set cap.
-      3. **Provider-declared native limit** — provider class knows what its
-         own models support. Lookup is case-insensitive. New models become
-         available without loom.toml edits.
-      4. ``_DEFAULT_OUTPUT_MAX_TOKENS`` — last-resort fallback.
-
-    The provider-native step (3) is the one that lets users drop the
-    overrides table entirely once their models are in the provider's
-    ``NATIVE_OUTPUT_LIMITS``.
-    """
-    cog = cfg.get("cognition", {}) or {}
-    overrides = cog.get("output_max_tokens_overrides", {}) or {}
-    if model in overrides:
-        try:
-            return int(overrides[model])
-        except (TypeError, ValueError):
-            pass
-    default = cog.get("output_max_tokens")
-    if default is not None:
-        try:
-            return int(default)
-        except (TypeError, ValueError):
-            pass
-    # Step 3 — ask the provider what its native ceiling is for this model.
-    if router is not None:
-        try:
-            provider = router.get_provider(model)
-            native = provider.native_max_tokens(model)
-            if native is not None and native > 0:
-                return int(native)
-        except Exception:
-            # Routing failures or missing provider shouldn't break the call;
-            # fall through to the constant default.
-            pass
-    return _DEFAULT_OUTPUT_MAX_TOKENS
-
-
-def _load_env(project_root: Path | None = None) -> dict[str, str]:
-    """Load .env from project root or current directory."""
-    search = [
-        Path.cwd() / ".env",
-        Path(__file__).parents[2] / ".env",
-    ]
-    if project_root:
-        search.insert(0, project_root / ".env")
-
-    for path in search:
-        if path.exists():
-            return dict(dotenv_values(str(path)))
-    return {}
-
-
-def _parse_skill_frontmatter(
-    raw: str,
-) -> tuple[str, str, list[str], list[dict], int | None]:
-    """
-    Parse YAML frontmatter from a SKILL.md file.
-
-    Returns ``(name, description, tags, precondition_check_refs, model_tier)``.
-    On parse failure returns empty strings / lists / ``None``.
-    Follows Agent Skills spec lenient validation: best-effort parsing.
-
-    Issue #276: ``model_tier`` is an optional positive int declaring the
-    LLM tier this skill expects (1 = daily, 2 = deep reasoning, …). The
-    harness escalates the active model when the skill is loaded. ``None``
-    means "no opinion".
-    """
-    if not raw.startswith("---"):
-        return "", "", [], [], None
-
-    parts = raw.split("---", 2)
-    if len(parts) < 3:
-        return "", "", [], [], None
-
-    yaml_text = parts[1].strip()
-    try:
-        import yaml
-        data = yaml.safe_load(yaml_text)
-        if not isinstance(data, dict):
-            return "", "", [], [], None
-    except Exception:
-        return "", "", [], [], None
-
-    name = str(data.get("name", "")).strip()
-    description = str(data.get("description", "")).strip()
-    tags = data.get("tags", [])
-    if isinstance(tags, str):
-        tags = [t.strip() for t in tags.split(",")]
-    elif not isinstance(tags, list):
-        tags = []
-
-    # Issue #64 Phase B: skill-declared precondition checks
-    pc_refs = data.get("precondition_checks", [])
-    if not isinstance(pc_refs, list):
-        pc_refs = []
-    # Validate each entry has at minimum 'ref' and 'applies_to'
-    valid_refs: list[dict] = []
-    for entry in pc_refs:
-        if isinstance(entry, dict) and entry.get("ref") and entry.get("applies_to"):
-            valid_refs.append(entry)
-
-    # Issue #276: skill-declared LLM tier requirement
-    raw_tier = data.get("model_tier")
-    model_tier: int | None
-    try:
-        model_tier = int(raw_tier) if raw_tier is not None else None
-        if model_tier is not None and model_tier < 1:
-            model_tier = None  # invalid; treat as unspecified
-    except (TypeError, ValueError):
-        model_tier = None
-
-    return name, description, tags, valid_refs, model_tier
-
-
-def _build_jobs_inject_message(jobstore: Any) -> str | None:
-    """Issue #154: render a pre-final-response reminder about background jobs.
-
-    Returns None when there is nothing to report — no new completions and no
-    still-running jobs. Only items finished since the last call are listed
-    under 'Completed since last turn' (JobStore.reap_since_last is idempotent).
-    """
-    new_finished, running = jobstore.reap_since_last()
-    if not new_finished and not running:
-        return None
-
-    lines = ["[Jobs update]"]
-    if new_finished:
-        lines.append("Completed since last turn:")
-        for j in new_finished:
-            if j.state.value == "done":
-                ref = f"scratchpad://{j.result_ref}" if j.result_ref else "(no output)"
-                size = f" ({j.result_summary})" if j.result_summary else ""
-                lines.append(f"  - {j.id} ({j.fn_name}): done → {ref}{size}")
-            elif j.state.value == "failed":
-                lines.append(f"  - {j.id} ({j.fn_name}): failed — {j.error}")
-            elif j.state.value == "cancelled":
-                lines.append(f"  - {j.id} ({j.fn_name}): cancelled — {j.cancel_reason}")
-    if running:
-        if new_finished:
-            lines.append("")
-        lines.append("Still running:")
-        for j in running:
-            elapsed = j.elapsed_seconds
-            elapsed_str = f" ({elapsed:.0f}s elapsed)" if elapsed else ""
-            lines.append(f"  - {j.id} ({j.fn_name}): {j.state.value}{elapsed_str}")
-    return "\n".join(lines)
 
 
 def build_router(active_model: str | None = None) -> LLMRouter:
@@ -4456,133 +4248,6 @@ class LoomSession:
             grants=summaries,
         )
 
-    @staticmethod
-    def _format_scope_panel(call: ToolCall) -> str:
-        """
-        Build a Rich-formatted string describing scope verdict + diff.
-
-        Phase C (Issue #45): when scope metadata is available, the confirm
-        prompt shows structured information instead of raw args.
-        """
-        from loom.core.harness.scope import (
-            DiffReason, PermissionVerdict, ScopeDiff, ScopeRequest,
-        )
-
-        verdict = call.metadata.get("scope_verdict")
-        diff: ScopeDiff | None = call.metadata.get("scope_diff")
-        scope_req: ScopeRequest | None = call.metadata.get("scope_request")
-
-        if verdict is None or scope_req is None:
-            # Legacy path — no scope metadata available.
-            # Format args with smart truncation so long paths remain readable.
-            arg_lines: list[str] = []
-            for k, v in call.args.items():
-                if isinstance(v, str):
-                    display = v if len(v) <= 120 else v[:40] + "…" + v[-40:]
-                    arg_lines.append(f"  [cyan]{k}[/cyan]: {display}")
-                else:
-                    arg_lines.append(f"  [cyan]{k}[/cyan]: {v!r}")
-            args_display = "\n".join(arg_lines) if arg_lines else "  (no args)"
-            return (
-                f"[#c8a464]{call.tool_name}[/#c8a464]  {call.trust_level.label}\n"
-                f"{args_display}"
-            )
-
-        # --- Verdict-aware header ---
-        _REASON_LABELS: dict[DiffReason, str] = {
-            DiffReason.FIRST_TIME: "First time accessing this resource",
-            DiffReason.SELECTOR_EXPANSION: "Expanding beyond previously approved scope",
-            DiffReason.CONSTRAINT_EXPANSION: "Exceeding previously approved limits",
-            DiffReason.RESOURCE_TYPE_NEW: "New resource type not previously authorized",
-        }
-
-        _VERDICT_TITLES: dict[PermissionVerdict, tuple[str, str]] = {
-            PermissionVerdict.CONFIRM: ("Tool requires confirmation", "yellow"),
-            PermissionVerdict.EXPAND_SCOPE: ("Scope expansion required", "red"),
-        }
-        title_text, border = _VERDICT_TITLES.get(
-            verdict, ("Tool requires confirmation", "yellow"),
-        )
-
-        lines: list[str] = [
-            f"[#c8a464]{call.tool_name}[/#c8a464]  {call.trust_level.label}",
-        ]
-
-        # Scope summary: what the tool wants to access
-        for req in scope_req.requirements:
-            lines.append(
-                f"  [cyan]{req.resource}[/cyan]:{req.action} → "
-                f"[bold]{req.selector}[/bold]"
-            )
-            if req.constraints.get("scope_unknown"):
-                lines.append("  [yellow]⚠ scope could not be fully resolved[/yellow]")
-
-        # Diff reason
-        if diff is not None and not diff.is_fully_covered:
-            reason_label = _REASON_LABELS.get(diff.reason, str(diff.reason.value))
-            lines.append(f"\n[dim]{reason_label}[/dim]")
-
-            # Show what's already covered vs missing
-            if diff.covered:
-                covered_selectors = ", ".join(r.selector for r in diff.covered)
-                lines.append(f"[green]✓ covered:[/green] {covered_selectors}")
-            if diff.missing:
-                missing_selectors = ", ".join(r.selector for r in diff.missing)
-                lines.append(f"[yellow]● new:[/yellow] {missing_selectors}")
-
-        return "\n".join(lines)
-
-    @staticmethod
-    def _format_scope_summary_plain(call: ToolCall) -> str:
-        """Plain-text scope summary for the LoomApp confirm widget.
-
-        Mirrors :meth:`_format_scope_panel` but strips Rich markup so it
-        renders cleanly inside a prompt_toolkit FormattedTextControl,
-        which doesn't speak Rich's ``[bold]`` syntax.
-        """
-        from loom.core.harness.scope import (
-            DiffReason, ScopeDiff, ScopeRequest,
-        )
-
-        scope_req: ScopeRequest | None = call.metadata.get("scope_request")
-        diff: ScopeDiff | None = call.metadata.get("scope_diff")
-
-        if scope_req is None:
-            arg_lines: list[str] = []
-            for k, v in call.args.items():
-                if isinstance(v, str):
-                    display = v if len(v) <= 120 else v[:40] + "…" + v[-40:]
-                    arg_lines.append(f"  {k}: {display}")
-                else:
-                    arg_lines.append(f"  {k}: {v!r}")
-            return "\n".join(arg_lines) if arg_lines else "(no args)"
-
-        _REASON_LABELS: dict[DiffReason, str] = {
-            DiffReason.FIRST_TIME: "First time accessing this resource",
-            DiffReason.SELECTOR_EXPANSION: "Expanding beyond previously approved scope",
-            DiffReason.CONSTRAINT_EXPANSION: "Exceeding previously approved limits",
-            DiffReason.RESOURCE_TYPE_NEW: "New resource type not previously authorized",
-        }
-
-        lines: list[str] = []
-        for req in scope_req.requirements:
-            line = f"  {req.resource}:{req.action} → {req.selector}"
-            if req.constraints.get("scope_unknown"):
-                line += "  ⚠ scope could not be fully resolved"
-            lines.append(line)
-        if diff is not None and not diff.is_fully_covered:
-            reason_label = _REASON_LABELS.get(diff.reason, str(diff.reason.value))
-            lines.append(reason_label)
-            if diff.covered:
-                lines.append(
-                    "  ✓ covered: " + ", ".join(r.selector for r in diff.covered)
-                )
-            if diff.missing:
-                lines.append(
-                    "  ● new: " + ", ".join(r.selector for r in diff.missing)
-                )
-        return "\n".join(lines)
-
     async def _confirm_tool_cli(self, call: ToolCall) -> "ConfirmDecision":
         """
         CLI-specific confirmation prompt — arrow-key inline widget.
@@ -4629,7 +4294,7 @@ class LoomSession:
         if loom_app is not None:
             return await loom_app.request_confirm(
                 title=widget_title,
-                body=self._format_scope_summary_plain(call),
+                body=_format_scope_summary_plain(call),
                 options=[
                     ("允許這次",                        ConfirmDecision.ONCE,   "y"),
                     ("允許並記住 30 分鐘 (lease)",      ConfirmDecision.SCOPE,  "s"),
@@ -4653,7 +4318,7 @@ class LoomSession:
             border_style = "loom.warning"
         console.print(
             Panel(
-                self._format_scope_panel(call),
+                _format_scope_panel(call),
                 title=title,
                 border_style=border_style,
             )

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -3405,6 +3405,9 @@ class LoomSession:
 
     @property
     def _skill_tier_snapshot(self) -> dict[str, int]:
+        # Returns the live dict, so in-place item writes during skill bootstrap
+        # (``self._skill_tier_snapshot[name] = tier``) land on the TierManager.
+        # Read-only as an attribute — never reassign the whole dict here.
         return self._tier.skill_tier_snapshot
 
     @property

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -126,6 +126,7 @@ from loom.core.memory.search import MemorySearch
 from loom.core.memory.semantic import SemanticEntry, SemanticMemory
 from loom.core.memory.session_log import SessionLog
 from loom.core.memory.store import SQLiteStore
+from loom.core.tier_manager import TierManager
 
 # Stateless helpers extracted to a sibling module (see session_support.py).
 # Re-exported here so historical import paths
@@ -696,33 +697,11 @@ class LoomSession:
         # name. Skills declare ``model_tier: N`` in frontmatter; when activated,
         # the harness escalates to that tier (sticky). Agent / user can
         # downgrade explicitly. ``reminder_after_turns`` triggers a soft hint
-        # — never auto-reverts.
-        _tier_cfg = (config.get("cognition") or {}).get("tiers", {}) or {}
-        self._tier_models: dict[int, str] = {}
-        for k, v in _tier_cfg.items():
-            try:
-                tier_int = int(k)
-                if isinstance(v, str) and v.strip():
-                    self._tier_models[tier_int] = v.strip()
-            except (TypeError, ValueError):
-                continue
-        self._default_tier: int = int(_tier_cfg.get("default_tier", 1) or 1)
-        self._tier_reminder_after_turns: int = int(
-            _tier_cfg.get("reminder_after_turns", 10) or 10
-        )
-        # ``None`` = follow ``_default_tier``; integer = sticky override.
-        self._sticky_tier: int | None = None
-        self._manual_model_override: bool = False
-        # Counts consecutive turns at the *active* tier (sticky or default).
-        # Reset on tier change; surfaces in TierExpiryHint after threshold.
-        self._turns_at_current_tier: int = 0
-        # Tracks "did we already emit a reminder this sticky session?" so we
-        # don't spam the agent every turn after the threshold is hit.
-        self._tier_reminder_emitted: bool = False
-        # Issue #276: skill name → declared tier, populated during skill
-        # bootstrap. ``_compute_skill_max_tier`` reads this synchronously
-        # from inside stream_turn (procedural.get is async).
-        self._skill_tier_snapshot: dict[str, int] = {}
+        # — never auto-reverts. The state machine lives in TierManager; it reads
+        # the base model live via the getter so ``self._model`` stays the single
+        # source of truth. The leaked attribute names (``_tier_models`` etc.)
+        # remain available to CLI / Discord through read-only properties below.
+        self._tier = TierManager.from_config(config, lambda: self._model)
 
         # Issue #271: when stop_reason='max_tokens' fires after 0 tools, inject
         # a system-reminder telling the agent to spill in-flight reasoning to
@@ -3404,21 +3383,41 @@ class LoomSession:
         )
         self._telemetry.mark_dirty()
 
+    # ------------------------------------------------------------------
+    # Tier / model resolution — delegates to TierManager (#276). The state
+    # machine lives in tier_manager.py; these stay on the session because
+    # they are part of its public surface (CLI / Discord reach into them)
+    # and because _set_sticky_tier owns the telemetry side effect.
+    # The leaked private-attribute names are preserved as read-only
+    # properties so external callers keep working unchanged.
+    # ------------------------------------------------------------------
+    @property
+    def _tier_models(self) -> dict[int, str]:
+        return self._tier.tier_models
+
+    @property
+    def _sticky_tier(self) -> int | None:
+        return self._tier.sticky_tier
+
+    @property
+    def _default_tier(self) -> int:
+        return self._tier.default_tier
+
+    @property
+    def _skill_tier_snapshot(self) -> dict[str, int]:
+        return self._tier.skill_tier_snapshot
+
+    @property
+    def _turns_at_current_tier(self) -> int:
+        return self._tier.turns_at_current_tier
+
     def _active_tier(self) -> int:
         """Effective tier this turn — sticky override or default."""
-        return self._sticky_tier if self._sticky_tier is not None else self._default_tier
+        return self._tier.active_tier()
 
     def _active_model(self) -> str:
-        """Resolve the model name for the active tier.
-
-        A manual ``/model`` selection wins until the user or agent explicitly
-        changes tier again. Otherwise, falls back to ``self._model`` when the
-        tier system isn't configured for this tier.
-        """
-        if getattr(self, "_manual_model_override", False):
-            return self._model
-        tier = self._active_tier()
-        return self._tier_models.get(tier, self._model)
+        """Resolve the model name for the active tier (delegates to TierManager)."""
+        return self._tier.active_model()
 
     def current_model(self) -> str:
         """Public single source of truth for the model serving the next turn.
@@ -3457,64 +3456,25 @@ class LoomSession:
         ``source`` is one of ``"skill"`` / ``"agent"`` / ``"user"`` / ``"clear"``
         and lands in the event for telemetry / graphify analysis.
         """
-        old_tier = self._active_tier()
-        # Normalize: setting sticky to default_tier is equivalent to clearing,
-        # so the "no override" state remains canonical.
-        if new_tier == self._default_tier:
-            new_tier = None
-        if new_tier == self._sticky_tier:
-            return None  # no-op
-        self._manual_model_override = False
-        self._sticky_tier = new_tier
-        self._turns_at_current_tier = 0
-        self._tier_reminder_emitted = False
-        active = self._active_tier()
-        if active == old_tier:
-            return None
-        # Issue #279/#471: refresh runtime_identity on tier switch through the
-        # single helper so it stays consistent with start / set_model.
-        self._refresh_runtime_identity()
-        return TierChanged(
-            from_tier=old_tier,
-            to_tier=active,
-            from_model=self._tier_models.get(old_tier, self._model),
-            to_model=self._tier_models.get(active, self._model),
-            source=source,
-            reason=reason,
-        )
+        ev = self._tier.set_sticky(new_tier, reason=reason, source=source)
+        if ev is not None:
+            # Issue #279/#471: refresh runtime_identity on tier switch so it
+            # stays consistent with start / set_model.
+            self._refresh_runtime_identity()
+        return ev
 
     def _tick_tier_counter(self) -> "TierExpiryHint | None":
         """Increment the per-turn counter for the active tier and return a
-        ``TierExpiryHint`` event the first time the threshold is crossed
-        within a sticky session.
-
-        Called once per ``stream_turn`` completion (immediately before
-        ``TurnDone``). Skips emission when:
-          - We're on the default tier (no sticky to expire)
-          - Threshold isn't configured (``<= 0``)
-          - The hint has already been emitted this sticky session
+        ``TierExpiryHint`` the first time the threshold is crossed within a
+        sticky session. Called once per ``stream_turn`` completion.
         """
-        self._turns_at_current_tier += 1
-        if self._sticky_tier is None:
-            return None
-        if self._tier_reminder_after_turns <= 0:
-            return None
-        if self._tier_reminder_emitted:
-            return None
-        if self._turns_at_current_tier < self._tier_reminder_after_turns:
-            return None
-        self._tier_reminder_emitted = True
-        return TierExpiryHint(
-            tier=self._sticky_tier,
-            model=self._active_model(),
-            turns_used=self._turns_at_current_tier,
-            threshold=self._tier_reminder_after_turns,
-        )
+        return self._tier.tick_counter()
 
     def _compute_skill_max_tier(self) -> int:
-        """Take max ``model_tier`` across currently-activated skills.
+        """Max ``model_tier`` across currently-activated skills (#276).
 
-        Skills with no declared tier contribute 0, never escalating.
+        The activated-skill list comes from the session-owned outcome tracker;
+        the tier lookup lives in TierManager's snapshot.
         """
         tracker = getattr(self, "_skill_outcome_tracker", None)
         if tracker is None:
@@ -3523,21 +3483,7 @@ class LoomSession:
             names = tracker.activated_skills
         except Exception:
             return 0
-        if not names:
-            return 0
-        max_tier = 0
-        for name in names:
-            try:
-                # Cached lookup; ProceduralMemory.get is async, so we use the
-                # in-memory snapshot if available. The snapshot is populated
-                # at session start by _refresh_memory_index.
-                snapshot = getattr(self, "_skill_tier_snapshot", {})
-                tier = snapshot.get(name, 0)
-            except Exception:
-                tier = 0
-            if tier > max_tier:
-                max_tier = tier
-        return max_tier
+        return self._tier.skill_max_tier(names)
 
     def _should_continue_reasoning(self, stop_reason: str, tool_count: int) -> bool:
         """Decide whether to inject a continuation reminder for #271.
@@ -4644,8 +4590,8 @@ class LoomSession:
                 self.router = rebuilt
                 ok = True
         if ok:
-            self._model = model
-            self._manual_model_override = True
+            self._model = model  # base model — TierManager reads it live
+            self._tier.mark_manual_override()
             # Keep the identity telemetry (agent_health) in lock-step with the
             # model that will actually serve — set_model previously skipped this.
             self._refresh_runtime_identity()

--- a/loom/core/session_support.py
+++ b/loom/core/session_support.py
@@ -1,0 +1,436 @@
+"""Stateless helpers extracted from ``LoomSession``.
+
+These are pure module-level functions and constants that never touched
+``self`` — they only ever lived in ``session.py`` for historical reasons and
+several of them already leaked out as a de-facto public API (imported by
+``loom.platform.cli.tools``, ``loom.core.diagnostic.startup`` and the test
+suite). Pulling them here tightens that surface and shrinks the
+``LoomSession`` module without changing any behaviour.
+
+``session.py`` re-exports everything in this module, so the historical import
+paths (``from loom.core.session import _load_env`` etc.) keep working.
+
+Grouped by concern:
+
+  * Envelope metadata markers — parse the ``▸ intent`` / ``✓ outcome`` lines
+    the agent embeds in its final text for the UI projection layer.
+  * Think-block streaming — split-tag lookahead for ``<think>`` filtering.
+  * Output-token resolution — per-model output cap precedence (#272).
+  * Environment / config loading — ``.env`` discovery.
+  * Skill frontmatter parsing — YAML header of a ``SKILL.md``.
+  * Background jobs reminder — pre-final-response job-status injection (#154).
+  * Scope panels — confirm-prompt formatting (Rich + plain variants).
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from dotenv import dotenv_values
+
+if TYPE_CHECKING:
+    from loom.core.cognition.router import LLMRouter
+    from loom.core.harness.middleware import ToolCall
+
+
+# ---------------------------------------------------------------------------
+# Envelope metadata markers
+# ---------------------------------------------------------------------------
+
+_OUTCOME_MARKERS: dict[str, str] = {
+    "✓": "fulfilled",
+    "◐": "partial",
+    "⚠": "unfulfilled",
+    "↪": "pivoted",
+    "🛑": "aborted",
+}
+
+
+def _clean_envelope_metadata_line(text: str, *, max_len: int = 140) -> str:
+    line = " ".join(str(text or "").strip().split())
+    if len(line) <= max_len:
+        return line
+    return line[: max_len - 1] + "…"
+
+
+def _iter_nonempty_lines(text: str) -> Iterator[str]:
+    for line in str(text or "").splitlines():
+        line = line.strip()
+        if line:
+            yield line
+
+
+def _extract_envelope_intent_marker(text: str) -> str:
+    for line in _iter_nonempty_lines(text):
+        if line.startswith("▸"):
+            return _clean_envelope_metadata_line(line.removeprefix("▸"))
+    return ""
+
+
+def _extract_envelope_outcome_marker(text: str) -> tuple[str, str]:
+    for line in _iter_nonempty_lines(text):
+        marker = line[0]
+        outcome = _OUTCOME_MARKERS.get(marker)
+        if outcome is None:
+            continue
+        summary = _clean_envelope_metadata_line(line[1:].lstrip("\ufe0f"))
+        return outcome, summary
+    return "", ""
+
+
+# ---------------------------------------------------------------------------
+# Think-block filter helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_partial_tag_suffix(text: str, tag: str) -> int:
+    """Return the length of the longest suffix of *text* that is a prefix of *tag*.
+
+    Used to detect `<think>` / `</think>` tags split across streaming chunks so
+    we can hold the partial tag in a lookahead buffer instead of emitting it.
+    """
+    for n in range(min(len(tag) - 1, len(text)), 0, -1):
+        if text[-n:] == tag[:n]:
+            return n
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Output-token resolution
+# ---------------------------------------------------------------------------
+
+# Issue #181: per-model output cap. Different providers have very different
+# output ceilings (MiniMax-M2.7 ~64K, Claude Sonnet 4.6 ~64K, smaller local
+# models often 4-8K) so a single hardcoded value was either wasteful or
+# clipping long tool-loop turns. Resolved once at session start.
+_DEFAULT_OUTPUT_MAX_TOKENS = 8192
+
+# Issue #271: max consecutive max_tokens-with-zero-tools recoveries within a
+# single stream_turn() before falling through to TurnDropped. Two attempts
+# is empirically enough for deep-reasoning prompts (10-question deductive
+# quizzes) without risking unbounded loops on pathologically long inputs.
+_MAX_REASONING_CONTINUATIONS = 2
+
+
+def _resolve_output_max_tokens(
+    cfg: dict, model: str, router: "LLMRouter | None" = None,
+) -> int:
+    """Return the output-token cap for *model*.
+
+    Precedence (Issue #272):
+      1. ``[cognition.output_max_tokens_overrides][<model>]`` — explicit
+         user override, case-sensitive (intentional: user typed it).
+      2. ``[cognition].output_max_tokens`` — global user-set cap.
+      3. **Provider-declared native limit** — provider class knows what its
+         own models support. Lookup is case-insensitive. New models become
+         available without loom.toml edits.
+      4. ``_DEFAULT_OUTPUT_MAX_TOKENS`` — last-resort fallback.
+
+    The provider-native step (3) is the one that lets users drop the
+    overrides table entirely once their models are in the provider's
+    ``NATIVE_OUTPUT_LIMITS``.
+    """
+    cog = cfg.get("cognition", {}) or {}
+    overrides = cog.get("output_max_tokens_overrides", {}) or {}
+    if model in overrides:
+        try:
+            return int(overrides[model])
+        except (TypeError, ValueError):
+            pass
+    default = cog.get("output_max_tokens")
+    if default is not None:
+        try:
+            return int(default)
+        except (TypeError, ValueError):
+            pass
+    # Step 3 — ask the provider what its native ceiling is for this model.
+    if router is not None:
+        try:
+            provider = router.get_provider(model)
+            native = provider.native_max_tokens(model)
+            if native is not None and native > 0:
+                return int(native)
+        except Exception:
+            # Routing failures or missing provider shouldn't break the call;
+            # fall through to the constant default.
+            pass
+    return _DEFAULT_OUTPUT_MAX_TOKENS
+
+
+# ---------------------------------------------------------------------------
+# Environment / config loading
+# ---------------------------------------------------------------------------
+
+
+def _load_env(project_root: Path | None = None) -> dict[str, str]:
+    """Load .env from project root or current directory."""
+    search = [
+        Path.cwd() / ".env",
+        Path(__file__).parents[2] / ".env",
+    ]
+    if project_root:
+        search.insert(0, project_root / ".env")
+
+    for path in search:
+        if path.exists():
+            return dict(dotenv_values(str(path)))
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Skill frontmatter parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_skill_frontmatter(
+    raw: str,
+) -> tuple[str, str, list[str], list[dict], int | None]:
+    """
+    Parse YAML frontmatter from a SKILL.md file.
+
+    Returns ``(name, description, tags, precondition_check_refs, model_tier)``.
+    On parse failure returns empty strings / lists / ``None``.
+    Follows Agent Skills spec lenient validation: best-effort parsing.
+
+    Issue #276: ``model_tier`` is an optional positive int declaring the
+    LLM tier this skill expects (1 = daily, 2 = deep reasoning, …). The
+    harness escalates the active model when the skill is loaded. ``None``
+    means "no opinion".
+    """
+    if not raw.startswith("---"):
+        return "", "", [], [], None
+
+    parts = raw.split("---", 2)
+    if len(parts) < 3:
+        return "", "", [], [], None
+
+    yaml_text = parts[1].strip()
+    try:
+        import yaml
+        data = yaml.safe_load(yaml_text)
+        if not isinstance(data, dict):
+            return "", "", [], [], None
+    except Exception:
+        return "", "", [], [], None
+
+    name = str(data.get("name", "")).strip()
+    description = str(data.get("description", "")).strip()
+    tags = data.get("tags", [])
+    if isinstance(tags, str):
+        tags = [t.strip() for t in tags.split(",")]
+    elif not isinstance(tags, list):
+        tags = []
+
+    # Issue #64 Phase B: skill-declared precondition checks
+    pc_refs = data.get("precondition_checks", [])
+    if not isinstance(pc_refs, list):
+        pc_refs = []
+    # Validate each entry has at minimum 'ref' and 'applies_to'
+    valid_refs: list[dict] = []
+    for entry in pc_refs:
+        if isinstance(entry, dict) and entry.get("ref") and entry.get("applies_to"):
+            valid_refs.append(entry)
+
+    # Issue #276: skill-declared LLM tier requirement
+    raw_tier = data.get("model_tier")
+    model_tier: int | None
+    try:
+        model_tier = int(raw_tier) if raw_tier is not None else None
+        if model_tier is not None and model_tier < 1:
+            model_tier = None  # invalid; treat as unspecified
+    except (TypeError, ValueError):
+        model_tier = None
+
+    return name, description, tags, valid_refs, model_tier
+
+
+# ---------------------------------------------------------------------------
+# Background jobs reminder
+# ---------------------------------------------------------------------------
+
+
+def _build_jobs_inject_message(jobstore: Any) -> str | None:
+    """Issue #154: render a pre-final-response reminder about background jobs.
+
+    Returns None when there is nothing to report — no new completions and no
+    still-running jobs. Only items finished since the last call are listed
+    under 'Completed since last turn' (JobStore.reap_since_last is idempotent).
+    """
+    new_finished, running = jobstore.reap_since_last()
+    if not new_finished and not running:
+        return None
+
+    lines = ["[Jobs update]"]
+    if new_finished:
+        lines.append("Completed since last turn:")
+        for j in new_finished:
+            if j.state.value == "done":
+                ref = f"scratchpad://{j.result_ref}" if j.result_ref else "(no output)"
+                size = f" ({j.result_summary})" if j.result_summary else ""
+                lines.append(f"  - {j.id} ({j.fn_name}): done → {ref}{size}")
+            elif j.state.value == "failed":
+                lines.append(f"  - {j.id} ({j.fn_name}): failed — {j.error}")
+            elif j.state.value == "cancelled":
+                lines.append(f"  - {j.id} ({j.fn_name}): cancelled — {j.cancel_reason}")
+    if running:
+        if new_finished:
+            lines.append("")
+        lines.append("Still running:")
+        for j in running:
+            elapsed = j.elapsed_seconds
+            elapsed_str = f" ({elapsed:.0f}s elapsed)" if elapsed else ""
+            lines.append(f"  - {j.id} ({j.fn_name}): {j.state.value}{elapsed_str}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Scope panels (confirm-prompt formatting)
+# ---------------------------------------------------------------------------
+
+
+def _format_scope_panel(call: "ToolCall") -> str:
+    """
+    Build a Rich-formatted string describing scope verdict + diff.
+
+    Phase C (Issue #45): when scope metadata is available, the confirm
+    prompt shows structured information instead of raw args.
+    """
+    from loom.core.harness.scope import (
+        DiffReason, PermissionVerdict, ScopeDiff, ScopeRequest,
+    )
+
+    verdict = call.metadata.get("scope_verdict")
+    diff: ScopeDiff | None = call.metadata.get("scope_diff")
+    scope_req: ScopeRequest | None = call.metadata.get("scope_request")
+
+    if verdict is None or scope_req is None:
+        # Legacy path — no scope metadata available.
+        # Format args with smart truncation so long paths remain readable.
+        arg_lines: list[str] = []
+        for k, v in call.args.items():
+            if isinstance(v, str):
+                display = v if len(v) <= 120 else v[:40] + "…" + v[-40:]
+                arg_lines.append(f"  [cyan]{k}[/cyan]: {display}")
+            else:
+                arg_lines.append(f"  [cyan]{k}[/cyan]: {v!r}")
+        args_display = "\n".join(arg_lines) if arg_lines else "  (no args)"
+        return (
+            f"[#c8a464]{call.tool_name}[/#c8a464]  {call.trust_level.label}\n"
+            f"{args_display}"
+        )
+
+    # --- Verdict-aware header ---
+    _REASON_LABELS: dict[DiffReason, str] = {
+        DiffReason.FIRST_TIME: "First time accessing this resource",
+        DiffReason.SELECTOR_EXPANSION: "Expanding beyond previously approved scope",
+        DiffReason.CONSTRAINT_EXPANSION: "Exceeding previously approved limits",
+        DiffReason.RESOURCE_TYPE_NEW: "New resource type not previously authorized",
+    }
+
+    _VERDICT_TITLES: dict[PermissionVerdict, tuple[str, str]] = {
+        PermissionVerdict.CONFIRM: ("Tool requires confirmation", "yellow"),
+        PermissionVerdict.EXPAND_SCOPE: ("Scope expansion required", "red"),
+    }
+    title_text, border = _VERDICT_TITLES.get(
+        verdict, ("Tool requires confirmation", "yellow"),
+    )
+
+    lines: list[str] = [
+        f"[#c8a464]{call.tool_name}[/#c8a464]  {call.trust_level.label}",
+    ]
+
+    # Scope summary: what the tool wants to access
+    for req in scope_req.requirements:
+        lines.append(
+            f"  [cyan]{req.resource}[/cyan]:{req.action} → "
+            f"[bold]{req.selector}[/bold]"
+        )
+        if req.constraints.get("scope_unknown"):
+            lines.append("  [yellow]⚠ scope could not be fully resolved[/yellow]")
+
+    # Diff reason
+    if diff is not None and not diff.is_fully_covered:
+        reason_label = _REASON_LABELS.get(diff.reason, str(diff.reason.value))
+        lines.append(f"\n[dim]{reason_label}[/dim]")
+
+        # Show what's already covered vs missing
+        if diff.covered:
+            covered_selectors = ", ".join(r.selector for r in diff.covered)
+            lines.append(f"[green]✓ covered:[/green] {covered_selectors}")
+        if diff.missing:
+            missing_selectors = ", ".join(r.selector for r in diff.missing)
+            lines.append(f"[yellow]● new:[/yellow] {missing_selectors}")
+
+    return "\n".join(lines)
+
+
+def _format_scope_summary_plain(call: "ToolCall") -> str:
+    """Plain-text scope summary for the LoomApp confirm widget.
+
+    Mirrors :func:`_format_scope_panel` but strips Rich markup so it
+    renders cleanly inside a prompt_toolkit FormattedTextControl,
+    which doesn't speak Rich's ``[bold]`` syntax.
+    """
+    from loom.core.harness.scope import (
+        DiffReason, ScopeDiff, ScopeRequest,
+    )
+
+    scope_req: ScopeRequest | None = call.metadata.get("scope_request")
+    diff: ScopeDiff | None = call.metadata.get("scope_diff")
+
+    if scope_req is None:
+        arg_lines: list[str] = []
+        for k, v in call.args.items():
+            if isinstance(v, str):
+                display = v if len(v) <= 120 else v[:40] + "…" + v[-40:]
+                arg_lines.append(f"  {k}: {display}")
+            else:
+                arg_lines.append(f"  {k}: {v!r}")
+        return "\n".join(arg_lines) if arg_lines else "(no args)"
+
+    _REASON_LABELS: dict[DiffReason, str] = {
+        DiffReason.FIRST_TIME: "First time accessing this resource",
+        DiffReason.SELECTOR_EXPANSION: "Expanding beyond previously approved scope",
+        DiffReason.CONSTRAINT_EXPANSION: "Exceeding previously approved limits",
+        DiffReason.RESOURCE_TYPE_NEW: "New resource type not previously authorized",
+    }
+
+    lines: list[str] = []
+    for req in scope_req.requirements:
+        line = f"  {req.resource}:{req.action} → {req.selector}"
+        if req.constraints.get("scope_unknown"):
+            line += "  ⚠ scope could not be fully resolved"
+        lines.append(line)
+    if diff is not None and not diff.is_fully_covered:
+        reason_label = _REASON_LABELS.get(diff.reason, str(diff.reason.value))
+        lines.append(reason_label)
+        if diff.covered:
+            lines.append(
+                "  ✓ covered: " + ", ".join(r.selector for r in diff.covered)
+            )
+        if diff.missing:
+            lines.append(
+                "  ● new: " + ", ".join(r.selector for r in diff.missing)
+            )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "_OUTCOME_MARKERS",
+    "_clean_envelope_metadata_line",
+    "_iter_nonempty_lines",
+    "_extract_envelope_intent_marker",
+    "_extract_envelope_outcome_marker",
+    "_find_partial_tag_suffix",
+    "_DEFAULT_OUTPUT_MAX_TOKENS",
+    "_MAX_REASONING_CONTINUATIONS",
+    "_resolve_output_max_tokens",
+    "_load_env",
+    "_parse_skill_frontmatter",
+    "_build_jobs_inject_message",
+    "_format_scope_panel",
+    "_format_scope_summary_plain",
+]

--- a/loom/core/tier_manager.py
+++ b/loom/core/tier_manager.py
@@ -1,0 +1,178 @@
+"""LLM tier state machine (Issue #276), extracted from ``LoomSession``.
+
+``[cognition.tiers]`` in ``loom.toml`` maps an int tier → model name. Skills
+declare ``model_tier: N`` in their frontmatter; activating one escalates the
+active model to that tier (sticky). The agent or user can downgrade explicitly;
+a ``/model`` selection is a manual override that wins until the tier changes
+again.
+
+The active model resolves with this precedence:
+
+    manual ``/model`` override  >  sticky tier  >  default tier  >  base model
+
+``TierManager`` is a pure state machine + event producer. It never touches
+telemetry or the router — the owning ``LoomSession`` reacts to the returned
+``TierChanged`` / ``TierExpiryHint`` events (refreshing ``runtime_identity``,
+queueing reminders) and performs the actual model switch. The base model lives
+on the session (``self._model``); ``TierManager`` reads it live through a
+getter so there is a single source of truth.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Callable
+
+from loom.core.events import TierChanged, TierExpiryHint
+
+
+class TierManager:
+    """Owns sticky-tier state and resolves the active model/tier."""
+
+    def __init__(
+        self,
+        *,
+        base_model_getter: Callable[[], str],
+        tier_models: dict[int, str],
+        default_tier: int,
+        reminder_after_turns: int,
+    ) -> None:
+        self._base_model = base_model_getter
+        self.tier_models = tier_models
+        self.default_tier = default_tier
+        self.reminder_after_turns = reminder_after_turns
+        # ``None`` = follow ``default_tier``; integer = sticky override.
+        self.sticky_tier: int | None = None
+        self.manual_override: bool = False
+        # Consecutive turns at the *active* tier (sticky or default). Reset on
+        # tier change; surfaces in TierExpiryHint after the threshold.
+        self.turns_at_current_tier: int = 0
+        # "Did we already emit a reminder this sticky session?" — avoids
+        # spamming the agent every turn once the threshold is crossed.
+        self.reminder_emitted: bool = False
+        # Skill name → declared tier, populated during skill bootstrap so
+        # ``skill_max_tier`` resolves synchronously (procedural.get is async).
+        self.skill_tier_snapshot: dict[str, int] = {}
+
+    @classmethod
+    def from_config(
+        cls, config: dict, base_model_getter: Callable[[], str],
+    ) -> "TierManager":
+        """Build from the ``[cognition.tiers]`` table."""
+        tier_cfg = (config.get("cognition") or {}).get("tiers", {}) or {}
+        tier_models: dict[int, str] = {}
+        for k, v in tier_cfg.items():
+            try:
+                tier_int = int(k)
+                if isinstance(v, str) and v.strip():
+                    tier_models[tier_int] = v.strip()
+            except (TypeError, ValueError):
+                continue
+        return cls(
+            base_model_getter=base_model_getter,
+            tier_models=tier_models,
+            default_tier=int(tier_cfg.get("default_tier", 1) or 1),
+            reminder_after_turns=int(tier_cfg.get("reminder_after_turns", 10) or 10),
+        )
+
+    # ------------------------------------------------------------------
+    # Resolution
+    # ------------------------------------------------------------------
+
+    def active_tier(self) -> int:
+        """Effective tier this turn — sticky override or default."""
+        return self.sticky_tier if self.sticky_tier is not None else self.default_tier
+
+    def active_model(self) -> str:
+        """Resolve the model name for the active tier.
+
+        A manual ``/model`` selection wins until tier changes again. Otherwise
+        falls back to the base model when the tier system isn't configured for
+        this tier.
+        """
+        base = self._base_model()
+        if self.manual_override:
+            return base
+        return self.tier_models.get(self.active_tier(), base)
+
+    # ------------------------------------------------------------------
+    # Transitions (return events; caller owns the side effects)
+    # ------------------------------------------------------------------
+
+    def set_sticky(
+        self, new_tier: int | None, *, reason: str, source: str,
+    ) -> TierChanged | None:
+        """Update sticky tier + reset counters. Returns a ``TierChanged`` when
+        the active tier actually moved, else ``None``.
+
+        ``source`` is one of ``"skill"`` / ``"agent"`` / ``"user"`` /
+        ``"clear"`` and lands in the event for telemetry / graphify analysis.
+        """
+        base = self._base_model()
+        old_tier = self.active_tier()
+        # Normalize: setting sticky to default_tier is equivalent to clearing,
+        # so the "no override" state remains canonical.
+        if new_tier == self.default_tier:
+            new_tier = None
+        if new_tier == self.sticky_tier:
+            return None  # no-op
+        self.manual_override = False
+        self.sticky_tier = new_tier
+        self.turns_at_current_tier = 0
+        self.reminder_emitted = False
+        active = self.active_tier()
+        if active == old_tier:
+            return None
+        return TierChanged(
+            from_tier=old_tier,
+            to_tier=active,
+            from_model=self.tier_models.get(old_tier, base),
+            to_model=self.tier_models.get(active, base),
+            source=source,
+            reason=reason,
+        )
+
+    def tick_counter(self) -> TierExpiryHint | None:
+        """Increment the per-turn counter for the active tier and return a
+        ``TierExpiryHint`` the first time the threshold is crossed within a
+        sticky session.
+
+        Called once per ``stream_turn`` completion. Skips emission when on the
+        default tier, when the threshold isn't configured (``<= 0``), or when
+        the hint already fired this sticky session.
+        """
+        self.turns_at_current_tier += 1
+        if self.sticky_tier is None:
+            return None
+        if self.reminder_after_turns <= 0:
+            return None
+        if self.reminder_emitted:
+            return None
+        if self.turns_at_current_tier < self.reminder_after_turns:
+            return None
+        self.reminder_emitted = True
+        return TierExpiryHint(
+            tier=self.sticky_tier,
+            model=self.active_model(),
+            turns_used=self.turns_at_current_tier,
+            threshold=self.reminder_after_turns,
+        )
+
+    def mark_manual_override(self) -> None:
+        """Record that a manual ``/model`` selection now governs the model."""
+        self.manual_override = True
+
+    def skill_max_tier(self, activated_names: Iterable[str]) -> int:
+        """Max ``model_tier`` across the currently-activated skills.
+
+        Skills with no declared tier contribute 0, never escalating.
+        """
+        max_tier = 0
+        for name in activated_names or ():
+            tier = self.skill_tier_snapshot.get(name, 0)
+            if tier > max_tier:
+                max_tier = tier
+        return max_tier
+
+
+__all__ = ["TierManager"]

--- a/tests/test_llm_tier_system.py
+++ b/tests/test_llm_tier_system.py
@@ -20,6 +20,7 @@ import pytest
 
 from loom.core.events import TierChanged, TierExpiryHint
 from loom.core.session import LoomSession, _parse_skill_frontmatter
+from loom.core.tier_manager import TierManager
 from loom.core.memory.procedural import SkillGenome
 from loom.platform.cli.tools import make_request_model_tier_tool, make_clear_model_tier_tool
 
@@ -91,6 +92,32 @@ class TestSkillGenomeStores:
 # Session state methods (duck-typed; mirrors test_observation_masking pattern)
 # ---------------------------------------------------------------------------
 
+class _FakeSession:
+    """Stand-in that mirrors LoomSession's tier surface faithfully.
+
+    The tier state machine now lives in TierManager (loom/core/tier_manager.py);
+    LoomSession's tier methods are thin delegators + read-only properties over
+    ``self._tier``. We reuse the *real* delegators and property logic here (no
+    re-implementation) over a real TierManager, so these tests exercise the
+    actual session surface AND the real state machine — including the leaked
+    private-attribute reads (``session._tier_models`` etc.) that the CLI tools
+    perform. State assertions read through ``s._tier``.
+    """
+
+    _tier_models = property(lambda self: self._tier.tier_models)
+    _sticky_tier = property(lambda self: self._tier.sticky_tier)
+    _default_tier = property(lambda self: self._tier.default_tier)
+    _turns_at_current_tier = property(lambda self: self._tier.turns_at_current_tier)
+    _skill_tier_snapshot = property(lambda self: self._tier.skill_tier_snapshot)
+
+    _active_tier = LoomSession._active_tier
+    _active_model = LoomSession._active_model
+    _set_sticky_tier = LoomSession._set_sticky_tier
+    _tick_tier_counter = LoomSession._tick_tier_counter
+    _compute_skill_max_tier = LoomSession._compute_skill_max_tier
+    _refresh_runtime_identity = LoomSession._refresh_runtime_identity
+
+
 def _mock_session(
     *,
     tier_models: dict[int, str] | None = None,
@@ -102,34 +129,23 @@ def _mock_session(
     turns_at_current_tier: int = 0,
     reminder_emitted: bool = False,
     base_model: str = "minimax-m2.7",
-) -> SimpleNamespace:
-    """Build a stand-in exposing the surface the tier methods read.
-
-    LoomSession's tier methods call each other (``_active_model`` calls
-    ``_active_tier``), so we must bind them onto the mock as bound methods
-    rather than calling unbound. Same idea as ``test_observation_masking``
-    but with multi-method binding.
-    """
-    s = SimpleNamespace(
-        _tier_models=tier_models or {1: "minimax-m2.7", 2: "deepseek-v4-pro"},
-        _default_tier=default_tier,
-        _sticky_tier=sticky_tier,
-        _skill_tier_snapshot=skill_snapshot or {},
-        _skill_outcome_tracker=SimpleNamespace(
-            activated_skills=activated_skills or [],
-        ),
-        _tier_reminder_after_turns=reminder_threshold,
-        _turns_at_current_tier=turns_at_current_tier,
-        _tier_reminder_emitted=reminder_emitted,
-        _model=base_model,
+) -> _FakeSession:
+    """Build a ``_FakeSession`` backed by a real TierManager."""
+    s = _FakeSession()
+    s._model = base_model
+    s._telemetry = None
+    s._skill_outcome_tracker = SimpleNamespace(activated_skills=activated_skills or [])
+    tier = TierManager(
+        base_model_getter=lambda: s._model,
+        tier_models=tier_models or {1: "minimax-m2.7", 2: "deepseek-v4-pro"},
+        default_tier=default_tier,
+        reminder_after_turns=reminder_threshold,
     )
-    # Bind the methods we exercise so internal self._x() calls resolve.
-    for attr in (
-        "_active_tier", "_active_model", "_set_sticky_tier",
-        "_compute_skill_max_tier", "_tick_tier_counter",
-        "_refresh_runtime_identity",
-    ):
-        setattr(s, attr, getattr(LoomSession, attr).__get__(s))
+    tier.sticky_tier = sticky_tier
+    tier.turns_at_current_tier = turns_at_current_tier
+    tier.reminder_emitted = reminder_emitted
+    tier.skill_tier_snapshot = skill_snapshot or {}
+    s._tier = tier
     return s
 
 
@@ -160,7 +176,7 @@ class TestActiveTierAndModel:
 
     def test_manual_model_override_wins_over_tier(self):
         s = _mock_session(sticky_tier=2, base_model="codex/gpt-5.5")
-        s._manual_model_override = True
+        s._tier.manual_override = True
         assert s._active_model() == "codex/gpt-5.5"
 
     def test_unknown_tier_falls_back_to_base_model(self):
@@ -173,7 +189,7 @@ class TestSetStickyTier:
     def test_set_default_tier_normalizes_to_none(self):
         s = _mock_session(sticky_tier=2)
         ev = s._set_sticky_tier(1, reason="done", source="agent")
-        assert s._sticky_tier is None  # normalized
+        assert s._tier.sticky_tier is None  # normalized
         assert ev is not None
         assert isinstance(ev, TierChanged)
         assert ev.from_tier == 2
@@ -189,7 +205,7 @@ class TestSetStickyTier:
     def test_escalation_emits_event(self):
         s = _mock_session(sticky_tier=None, default_tier=1)
         ev = s._set_sticky_tier(2, reason="hard", source="skill")
-        assert s._sticky_tier == 2
+        assert s._tier.sticky_tier == 2
         assert ev is not None
         assert ev.from_tier == 1
         assert ev.to_tier == 2
@@ -199,7 +215,7 @@ class TestSetStickyTier:
     def test_explicit_clear_via_none(self):
         s = _mock_session(sticky_tier=2)
         ev = s._set_sticky_tier(None, reason="ok", source="clear")
-        assert s._sticky_tier is None
+        assert s._tier.sticky_tier is None
         assert ev is not None
         assert ev.to_tier == 1  # default
 
@@ -208,14 +224,14 @@ class TestSetStickyTier:
             sticky_tier=None, turns_at_current_tier=7, reminder_emitted=True,
         )
         s._set_sticky_tier(2, reason="x", source="skill")
-        assert s._turns_at_current_tier == 0
-        assert s._tier_reminder_emitted is False
+        assert s._tier.turns_at_current_tier == 0
+        assert s._tier.reminder_emitted is False
 
     def test_tier_change_clears_manual_model_override(self):
         s = _mock_session(sticky_tier=None, base_model="codex/gpt-5.5")
-        s._manual_model_override = True
+        s._tier.manual_override = True
         s._set_sticky_tier(2, reason="x", source="user")
-        assert s._manual_model_override is False
+        assert s._tier.manual_override is False
         assert s._active_model() == "deepseek-v4-pro"
 
 
@@ -252,7 +268,7 @@ class TestTickTierCounter:
         s = _mock_session(sticky_tier=None)
         ev = s._tick_tier_counter()
         assert ev is None
-        assert s._turns_at_current_tier == 1  # still increments
+        assert s._tier.turns_at_current_tier == 1  # still increments
 
     def test_below_threshold_no_hint(self):
         s = _mock_session(
@@ -260,7 +276,7 @@ class TestTickTierCounter:
         )
         ev = s._tick_tier_counter()
         assert ev is None
-        assert s._turns_at_current_tier == 6
+        assert s._tier.turns_at_current_tier == 6
 
     def test_at_threshold_emits_hint_once(self):
         s = _mock_session(
@@ -271,7 +287,7 @@ class TestTickTierCounter:
         assert ev.tier == 2
         assert ev.turns_used == 10
         assert ev.threshold == 10
-        assert s._tier_reminder_emitted is True
+        assert s._tier.reminder_emitted is True
 
         # Subsequent ticks don't re-emit
         ev2 = s._tick_tier_counter()
@@ -321,7 +337,7 @@ class TestRequestModelTierTool:
             "request_model_tier", tier=2, reason="multi-constraint puzzle",
         ))
         assert result.success
-        assert s._sticky_tier == 2
+        assert s._tier.sticky_tier == 2
         # TierChanged was queued
         assert not s._lifecycle_events.empty()
         ev = s._lifecycle_events.get_nowait()
@@ -337,7 +353,7 @@ class TestRequestModelTierTool:
             "clear_model_tier", reason="phase done",
         ))
         assert result.success
-        assert s._sticky_tier is None
+        assert s._tier.sticky_tier is None
         assert "cleared" in result.output.lower()
 
     async def test_clear_model_tier_rejects_empty_reason(self):

--- a/tests/test_scope_phase_cd.py
+++ b/tests/test_scope_phase_cd.py
@@ -97,9 +97,9 @@ class TestFormatScopePanel:
     """Test _format_scope_panel produces correct Rich markup."""
 
     def _import_format(self):
-        # Import the static method from LoomSession
-        from loom.core.session import LoomSession
-        return LoomSession._format_scope_panel
+        # Stateless helper extracted to session_support (re-exported by session).
+        from loom.core.session import _format_scope_panel
+        return _format_scope_panel
 
     def test_legacy_no_metadata(self):
         fmt = self._import_format()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -10,6 +10,22 @@ import pytest
 import pytest_asyncio
 
 import loom as loom_pkg
+from loom.core.tier_manager import TierManager
+
+
+def _bare_tier(session, *, tier_models=None, default_tier=1):
+    """Attach a TierManager to a bare ``LoomSession.__new__`` instance.
+
+    set_model() / the runtime-identity path delegate to ``self._tier``; tests
+    that drive a hand-built session need it wired.
+    """
+    session._tier = TierManager(
+        base_model_getter=lambda: session._model,
+        tier_models=tier_models or {},
+        default_tier=default_tier,
+        reminder_after_turns=10,
+    )
+    return session._tier
 
 
 @pytest.fixture(autouse=True)
@@ -142,13 +158,14 @@ class TestSetModel:
         session = LoomSession.__new__(LoomSession)
         session.router = initial_router
         session._model = "MiniMax-M2.7"
+        tier = _bare_tier(session)
 
         assert session.set_model("codex/gpt-5.5") is True
         initial_router.switch_model.assert_called_once_with("codex/gpt-5.5")
         codex_router.switch_model.assert_called_once_with("codex/gpt-5.5")
         assert session.router is codex_router
         assert session.model == "codex/gpt-5.5"
-        assert session._manual_model_override is True
+        assert tier.manual_override is True
 
     def test_lazy_registers_xai_provider_on_switch(self, monkeypatch: pytest.MonkeyPatch):
         # #471: the rebuild-retry used to be codex-only, so /model xai/... left
@@ -165,6 +182,7 @@ class TestSetModel:
         session = LoomSession.__new__(LoomSession)
         session.router = initial_router
         session._model = "MiniMax-M2.7"
+        _bare_tier(session)
 
         assert session.set_model("xai/grok-4.3") is True
         assert session.router is xai_router
@@ -224,9 +242,7 @@ class TestSetModel:
         session = LoomSession.__new__(LoomSession)
         session.router = router
         session._model = "MiniMax-M2.7"
-        session._sticky_tier = None
-        session._default_tier = 1
-        session._tier_models = {}
+        _bare_tier(session)
         ri = MagicMock()
         telemetry = MagicMock()
         telemetry.get.return_value = ri


### PR DESCRIPTION
## 背景

`loom/core/session.py` 是 5000 行的中樞 orchestrator god object，PR #407 那波 audit 時刻意保留不動。這個 PR 是「整理 session.py」的第一波，目標**不是壓行數**，而是把**真正可分離、且 state 切得乾淨**的東西移出去，讓 session.py 收斂成協調者。

明確**不做**把 13 個 section 散成 mixin 檔的純物理拆分（只會分散糾纏、增加 merge 成本）。也**不碰** `stream_turn` 與 compaction 叢集。

兩個 commit，兩類抽取：

## Commit 1 — 無狀態 helper → `session_support.py`

Module-level helper（其中 7 個已外流成 de-facto public API，被 cli/tools、diagnostic/startup、測試 import）搬到新的 `loom/core/session_support.py`：envelope marker parser、think-block 串流 lookahead、output-token 解析、`.env` 載入、skill frontmatter parser、background-jobs 提醒、兩個 scope formatter（原 `@staticmethod` → 模組函式）。

session.py **re-export 全部**，歷史 import path（`from loom.core.session import _load_env` 等）不變。零行為風險。

## Commit 2 — tier 狀態機 → `tier_manager.py`

Section 8 的 tier 邏輯（#276）是自成一體的狀態機：~8 個 instance attr + 6 個方法解析「這回合哪個 model 服務」（manual /model override > sticky tier > default tier > base model）+ skill 升級 snapshot + 過期計數器。

抽到新的 `loom/core/tier_manager.py`，是**純狀態機 + event producer**：不碰 telemetry/router。base model 仍留 session（`self._model`），TierManager 用 getter 即時讀取，維持單一真相。

LoomSession 保留薄 delegator（`_active_model`/`_set_sticky_tier`/`current_model`/`set_model`…）+ read-only properties（`_tier_models`/`_sticky_tier`/`_default_tier`/`_turns_at_current_tier`/`_skill_tier_snapshot`），讓 CLI/Discord 的外部存取面**完全不變**。`_set_sticky_tier` 保留 runtime_identity refresh 副作用。

## session.py：5000 → 4611 行

## 為什麼沒有 envelope view 那一步

原計畫的第三步（envelope view 整併）勘查後**刻意略過**：PR1 已抓走真正可分離的無狀態 helper；剩下的 `_build_envelope_view`/`_author_envelope_outcome_summary` 是合法地與 session 耦合的 adapter，而 `LedgerEnvelopeProjector` 的 docstring 明寫「stateless across calls」——硬抽會違反它的設計、或必須動到刻意 defer 的 stream_turn。cohesion 還沒失敗，不強拆。

## 測試

- 全套 `pytest tests/` 綠（2252 passed）。3 個 pre-existing 失敗（version-sync ×2 + 一個 discord current_model mock）在乾淨 master 上一樣失敗，與本 PR 無關，已 stash 驗證。
- tier 測試 fake 改用真 TierManager backing + 重用真 delegator/property（不重新實作），同時測 session 表面與狀態機。
- gitnexus `detect_changes`：risk LOW、0 affected processes。

🤖 Generated with [Claude Code](https://claude.com/claude-code)