### PR TITLE
fix(tests): resolve three pre-existing test failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ The `doc/` directory contains full technical documentation for every subsystem:
 
 | Version | Date | Highlights |
 |---------|------|-----------|
+| **v0.3.8.2** | 2026-05-28 | Circadian autonomy lifecycle completed (PRs #459–463); cognition provider split (Codex/xAI) + model identity convergence (PR #474); CLI/Discord LivenessSensor convergence (PR #483); Discord confirm timeout fix (PR #484) |
 | **v0.3.8.1** | 2026-05-23 | Lens import family retired (`loom import` CLI · `Hermes`/`OpenAI` lenses removed); extensibility surface convergence to `@loom.tool` / `LoomPlugin` / MCP (PR #442) |
 | **v0.3.8.0** | 2026-05-21 | Interaction Language UI/UX overhaul (envelope intent/outcome render, CLI heartbeat, stalled-status proxy); TaskList v2 with `done_when` acceptance criterion; semantic-dup admission gate; three-round system audit; Textual TUI subsystem retired |
 | **v0.3.7.5** | 2026-05-18 | OS-level sandbox for `run_bash` via Anthropic's `sandbox-runtime` — opt-in kernel-level filesystem + network confinement (Quest A · Issue #29) |

--- a/doc/00-總覽.md
+++ b/doc/00-總覽.md
@@ -1,6 +1,6 @@
 # Loom 總覽
 
-<!-- loom-version: 0.3.8.0 -->
+<!-- loom-version: 0.3.8.2 -->
 
 > *The loom is what the harness belongs to. Claude Code is one thread; Loom is the machine that weaves any thread into the same quality fabric.*
 

--- a/loom/__init__.py
+++ b/loom/__init__.py
@@ -1,6 +1,6 @@
 """Loom — Harness-first, memory-native, self-directing agent framework."""
 
-__version__ = "0.3.8.0"
+__version__ = "0.3.8.2"
 
 from loom.extensibility.adapter import AdapterRegistry as _AdapterRegistry
 from loom.extensibility.plugin import LoomPlugin, PluginRegistry as _PluginRegistry

--- a/tests/test_discord_slash_commands.py
+++ b/tests/test_discord_slash_commands.py
@@ -52,6 +52,7 @@ def _fake_session(
     session = MagicMock()
     session.session_id = "sess-test"
     session.model = model
+    session.current_model = lambda: session.model
     session.current_personality = personality
     session._stack = MagicMock()
     session._stack.available_personalities = MagicMock(return_value=list(available_personalities))


### PR DESCRIPTION
## Background

PR #485 merged and left three pre-existing test failures in the suite:

1. `tests/test_discord_slash_commands.py::test_model_no_arg_shows_current_and_providers`
2. `tests/test_doc_integrity.py::test_layer3_version_sync`
3. `tests/test_package_metadata.py::test_package_version_matches_pyproject`

These are unrelated to #485 but belong in the same sweep since they are version-sync and mock-surface issues.

## Changes

### `tests/test_discord_slash_commands.py` — `_fake_session` missing `current_model()`

`_cmd_model` on `LoomDiscordBot` calls `session.current_model()` to render the currently active model name. The `_fake_session` helper in the test suite set `session.model` but not `session.current_model`, so the command output showed a `MagicMock` repr instead of the expected model name.

**Fix:** add `session.current_model = lambda: session.model` to `_fake_session`.

### `loom/__init__.py` — version drift

`__version__` was `0.3.8.0` while `pyproject.toml` declared `0.3.8.2` after the v0.3.8.2 release commit.

**Fix:** update `__version__ = "0.3.8.2"`.

### `doc/00-總覽.md` — version marker drift

The `<!-- loom-version: 0.3.8.0 -->` comment was out of sync with `pyproject.toml`.

**Fix:** update to `<!-- loom-version: 0.3.8.2 -->`.

### `README.md` — missing v0.3.8.2 changelog entry

The version history table had no entry for v0.3.8.2, causing `test_layer3_version_sync` to flag "latest changelog v0.3.8.1 != pyproject 0.3.8.2".

**Fix:** insert the v0.3.8.2 row before the v0.3.8.1 row:

```
| **v0.3.8.2** | 2026-05-28 | Circadian autonomy lifecycle completed (PRs #459–463); cognition provider split (Codex/xAI) + model identity convergence (PR #474); CLI/Discord LivenessSensor convergence (PR #483); Discord confirm timeout fix (PR #484) |
```

## Verification

```bash
pytest tests/ -q
# 2255 passed, 4 skipped, 0 failed
```