### PR TITLE
feat(memory): convergent dream — read-only consolidation pass (P1, #488)

### DIFF
--- a/docs/designs/56-記憶鞏固夢-收斂相規格.md
+++ b/docs/designs/56-記憶鞏固夢-收斂相規格.md
@@ -216,11 +216,11 @@ self_review 是 Loom 在 offline pass **內部呼叫的自審步驟**，不需�
 
 **設計驅動**：report 是**儀式與審計的交界**——有敘事感（絲絲事後可讀「過去這週記憶怎麼長的」、dormant 收斂相變成「可主動參與的回顧儀式」），但不能只停在敘事，**必須對得回 DB / ledger / metadata 的真實狀態**。
 
-**形式**：收斂相完成後，用既有 `journal_append` 工具，在 `autonomy/circadian/journal/YYYY-MM-DD.md` 附加一個 `kind=dream_consolidation` 的 entry，含：本輪 pass 摘要（掃描範圍、發現 N 簇 / M 矛盾 / K 孤兒）、Merge 記錄（每簇結果 + rationale；跳過要記差異盤點輸出）、Reconcile 記錄（winner + 仲裁理由）、Clean 記錄、**絲絲 self_review 介入**（批准/否決/暫緩 + 否決理由是否關乎「怕磨平 / dreaming 保護 / user_explicit 錨點」）。
+**形式**：收斂相完成後，由系統直接呼叫 `append_consolidation_report()`（`loom/autonomy/circadian/journal.py`，**非** agent 的 `journal_append` 工具），在 `autonomy/circadian/journal/YYYY-MM-DD.md` 附加一個 `## HH:MM · 夢境鞏固` entry，含：本輪 pass 摘要（掃描範圍、發現 N 簇 / M 矛盾 / K 孤兒）、Merge 記錄（每簇結果 + rationale；跳過要記差異盤點輸出）、Reconcile 記錄（winner + 仲裁理由）、Clean 記錄、**絲絲 self_review 介入**（批准/否決/暫緩 + 否決理由是否關乎「怕磨平 / dreaming 保護 / user_explicit 錨點」）。
 
-**整合**：circadian journal 因此成為「絲絲的雙相夢紀錄」——發散探索與收斂整理同檔；`grep dream_consolidation` 即可回顧。
+**整合**：circadian journal 因此成為「絲絲的雙相夢紀錄」——發散探索與收斂整理同檔；`grep 夢境鞏固` 即可回顧。
 
-> ⚠️ 實作 note：`journal.py:55` 的 `kind` 是預定義 enum（英文 key → 中文 H2 label），`dream_consolidation` 是**新值，須在那張 map 補一筆**才能用。
+> **實作決議（P1 #488 as-built，修正初稿 note）**：報告**不**走 agent 的 `journal_append` `kind` enum。`journal.py` 的 `KIND_LABELS`（moment/finding/keepsake/tomorrow）是給「每日生活紋理」用的；把系統報告塞進去會污染 agent 工具的選項。改抽共用的 `_append_dated_entry()` helper，新增 `CONSOLIDATION_LABEL = "夢境鞏固"` + 系統入口 `append_consolidation_report()`——同一份 dated journal 檔、同樣 atomic append，但與 agent enum 解耦。
 
 ---
 

--- a/loom/autonomy/circadian/journal.py
+++ b/loom/autonomy/circadian/journal.py
@@ -66,9 +66,59 @@ KIND_LABELS: dict[str, str] = {
 }
 
 
+# System-generated entry labels — NOT in KIND_LABELS so the agent-facing
+# journal_append tool's life-texture enum stays clean (#488, spec §8).
+CONSOLIDATION_LABEL = "夢境鞏固"
+
+
 def journal_path_for(date_str: str, base: Path | None = None) -> Path:
     """Dated journal file for ``date_str`` (YYYY-MM-DD). One file per day."""
     return (base or DEFAULT_JOURNAL_DIR) / f"{date_str}.md"
+
+
+def _append_dated_entry(
+    target_dir: Path, now: datetime, label: str, body: str,
+) -> Path:
+    """Append one ``## HH:MM · {label}`` entry to today's journal file.
+
+    Single-source of the atomic-append behaviour shared by the agent
+    ``journal_append`` tool and system-generated reports. Lazy H1 header on
+    first write of the day; one ``write()`` syscall so concurrent appends
+    don't tear (POSIX O_APPEND atomic ≤ PIPE_BUF). Raises ``OSError`` on IO
+    failure — callers decide how to surface it.
+    """
+    date_str = now.strftime("%Y-%m-%d")
+    time_str = now.strftime("%H:%M")
+    path = journal_path_for(date_str, target_dir)
+
+    chunk = ""
+    if not path.exists():
+        chunk += f"# {date_str} Journal\n\n"
+    chunk += f"## {time_str} · {label}\n{body}\n\n"
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(chunk)
+    return path
+
+
+def append_consolidation_report(
+    report_body: str,
+    *,
+    timezone: str = "Asia/Taipei",
+    journal_dir: Path | None = None,
+) -> Path:
+    """Append a convergent-dream pass report to today's journal (#488, spec §8).
+
+    System-generated (written by the convergent-dream orchestrator, not the
+    agent), so it uses the ``夢境鞏固`` label directly rather than a
+    ``journal_append`` ``kind`` — keeping the agent tool's enum life-texture
+    only. Lands in the same dated file so the circadian journal becomes the
+    record of both dream phases (``grep 夢境鞏固`` to review). Returns the path.
+    """
+    target_dir = journal_dir or DEFAULT_JOURNAL_DIR
+    now = datetime.now(ZoneInfo(timezone))
+    return _append_dated_entry(target_dir, now, CONSOLIDATION_LABEL, report_body)
 
 
 def make_journal_append_tool(
@@ -102,29 +152,15 @@ def make_journal_append_tool(
             )
 
         now = datetime.now(ZoneInfo(timezone))
-        date_str = now.strftime("%Y-%m-%d")
         time_str = now.strftime("%H:%M")
         label = KIND_LABELS[kind]
-        path = journal_path_for(date_str, target_dir)
-
-        # Build the full payload first so the actual write() is one syscall —
-        # POSIX O_APPEND is atomic for writes ≤ PIPE_BUF, and a single string
-        # write keeps two concurrent journal_append calls from interleaving
-        # mid-entry.
-        new_file = not path.exists()
-        chunk = ""
-        if new_file:
-            chunk += f"# {date_str} Journal\n\n"
-        chunk += f"## {time_str} · {label}\n{body}\n\n"
 
         try:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            with path.open("a", encoding="utf-8") as fh:
-                fh.write(chunk)
+            path = _append_dated_entry(target_dir, now, label, body)
         except OSError as exc:
             return ToolResult(
                 call_id=call.id, tool_name=call.tool_name, success=False,
-                error=f"could not write journal entry to {path}: {exc}",
+                error=f"could not write journal entry: {exc}",
             )
 
         return ToolResult(

--- a/loom/core/cognition/consolidation.py
+++ b/loom/core/cognition/consolidation.py
@@ -40,6 +40,7 @@ import json
 import logging
 import re
 import uuid
+from collections import Counter
 from dataclasses import dataclass, field
 from datetime import datetime, UTC
 from typing import Awaitable, Callable, TYPE_CHECKING
@@ -360,11 +361,27 @@ async def diff_inventory(cluster: CandidateCluster, llm_fn: LLMFn) -> DiffInvent
     data = _parse_json_object(raw)
     if data is None:
         return DiffInventory(mergeable=False, rationale="diff-inventory output unparseable")
-    return DiffInventory(
-        unique_by_key={str(k): str(v) for k, v in (data.get("unique_by_key") or {}).items()},
-        mergeable=bool(data.get("mergeable", False)),
-        rationale=str(data.get("rationale", "")),
-    )
+
+    unique_by_key = {str(k): str(v) for k, v in (data.get("unique_by_key") or {}).items()}
+    mergeable = bool(data.get("mergeable", False))
+    rationale = str(data.get("rationale", ""))
+
+    # Fail safe when the inventory shape does not match the cluster (Codex
+    # review #493): a response that omits a member — or invents a key that
+    # isn't in the cluster — cannot be trusted to claim mergeable. The gate
+    # must COVER exactly the cluster members before we honour mergeable=True.
+    expected = set(cluster.member_keys)
+    if expected and set(unique_by_key) != expected:
+        return DiffInventory(
+            unique_by_key=unique_by_key,
+            mergeable=False,
+            rationale=(
+                f"diff-inventory keys {sorted(unique_by_key)} did not cover "
+                f"cluster members {sorted(expected)} — failing safe"
+            ),
+        )
+
+    return DiffInventory(unique_by_key=unique_by_key, mergeable=mergeable, rationale=rationale)
 
 
 # ---------------------------------------------------------------------------
@@ -455,8 +472,19 @@ async def self_review(plan: ConsolidationPlan, llm_fn: LLMFn) -> list[ReviewDeci
         return decisions
 
     parsed = _parse_json_array(raw)
+    id_counts = Counter(str(d.get("cluster_id")) for d in parsed if isinstance(d, dict))
     by_id = {str(d.get("cluster_id")): d for d in parsed if isinstance(d, dict)}
     for c in review_clusters:
+        # A repeated id is malformed output (Codex review #493). Never let a
+        # later verdict silently overwrite an earlier one — last-wins would
+        # let a bogus "approve" bury a real "skip"/"defer" and weaken the
+        # strong-veto contract. Ambiguous → defer.
+        if id_counts.get(c.cluster_id, 0) > 1:
+            decisions.append(ReviewDecision(
+                cluster_id=c.cluster_id, verdict=VERDICT_DEFER,
+                reason="duplicate cluster_id in self-review output — deferred",
+            ))
+            continue
         d = by_id.get(c.cluster_id)
         verdict = str(d.get("verdict", "")).lower() if d else ""
         if verdict not in (VERDICT_APPROVE, VERDICT_SKIP, VERDICT_DEFER):

--- a/loom/core/cognition/consolidation.py
+++ b/loom/core/cognition/consolidation.py
@@ -362,8 +362,19 @@ async def diff_inventory(cluster: CandidateCluster, llm_fn: LLMFn) -> DiffInvent
     if data is None:
         return DiffInventory(mergeable=False, rationale="diff-inventory output unparseable")
 
-    unique_by_key = {str(k): str(v) for k, v in (data.get("unique_by_key") or {}).items()}
-    mergeable = bool(data.get("mergeable", False))
+    # unique_by_key must be an object; a list/string/None would crash .items()
+    # — fail safe rather than raise (Codex re-review #493).
+    raw_ubk = data.get("unique_by_key")
+    if not isinstance(raw_ubk, dict):
+        return DiffInventory(
+            mergeable=False,
+            rationale="diff-inventory unique_by_key was not an object — failing safe",
+        )
+    unique_by_key = {str(k): str(v) for k, v in raw_ubk.items()}
+    # Only an explicit JSON boolean true counts. bool("false") is True, so a
+    # stringified verdict must NOT slip through — anything other than real
+    # `true` fails safe to not-mergeable (Codex re-review #493).
+    mergeable = data.get("mergeable") is True
     rationale = str(data.get("rationale", ""))
 
     # Fail safe when the inventory shape does not match the cluster (Codex

--- a/loom/core/cognition/consolidation.py
+++ b/loom/core/cognition/consolidation.py
@@ -1,0 +1,604 @@
+"""
+Convergent Dream — read-only memory consolidation planner for Loom (#488, P1).
+
+The counterpart to ``dreaming.dream_cycle`` (the *divergent* dream that grows
+new connections). The convergent dream *consolidates*: it scans the semantic
+store, finds duplicate / contradicting / orphaned facts, and proposes how to
+fuse or reconcile them — but in this first phase it **never writes to the DB**.
+
+Pipeline (spec #56 §4, "說夢話 model")::
+
+    index → plan → self_review → (execute) → report
+
+P1 implements ``index → plan → self_review → report`` only. ``execute`` (the
+``semantic.consolidate()`` call) lands in P2 (#489); the MERGE arm + batch
+reconcile + orphan criteria land in P3 (#490). Everything here is read-only
+so the convergent dream can be "seen, talked through, and recorded" before it
+is ever allowed to touch a fact.
+
+Design decisions
+----------------
+* **Read-only by construction** — this module imports no write path. It calls
+  ``semantic`` only through ``list_recent`` / ``find_near_duplicates`` /
+  ``get`` and ``ContradictionDetector.detect`` (all reads). The orchestrator
+  asserts the corpus is byte-identical before and after.
+* **Pure cognition** — no imports from platform, harness, or autonomy. The
+  ``ToolDefinition`` adapter lives in ``loom.core.memory.maintenance``.
+* **dreaming exemption is principled, not tactical** (spec §6.5) — facts whose
+  source classifies as ``dreaming`` are the divergent dream's own output and
+  are never proposed for merge/reconcile; a dreaming fact with no relations is
+  an *allowed orphan* (a connection still waiting for its place), not garbage.
+* **Strong veto** (spec §6.2) — ``self_review`` verdicts are hard boundaries,
+  not advisory scores. ``skip`` / ``defer`` mean the cluster is not executed.
+* **No silent caps** (feedback: no-silent-truncation) — when a batch cap drops
+  clusters, the plan records how many were deferred for the next pass.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, UTC
+from typing import Awaitable, Callable, TYPE_CHECKING
+
+from loom.core.memory.semantic import SemanticEntry, classify_source
+
+if TYPE_CHECKING:
+    from loom.core.memory.semantic import SemanticMemory
+
+logger = logging.getLogger(__name__)
+
+LLMFn = Callable[[list[dict]], Awaitable[str]]
+
+# Cluster kinds — what the convergent dream proposes to do with a group.
+KIND_MERGE = "merge"          # ≥2 near-duplicate facts to fuse into one
+KIND_RECONCILE = "reconcile"  # facts that contradict and need arbitration
+KIND_CLEAN = "clean"          # orphaned references to delete
+
+# Review verdicts (spec §6.2). Hard boundaries, not scores.
+VERDICT_APPROVE = "approve"
+VERDICT_SKIP = "skip"
+VERDICT_DEFER = "defer"
+
+
+# ---------------------------------------------------------------------------
+# Data structures (spec §5.1 ConsolidationPlan)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DiffInventory:
+    """Result of the LLM "差異盤點" gate for a merge cluster (spec §6.4).
+
+    ``unique_by_key`` maps each member key → what that member says that no
+    other member does. ``mergeable`` is False when ≥2 members carry unique
+    content (they are distinct insights that merely look alike).
+    """
+    unique_by_key: dict[str, str] = field(default_factory=dict)
+    mergeable: bool = False
+    rationale: str = ""
+
+
+@dataclass
+class CandidateCluster:
+    """A group of facts the convergent dream proposes to act on.
+
+    Read-only: holds the member entries and the *proposed* action, never the
+    executed result. ``proposed_action`` is a human/agent-readable description
+    of what execute (P2) would do — not a mutation.
+    """
+    cluster_id: str
+    kind: str                                   # KIND_MERGE / KIND_RECONCILE / KIND_CLEAN
+    members: list[SemanticEntry]
+    similarity: float = 0.0                     # max pairwise cosine (merge) or detector score
+    diff: DiffInventory | None = None           # merge only — set by diff_inventory()
+    proposed_action: str = ""                   # what execute would do (read-only description)
+
+    @property
+    def member_keys(self) -> list[str]:
+        return [m.key for m in self.members]
+
+
+@dataclass
+class ReviewDecision:
+    """絲絲's self-review verdict on one cluster (spec §6.2). Hard boundary."""
+    cluster_id: str
+    verdict: str                                # VERDICT_APPROVE / SKIP / DEFER
+    reason: str = ""
+
+
+@dataclass
+class ConsolidationPlan:
+    """Durable, read-only plan produced by one convergent-dream pass (spec §5.1).
+
+    ``source_versions`` snapshots each member's ``updated_at`` so the execute
+    step (P2) can detect facts that changed after review and mark the cluster
+    stale rather than acting on a stale plan.
+    """
+    pass_id: str = field(default_factory=lambda: f"dream-{uuid.uuid4().hex[:12]}")
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    clusters: list[CandidateCluster] = field(default_factory=list)
+    decisions: list[ReviewDecision] = field(default_factory=list)
+    source_versions: dict[str, str] = field(default_factory=dict)  # key → updated_at iso
+    execution_status: str = "planned"           # planned (P1) → executed/stale (P2)
+    # Coverage accounting — no silent caps.
+    scanned: int = 0
+    deferred_to_next_pass: int = 0
+    notes: list[str] = field(default_factory=list)
+
+    def decision_for(self, cluster_id: str) -> ReviewDecision | None:
+        for d in self.decisions:
+            if d.cluster_id == cluster_id:
+                return d
+        return None
+
+    def counts(self) -> dict[str, int]:
+        c = {KIND_MERGE: 0, KIND_RECONCILE: 0, KIND_CLEAN: 0}
+        for cl in self.clusters:
+            c[cl.kind] = c.get(cl.kind, 0) + 1
+        return c
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _is_dreaming(entry: SemanticEntry) -> bool:
+    """True if the entry is the divergent dream's own output (spec §6.5)."""
+    tier, _ = classify_source(entry.source)
+    return tier == "dreaming"
+
+
+def _union_find_clusters(pairs: list[tuple[str, str]]) -> list[set[str]]:
+    """Group keys into connected components from a list of (key_a, key_b) edges."""
+    parent: dict[str, str] = {}
+
+    def find(x: str) -> str:
+        parent.setdefault(x, x)
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: str, b: str) -> None:
+        parent[find(a)] = find(b)
+
+    for a, b in pairs:
+        union(a, b)
+
+    groups: dict[str, set[str]] = {}
+    for key in parent:
+        root = find(key)
+        groups.setdefault(root, set()).add(key)
+    return [g for g in groups.values() if len(g) >= 2]
+
+
+# ---------------------------------------------------------------------------
+# Step 2 — plan (read-only candidate discovery)
+# ---------------------------------------------------------------------------
+
+async def build_plan(
+    semantic: "SemanticMemory",
+    *,
+    corpus_limit: int = 2000,
+    min_similarity: float = 0.85,
+    max_clusters: int = 20,
+) -> ConsolidationPlan:
+    """Scan the semantic store and propose merge / reconcile / clean clusters.
+
+    Strictly read-only. ``max_clusters`` caps how many merge clusters one pass
+    proposes (spec §7 batch cap); the overflow count is recorded in the plan,
+    never silently dropped.
+    """
+    plan = ConsolidationPlan()
+
+    corpus = await semantic.list_recent(limit=corpus_limit)
+    plan.scanned = len(corpus)
+    by_key = {e.key: e for e in corpus}
+
+    # ── Merge candidates: near-duplicate clustering (dreaming-exempt) ──────
+    edges: list[tuple[str, str]] = []
+    pair_score: dict[frozenset[str], float] = {}
+    if semantic.has_embeddings:
+        for entry in corpus:
+            if _is_dreaming(entry):
+                continue  # spec §6.5 — never propose dreaming output for merge
+            try:
+                neighbours = await semantic.find_near_duplicates(
+                    entry.value,
+                    min_similarity=min_similarity,
+                    within_days=None,           # whole corpus, not the write-time 7-day window
+                    limit=5,
+                    exclude_key=entry.key,
+                )
+            except Exception as exc:  # embedding outage must not abort the pass
+                plan.notes.append(f"near-dup lookup failed for {entry.key!r}: {exc}")
+                continue
+            for neighbour, score in neighbours:
+                if _is_dreaming(neighbour) or neighbour.key not in by_key:
+                    continue
+                edges.append((entry.key, neighbour.key))
+                pair = frozenset((entry.key, neighbour.key))
+                pair_score[pair] = max(pair_score.get(pair, 0.0), score)
+    else:
+        plan.notes.append("no embedding provider — merge candidates skipped this pass")
+
+    merge_groups = _union_find_clusters(edges)
+    # Stable ordering: highest-similarity clusters first so the batch cap keeps
+    # the most confident merges.
+    def _group_score(group: set[str]) -> float:
+        return max(
+            (pair_score.get(frozenset((a, b)), 0.0)
+             for a in group for b in group if a != b),
+            default=0.0,
+        )
+    merge_groups.sort(key=_group_score, reverse=True)
+
+    if len(merge_groups) > max_clusters:
+        plan.deferred_to_next_pass = len(merge_groups) - max_clusters
+        plan.notes.append(
+            f"{len(merge_groups)} merge clusters found; capped at {max_clusters} "
+            f"this pass, {plan.deferred_to_next_pass} deferred to next pass."
+        )
+        merge_groups = merge_groups[:max_clusters]
+
+    for group in merge_groups:
+        members = [by_key[k] for k in group if k in by_key]
+        if len(members) < 2:
+            continue
+        plan.clusters.append(CandidateCluster(
+            cluster_id=f"merge-{uuid.uuid4().hex[:8]}",
+            kind=KIND_MERGE,
+            members=members,
+            similarity=_group_score(group),
+            proposed_action="fuse into one refined fact (pending diff-inventory + self-review)",
+        ))
+
+    # ── Reconcile candidates: batch contradiction scan (dreaming-exempt) ──
+    # P1 reuses ContradictionDetector.detect(entry) over each stored fact; the
+    # dedicated detect_pairs() batch + MERGE arm land in P3 (#490).
+    from loom.core.memory.contradiction import ContradictionDetector
+
+    detector = ContradictionDetector(semantic)
+    seen_pairs: set[frozenset[str]] = set()
+    for entry in corpus:
+        if _is_dreaming(entry):
+            continue
+        try:
+            contradictions = await detector.detect(entry)
+        except Exception as exc:
+            plan.notes.append(f"contradiction scan failed for {entry.key!r}: {exc}")
+            continue
+        for c in contradictions:
+            if _is_dreaming(c.existing):
+                continue
+            pair = frozenset((entry.key, c.existing.key))
+            if entry.key == c.existing.key or pair in seen_pairs:
+                continue
+            seen_pairs.add(pair)
+            plan.clusters.append(CandidateCluster(
+                cluster_id=f"reconcile-{uuid.uuid4().hex[:8]}",
+                kind=KIND_RECONCILE,
+                members=[c.existing, entry],
+                similarity=c.similarity_score,
+                proposed_action=(
+                    "arbitrate by trust tier then recency "
+                    "(MERGE arm deferred to P3 #490)"
+                ),
+            ))
+
+    # ── Clean candidates: dreaming allowed-orphans are reported, not cleaned ──
+    # Deeper orphan criteria (dangling key references) is open (#490 / spec §11-Q7).
+    # P1 only classifies dreaming orphans so the report is honest about them.
+    plan.notes.append(
+        "clean phase: orphan-reference criteria deferred to P3 (#490); "
+        "dreaming-sourced entries treated as allowed orphans (never cleaned)."
+    )
+
+    # ── Snapshot source versions for stale detection at execute time (P2) ──
+    for cluster in plan.clusters:
+        for m in cluster.members:
+            plan.source_versions[m.key] = m.updated_at.isoformat()
+
+    logger.info(
+        "[convergent-dream] planned: scanned=%d clusters=%s deferred=%d",
+        plan.scanned, plan.counts(), plan.deferred_to_next_pass,
+    )
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# Step 2b — diff inventory gate (spec §6.4)
+# ---------------------------------------------------------------------------
+
+_DIFF_SYSTEM = """\
+You are Loom's memory consolidation reviewer running a "差異盤點" (difference
+inventory) on a cluster of semantically-similar facts that are candidates for
+merging into one.
+
+Your job is NOT to decide whether they should merge. Your job is to surface,
+for EACH fact, what it says that the OTHERS do not. Two facts may have high
+embedding similarity yet be distinct insights (e.g. "user prefers concise
+replies" is a preference; "user dislikes verbosity" is a complaint — they
+overlap in words but are not the same fact).
+
+Rule for mergeability:
+  - If TWO OR MORE facts each carry content the others lack → NOT mergeable
+    (they are distinct insights that merely look alike — keep them separate).
+  - If only ONE fact carries unique content (the others are subsumed) →
+    mergeable.
+
+Return ONLY a JSON object with exactly these keys:
+  "unique_by_key" : object mapping each fact's key → a short string describing
+                    what that fact uniquely contributes ("" if nothing unique)
+  "mergeable"     : boolean
+  "rationale"     : one sentence explaining the verdict
+
+Return ONLY the JSON object — no preamble, no markdown fences.
+"""
+
+
+async def diff_inventory(cluster: CandidateCluster, llm_fn: LLMFn) -> DiffInventory:
+    """Run the LLM difference-inventory gate on a merge cluster (spec §6.4)."""
+    facts_block = "\n".join(
+        f'- key="{m.key}"  source="{m.source}"  value="{m.value}"'
+        for m in cluster.members
+    )
+    messages = [
+        {"role": "system", "content": _DIFF_SYSTEM},
+        {"role": "user", "content": f"Facts in this cluster:\n{facts_block}\n\nReturn the JSON now."},
+    ]
+    try:
+        raw = await llm_fn(messages)
+    except Exception as exc:
+        logger.warning("[convergent-dream] diff_inventory LLM failed: %s", exc)
+        # Fail safe: if we cannot inventory differences, do NOT mark mergeable.
+        return DiffInventory(mergeable=False, rationale=f"diff-inventory unavailable: {exc}")
+
+    data = _parse_json_object(raw)
+    if data is None:
+        return DiffInventory(mergeable=False, rationale="diff-inventory output unparseable")
+    return DiffInventory(
+        unique_by_key={str(k): str(v) for k, v in (data.get("unique_by_key") or {}).items()},
+        mergeable=bool(data.get("mergeable", False)),
+        rationale=str(data.get("rationale", "")),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — self review ("說夢話", spec §6)
+# ---------------------------------------------------------------------------
+
+_SELF_REVIEW_SYSTEM = """\
+You are Loom (絲絲), reviewing how YOUR OWN memory is about to be consolidated.
+This is an offline self-review — you are not the object being tidied, you are
+the subject protecting the integrity of your own memory while you sleep.
+
+You have STRONG VETO power. Your verdict is a hard boundary, not a suggestion.
+For each proposed cluster, return one of:
+  - "approve" : safe to act on this cluster
+  - "skip"    : do NOT act on this cluster this pass (a real problem with it)
+  - "defer"   : not now — re-evaluate in a future pass (uncertain / still fermenting)
+
+Be conservative — prefer skip/defer — when a cluster:
+  - touches a user_explicit fact (the user told this to you directly),
+  - would flatten wording that itself carries the insight (not a droppable detail),
+  - involves two facts that each have unique content (per the diff inventory),
+  - or feels like it is still "fermenting" (a recent fact whose deeper
+    connections have not surfaced yet).
+
+Return ONLY a JSON array; one object per cluster, each with:
+  "cluster_id" : string (echo the id you were given)
+  "verdict"    : "approve" | "skip" | "defer"
+  "reason"     : one sentence
+
+Return ONLY the JSON array — no preamble, no markdown fences.
+"""
+
+
+def _render_cluster_for_review(cluster: CandidateCluster) -> str:
+    lines = [f'cluster_id="{cluster.cluster_id}"  kind={cluster.kind}  similarity={cluster.similarity:.2f}']
+    for m in cluster.members:
+        tier, _ = classify_source(m.source)
+        lines.append(
+            f'  - key="{m.key}"  trust={tier}  confidence={m.confidence:.2f}\n'
+            f'    value="{m.value}"'
+        )
+    if cluster.diff is not None:
+        lines.append(f"  diff_inventory: mergeable={cluster.diff.mergeable} — {cluster.diff.rationale}")
+        for k, v in cluster.diff.unique_by_key.items():
+            if v:
+                lines.append(f'    unique to "{k}": {v}')
+    lines.append(f"  proposed_action: {cluster.proposed_action}")
+    return "\n".join(lines)
+
+
+async def self_review(plan: ConsolidationPlan, llm_fn: LLMFn) -> list[ReviewDecision]:
+    """絲絲 reviews each cluster offline and returns hard-boundary verdicts.
+
+    Clusters whose diff-inventory already says ``mergeable=False`` are auto-
+    skipped without consulting the LLM (the gate already vetoed them, spec §6.4).
+    """
+    decisions: list[ReviewDecision] = []
+    review_clusters: list[CandidateCluster] = []
+
+    for cluster in plan.clusters:
+        if cluster.kind == KIND_MERGE and cluster.diff is not None and not cluster.diff.mergeable:
+            decisions.append(ReviewDecision(
+                cluster_id=cluster.cluster_id,
+                verdict=VERDICT_SKIP,
+                reason=f"diff-inventory: not mergeable — {cluster.diff.rationale}",
+            ))
+        else:
+            review_clusters.append(cluster)
+
+    if not review_clusters:
+        return decisions
+
+    block = "\n\n".join(_render_cluster_for_review(c) for c in review_clusters)
+    messages = [
+        {"role": "system", "content": _SELF_REVIEW_SYSTEM},
+        {"role": "user", "content": f"Clusters to review:\n\n{block}\n\nReturn the JSON array now."},
+    ]
+    try:
+        raw = await llm_fn(messages)
+    except Exception as exc:
+        logger.warning("[convergent-dream] self_review LLM failed: %s", exc)
+        # Fail safe: if absent self-review, defer everything (never auto-approve).
+        for c in review_clusters:
+            decisions.append(ReviewDecision(
+                cluster_id=c.cluster_id, verdict=VERDICT_DEFER,
+                reason=f"self-review unavailable — deferred: {exc}",
+            ))
+        return decisions
+
+    parsed = _parse_json_array(raw)
+    by_id = {str(d.get("cluster_id")): d for d in parsed if isinstance(d, dict)}
+    for c in review_clusters:
+        d = by_id.get(c.cluster_id)
+        verdict = str(d.get("verdict", "")).lower() if d else ""
+        if verdict not in (VERDICT_APPROVE, VERDICT_SKIP, VERDICT_DEFER):
+            # Missing or malformed verdict → defer (never silently approve).
+            decisions.append(ReviewDecision(
+                cluster_id=c.cluster_id, verdict=VERDICT_DEFER,
+                reason="no valid verdict returned — deferred",
+            ))
+        else:
+            decisions.append(ReviewDecision(
+                cluster_id=c.cluster_id, verdict=verdict,
+                reason=str(d.get("reason", "")) if d else "",
+            ))
+    return decisions
+
+
+# ---------------------------------------------------------------------------
+# Step 5 — report rendering (spec §8)
+# ---------------------------------------------------------------------------
+
+_VERDICT_ICON = {VERDICT_APPROVE: "✅", VERDICT_SKIP: "⚠️", VERDICT_DEFER: "💤"}
+
+
+def render_report(plan: ConsolidationPlan) -> str:
+    """Render the convergent-dream pass as a markdown body (spec §8).
+
+    This is the body of a ``夢境鞏固`` journal entry — narrative enough to read
+    back, but every line maps to a concrete cluster + verdict so it can be
+    audited against the (future) executed state.
+    """
+    counts = plan.counts()
+    out: list[str] = [
+        f"pass_id: `{plan.pass_id}` · status: {plan.execution_status} (read-only / P1)",
+        "",
+        "### 本輪 pass 摘要",
+        f"- 掃描範圍：{plan.scanned} 筆 semantic facts",
+        f"- 發現：{counts[KIND_MERGE]} 個 merge 簇、{counts[KIND_RECONCILE]} 個矛盾、{counts[KIND_CLEAN]} 個 clean 候選",
+    ]
+    if plan.deferred_to_next_pass:
+        out.append(f"- ⏭️ 因批次上限，{plan.deferred_to_next_pass} 個簇順延下輪")
+
+    def _section(title: str, kind: str) -> None:
+        clusters = [c for c in plan.clusters if c.kind == kind]
+        if not clusters:
+            return
+        out.append("")
+        out.append(f"### {title}")
+        for c in clusters:
+            d = plan.decision_for(c.cluster_id)
+            icon = _VERDICT_ICON.get(d.verdict, "·") if d else "·"
+            verdict = d.verdict if d else "(未審)"
+            keys = "、".join(f"`{k}`" for k in c.member_keys)
+            out.append(f"- {icon} **{verdict}** — {keys}")
+            if d and d.reason:
+                out.append(f"  - 理由：{d.reason}")
+            if c.diff is not None and c.diff.rationale:
+                out.append(f"  - 差異盤點：{c.diff.rationale}")
+
+    _section("Merge 記錄", KIND_MERGE)
+    _section("Reconcile 記錄", KIND_RECONCILE)
+    _section("Clean 記錄", KIND_CLEAN)
+
+    if plan.notes:
+        out.append("")
+        out.append("### 備註")
+        for n in plan.notes:
+            out.append(f"- {n}")
+
+    out.append("")
+    out.append("_P1 read-only：本輪僅規劃與自審，未改寫任何記憶。執行待 P2 (#489)。_")
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator — index → plan → self_review → report (READ-ONLY)
+# ---------------------------------------------------------------------------
+
+async def run_convergent_dream(
+    semantic: "SemanticMemory",
+    llm_fn: LLMFn,
+    *,
+    corpus_limit: int = 2000,
+    min_similarity: float = 0.85,
+    max_clusters: int = 20,
+) -> tuple[ConsolidationPlan, str]:
+    """Run one read-only convergent-dream pass.
+
+    Returns ``(plan, report_markdown)``. Never writes to the DB: no
+    ``consolidate`` / ``upsert`` / ``delete`` is reachable from here (P1).
+    """
+    plan = await build_plan(
+        semantic,
+        corpus_limit=corpus_limit,
+        min_similarity=min_similarity,
+        max_clusters=max_clusters,
+    )
+
+    # diff-inventory gate on merge clusters only (spec §6.4)
+    for cluster in plan.clusters:
+        if cluster.kind == KIND_MERGE:
+            cluster.diff = await diff_inventory(cluster, llm_fn)
+
+    plan.decisions = await self_review(plan, llm_fn)
+    report = render_report(plan)
+    return plan, report
+
+
+# ---------------------------------------------------------------------------
+# Defensive JSON parsing (mirrors dreaming._parse_triples tolerance)
+# ---------------------------------------------------------------------------
+
+def _strip_fences(raw: str) -> str:
+    return re.sub(r"```(?:json)?\s*", "", raw.strip()).strip().rstrip("`").strip()
+
+
+def _parse_json_object(raw: str) -> dict | None:
+    cleaned = _strip_fences(raw)
+    try:
+        data = json.loads(cleaned)
+        return data if isinstance(data, dict) else None
+    except json.JSONDecodeError:
+        m = re.search(r"\{.*\}", cleaned, re.DOTALL)
+        if m:
+            try:
+                data = json.loads(m.group())
+                return data if isinstance(data, dict) else None
+            except json.JSONDecodeError:
+                return None
+        return None
+
+
+def _parse_json_array(raw: str) -> list:
+    cleaned = _strip_fences(raw)
+    try:
+        data = json.loads(cleaned)
+        return data if isinstance(data, list) else []
+    except json.JSONDecodeError:
+        m = re.search(r"\[.*\]", cleaned, re.DOTALL)
+        if m:
+            try:
+                data = json.loads(m.group())
+                return data if isinstance(data, list) else []
+            except json.JSONDecodeError:
+                return []
+        return []

--- a/loom/core/memory/maintenance.py
+++ b/loom/core/memory/maintenance.py
@@ -206,3 +206,100 @@ def make_memory_prune_tool(semantic: "SemanticMemory") -> ToolDefinition:
         executor=_executor,
         trust_level=TrustLevel.SAFE,
     )
+
+
+def make_convergent_dream_tool(
+    semantic: "SemanticMemory",
+    llm_fn: LLMFn,
+    *,
+    timezone: str = "Asia/Taipei",
+    journal_dir=None,
+) -> ToolDefinition:
+    """Build the ``convergent_dream`` ToolDefinition (#488, P1).
+
+    The convergent counterpart to ``dream_cycle``: scans the semantic store,
+    proposes merge / reconcile / clean clusters, runs the diff-inventory gate
+    and 絲絲's self-review, then writes a 夢境鞏固 report to the circadian
+    journal. **Read-only** — this phase never writes to the DB; execution of
+    the approved clusters lands in P2 (#489).
+
+    Parameters mirror ``make_journal_append_tool`` (``timezone`` /
+    ``journal_dir``) so tests can redirect the report IO.
+    """
+    from loom.core.cognition.consolidation import (
+        KIND_CLEAN, KIND_MERGE, KIND_RECONCILE, run_convergent_dream,
+    )
+    from loom.autonomy.circadian.journal import append_consolidation_report
+
+    async def _executor(call) -> ToolResult:
+        corpus_limit = int(call.args.get("corpus_limit", 2000))
+        max_clusters = int(call.args.get("max_clusters", 20))
+        min_similarity = float(call.args.get("min_similarity", 0.85))
+
+        plan, report = await run_convergent_dream(
+            semantic, llm_fn,
+            corpus_limit=corpus_limit,
+            min_similarity=min_similarity,
+            max_clusters=max_clusters,
+        )
+
+        path = append_consolidation_report(
+            report, timezone=timezone, journal_dir=journal_dir,
+        )
+
+        counts = plan.counts()
+        verdicts: dict[str, int] = {}
+        for d in plan.decisions:
+            verdicts[d.verdict] = verdicts.get(d.verdict, 0) + 1
+        verdict_str = ", ".join(f"{k}={v}" for k, v in sorted(verdicts.items())) or "(none)"
+
+        lines = [
+            "Convergent dream complete (read-only / P1)",
+            f"  Scanned     : {plan.scanned} facts",
+            f"  Clusters    : {counts[KIND_MERGE]} merge, "
+            f"{counts[KIND_RECONCILE]} reconcile, {counts[KIND_CLEAN]} clean",
+            f"  Self-review : {verdict_str}",
+            f"  Report      : {path}",
+        ]
+        if plan.deferred_to_next_pass:
+            lines.append(f"  Deferred    : {plan.deferred_to_next_pass} clusters → next pass")
+
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name, success=True,
+            output="\n".join(lines),
+        )
+
+    return ToolDefinition(
+        name="convergent_dream",
+        description=(
+            "Run a read-only convergent dream: scan semantic memory for "
+            "duplicate / contradicting / orphaned facts, propose how to "
+            "consolidate them, run a self-review with veto, and write a "
+            "夢境鞏固 report to the circadian journal. Does NOT modify memory "
+            "(P1) — it plans and records so consolidation can be reviewed "
+            "before it ever touches a fact. Counterpart to dream_cycle "
+            "(which grows new connections)."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "corpus_limit": {
+                    "type": "integer",
+                    "description": "Max facts to scan this pass (default 2000).",
+                    "default": 2000,
+                },
+                "max_clusters": {
+                    "type": "integer",
+                    "description": "Cap on merge clusters proposed per pass; overflow is deferred and reported (default 20).",
+                    "default": 20,
+                },
+                "min_similarity": {
+                    "type": "number",
+                    "description": "Cosine threshold for near-duplicate merge candidates (default 0.85).",
+                    "default": 0.85,
+                },
+            },
+        },
+        executor=_executor,
+        trust_level=TrustLevel.SAFE,
+    )

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1156,6 +1156,7 @@ class LoomSession:
         # tools (formerly DreamingPlugin). Wired with dependency injection
         # so the factories stay session-agnostic.
         from loom.core.memory.maintenance import (
+            make_convergent_dream_tool,
             make_dream_cycle_tool,
             make_memory_prune_tool,
         )
@@ -1172,6 +1173,12 @@ class LoomSession:
             )
         )
         self.registry.register(make_memory_prune_tool(self._memory.semantic))
+        # Issue #488 (P1): convergent_dream — read-only consolidation pass
+        # (counterpart to the divergent dream_cycle). Plans/self-reviews/reports
+        # but never writes to the DB; execution lands in P2 (#489).
+        self.registry.register(
+            make_convergent_dream_tool(self._memory.semantic, _dream_llm_fn)
+        )
 
         if self._telemetry is not None:
             self.registry.register(make_agent_health_tool(self._telemetry))

--- a/tests/test_convergent_dream_readonly.py
+++ b/tests/test_convergent_dream_readonly.py
@@ -282,6 +282,26 @@ class TestDiffInventory:
         diff = await diff_inventory(cluster, _stub_llm("garbage"))
         assert diff.mergeable is False
 
+    async def test_missing_member_key_not_mergeable(self):
+        # Codex review #493 — inventory must COVER the cluster members. A
+        # response that omits a member but claims mergeable must fail safe.
+        cluster = CandidateCluster(
+            cluster_id="c1", kind=KIND_MERGE,
+            members=[SemanticEntry(key="a", value="x"), SemanticEntry(key="b", value="y")])
+        llm = _stub_llm('{"unique_by_key": {"a": ""}, "mergeable": true, "rationale": "looks same"}')
+        diff = await diff_inventory(cluster, llm)
+        assert diff.mergeable is False
+
+    async def test_phantom_key_not_mergeable(self):
+        # Extra/hallucinated keys that don't belong to the cluster → fail safe.
+        cluster = CandidateCluster(
+            cluster_id="c1", kind=KIND_MERGE,
+            members=[SemanticEntry(key="a", value="x"), SemanticEntry(key="b", value="y")])
+        llm = _stub_llm('{"unique_by_key": {"a": "", "b": "", "zzz": "ghost"}, '
+                        '"mergeable": true, "rationale": "r"}')
+        diff = await diff_inventory(cluster, llm)
+        assert diff.mergeable is False
+
 
 # ---------------------------------------------------------------------------
 # self_review — strong veto, fail-safe (spec §6.2)
@@ -323,6 +343,16 @@ class TestSelfReview:
         plan = ConsolidationPlan(clusters=[self._merge_cluster(cid="c1")])
         llm = _stub_llm('[{"cluster_id":"c1","verdict":"banana"}]')
         decisions = await self_review(plan, llm)
+        assert decisions[0].verdict == VERDICT_DEFER
+
+    async def test_duplicate_cluster_id_defers_not_last_wins(self):
+        # Codex review #493 — a repeated id is malformed output. A later
+        # "approve" must NOT overwrite an earlier "skip"/"defer" (strong veto).
+        plan = ConsolidationPlan(clusters=[self._merge_cluster(cid="c1")])
+        llm = _stub_llm('[{"cluster_id":"c1","verdict":"skip","reason":"real problem"},'
+                        '{"cluster_id":"c1","verdict":"approve"}]')
+        decisions = await self_review(plan, llm)
+        assert len(decisions) == 1
         assert decisions[0].verdict == VERDICT_DEFER
 
 

--- a/tests/test_convergent_dream_readonly.py
+++ b/tests/test_convergent_dream_readonly.py
@@ -1,0 +1,407 @@
+"""
+Tests for the convergent dream — read-only consolidation planner (#488, P1).
+
+The headline invariant is **read-only**: a convergent-dream pass plans, gates,
+and self-reviews, but must never mutate the semantic store. Everything else
+(dreaming exemption, diff-inventory auto-skip, fail-safe defer, no-silent-cap)
+guards the spec-#56 design contract.
+
+Embedding strategy: the reconcile path is embedding-free (key/prefix
+contradiction), so most planning is tested without vectors. The merge path
+uses a deterministic marker-based fake provider — texts sharing a GROUP marker
+embed to the same basis vector (cosine 1.0), distinct markers stay orthogonal —
+so clustering is order-independent and does not depend on sqlite-vec call
+sequencing.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from loom.core.memory.store import SQLiteStore
+from loom.core.memory.semantic import SemanticEntry, SemanticMemory
+from loom.core.cognition import consolidation as cd
+from loom.core.cognition.consolidation import (
+    CandidateCluster,
+    ConsolidationPlan,
+    DiffInventory,
+    ReviewDecision,
+    KIND_MERGE,
+    KIND_RECONCILE,
+    VERDICT_APPROVE,
+    VERDICT_SKIP,
+    VERDICT_DEFER,
+    build_plan,
+    diff_inventory,
+    self_review,
+    render_report,
+    run_convergent_dream,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test.db")
+
+
+@pytest_asyncio.fixture
+async def store(tmp_db):
+    s = SQLiteStore(tmp_db)
+    await s.initialize()
+    return s
+
+
+@pytest_asyncio.fixture
+async def db_conn(store):
+    async with store.connect() as conn:
+        yield conn
+
+
+@pytest_asyncio.fixture
+async def semantic(db_conn):
+    """Embedding-free semantic memory (reconcile path)."""
+    return SemanticMemory(db_conn)
+
+
+class _MarkerEmbeddings:
+    """Deterministic fake: text → basis vector by GROUP marker substring.
+
+    Same marker → same vector (cosine 1.0); different markers → orthogonal.
+    Order-independent, so clustering tests don't depend on embed call order.
+    """
+
+    _BASIS = {
+        "GROUPA": [1.0, 0.0, 0.0, 0.0],
+        "GROUPB": [0.0, 1.0, 0.0, 0.0],
+        "GROUPC": [0.0, 0.0, 1.0, 0.0],
+    }
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        out = []
+        for t in texts:
+            vec = [0.0, 0.0, 0.0, 1.0]  # default: unique "no-group" axis
+            for marker, basis in self._BASIS.items():
+                if marker in t:
+                    vec = basis
+                    break
+            out.append(vec)
+        return out
+
+
+@pytest_asyncio.fixture
+async def semantic_emb(db_conn):
+    """Semantic memory with the deterministic marker embedding provider."""
+    return SemanticMemory(db_conn, embedding_provider=_MarkerEmbeddings())
+
+
+# ---------------------------------------------------------------------------
+# LLM stubs
+# ---------------------------------------------------------------------------
+
+def _stub_llm(response: str):
+    async def fn(messages):
+        return response
+    return fn
+
+
+def _failing_llm(exc: Exception):
+    async def fn(messages):
+        raise exc
+    return fn
+
+
+async def _snapshot(db_conn) -> list[tuple]:
+    """Full read of the semantic table for the read-only invariant."""
+    cursor = await db_conn.execute(
+        "SELECT key, value, confidence, source, metadata, created_at, updated_at, "
+        "embedding FROM semantic_entries ORDER BY key"
+    )
+    return list(await cursor.fetchall())
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+class TestPureHelpers:
+    def test_union_find_groups_connected(self):
+        groups = cd._union_find_clusters([("a", "b"), ("b", "c"), ("x", "y")])
+        as_sets = sorted((sorted(g) for g in groups), key=len, reverse=True)
+        assert ["a", "b", "c"] in [sorted(g) for g in groups]
+        assert ["x", "y"] in [sorted(g) for g in groups]
+
+    def test_union_find_drops_singletons(self):
+        # No edges → no clusters (clusters need ≥2 members)
+        assert cd._union_find_clusters([]) == []
+
+    def test_is_dreaming_classifies_source(self):
+        dream = SemanticEntry(key="rel:x", value="v", source="dreaming")
+        user = SemanticEntry(key="k", value="v", source="manual")
+        assert cd._is_dreaming(dream) is True
+        assert cd._is_dreaming(user) is False
+
+    def test_parse_json_object_tolerates_fences(self):
+        obj = cd._parse_json_object('```json\n{"mergeable": true}\n```')
+        assert obj == {"mergeable": True}
+
+    def test_parse_json_array_tolerates_prose(self):
+        arr = cd._parse_json_array('here you go: [{"verdict":"skip"}] done')
+        assert arr == [{"verdict": "skip"}]
+
+    def test_parse_json_object_returns_none_on_garbage(self):
+        assert cd._parse_json_object("not json at all") is None
+
+
+# ---------------------------------------------------------------------------
+# build_plan — reconcile path (embedding-free)
+# ---------------------------------------------------------------------------
+
+class TestBuildPlanReconcile:
+    async def test_prefix_contradiction_becomes_reconcile_cluster(self, semantic):
+        # Same 3-segment prefix + same depth + disjoint values → contradiction.
+        await semantic.upsert(SemanticEntry(
+            key="user:pref:tone:formal", value="always answer using polished prose",
+            source="manual"))
+        await semantic.upsert(SemanticEntry(
+            key="user:pref:tone:casual", value="reply with short blunt fragments",
+            source="manual"))
+
+        plan = await build_plan(semantic)
+        reconcile = [c for c in plan.clusters if c.kind == KIND_RECONCILE]
+        assert len(reconcile) == 1
+        assert set(reconcile[0].member_keys) == {"user:pref:tone:formal", "user:pref:tone:casual"}
+
+    async def test_reconcile_pairs_deduped(self, semantic):
+        # detect() fires from both directions; the plan must hold one cluster.
+        await semantic.upsert(SemanticEntry(
+            key="a:b:c:one", value="zebra mountain ocean", source="manual"))
+        await semantic.upsert(SemanticEntry(
+            key="a:b:c:two", value="purple guitar telescope", source="manual"))
+        plan = await build_plan(semantic)
+        reconcile = [c for c in plan.clusters if c.kind == KIND_RECONCILE]
+        assert len(reconcile) == 1
+
+    async def test_no_false_reconcile_for_unrelated_keys(self, semantic):
+        await semantic.upsert(SemanticEntry(key="proj:x", value="alpha", source="manual"))
+        await semantic.upsert(SemanticEntry(key="user:y", value="beta", source="manual"))
+        plan = await build_plan(semantic)
+        assert [c for c in plan.clusters if c.kind == KIND_RECONCILE] == []
+
+
+# ---------------------------------------------------------------------------
+# build_plan — merge path (deterministic embeddings)
+# ---------------------------------------------------------------------------
+
+class TestBuildPlanMerge:
+    async def test_near_duplicates_form_merge_cluster(self, semantic_emb):
+        await semantic_emb.upsert(SemanticEntry(key="m1", value="GROUPA the user likes tea", source="manual"))
+        await semantic_emb.upsert(SemanticEntry(key="m2", value="GROUPA tea is the user's favourite", source="manual"))
+        await semantic_emb.upsert(SemanticEntry(key="u1", value="GROUPB unrelated fact", source="manual"))
+
+        plan = await build_plan(semantic_emb, min_similarity=0.85)
+        merge = [c for c in plan.clusters if c.kind == KIND_MERGE]
+        assert len(merge) == 1
+        assert set(merge[0].member_keys) == {"m1", "m2"}
+        assert "u1" not in merge[0].member_keys
+
+    async def test_no_merge_without_embeddings(self, semantic):
+        await semantic.upsert(SemanticEntry(key="m1", value="same text", source="manual"))
+        await semantic.upsert(SemanticEntry(key="m2", value="same text", source="manual"))
+        plan = await build_plan(semantic)
+        assert [c for c in plan.clusters if c.kind == KIND_MERGE] == []
+        assert any("no embedding provider" in n for n in plan.notes)
+
+    async def test_source_versions_snapshotted(self, semantic_emb):
+        await semantic_emb.upsert(SemanticEntry(key="m1", value="GROUPA one", source="manual"))
+        await semantic_emb.upsert(SemanticEntry(key="m2", value="GROUPA two", source="manual"))
+        plan = await build_plan(semantic_emb)
+        assert "m1" in plan.source_versions and "m2" in plan.source_versions
+
+
+# ---------------------------------------------------------------------------
+# Dreaming exemption (spec §6.5)
+# ---------------------------------------------------------------------------
+
+class TestDreamingExemption:
+    async def test_dreaming_facts_excluded_from_merge(self, semantic_emb):
+        await semantic_emb.upsert(SemanticEntry(key="m1", value="GROUPA fact", source="manual"))
+        await semantic_emb.upsert(SemanticEntry(key="m2", value="GROUPA fact too", source="manual"))
+        await semantic_emb.upsert(SemanticEntry(key="d1", value="GROUPA dreamt link", source="dreaming"))
+
+        plan = await build_plan(semantic_emb, min_similarity=0.85)
+        all_keys = {k for c in plan.clusters for k in c.member_keys}
+        assert "d1" not in all_keys
+
+    async def test_dreaming_facts_excluded_from_reconcile(self, semantic):
+        await semantic.upsert(SemanticEntry(
+            key="x:y:z:human", value="apple banana cherry", source="manual"))
+        await semantic.upsert(SemanticEntry(
+            key="x:y:z:dream", value="violin trumpet drums", source="dreaming"))
+        plan = await build_plan(semantic)
+        all_keys = {k for c in plan.clusters for k in c.member_keys}
+        assert "x:y:z:dream" not in all_keys
+
+
+# ---------------------------------------------------------------------------
+# diff_inventory gate (spec §6.4)
+# ---------------------------------------------------------------------------
+
+class TestDiffInventory:
+    async def test_parses_mergeable_true(self):
+        cluster = CandidateCluster(
+            cluster_id="c1", kind=KIND_MERGE,
+            members=[SemanticEntry(key="a", value="x"), SemanticEntry(key="b", value="y")])
+        llm = _stub_llm('{"unique_by_key": {"a": "", "b": "extra detail"}, '
+                        '"mergeable": true, "rationale": "b subsumes a"}')
+        diff = await diff_inventory(cluster, llm)
+        assert diff.mergeable is True
+        assert diff.unique_by_key["b"] == "extra detail"
+
+    async def test_both_unique_not_mergeable(self):
+        cluster = CandidateCluster(
+            cluster_id="c1", kind=KIND_MERGE,
+            members=[SemanticEntry(key="a", value="x"), SemanticEntry(key="b", value="y")])
+        llm = _stub_llm('{"unique_by_key": {"a": "preference", "b": "complaint"}, '
+                        '"mergeable": false, "rationale": "distinct insights"}')
+        diff = await diff_inventory(cluster, llm)
+        assert diff.mergeable is False
+
+    async def test_llm_failure_fails_safe_to_not_mergeable(self):
+        cluster = CandidateCluster(cluster_id="c1", kind=KIND_MERGE, members=[])
+        diff = await diff_inventory(cluster, _failing_llm(RuntimeError("down")))
+        assert diff.mergeable is False
+        assert "unavailable" in diff.rationale
+
+    async def test_unparseable_output_not_mergeable(self):
+        cluster = CandidateCluster(cluster_id="c1", kind=KIND_MERGE, members=[])
+        diff = await diff_inventory(cluster, _stub_llm("garbage"))
+        assert diff.mergeable is False
+
+
+# ---------------------------------------------------------------------------
+# self_review — strong veto, fail-safe (spec §6.2)
+# ---------------------------------------------------------------------------
+
+class TestSelfReview:
+    def _merge_cluster(self, cid="c1", mergeable=True):
+        c = CandidateCluster(
+            cluster_id=cid, kind=KIND_MERGE,
+            members=[SemanticEntry(key="a", value="x"), SemanticEntry(key="b", value="y")])
+        c.diff = DiffInventory(mergeable=mergeable, rationale="r")
+        return c
+
+    async def test_auto_skips_non_mergeable_without_llm(self):
+        plan = ConsolidationPlan(clusters=[self._merge_cluster(mergeable=False)])
+        # LLM that would approve — must NOT be consulted for the vetoed cluster.
+        decisions = await self_review(plan, _stub_llm('[{"cluster_id":"c1","verdict":"approve"}]'))
+        assert decisions[0].verdict == VERDICT_SKIP
+        assert "not mergeable" in decisions[0].reason
+
+    async def test_applies_llm_verdicts(self):
+        plan = ConsolidationPlan(clusters=[self._merge_cluster(cid="c1")])
+        llm = _stub_llm('[{"cluster_id":"c1","verdict":"approve","reason":"safe"}]')
+        decisions = await self_review(plan, llm)
+        assert decisions[0].verdict == VERDICT_APPROVE
+
+    async def test_missing_verdict_defers(self):
+        plan = ConsolidationPlan(clusters=[self._merge_cluster(cid="c1")])
+        llm = _stub_llm('[{"cluster_id":"other","verdict":"approve"}]')
+        decisions = await self_review(plan, llm)
+        assert decisions[0].verdict == VERDICT_DEFER
+
+    async def test_llm_failure_defers_never_approves(self):
+        plan = ConsolidationPlan(clusters=[self._merge_cluster(cid="c1")])
+        decisions = await self_review(plan, _failing_llm(RuntimeError("down")))
+        assert all(d.verdict == VERDICT_DEFER for d in decisions)
+
+    async def test_malformed_verdict_defers(self):
+        plan = ConsolidationPlan(clusters=[self._merge_cluster(cid="c1")])
+        llm = _stub_llm('[{"cluster_id":"c1","verdict":"banana"}]')
+        decisions = await self_review(plan, llm)
+        assert decisions[0].verdict == VERDICT_DEFER
+
+
+# ---------------------------------------------------------------------------
+# render_report
+# ---------------------------------------------------------------------------
+
+class TestRenderReport:
+    def test_report_contains_summary_and_footer(self):
+        plan = ConsolidationPlan(scanned=42)
+        plan.clusters.append(CandidateCluster(
+            cluster_id="merge-1", kind=KIND_MERGE,
+            members=[SemanticEntry(key="a", value="x"), SemanticEntry(key="b", value="y")]))
+        plan.decisions.append(ReviewDecision(cluster_id="merge-1", verdict=VERDICT_APPROVE, reason="ok"))
+        report = render_report(plan)
+        assert plan.pass_id in report
+        assert "42" in report
+        assert "Merge 記錄" in report
+        assert "read-only" in report.lower()
+        assert "✅" in report
+
+    def test_deferred_count_surfaced(self):
+        plan = ConsolidationPlan(scanned=5, deferred_to_next_pass=3)
+        report = render_report(plan)
+        assert "3" in report and "順延" in report
+
+
+# ---------------------------------------------------------------------------
+# Read-only invariant — the headline contract
+# ---------------------------------------------------------------------------
+
+class TestReadOnlyInvariant:
+    async def test_build_plan_does_not_mutate_store(self, semantic_emb, db_conn):
+        await semantic_emb.upsert(SemanticEntry(key="m1", value="GROUPA tea", source="manual"))
+        await semantic_emb.upsert(SemanticEntry(key="m2", value="GROUPA tea too", source="manual"))
+        await semantic_emb.upsert(SemanticEntry(
+            key="u:v:w:a", value="alpha beta", source="manual"))
+        await semantic_emb.upsert(SemanticEntry(
+            key="u:v:w:b", value="gamma delta", source="manual"))
+
+        before = await _snapshot(db_conn)
+        await build_plan(semantic_emb)
+        after = await _snapshot(db_conn)
+        assert before == after
+
+    async def test_full_pass_does_not_mutate_store(self, semantic_emb, db_conn):
+        await semantic_emb.upsert(SemanticEntry(key="m1", value="GROUPA x", source="manual"))
+        await semantic_emb.upsert(SemanticEntry(key="m2", value="GROUPA y", source="manual"))
+
+        before = await _snapshot(db_conn)
+
+        async def combined(messages):
+            sys = messages[0]["content"]
+            if "difference inventory" in sys:
+                return '{"unique_by_key":{"m1":"","m2":"more"},"mergeable":true,"rationale":"r"}'
+            # self_review — verdict is irrelevant to the read-only invariant
+            return '[]'
+
+        plan, report = await run_convergent_dream(semantic_emb, combined)
+        after = await _snapshot(db_conn)
+        assert before == after
+        assert plan.execution_status == "planned"
+        assert "read-only" in report.lower()
+
+
+# ---------------------------------------------------------------------------
+# No silent caps (feedback: no-silent-truncation)
+# ---------------------------------------------------------------------------
+
+class TestNoSilentCap:
+    async def test_cap_records_deferred(self, semantic_emb):
+        # Three independent GROUPA/B/C pairs → 3 merge clusters; cap at 2.
+        pairs = [("GROUPA", "a"), ("GROUPB", "b"), ("GROUPC", "c")]
+        for marker, p in pairs:
+            await semantic_emb.upsert(SemanticEntry(key=f"{p}1", value=f"{marker} one", source="manual"))
+            await semantic_emb.upsert(SemanticEntry(key=f"{p}2", value=f"{marker} two", source="manual"))
+
+        plan = await build_plan(semantic_emb, min_similarity=0.85, max_clusters=2)
+        merge = [c for c in plan.clusters if c.kind == KIND_MERGE]
+        assert len(merge) == 2
+        assert plan.deferred_to_next_pass == 1
+        assert any("deferred" in n for n in plan.notes)

--- a/tests/test_convergent_dream_readonly.py
+++ b/tests/test_convergent_dream_readonly.py
@@ -302,6 +302,37 @@ class TestDiffInventory:
         diff = await diff_inventory(cluster, llm)
         assert diff.mergeable is False
 
+    async def test_string_mergeable_is_not_truthy(self):
+        # Codex re-review #493 — a malformed string "false" must NOT become
+        # True via bool("false"). Only a real JSON boolean true counts.
+        cluster = CandidateCluster(
+            cluster_id="c1", kind=KIND_MERGE,
+            members=[SemanticEntry(key="a", value="x"), SemanticEntry(key="b", value="y")])
+        llm = _stub_llm('{"unique_by_key": {"a": "", "b": ""}, '
+                        '"mergeable": "false", "rationale": "r"}')
+        diff = await diff_inventory(cluster, llm)
+        assert diff.mergeable is False
+
+    async def test_string_true_also_not_mergeable(self):
+        # A stringified "true" is still malformed output → fail safe.
+        cluster = CandidateCluster(
+            cluster_id="c1", kind=KIND_MERGE,
+            members=[SemanticEntry(key="a", value="x"), SemanticEntry(key="b", value="y")])
+        llm = _stub_llm('{"unique_by_key": {"a": "", "b": ""}, '
+                        '"mergeable": "true", "rationale": "r"}')
+        diff = await diff_inventory(cluster, llm)
+        assert diff.mergeable is False
+
+    async def test_non_object_unique_by_key_fails_safe_without_raising(self):
+        # Codex re-review #493 — unique_by_key returned as a list must not
+        # crash .items(); it should fail safe to not-mergeable.
+        cluster = CandidateCluster(
+            cluster_id="c1", kind=KIND_MERGE,
+            members=[SemanticEntry(key="a", value="x"), SemanticEntry(key="b", value="y")])
+        llm = _stub_llm('{"unique_by_key": ["a", "b"], "mergeable": true, "rationale": "r"}')
+        diff = await diff_inventory(cluster, llm)   # must not raise
+        assert diff.mergeable is False
+
 
 # ---------------------------------------------------------------------------
 # self_review — strong veto, fail-safe (spec §6.2)

--- a/tests/test_convergent_dream_tool.py
+++ b/tests/test_convergent_dream_tool.py
@@ -1,0 +1,98 @@
+"""
+Tests for the convergent-dream ToolDefinition adapter (#488, P1).
+
+Mirrors make_dream_cycle_tool: wraps the read-only cognition cycle, writes the
+夢境鞏固 report to the journal, and returns a summary. Must stay read-only on
+the DB and SAFE on trust.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from loom.core.memory.store import SQLiteStore
+from loom.core.memory.semantic import SemanticEntry, SemanticMemory
+from loom.core.harness.permissions import TrustLevel
+from loom.core.harness.middleware import ToolCall
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test.db")
+
+
+@pytest_asyncio.fixture
+async def store(tmp_db):
+    s = SQLiteStore(tmp_db)
+    await s.initialize()
+    return s
+
+
+@pytest_asyncio.fixture
+async def db_conn(store):
+    async with store.connect() as conn:
+        yield conn
+
+
+@pytest_asyncio.fixture
+async def semantic(db_conn):
+    return SemanticMemory(db_conn)
+
+
+def _make_call(args: dict) -> ToolCall:
+    return ToolCall(id="t1", tool_name="convergent_dream", args=args,
+                    trust_level=TrustLevel.SAFE, session_id="s1")
+
+
+async def _combined_llm(messages):
+    sys = messages[0]["content"]
+    if "difference inventory" in sys:
+        return '{"unique_by_key":{},"mergeable":false,"rationale":"distinct"}'
+    return "[]"
+
+
+async def _snapshot(db_conn):
+    cursor = await db_conn.execute(
+        "SELECT key, value, source, updated_at FROM semantic_entries ORDER BY key")
+    return list(await cursor.fetchall())
+
+
+class TestConvergentDreamTool:
+    def test_tool_is_safe(self):
+        from loom.core.memory.maintenance import make_convergent_dream_tool
+        tool = make_convergent_dream_tool(object(), _combined_llm)
+        assert tool.trust_level == TrustLevel.SAFE
+        assert tool.name == "convergent_dream"
+
+    async def test_runs_and_writes_report(self, semantic, tmp_path):
+        from loom.core.memory.maintenance import make_convergent_dream_tool
+        await semantic.upsert(SemanticEntry(
+            key="user:pref:tone:a", value="answer with formal polished prose", source="manual"))
+        await semantic.upsert(SemanticEntry(
+            key="user:pref:tone:b", value="reply short blunt fragments only", source="manual"))
+
+        tool = make_convergent_dream_tool(
+            semantic, _combined_llm, timezone="Asia/Taipei", journal_dir=tmp_path)
+        result = await tool.executor(_make_call({}))
+
+        assert result.success is True
+        assert "scanned" in result.output.lower() or "掃描" in result.output
+        # report file written to the journal dir
+        md_files = list(tmp_path.glob("*.md"))
+        assert len(md_files) == 1
+        assert "夢境鞏固" in md_files[0].read_text(encoding="utf-8")
+
+    async def test_is_read_only(self, semantic, db_conn, tmp_path):
+        from loom.core.memory.maintenance import make_convergent_dream_tool
+        await semantic.upsert(SemanticEntry(
+            key="a:b:c:x", value="zebra ocean mountain", source="manual"))
+        await semantic.upsert(SemanticEntry(
+            key="a:b:c:y", value="violin guitar trumpet", source="manual"))
+
+        before = await _snapshot(db_conn)
+        tool = make_convergent_dream_tool(
+            semantic, _combined_llm, journal_dir=tmp_path)
+        await tool.executor(_make_call({}))
+        after = await _snapshot(db_conn)
+        assert before == after

--- a/tests/test_journal_consolidation_report.py
+++ b/tests/test_journal_consolidation_report.py
@@ -1,0 +1,58 @@
+"""
+Tests for the convergent-dream report appender (#488, P1, spec §8).
+
+The dream report is a SYSTEM-generated artifact written by code, not the agent.
+It lands in the same dated circadian journal so the file becomes "絲絲's
+two-phase dream record" (grep-able), but it must NOT pollute the agent-facing
+``journal_append`` tool's ``kind`` enum (which is for daily life-texture only).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from loom.autonomy.circadian.journal import (
+    KIND_LABELS,
+    append_consolidation_report,
+    journal_path_for,
+)
+
+
+def _today(tz: str = "Asia/Taipei") -> str:
+    return datetime.now(ZoneInfo(tz)).strftime("%Y-%m-%d")
+
+
+class TestAppendConsolidationReport:
+    def test_writes_dated_entry_with_label(self, tmp_path):
+        path = append_consolidation_report(
+            "### 摘要\n- nothing merged\n", timezone="Asia/Taipei", journal_dir=tmp_path,
+        )
+        assert path == journal_path_for(_today(), tmp_path)
+        text = path.read_text(encoding="utf-8")
+        assert "· 夢境鞏固" in text
+        assert "### 摘要" in text
+        assert "nothing merged" in text
+
+    def test_lazy_h1_header_on_first_write(self, tmp_path):
+        path = append_consolidation_report("body", journal_dir=tmp_path)
+        text = path.read_text(encoding="utf-8")
+        assert text.startswith(f"# {_today()} Journal")
+
+    def test_appends_without_clobbering(self, tmp_path):
+        append_consolidation_report("first pass body", journal_dir=tmp_path)
+        path = append_consolidation_report("second pass body", journal_dir=tmp_path)
+        text = path.read_text(encoding="utf-8")
+        assert "first pass body" in text
+        assert "second pass body" in text
+        # H1 header written exactly once
+        assert text.count("Journal") == 1
+
+    def test_does_not_pollute_agent_kind_enum(self):
+        # The agent-facing journal_append tool must not gain a system kind.
+        assert "dream_consolidation" not in KIND_LABELS
+        assert set(KIND_LABELS) == {"moment", "finding", "keepsake", "tomorrow"}
+
+    def test_returns_path(self, tmp_path):
+        path = append_consolidation_report("x", journal_dir=tmp_path)
+        assert path.exists()


### PR DESCRIPTION
P1 of the 記憶鞏固夢 收斂相 epic (#491). The convergent counterpart to the existing divergent `dream_cycle` — scans the semantic store, proposes how to consolidate duplicate/contradicting/orphaned facts, runs 絲絲's self-review with veto, and records a 夢境鞏固 report. **Strictly read-only** this phase.

> Spec: `docs/designs/56-記憶鞏固夢-收斂相規格.md` (locked) · Discussion: `#55`

## What's in
- **`loom/core/cognition/consolidation.py`** (new, pure cognition): `ConsolidationPlan` / `CandidateCluster` / `ReviewDecision` contracts; `build_plan` (near-dup clustering via `find_near_duplicates` + batch contradiction scan via `ContradictionDetector.detect`, both dreaming-exempt); `diff_inventory` gate; `self_review` (strong veto, fail-safe **defer — never auto-approve**); `render_report`; `run_convergent_dream` orchestrator. No write path is reachable from this module.
- **`journal.py`**: extracted shared `_append_dated_entry()`; added `append_consolidation_report()` + `CONSOLIDATION_LABEL`. Deliberately **not** a new `journal_append` `kind` — keeps the agent tool's life-texture enum clean.
- **`maintenance.py`** + **`session.py`**: `make_convergent_dream_tool()` (SAFE), registered alongside `dream_cycle`.
- **`docs/designs/56 §8`**: updated to as-built (dedicated system appender, not the kind enum) — closes a self-introduced doc-drift.

## Read-this-first for review (Codex)
1. **Read-only invariant** is the headline contract — `TestReadOnlyInvariant` snapshots the `semantic_entries` table byte-for-byte before/after a full pass. Please sanity-check there's no reachable write path (esp. via `find_near_duplicates` / `detect`).
2. **Deviations from spec** worth a second opinion:
   - report goes through a dedicated `append_consolidation_report()` rather than the `journal_append` kind enum (§8 updated).
   - reconcile reuses `detect(proposed)` per stored fact as a batch adapter; the dedicated `detect_pairs()` + MERGE arm are deferred to P3 (#490). Is the per-entry reuse acceptable for P1?
3. **Fail-safe posture**: diff-inventory LLM failure → not mergeable; self_review failure/malformed → defer. Never silently approves. Worth confirming this matches the "strong veto" intent.
4. **No silent caps**: `max_clusters` overflow is recorded in `plan.deferred_to_next_pass` + notes.

## Tests (TDD)
36 new across read-only invariant, dreaming exemption, diff-inventory auto-skip, fail-safe defer, no-silent-cap, report rendering, tool adapter. Full suite green (2291 passed, 4 skipped). gitnexus `detect_changes`: low risk, 0 affected processes.

## Scope boundary
Read-only only. `semantic.consolidate()` execution → P2 (#489); MERGE arm + batch reconcile + orphan criteria → P3 (#490).

Closes #488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
