### PR TITLE
fix(memory): reconcile noise exclusion + unrelated safety net (slice 2a/2b)

### DIFF
--- a/docs/designs/56-記憶鞏固夢-收斂相規格.md
+++ b/docs/designs/56-記憶鞏固夢-收斂相規格.md
@@ -253,7 +253,29 @@ self_review 是 Loom 在 offline pass **內部呼叫的自審步驟**，不需�
 4. **收斂相在 dormant 觸發的優先序**：與其他 jobs 並存時排第幾？
 5. **與 `MemoryHealthTracker` 的關係**：鞏固成效要不要進 health report？
 6. **與 memory v2 三軸 schema（`project_memory_system_v2`）對齊**：`consolidate()` 是否就是 v2 規劃的 merge primitive？
-7. **孤兒偵測判準**：哪些 metadata 欄位指向「已刪 key」？
+7. **孤兒偵測判準**：哪些 metadata 欄位指向「已刪 key」？（P3 已實作「懸空 redirect stub」一類，見 #490）
+
+---
+
+## 12. Real-run 已確認發現（2026-06-01，絲絲手動跑 `convergent_dream`）
+
+> 第一次對真實記憶庫(2000 筆)read-only 跑收斂夢的觀測，已確認、據以調整實作。保留於此供「決策怎麼做出的」回溯。
+
+**數據**：掃 2000 筆 → 20 merge 簇(11 skip / 9 defer)、**2538 reconcile 候選**、0 clean。
+
+**確認發現 A — 2538 reconcile 中 98% 是 same-session 兄弟事實的偽陽性。**
+trust 分佈：`session_compress × session_compress` 佔 98%(2490)、same-session sibling 佔 98%(2504)。根因:session 壓縮寫入的事實 key 為 `session:<id>:<ts>:fact:<n>`，**共用前三段前綴、深度相同、彼此詞彙重疊低** → `ContradictionDetector.detect()` 的 tier-2 prefix 規則把同場 session 的兄弟事實兩兩標成「矛盾」。但 prefix 此處只是 provenance 命名空間，不是語義子題；兄弟事實是「同一記憶過程的自然切分」(如一篇文章的 N 段)，不是競爭性主張。
+→ **決策**:reconcile 候選**排除 same-session 兄弟**(slice 2a)。真實需 reconcile 量從 2538 降到數十，量級合理。
+→ **延伸風險(被 read-only 擋下)**:`classify_reconcile` 原無「兩者無關」選項，無關兄弟若誤入 execute 會被判 arbitrate → 按 trust/recency 把一筆無關好記憶 redirect 摧毀。故加 slice 2b「unrelated → skip」安全網。
+
+**確認發現 B — `self_review` 不分批，規模下會撞 context window(2013)。**
+2538 候選全 render 進單一 prompt → 超限 → 全部 fallback `defer`。**fail-safe gate 正確自保**(LLM 不可用 → defer，非 approve)，但 self_review 在規模下等於失效。
+→ **決策**:self_review 分批 + cap(slice 2c，issue #499)。
+
+**確認發現 C — dry-run / read-only 是系統保護層，非僅審批便利。**
+若無 self_review 的 2013 gate，2538 候選會被塞進 arbitration prompt → token 爆炸使整個 pass crash。read-only 先行在操作者知情前就擋下了一次潛在生產事故 → 強化「P4 排程 read-only 先行(P4a)再放行 execute(P4b)」的決定。
+
+**slice 重排(取代原 P3 內部排序)**：2a same-session 排除(correctness) → 2b unrelated→skip(安全網) → 2c self_review 分批(#499) → 2d 報告獨立檔(#499)。2a 必須**先於** tier-3(#497)評估，否則 tier-3 數據仍被 same-session 噪音污染。(孤兒清理 = P3 slice 4，**已實作落地**。)
 
 ---
 

--- a/loom/core/cognition/consolidation.py
+++ b/loom/core/cognition/consolidation.py
@@ -157,6 +157,20 @@ def _is_stub(entry: SemanticEntry) -> bool:
     return bool(entry.metadata.get("redirected_to"))
 
 
+def _is_session_sibling(key_a: str, key_b: str) -> bool:
+    """True if two keys are sibling facts from the same session compression.
+
+    Session facts use ``session:<id>:<ts>:fact:<n>`` — siblings share the first
+    three segments. That prefix is a *provenance namespace*, not a semantic
+    subtopic, so they must NOT be treated as contradictions (#497, real-run
+    finding: 98% of reconcile candidates were this noise). They are the natural
+    segmentation of one compression, not competing claims.
+    """
+    if not (key_a.startswith("session:") and key_b.startswith("session:")):
+        return False
+    return key_a.split(":")[:3] == key_b.split(":")[:3]
+
+
 def _union_find_clusters(pairs: list[tuple[str, str]]) -> list[set[str]]:
     """Group keys into connected components from a list of (key_a, key_b) edges."""
     parent: dict[str, str] = {}
@@ -280,6 +294,8 @@ async def build_plan(
         for c in contradictions:
             if _is_dreaming(c.existing) or _is_stub(c.existing):
                 continue
+            if _is_session_sibling(entry.key, c.existing.key):
+                continue  # provenance-namespace siblings, not contradictions (#497)
             pair = frozenset((entry.key, c.existing.key))
             if entry.key == c.existing.key or pair in seen_pairs:
                 continue
@@ -744,16 +760,19 @@ async def synthesize_merge(cluster: CandidateCluster, llm_fn: LLMFn) -> MergeSyn
 
 
 _RECONCILE_CLASSIFY_SYSTEM = """\
-Two facts were flagged as contradicting. Decide which kind of conflict this is:
+Two facts were flagged as possibly contradicting. Decide which kind this is:
   - "merge": they are actually the SAME fact in different words — no real
     conflict, they should be fused into one.
   - "arbitrate": they are genuinely OPPOSING (one says something the other
     denies) — the more trustworthy / more recent one should win and the other
     becomes a superseded belief.
+  - "unrelated": they are NEITHER the same nor opposing — two distinct facts
+    that merely look similar. Keep BOTH, do nothing.
 
-Do NOT guess. If you cannot tell, that is itself important — say so.
+Do NOT guess. When in doubt prefer "unrelated" — merging or arbitrating two
+distinct facts destroys a good memory.
 
-Return ONLY a JSON object: {"kind": "merge" | "arbitrate", "reason": "..."}.
+Return ONLY a JSON object: {"kind": "merge"|"arbitrate"|"unrelated", "reason": "..."}.
 Return ONLY the JSON object — no preamble, no markdown fences.
 """
 
@@ -781,6 +800,8 @@ async def classify_reconcile(cluster: CandidateCluster, llm_fn: LLMFn) -> str:
     if data is None:
         return "skip"
     kind = str(data.get("kind", "")).strip().lower()
+    # "unrelated" (and anything unrecognised) → skip: never merge/arbitrate
+    # two facts that aren't actually in conflict.
     return kind if kind in ("merge", "arbitrate") else "skip"
 
 

--- a/tests/test_convergent_dream_reconcile.py
+++ b/tests/test_convergent_dream_reconcile.py
@@ -26,6 +26,7 @@ from loom.core.cognition.consolidation import (
     ReviewDecision,
     KIND_RECONCILE,
     VERDICT_APPROVE,
+    build_plan,
     classify_reconcile,
     execute_plan,
 )
@@ -108,6 +109,38 @@ class TestClassifyReconcile:
 
     async def test_unknown_kind_returns_skip(self):
         assert await classify_reconcile(self._cluster(), _reconcile_llm("banana")) == "skip"
+
+    async def test_unrelated_returns_skip(self):
+        # 2b safety net: "unrelated" is an explicit option; it maps to skip so
+        # two facts that are neither same nor opposing are never arbitrated.
+        assert await classify_reconcile(self._cluster(), _reconcile_llm("unrelated")) == "skip"
+
+
+class TestSameSessionExclusion:
+    """2a: same-session sibling facts must not be reconcile candidates (#497)."""
+
+    async def test_same_session_siblings_excluded(self, semantic):
+        # session:<id>:<ts>:fact:<n> siblings share the tier-2 prefix but are
+        # natural segmentation of one compression, not contradictions.
+        await semantic.upsert(SemanticEntry(
+            key="session:s1:t0:fact:0", value="zebra ocean mountain peak",
+            source="session:s1:t0:fact:0"))
+        await semantic.upsert(SemanticEntry(
+            key="session:s1:t0:fact:1", value="violin guitar drum trumpet",
+            source="session:s1:t0:fact:1"))
+        plan = await build_plan(semantic)
+        assert [c for c in plan.clusters if c.kind == KIND_RECONCILE] == []
+
+    async def test_cross_session_or_semantic_prefix_still_detected(self, semantic):
+        # A genuine semantic-namespace contradiction is still a candidate.
+        await semantic.upsert(SemanticEntry(
+            key="user:pref:tone:formal", value="answer in polished formal prose",
+            source="manual"))
+        await semantic.upsert(SemanticEntry(
+            key="user:pref:tone:casual", value="reply with short blunt fragments",
+            source="manual"))
+        plan = await build_plan(semantic)
+        assert len([c for c in plan.clusters if c.kind == KIND_RECONCILE]) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to the convergent-dream epic (#491), driven by the first real-run of `convergent_dream` (絲絲, 2000 real facts). Full finding archived in `docs/designs/56` §12.

## The finding
Read-only run surfaced **2538 reconcile candidates — 98% same-session sibling false positives**. Session facts (`session:<id>:<ts>:fact:<n>`) share the `detect()` tier-2 prefix but are the natural segmentation of one compression, not contradictions. Trust dist: `session_compress × session_compress` = 98%.

## Fixes
- **2a — same-session exclusion** (`_is_session_sibling`): `build_plan` skips reconcile pairs sharing a `session:<id>:<ts>` provenance prefix. **Verified on the real DB: 2538 → 34 reconcile candidates (−98.7%)**; the remaining 34 are genuine cross-context conflicts.
- **2b — `unrelated` safety net**: `classify_reconcile` prompt now offers an explicit `unrelated` verdict (keep both) mapped to skip. Without this, an unrelated pair reaching execute could be arbitrated → loser redirected → **a good memory destroyed**. (Read-only-first prevented this from happening live.)

## Read-this-first for review (Codex)
1. **`_is_session_sibling`** keys on `session:` prefix + first-3-segment match. Is the provenance-namespace assumption right, or should the fix live deeper in `ContradictionDetector.detect()` tier-2 (which has the same latent issue at write-time via governed_upsert)? I kept it in `build_plan` to avoid touching the write path — flag if you'd prefer the root fix.
2. Cross-session contradictions are NOT excluded (different prefix → tier-2 doesn't group them anyway), so genuine conflicts survive — please confirm.

## Not in this PR (tracked)
- self_review batching (context-2013) + report → own file → **#499**
- tier-3 embedding reconcile → **#497** (now unblocked: its eval data is no longer polluted by same-session noise)

## Tests (TDD)
same-session excluded, semantic-namespace contradiction still detected, unrelated→skip. Full suite green (2349 passed, 4 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
