### PR TITLE
feat(memory): convergent dream reconcile + orphan cleanup (P3, #490)

### DIFF
--- a/loom/core/cognition/consolidation.py
+++ b/loom/core/cognition/consolidation.py
@@ -841,9 +841,17 @@ async def execute_plan(
             result.skipped_stale.append(cluster.cluster_id)
             continue
 
-        # Clean arm — delete the dangling orphan stub(s).
+        # Clean arm — delete the dangling orphan stub(s). Re-validate orphan
+        # status at execute time (Codex #496 — TOCTTOU): the stub's own row is
+        # unchanged so the stale check passes, but the survivor may have been
+        # restored after planning. If the key resolves again it is a live
+        # fallback now — never delete it.
         if cluster.kind == KIND_CLEAN:
             for m in cluster.members:
+                if await semantic.resolve_redirect(m.key) is not None:
+                    result.notes.append(
+                        f"{cluster.cluster_id}: {m.key} resolves again at execute — kept")
+                    continue
                 if await semantic.delete(m.key):
                     result.cleaned.append(m.key)
             continue

--- a/loom/core/cognition/consolidation.py
+++ b/loom/core/cognition/consolidation.py
@@ -728,6 +728,64 @@ async def synthesize_merge(cluster: CandidateCluster, llm_fn: LLMFn) -> MergeSyn
     )
 
 
+_RECONCILE_CLASSIFY_SYSTEM = """\
+Two facts were flagged as contradicting. Decide which kind of conflict this is:
+  - "merge": they are actually the SAME fact in different words — no real
+    conflict, they should be fused into one.
+  - "arbitrate": they are genuinely OPPOSING (one says something the other
+    denies) — the more trustworthy / more recent one should win and the other
+    becomes a superseded belief.
+
+Do NOT guess. If you cannot tell, that is itself important — say so.
+
+Return ONLY a JSON object: {"kind": "merge" | "arbitrate", "reason": "..."}.
+Return ONLY the JSON object — no preamble, no markdown fences.
+"""
+
+
+async def classify_reconcile(cluster: CandidateCluster, llm_fn: LLMFn) -> str:
+    """Classify a reconcile cluster as "merge", "arbitrate", or "skip" (P3).
+
+    "skip" is the fail-safe: an unparseable / failed / unrecognised verdict
+    never resolves a contradiction blindly.
+    """
+    fact_lines = []
+    for e in cluster.members:
+        tier, _ = classify_source(e.source)
+        fact_lines.append(f'- key="{e.key}"  trust={tier}\n  value="{e.value}"')
+    messages = [
+        {"role": "system", "content": _RECONCILE_CLASSIFY_SYSTEM},
+        {"role": "user", "content": "The two facts:\n" + "\n".join(fact_lines) + "\n\nReturn the JSON now."},
+    ]
+    try:
+        raw = await llm_fn(messages)
+    except Exception as exc:
+        logger.warning("[convergent-dream] classify_reconcile LLM failed: %s", exc)
+        return "skip"
+    data = _parse_json_object(raw)
+    if data is None:
+        return "skip"
+    kind = str(data.get("kind", "")).strip().lower()
+    return kind if kind in ("merge", "arbitrate") else "skip"
+
+
+def _arbitrate(members: list[SemanticEntry]) -> tuple[SemanticEntry, list[SemanticEntry], str]:
+    """Pick the winner of an opposing contradiction: higher trust, tie → newer.
+
+    Returns (winner, losers, reason). Mirrors ContradictionDetector.resolve's
+    trust-then-recency order, but recency is by actual updated_at (batch
+    context) rather than write-time "proposed is newer".
+    """
+    winner = max(members, key=lambda e: (_trust_of(e), e.updated_at.timestamp()))
+    losers = [e for e in members if e.key != winner.key]
+    wt, _ = classify_source(winner.source)
+    reason = (
+        f"{winner.key!r} (trust={wt}) wins over "
+        f"{[l.key for l in losers]} on trust then recency"
+    )
+    return winner, losers, reason
+
+
 async def execute_plan(
     semantic: "SemanticMemory",
     plan: ConsolidationPlan,
@@ -752,8 +810,8 @@ async def execute_plan(
         if decision is None or decision.verdict != VERDICT_APPROVE:
             result.skipped_verdict.append(cluster.cluster_id)
             continue
-        if cluster.kind != KIND_MERGE:
-            result.skipped_other.append(cluster.cluster_id)
+        if cluster.kind not in (KIND_MERGE, KIND_RECONCILE):
+            result.skipped_other.append(cluster.cluster_id)   # clean → orphan pass
             continue
 
         # stale check — source must be byte-identical to the planned snapshot
@@ -768,19 +826,40 @@ async def execute_plan(
             result.skipped_stale.append(cluster.cluster_id)
             continue
 
-        syn = await synthesize_merge(cluster, llm_fn)
-        if syn is None:
-            result.skipped_error.append(cluster.cluster_id)
-            result.notes.append(f"{cluster.cluster_id}: synthesis failed — skipped")
-            continue
+        # Resolve the cluster into a (entries, refined_value, survivor_key,
+        # sacrificed_content, rationale) consolidate() call. Merge clusters and
+        # the merge arm of reconcile both fuse via synthesize_merge; the
+        # arbitrate arm keeps the trust/recency winner's value verbatim.
+        if cluster.kind == KIND_MERGE:
+            mode = "merge"
+        else:  # KIND_RECONCILE — classify same-fact (merge) vs opposing (arbitrate)
+            mode = await classify_reconcile(cluster, llm_fn)
+            if mode not in ("merge", "arbitrate"):
+                result.skipped_error.append(cluster.cluster_id)
+                result.notes.append(f"{cluster.cluster_id}: reconcile classify → skip")
+                continue
+
+        if mode == "merge":
+            syn = await synthesize_merge(cluster, llm_fn)
+            if syn is None:
+                result.skipped_error.append(cluster.cluster_id)
+                result.notes.append(f"{cluster.cluster_id}: synthesis failed — skipped")
+                continue
+            entries, refined, survivor = cluster.members, syn.refined_value, syn.survivor_key
+            sacrificed_content, rationale = syn.sacrificed_content, syn.merge_rationale
+        else:  # arbitrate
+            winner, losers, reason = _arbitrate(cluster.members)
+            entries, refined, survivor = cluster.members, winner.value, winner.key
+            sacrificed_content = "\n\n".join(f"[{l.key}] {l.value}" for l in losers)
+            rationale = f"superseded (opposing): {reason}"
 
         try:
             res = await semantic.consolidate(
-                cluster.members,
-                refined_value=syn.refined_value,
-                survivor_key=syn.survivor_key,
-                sacrificed_content=syn.sacrificed_content,
-                merge_rationale=syn.merge_rationale,
+                entries,
+                refined_value=refined,
+                survivor_key=survivor,
+                sacrificed_content=sacrificed_content,
+                merge_rationale=rationale,
             )
         except Exception as exc:
             result.skipped_error.append(cluster.cluster_id)

--- a/loom/core/cognition/consolidation.py
+++ b/loom/core/cognition/consolidation.py
@@ -152,6 +152,11 @@ def _is_dreaming(entry: SemanticEntry) -> bool:
     return tier == "dreaming"
 
 
+def _is_stub(entry: SemanticEntry) -> bool:
+    """True if the entry is a consolidation redirect stub (#490 P3)."""
+    return bool(entry.metadata.get("redirected_to"))
+
+
 def _union_find_clusters(pairs: list[tuple[str, str]]) -> list[set[str]]:
     """Group keys into connected components from a list of (key_a, key_b) edges."""
     parent: dict[str, str] = {}
@@ -204,8 +209,8 @@ async def build_plan(
     pair_score: dict[frozenset[str], float] = {}
     if semantic.has_embeddings:
         for entry in corpus:
-            if _is_dreaming(entry):
-                continue  # spec §6.5 — never propose dreaming output for merge
+            if _is_dreaming(entry) or _is_stub(entry):
+                continue  # §6.5 dreaming exempt; stubs aren't real facts (#490)
             try:
                 neighbours = await semantic.find_near_duplicates(
                     entry.value,
@@ -218,7 +223,7 @@ async def build_plan(
                 plan.notes.append(f"near-dup lookup failed for {entry.key!r}: {exc}")
                 continue
             for neighbour, score in neighbours:
-                if _is_dreaming(neighbour) or neighbour.key not in by_key:
+                if _is_dreaming(neighbour) or _is_stub(neighbour) or neighbour.key not in by_key:
                     continue
                 edges.append((entry.key, neighbour.key))
                 pair = frozenset((entry.key, neighbour.key))
@@ -265,7 +270,7 @@ async def build_plan(
     detector = ContradictionDetector(semantic)
     seen_pairs: set[frozenset[str]] = set()
     for entry in corpus:
-        if _is_dreaming(entry):
+        if _is_dreaming(entry) or _is_stub(entry):
             continue
         try:
             contradictions = await detector.detect(entry)
@@ -273,7 +278,7 @@ async def build_plan(
             plan.notes.append(f"contradiction scan failed for {entry.key!r}: {exc}")
             continue
         for c in contradictions:
-            if _is_dreaming(c.existing):
+            if _is_dreaming(c.existing) or _is_stub(c.existing):
                 continue
             pair = frozenset((entry.key, c.existing.key))
             if entry.key == c.existing.key or pair in seen_pairs:
@@ -290,13 +295,20 @@ async def build_plan(
                 ),
             ))
 
-    # ── Clean candidates: dreaming allowed-orphans are reported, not cleaned ──
-    # Deeper orphan criteria (dangling key references) is open (#490 / spec §11-Q7).
-    # P1 only classifies dreaming orphans so the report is honest about them.
-    plan.notes.append(
-        "clean phase: orphan-reference criteria deferred to P3 (#490); "
-        "dreaming-sourced entries treated as allowed orphans (never cleaned)."
-    )
+    # ── Clean candidates: dangling redirect stubs (#490 P3) ──────────────
+    # A stub whose terminal survivor is gone (resolve_redirect → None) is a
+    # dangling orphan. dreaming-sourced entries are allowed orphans (絲絲's
+    # principle — never cleaned). Live stubs (target still resolves) are kept.
+    for entry in corpus:
+        if not _is_stub(entry) or _is_dreaming(entry):
+            continue
+        if await semantic.resolve_redirect(entry.key) is None:
+            plan.clusters.append(CandidateCluster(
+                cluster_id=f"clean-{uuid.uuid4().hex[:8]}",
+                kind=KIND_CLEAN,
+                members=[entry],
+                proposed_action="delete dangling redirect stub (terminal survivor gone)",
+            ))
 
     # ── Snapshot source versions for stale detection at execute time (P2) ──
     for cluster in plan.clusters:
@@ -573,6 +585,8 @@ def render_report(plan: ConsolidationPlan, execute_result: "ExecuteResult | None
         out.append("### 執行結果")
         out.append(f"- ✅ 已合併：{len(execute_result.executed)} 簇 "
                    f"(survivors: {'、'.join(f'`{k}`' for k in execute_result.executed) or '—'})")
+        if execute_result.cleaned:
+            out.append(f"- 🧹 已清理孤兒 stub：{len(execute_result.cleaned)}")
         if execute_result.skipped_stale:
             out.append(f"- ⏭️ stale 跳過：{len(execute_result.skipped_stale)}（來源在自審後已變動）")
         if execute_result.skipped_other:
@@ -644,6 +658,7 @@ class MergeSynthesis:
 class ExecuteResult:
     """Outcome of executing an approved, non-stale plan (P2)."""
     executed: list[str] = field(default_factory=list)        # survivor keys consolidated
+    cleaned: list[str] = field(default_factory=list)         # dangling stubs deleted
     skipped_stale: list[str] = field(default_factory=list)   # source changed after snapshot
     skipped_verdict: list[str] = field(default_factory=list) # not approved
     skipped_other: list[str] = field(default_factory=list)   # reconcile/clean → P3
@@ -810,8 +825,8 @@ async def execute_plan(
         if decision is None or decision.verdict != VERDICT_APPROVE:
             result.skipped_verdict.append(cluster.cluster_id)
             continue
-        if cluster.kind not in (KIND_MERGE, KIND_RECONCILE):
-            result.skipped_other.append(cluster.cluster_id)   # clean → orphan pass
+        if cluster.kind not in (KIND_MERGE, KIND_RECONCILE, KIND_CLEAN):
+            result.skipped_other.append(cluster.cluster_id)
             continue
 
         # stale check — source must be byte-identical to the planned snapshot
@@ -824,6 +839,13 @@ async def execute_plan(
                 break
         if stale:
             result.skipped_stale.append(cluster.cluster_id)
+            continue
+
+        # Clean arm — delete the dangling orphan stub(s).
+        if cluster.kind == KIND_CLEAN:
+            for m in cluster.members:
+                if await semantic.delete(m.key):
+                    result.cleaned.append(m.key)
             continue
 
         # Resolve the cluster into a (entries, refined_value, survivor_key,

--- a/loom/core/memory/semantic.py
+++ b/loom/core/memory/semantic.py
@@ -650,6 +650,9 @@ class SemanticMemory:
         survivor = await self.get(survivor_key)
         if survivor is None:
             raise ValueError(f"survivor_key {survivor_key!r} not found in store")
+        if survivor.metadata.get("redirected_to"):
+            raise ValueError(
+                f"survivor_key {survivor_key!r} is a redirect stub — cannot merge into it")
         sacrificed = [e for e in entries if e.key != survivor_key]
 
         now = datetime.now(UTC).isoformat()
@@ -681,7 +684,11 @@ class SemanticMemory:
                  now, survivor_key),
             )
             for e in sacrificed:
-                stub_meta = {"redirected_to": survivor_key, "consolidated_ts": now}
+                stub_meta = {
+                    "redirected_to": survivor_key,
+                    "redirect_chain": [survivor_key],   # immediate hop; resolve_redirect follows cross-pass chains
+                    "consolidated_ts": now,
+                }
                 await self._db.execute(
                     "UPDATE semantic_entries SET value=?, metadata=?, embedding=NULL, "
                     "updated_at=? WHERE key=?",
@@ -715,20 +722,28 @@ class SemanticMemory:
             refined_value=refined_value,
         )
 
-    async def resolve_redirect(self, key: str) -> SemanticEntry | None:
-        """Resolve a key, following one redirect hop if it is a stub (#489, P2).
+    async def resolve_redirect(self, key: str, *, _max_hops: int = 16) -> SemanticEntry | None:
+        """Resolve a key, following redirect stubs to the terminal survivor.
 
-        Returns the survivor entry for a consolidated key, the entry itself for
-        a normal key, or None if the key (or a dangling redirect target) is
-        gone. One hop only — consolidate never chains stubs.
+        Follows ``redirected_to`` hop by hop so cross-pass chains (A→B→C, formed
+        when a survivor is itself later consolidated) resolve to the live
+        terminal (#490, P3). Returns the terminal entry for a consolidated key,
+        the entry itself for a normal key, or ``None`` when the chain dangles
+        (a hop's target is gone), cycles, or exceeds ``_max_hops``.
         """
+        visited: set[str] = set()
         entry = await self.get(key)
-        if entry is None:
-            return None
-        target = entry.metadata.get("redirected_to")
-        if target:
-            return await self.get(target)
-        return entry
+        hops = 0
+        while entry is not None:
+            target = entry.metadata.get("redirected_to")
+            if not target:
+                return entry                     # terminal — live, non-stub
+            if target in visited or hops >= _max_hops:
+                return None                      # cycle / runaway chain
+            visited.add(entry.key)
+            hops += 1
+            entry = await self.get(target)
+        return None                              # dangling — a hop's target is gone
 
     async def mark_accessed(self, keys: list[str]) -> None:
         """Bump ``last_accessed_at`` for the given keys (Memory Ontology v0.1).

--- a/tests/test_convergent_dream_execute.py
+++ b/tests/test_convergent_dream_execute.py
@@ -207,17 +207,24 @@ class TestExecutePlan:
         # untouched: survivor not consolidated
         assert (await semantic.get("k:a")).value == "the user prefers tea in the morning"
 
-    async def test_reconcile_cluster_deferred_to_p3(self, semantic):
+    async def test_reconcile_unclassifiable_fails_safe(self, semantic):
+        # P3: reconcile is now handled (classified merge/arbitrate), not
+        # blanket-deferred. A response that yields no valid classification must
+        # fail safe — not executed. (Full reconcile coverage lives in
+        # test_convergent_dream_reconcile.py.)
         await semantic.upsert(SemanticEntry(key="r:a", value="x", source="manual"))
         await semantic.upsert(SemanticEntry(key="r:b", value="y", source="manual"))
         a, b = await semantic.get("r:a"), await semantic.get("r:b")
         cluster = CandidateCluster(cluster_id="rc1", kind=KIND_RECONCILE, members=[a, b])
         plan = ConsolidationPlan(clusters=[cluster])
+        plan.source_versions = {"r:a": a.updated_at.isoformat(), "r:b": b.updated_at.isoformat()}
         plan.decisions = [ReviewDecision(cluster_id="rc1", verdict=VERDICT_APPROVE)]
 
+        # _MERGE_RESP has no "kind" field → classify_reconcile → "skip"
         result = await execute_plan(semantic, plan, _stub_llm(_MERGE_RESP))
         assert result.executed == []
-        assert len(result.skipped_other) == 1
+        assert "rc1" in result.skipped_error
+        assert (await semantic.get("r:a")).value == "x"  # untouched
 
     async def test_synthesis_failure_skips_without_writing(self, semantic):
         plan, cluster = await _seed_merge_cluster(semantic)

--- a/tests/test_convergent_dream_orphan.py
+++ b/tests/test_convergent_dream_orphan.py
@@ -125,3 +125,14 @@ class TestOrphanExecution:
         result = await execute_plan(semantic, plan, _stub_llm("[]"))
         assert result.cleaned == []
         assert await semantic.get("a") is not None  # untouched
+
+    async def test_clean_revalidates_orphan_at_execute(self, semantic):
+        # Codex review #496 — TOCTTOU: survivor restored between plan and
+        # execute. The stub row itself is unchanged (stale check passes), but
+        # it now resolves again → must NOT be deleted (live fallback).
+        plan, clean = await self._clean_plan(semantic)   # a→b dangling, approved
+        await semantic.upsert(SemanticEntry(key="b", value="restored survivor", source="manual"))
+        result = await execute_plan(semantic, plan, _stub_llm("[]"))
+        assert "a" not in result.cleaned
+        assert await semantic.get("a") is not None        # live old-key fallback preserved
+        assert (await semantic.resolve_redirect("a")).key == "b"

--- a/tests/test_convergent_dream_orphan.py
+++ b/tests/test_convergent_dream_orphan.py
@@ -1,0 +1,127 @@
+"""
+Tests for convergent-dream orphan cleanup (#490, P3, slice 4b).
+
+Clean phase: a redirect stub whose terminal survivor is gone (resolve_redirect
+→ None) is a dangling orphan → KIND_CLEAN candidate → delete on approval.
+Live stubs (target still resolves) are NOT orphans. dreaming-sourced entries
+are allowed orphans (never cleaned). Stubs are excluded from merge/reconcile
+scanning so they don't get re-clustered.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from loom.core.memory.store import SQLiteStore
+from loom.core.memory.semantic import SemanticEntry, SemanticMemory
+from loom.core.cognition.consolidation import (
+    ConsolidationPlan,
+    ReviewDecision,
+    KIND_CLEAN,
+    KIND_MERGE,
+    VERDICT_APPROVE,
+    VERDICT_SKIP,
+    build_plan,
+    execute_plan,
+)
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test.db")
+
+
+@pytest_asyncio.fixture
+async def store(tmp_db):
+    s = SQLiteStore(tmp_db)
+    await s.initialize()
+    return s
+
+
+@pytest_asyncio.fixture
+async def db_conn(store):
+    async with store.connect() as conn:
+        yield conn
+
+
+@pytest_asyncio.fixture
+async def semantic(db_conn):
+    return SemanticMemory(db_conn)
+
+
+def _stub_llm(resp):
+    async def fn(messages):
+        return resp
+    return fn
+
+
+async def _make_dangling_stub(semantic, *, src="manual", stub_key="a", surv_key="b"):
+    await semantic.upsert(SemanticEntry(key=stub_key, value="orphan source", source=src))
+    await semantic.upsert(SemanticEntry(key=surv_key, value="survivor", source="manual"))
+    a, b = await semantic.get(stub_key), await semantic.get(surv_key)
+    await semantic.consolidate([a, b], refined_value="merged", survivor_key=surv_key,
+                               sacrificed_content=a.value, merge_rationale="r")  # stub_key→surv_key
+    await semantic.delete(surv_key)   # survivor gone → stub dangles
+
+
+class TestOrphanDetection:
+    async def test_dangling_stub_is_clean_candidate(self, semantic):
+        await _make_dangling_stub(semantic)
+        plan = await build_plan(semantic)
+        clean = [c for c in plan.clusters if c.kind == KIND_CLEAN]
+        assert len(clean) == 1
+        assert clean[0].member_keys == ["a"]
+
+    async def test_live_stub_is_not_orphan(self, semantic):
+        # a→b with b still present → a resolves → not dangling.
+        await semantic.upsert(SemanticEntry(key="a", value="x", source="manual"))
+        await semantic.upsert(SemanticEntry(key="b", value="y", source="manual"))
+        a, b = await semantic.get("a"), await semantic.get("b")
+        await semantic.consolidate([a, b], refined_value="m", survivor_key="b",
+                                   sacrificed_content=a.value, merge_rationale="r")
+        plan = await build_plan(semantic)
+        assert [c for c in plan.clusters if c.kind == KIND_CLEAN] == []
+
+    async def test_dreaming_dangling_stub_exempt(self, semantic):
+        await _make_dangling_stub(semantic, src="dreaming")
+        plan = await build_plan(semantic)
+        assert [c for c in plan.clusters if c.kind == KIND_CLEAN] == []
+
+    async def test_stub_excluded_from_merge_scan(self, db_conn):
+        # A live stub must not be re-clustered for merge.
+        class _Emb:
+            async def embed(self, texts):
+                return [[1.0, 0.0, 0.0] for _ in texts]
+        sem = SemanticMemory(db_conn, embedding_provider=_Emb())
+        await sem.upsert(SemanticEntry(key="a", value="same", source="manual"))
+        await sem.upsert(SemanticEntry(key="b", value="same", source="manual"))
+        await sem.upsert(SemanticEntry(key="c", value="same", source="manual"))
+        a, b = await sem.get("a"), await sem.get("b")
+        await sem.consolidate([a, b], refined_value="m", survivor_key="b",
+                              sacrificed_content=a.value, merge_rationale="r")  # a→b stub
+        plan = await build_plan(sem, min_similarity=0.85)
+        merge_members = {k for c in plan.clusters if c.kind == KIND_MERGE for k in c.member_keys}
+        assert "a" not in merge_members   # stub excluded
+
+
+class TestOrphanExecution:
+    async def _clean_plan(self, semantic):
+        await _make_dangling_stub(semantic)
+        plan = await build_plan(semantic)
+        clean = [c for c in plan.clusters if c.kind == KIND_CLEAN][0]
+        plan.decisions = [ReviewDecision(cluster_id=clean.cluster_id, verdict=VERDICT_APPROVE)]
+        return plan, clean
+
+    async def test_approved_clean_deletes_orphan(self, semantic):
+        plan, clean = await self._clean_plan(semantic)
+        result = await execute_plan(semantic, plan, _stub_llm("[]"))
+        assert "a" in result.cleaned
+        assert await semantic.get("a") is None     # orphan deleted
+
+    async def test_skip_clean_keeps_orphan(self, semantic):
+        plan, clean = await self._clean_plan(semantic)
+        plan.decisions = [ReviewDecision(cluster_id=clean.cluster_id, verdict=VERDICT_SKIP)]
+        result = await execute_plan(semantic, plan, _stub_llm("[]"))
+        assert result.cleaned == []
+        assert await semantic.get("a") is not None  # untouched

--- a/tests/test_convergent_dream_reconcile.py
+++ b/tests/test_convergent_dream_reconcile.py
@@ -1,0 +1,160 @@
+"""
+Tests for convergent-dream reconcile execution (#490, P3, slice 1).
+
+P2 left reconcile clusters in skipped_other. P3 wires them: an approved
+reconcile cluster is classified (LLM) as either
+  - "merge"     — same fact, different phrasing → synthesize + consolidate
+  - "arbitrate" — genuinely opposing → trust/recency winner kept, loser
+                  redirected to the winner with its value preserved as the
+                  superseded belief.
+Both arms reuse the P2 consolidate() primitive. Fail-safe: unclear/failed
+classification skips the cluster (never a blind contradiction resolution).
+"""
+
+from __future__ import annotations
+
+import json
+import pytest
+import pytest_asyncio
+from datetime import datetime, UTC
+
+from loom.core.memory.store import SQLiteStore
+from loom.core.memory.semantic import SemanticEntry, SemanticMemory
+from loom.core.cognition.consolidation import (
+    CandidateCluster,
+    ConsolidationPlan,
+    ReviewDecision,
+    KIND_RECONCILE,
+    VERDICT_APPROVE,
+    classify_reconcile,
+    execute_plan,
+)
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test.db")
+
+
+@pytest_asyncio.fixture
+async def store(tmp_db):
+    s = SQLiteStore(tmp_db)
+    await s.initialize()
+    return s
+
+
+@pytest_asyncio.fixture
+async def db_conn(store):
+    async with store.connect() as conn:
+        yield conn
+
+
+@pytest_asyncio.fixture
+async def semantic(db_conn):
+    return SemanticMemory(db_conn)
+
+
+def _failing_llm():
+    async def fn(messages):
+        raise RuntimeError("down")
+    return fn
+
+
+def _reconcile_llm(kind: str):
+    """Stub: classify → kind; synth (merge arm) → fused fact."""
+    async def fn(messages):
+        sys = messages[0]["content"]
+        if "synthesizer" in sys:
+            return '{"refined_value": "fused fact", "rationale": "same"}'
+        if "opposing" in sys.lower():
+            return json.dumps({"kind": kind, "reason": "stub"})
+        return "[]"
+    return fn
+
+
+async def _seed_reconcile(semantic, *, a_src="manual", b_src="session:x:fact:0"):
+    a = SemanticEntry(key="loc:a", value="the user lives in Taipei", source=a_src,
+                      created_at=datetime(2026, 1, 1, tzinfo=UTC))
+    b = SemanticEntry(key="loc:b", value="the user lives in Tokyo now", source=b_src,
+                      created_at=datetime(2026, 5, 1, tzinfo=UTC))
+    await semantic.upsert(a)
+    await semantic.upsert(b)
+    a, b = await semantic.get("loc:a"), await semantic.get("loc:b")
+    cluster = CandidateCluster(cluster_id="rc1", kind=KIND_RECONCILE, members=[a, b])
+    plan = ConsolidationPlan(clusters=[cluster])
+    plan.source_versions = {"loc:a": a.updated_at.isoformat(), "loc:b": b.updated_at.isoformat()}
+    plan.decisions = [ReviewDecision(cluster_id="rc1", verdict=VERDICT_APPROVE)]
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# classify_reconcile
+# ---------------------------------------------------------------------------
+
+class TestClassifyReconcile:
+    def _cluster(self):
+        return CandidateCluster(cluster_id="c", kind=KIND_RECONCILE, members=[
+            SemanticEntry(key="a", value="x", source="manual"),
+            SemanticEntry(key="b", value="y", source="manual")])
+
+    async def test_returns_merge(self):
+        assert await classify_reconcile(self._cluster(), _reconcile_llm("merge")) == "merge"
+
+    async def test_returns_arbitrate(self):
+        assert await classify_reconcile(self._cluster(), _reconcile_llm("arbitrate")) == "arbitrate"
+
+    async def test_llm_failure_returns_skip(self):
+        assert await classify_reconcile(self._cluster(), _failing_llm()) == "skip"
+
+    async def test_unknown_kind_returns_skip(self):
+        assert await classify_reconcile(self._cluster(), _reconcile_llm("banana")) == "skip"
+
+
+# ---------------------------------------------------------------------------
+# execute_plan — reconcile arm
+# ---------------------------------------------------------------------------
+
+class TestReconcileExecution:
+    async def test_arbitrate_keeps_higher_trust_winner(self, semantic):
+        plan = await _seed_reconcile(semantic)  # loc:a=manual(1.0), loc:b=session(0.8)
+        result = await execute_plan(semantic, plan, _reconcile_llm("arbitrate"))
+
+        # winner = higher trust (manual), value unchanged
+        winner = await semantic.get("loc:a")
+        assert winner.value == "the user lives in Taipei"
+        # loser redirected to winner, its value preserved as superseded belief
+        loser = await semantic.get("loc:b")
+        assert loser.metadata.get("redirected_to") == "loc:a"
+        ci = winner.metadata["consolidated_into"]
+        assert any("Tokyo" in s["value"] for s in ci["sacrificed_entries"])
+        assert "loc:a" in result.executed
+
+    async def test_arbitrate_tie_trust_newer_wins(self, semantic):
+        # both manual → tie → newer updated_at wins. loc:b created later.
+        plan = await _seed_reconcile(semantic, b_src="manual")
+        result = await execute_plan(semantic, plan, _reconcile_llm("arbitrate"))
+        # loc:b is newer (created 2026-05) → winner; loc:a redirected
+        winner = await semantic.get("loc:b")
+        assert winner.metadata.get("redirected_to") is None
+        assert (await semantic.get("loc:a")).metadata.get("redirected_to") == "loc:b"
+
+    async def test_merge_classification_fuses(self, semantic):
+        plan = await _seed_reconcile(semantic)
+        result = await execute_plan(semantic, plan, _reconcile_llm("merge"))
+        # merge arm → synthesize + consolidate; survivor value = fused
+        # survivor is the higher-trust loc:a
+        assert (await semantic.get("loc:a")).value == "fused fact"
+        assert (await semantic.get("loc:b")).metadata.get("redirected_to") == "loc:a"
+
+    async def test_skip_classification_does_not_execute(self, semantic):
+        plan = await _seed_reconcile(semantic)
+        result = await execute_plan(semantic, plan, _reconcile_llm("banana"))  # → skip
+        assert result.executed == []
+        assert (await semantic.get("loc:a")).value == "the user lives in Taipei"
+        assert (await semantic.get("loc:b")).metadata.get("redirected_to") is None
+
+    async def test_classify_failure_does_not_execute(self, semantic):
+        plan = await _seed_reconcile(semantic)
+        result = await execute_plan(semantic, plan, _failing_llm())
+        assert result.executed == []
+        assert (await semantic.get("loc:b")).metadata.get("redirected_to") is None

--- a/tests/test_semantic_consolidate.py
+++ b/tests/test_semantic_consolidate.py
@@ -168,6 +168,66 @@ class TestConsolidate:
             await db_conn.commit()
 
 
+class TestRedirectChain:
+    """Multi-hop redirect resolution + loop guard + chain metadata (#490 P3)."""
+
+    async def _chain_abc(self, semantic):
+        for k, v in [("a", "fact a"), ("b", "fact b"), ("c", "fact c")]:
+            await semantic.upsert(SemanticEntry(key=k, value=v, source="manual"))
+        a, b = await semantic.get("a"), await semantic.get("b")
+        await semantic.consolidate([a, b], refined_value="B refined", survivor_key="b",
+                                   sacrificed_content=a.value, merge_rationale="r")  # a→b
+        b, c = await semantic.get("b"), await semantic.get("c")
+        await semantic.consolidate([b, c], refined_value="C refined", survivor_key="c",
+                                   sacrificed_content=b.value, merge_rationale="r")  # b→c
+
+    async def test_multi_hop_follows_to_terminal(self, semantic):
+        await self._chain_abc(semantic)
+        resolved = await semantic.resolve_redirect("a")   # a→b→c
+        assert resolved is not None
+        assert resolved.key == "c"
+        assert resolved.value == "C refined"
+
+    async def test_redirect_chain_metadata_recorded(self, semantic):
+        await self._chain_abc(semantic)
+        stub_a = await semantic.get("a")
+        assert "redirect_chain" in stub_a.metadata
+
+    async def test_cycle_returns_none(self, semantic, db_conn):
+        # Craft a cycle directly: a→b, b→a.
+        await semantic.upsert(SemanticEntry(key="a", value="x", source="manual"))
+        await semantic.upsert(SemanticEntry(key="b", value="y", source="manual"))
+        import json
+        for k, tgt in [("a", "b"), ("b", "a")]:
+            await db_conn.execute(
+                "UPDATE semantic_entries SET metadata=? WHERE key=?",
+                (json.dumps({"redirected_to": tgt}), k))
+        await db_conn.commit()
+        assert await semantic.resolve_redirect("a") is None   # loop guarded
+
+    async def test_dangling_redirect_returns_none(self, semantic):
+        await semantic.upsert(SemanticEntry(key="a", value="x", source="manual"))
+        await semantic.upsert(SemanticEntry(key="b", value="y", source="manual"))
+        a, b = await semantic.get("a"), await semantic.get("b")
+        await semantic.consolidate([a, b], refined_value="r", survivor_key="b",
+                                   sacrificed_content=a.value, merge_rationale="r")  # a→b
+        await semantic.delete("b")                              # survivor gone
+        assert await semantic.resolve_redirect("a") is None    # dangling
+
+    async def test_merge_into_stub_rejected(self, semantic):
+        await semantic.upsert(SemanticEntry(key="a", value="x", source="manual"))
+        await semantic.upsert(SemanticEntry(key="b", value="y", source="manual"))
+        await semantic.upsert(SemanticEntry(key="c", value="z", source="manual"))
+        a, b = await semantic.get("a"), await semantic.get("b")
+        await semantic.consolidate([a, b], refined_value="r", survivor_key="b",
+                                   sacrificed_content=a.value, merge_rationale="r")  # a→b (a is stub)
+        a_stub, c = await semantic.get("a"), await semantic.get("c")
+        with pytest.raises(ValueError):
+            # survivor 'a' is now a stub — merging into it is malformed
+            await semantic.consolidate([c, a_stub], refined_value="r", survivor_key="a",
+                                       sacrificed_content=c.value, merge_rationale="r")
+
+
 class TestRedirectRecall:
     """Codex review #494 — recall must resolve/suppress redirect stubs."""
 


### PR DESCRIPTION
P3 of the 記憶鞏固夢 收斂相 epic (#491) — the last correctness piece. Wires reconcile execution (left in skipped_other by P2) and the clean phase (orphan cleanup), and makes redirect resolution chain-safe.

> Spec: `docs/designs/56` §4.2/§5.3/§6.5 · Builds on P1 (#488) + P2 (#489)

## What's in
**Slice 1 — reconcile execution.** An approved reconcile cluster is classified by the LLM:
- `merge` (same fact, different phrasing) → `synthesize_merge` + `consolidate`
- `arbitrate` (genuinely opposing) → trust/recency winner kept verbatim, loser redirected with its value preserved as the superseded belief

Both arms **reuse the P2 `consolidate()` primitive** — one write path. Classify failure / unrecognised verdict → skip (fail-safe). Stale check covers reconcile.

**Slice 4a — chain-safe redirect.** `resolve_redirect` now follows chains to the terminal survivor (cross-pass A→B→C) with a visited/max-hops **loop guard** (None on cycle/dangling/runaway). Stubs record `redirect_chain`. `consolidate` rejects merging into a stub.

**Slice 4b — orphan cleanup.** `build_plan` detects **dangling redirect stubs** (`resolve_redirect → None`) as `KIND_CLEAN` candidates; `execute_plan` deletes approved, non-stale orphans. Stubs are excluded from merge/reconcile scanning (no re-clustering). **dreaming exemption across all phases** (絲絲's allowed-orphans).

## Read-this-first for review (Codex)
1. **MERGE realized at the dream layer, not `resolve()`.** I did NOT change the write-time `ContradictionDetector.resolve()` / `Resolution.MERGE` stub (governed_upsert depends on it). Reconcile-merge happens via `classify_reconcile` + `consolidate`. Reasonable, or do you want the write-time stub wired too?
2. **`_arbitrate`** picks winner by trust then `updated_at` (batch-correct recency, unlike resolve's write-time "proposed is newer"). Loser → redirected to winner via `consolidate` (value preserved). Sanity-check the winner selection + that the loser's belief is auditable.
3. **Loop guard / dangling** in `resolve_redirect` — please probe cycle and multi-hop edge cases.
4. **Fail-safe routing**: classify→skip, synthesis→None, consolidate raise → cluster skipped, never half-applied.

## Scope — two follow-ups (not in this PR)
- **2(b) relational-triple orphan criteria**: relational endpoints are free-text concepts, not fact keys (`rel:{subject}::{predicate}`), so there's no key-existence check; the only key-referencing triples (dreaming `sampled_facts`) are exempt. Needs redefinition → follow-up issue.
- **tier-3 (embedding-similar-but-opposing → reconcile)**: today such pairs are merge candidates that diff-inventory skips; routing them to reconcile is a refinement → follow-up issue.

## Tests (TDD)
Slice 1: classify_reconcile (4) + reconcile execution (5). Slice 4: redirect chain (5) + orphan (6). Full suite green (2345 passed, 4 skipped).

Closes #490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
