### PR TITLE
fix(memory): batch self_review + separate dream report file (#499)

### DIFF
--- a/docs/designs/56-記憶鞏固夢-收斂相規格.md
+++ b/docs/designs/56-記憶鞏固夢-收斂相規格.md
@@ -281,6 +281,33 @@ trust 分佈：`session_compress × session_compress` 佔 98%(2490)、same-sessi
 
 > **2c as-built**：`self_review` 改為每 `batch_size`(預設 10)簇一個 LLM call，並設 `max_review_clusters`(預設 40)per-pass cap；超量循 `deferred_to_next_pass` 順延下輪(無聲截斷禁止)。單批失敗(含 context 超限)只 defer 該批，不拖垮整輪。抽出 `_review_batch()` 承載單批邏輯。`run_convergent_dream` / `convergent_dream` 工具皆透出 `review_batch_size` / `max_review_clusters`。
 
+### 12.1 Real-run 第二輪（2026-06-01，2a+2c+2d 落地後重跑）
+
+> 第二次真實跑(同 2000 筆、報告落獨立 `dreams/` 檔)。2a same-session 排除把 reconcile 從 2538 → **34**；self_review 分批正常運作(報告「34 個順延」= build_plan merge cap 溢出 31 + self_review cap 溢出 3，非單一來源)。據此對 34 個 reconcile 候選做 trust 分佈分析，**直接證偽 tier-3(#497)的價值前提**。
+
+**數據(34 個 reconcile 候選，read-only 查真實 DB)**：
+
+| 維度 | 分佈 |
+|---|---|
+| verdict | skip 17 · defer 17 · **approve 0** |
+| trust 對稱性 | **SYM 34 · ASYM 0**（全部同 tier） |
+| tier 配對 | `agent_memorize×agent_memorize` 22 · `unknown×unknown` 12 |
+
+**確認發現 D — 34 個候選中，trust 不對稱 = 0、genuine 語義對立 = 0。**
+- 全部 34 對**同 trust tier**，無梯度可用 → `_arbitrate` 在這批完全使不上力（trust-aware 解 0 個）。
+- self_review **無一判為真矛盾**：17 skip 全是「兩者無關/獨立屬性」，17 defer 全是「怕磨平 unique content / 還在發酵 / 同日不同面向」（defer 是 **merge 側顧慮**，非對立）。真正「A 說 X、B 說非 X」的對立對：**零**。
+- → **#497 tier-3（embedding-相似-但-對立 路由）在此語料需求近乎為零**：genuine 對立根本沒出現。tier-3 **降級/緩議**，等語料真的出現對立再評估。
+
+**確認發現 E — same-session 排除後，下一層噪音是「結構化 namespace prefix 兄弟」。**
+34 對清楚分族，全是 tier-2 prefix 把同命名空間的不同事實兩兩誤標：
+- `rel:S::*`（關係三元組）：同主語**不同謂語**（`rel:self::role` × `rel:self::complements`）—— 12 對。
+- `skill:X:eval:*`：不同輪次/case 的評估（`r1:summary` × `r2:summary`）。
+- `loom:...:diagnosis:*`：同次診斷不同切面。
+- `loom:diary:DATE:*` / `diary:self_check:daily:*`：同日或跨日不同記事。
+
+prefix 在此是 **provenance 命名空間（主語 / 技能 / 日期桶）**，非語義子題——與 same-session 兄弟**同一失敗模式**。
+→ **決策**：高價值下一步 = 把 2a 的修法推廣到「結構化 namespace prefix 兄弟排除」（follow-up issue，epic #491），預期把 34 → 趨近 0，detector 只在真 same-key / 真衝突時響。**優先於 tier-3**。
+
 ---
 
 ## 實作追蹤

--- a/docs/designs/56-記憶鞏固夢-收斂相規格.md
+++ b/docs/designs/56-記憶鞏固夢-收斂相規格.md
@@ -216,11 +216,13 @@ self_review 是 Loom 在 offline pass **內部呼叫的自審步驟**，不需�
 
 **設計驅動**：report 是**儀式與審計的交界**——有敘事感（絲絲事後可讀「過去這週記憶怎麼長的」、dormant 收斂相變成「可主動參與的回顧儀式」），但不能只停在敘事，**必須對得回 DB / ledger / metadata 的真實狀態**。
 
-**形式**：收斂相完成後，由系統直接呼叫 `append_consolidation_report()`（`loom/autonomy/circadian/journal.py`，**非** agent 的 `journal_append` 工具），在 `autonomy/circadian/journal/YYYY-MM-DD.md` 附加一個 `## HH:MM · 夢境鞏固` entry，含：本輪 pass 摘要（掃描範圍、發現 N 簇 / M 矛盾 / K 孤兒）、Merge 記錄（每簇結果 + rationale；跳過要記差異盤點輸出）、Reconcile 記錄（winner + 仲裁理由）、Clean 記錄、**絲絲 self_review 介入**（批准/否決/暫緩 + 否決理由是否關乎「怕磨平 / dreaming 保護 / user_explicit 錨點」）。
+**形式**：收斂相完成後，由系統直接呼叫 `append_consolidation_report()`（`loom/autonomy/circadian/journal.py`，**非** agent 的 `journal_append` 工具），在 `autonomy/circadian/dreams/YYYY-MM-DD.md` 附加一個 `## HH:MM · 夢境鞏固` entry，含：本輪 pass 摘要（掃描範圍、發現 N 簇 / M 矛盾 / K 孤兒）、Merge 記錄（每簇結果 + rationale；跳過要記差異盤點輸出）、Reconcile 記錄（winner + 仲裁理由）、Clean 記錄、**絲絲 self_review 介入**（批准/否決/暫緩 + 否決理由是否關乎「怕磨平 / dreaming 保護 / user_explicit 錨點」）。
 
-**整合**：circadian journal 因此成為「絲絲的雙相夢紀錄」——發散探索與收斂整理同檔；`grep 夢境鞏固` 即可回顧。
+**整合**：發散探索（journal）與收斂整理（dreams）**並列雙檔**，同根 `autonomy/circadian/`；`grep 夢境鞏固 dreams/` 即可回顧收斂相。
 
-> **實作決議（P1 #488 as-built，修正初稿 note）**：報告**不**走 agent 的 `journal_append` `kind` enum。`journal.py` 的 `KIND_LABELS`（moment/finding/keepsake/tomorrow）是給「每日生活紋理」用的；把系統報告塞進去會污染 agent 工具的選項。改抽共用的 `_append_dated_entry()` helper，新增 `CONSOLIDATION_LABEL = "夢境鞏固"` + 系統入口 `append_consolidation_report()`——同一份 dated journal 檔、同樣 atomic append，但與 agent enum 解耦。
+> **實作決議（P1 #488 as-built，修正初稿 note）**：報告**不**走 agent 的 `journal_append` `kind` enum。`journal.py` 的 `KIND_LABELS`（moment/finding/keepsake/tomorrow）是給「每日生活紋理」用的；把系統報告塞進去會污染 agent 工具的選項。改抽共用的 `_append_dated_entry()` helper，新增 `CONSOLIDATION_LABEL = "夢境鞏固"` + 系統入口 `append_consolidation_report()`——同樣 atomic append，與 agent enum 解耦。
+>
+> **修正決議（#499 slice 2d，real-run 證偽「同檔」）**：初稿與 P1 as-built 都把報告寫進**與生活日記同一份** `journal/YYYY-MM-DD.md`，想讓 circadian journal 成為「雙相夢同檔紀錄」。真實跑（2026-06-01，絲絲）證偽此決定：報告體量遠大於當天日記，把生活紋理**淹沒**（DK 須手動復原）。改寫到**獨立** dated 檔 `autonomy/circadian/dreams/YYYY-MM-DD.md`（`DEFAULT_DREAMS_DIR` + `dream_path_for()`，header `# {date} Dream Consolidation`），與 `journal/` 並列。`_append_dated_entry()` 仍共用，靠新 `header_title` 參數區隔兩種檔頭；agent 的 `journal_append` 路徑完全不變。
 
 ---
 
@@ -275,7 +277,9 @@ trust 分佈：`session_compress × session_compress` 佔 98%(2490)、same-sessi
 **確認發現 C — dry-run / read-only 是系統保護層，非僅審批便利。**
 若無 self_review 的 2013 gate，2538 候選會被塞進 arbitration prompt → token 爆炸使整個 pass crash。read-only 先行在操作者知情前就擋下了一次潛在生產事故 → 強化「P4 排程 read-only 先行(P4a)再放行 execute(P4b)」的決定。
 
-**slice 重排(取代原 P3 內部排序)**：2a same-session 排除(correctness) → 2b unrelated→skip(安全網) → 2c self_review 分批(#499) → 2d 報告獨立檔(#499)。2a 必須**先於** tier-3(#497)評估，否則 tier-3 數據仍被 same-session 噪音污染。(孤兒清理 = P3 slice 4，**已實作落地**。)
+**slice 重排(取代原 P3 內部排序)**：2a same-session 排除(correctness，✅ PR #500) → 2b unrelated→skip(安全網，✅ PR #500) → 2c self_review 分批 + per-pass cap(✅ #499) → 2d 報告獨立檔 `dreams/`(✅ #499)。2a 必須**先於** tier-3(#497)評估，否則 tier-3 數據仍被 same-session 噪音污染。(孤兒清理 = P3 slice 4，**已實作落地**。)
+
+> **2c as-built**：`self_review` 改為每 `batch_size`(預設 10)簇一個 LLM call，並設 `max_review_clusters`(預設 40)per-pass cap；超量循 `deferred_to_next_pass` 順延下輪(無聲截斷禁止)。單批失敗(含 context 超限)只 defer 該批，不拖垮整輪。抽出 `_review_batch()` 承載單批邏輯。`run_convergent_dream` / `convergent_dream` 工具皆透出 `review_batch_size` / `max_review_clusters`。
 
 ---
 

--- a/loom/autonomy/circadian/journal.py
+++ b/loom/autonomy/circadian/journal.py
@@ -52,6 +52,12 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_JOURNAL_DIR = Path("autonomy/circadian/journal")
 
+# Convergent-dream reports land in their OWN dated tree, parallel to journal/.
+# #499 (real run): sharing the journal file drowned the day's life entries under
+# the much larger consolidation report — the spec §8 "two phases, one file"
+# decision was falsified under real volume.
+DEFAULT_DREAMS_DIR = Path("autonomy/circadian/dreams")
+
 # kind: stable English enum keys (tool args) → Chinese H2 labels (file output).
 # Mirrors the four bullet list in doc/56 §10.3.
 #   moment    — 生活片段     a piece of the day's texture
@@ -76,24 +82,36 @@ def journal_path_for(date_str: str, base: Path | None = None) -> Path:
     return (base or DEFAULT_JOURNAL_DIR) / f"{date_str}.md"
 
 
+def dream_path_for(date_str: str, base: Path | None = None) -> Path:
+    """Dated convergent-dream report file for ``date_str`` (YYYY-MM-DD).
+
+    Parallel to ``journal_path_for`` but rooted at ``dreams/`` so the
+    consolidation report never shares a file with the life journal (#499).
+    """
+    return (base or DEFAULT_DREAMS_DIR) / f"{date_str}.md"
+
+
 def _append_dated_entry(
     target_dir: Path, now: datetime, label: str, body: str,
+    *, header_title: str = "Journal",
 ) -> Path:
-    """Append one ``## HH:MM · {label}`` entry to today's journal file.
+    """Append one ``## HH:MM · {label}`` entry to today's dated file.
 
     Single-source of the atomic-append behaviour shared by the agent
-    ``journal_append`` tool and system-generated reports. Lazy H1 header on
-    first write of the day; one ``write()`` syscall so concurrent appends
-    don't tear (POSIX O_APPEND atomic ≤ PIPE_BUF). Raises ``OSError`` on IO
-    failure — callers decide how to surface it.
+    ``journal_append`` tool and system-generated reports. Lazy H1 header
+    (``# {date} {header_title}``) on first write of the day; one ``write()``
+    syscall so concurrent appends don't tear (POSIX O_APPEND atomic ≤
+    PIPE_BUF). ``header_title`` distinguishes the life journal from the dream
+    report file. Raises ``OSError`` on IO failure — callers decide how to
+    surface it.
     """
     date_str = now.strftime("%Y-%m-%d")
     time_str = now.strftime("%H:%M")
-    path = journal_path_for(date_str, target_dir)
+    path = target_dir / f"{date_str}.md"
 
     chunk = ""
     if not path.exists():
-        chunk += f"# {date_str} Journal\n\n"
+        chunk += f"# {date_str} {header_title}\n\n"
     chunk += f"## {time_str} · {label}\n{body}\n\n"
 
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -106,19 +124,24 @@ def append_consolidation_report(
     report_body: str,
     *,
     timezone: str = "Asia/Taipei",
-    journal_dir: Path | None = None,
+    dreams_dir: Path | None = None,
 ) -> Path:
-    """Append a convergent-dream pass report to today's journal (#488, spec §8).
+    """Append a convergent-dream pass report to today's dream file (spec §8; #499).
 
     System-generated (written by the convergent-dream orchestrator, not the
     agent), so it uses the ``夢境鞏固`` label directly rather than a
     ``journal_append`` ``kind`` — keeping the agent tool's enum life-texture
-    only. Lands in the same dated file so the circadian journal becomes the
-    record of both dream phases (``grep 夢境鞏固`` to review). Returns the path.
+    only. Lands in its OWN dated tree (``autonomy/circadian/dreams/``), parallel
+    to the life journal: #499 real-run finding showed the report dwarfs and
+    drowns the day's journal entries when they share a file. ``grep 夢境鞏固
+    dreams/`` to review. Returns the path.
     """
-    target_dir = journal_dir or DEFAULT_JOURNAL_DIR
+    target_dir = dreams_dir or DEFAULT_DREAMS_DIR
     now = datetime.now(ZoneInfo(timezone))
-    return _append_dated_entry(target_dir, now, CONSOLIDATION_LABEL, report_body)
+    return _append_dated_entry(
+        target_dir, now, CONSOLIDATION_LABEL, report_body,
+        header_title="Dream Consolidation",
+    )
 
 
 def make_journal_append_tool(

--- a/loom/core/cognition/consolidation.py
+++ b/loom/core/cognition/consolidation.py
@@ -471,29 +471,17 @@ def _render_cluster_for_review(cluster: CandidateCluster) -> str:
     return "\n".join(lines)
 
 
-async def self_review(plan: ConsolidationPlan, llm_fn: LLMFn) -> list[ReviewDecision]:
-    """絲絲 reviews each cluster offline and returns hard-boundary verdicts.
+async def _review_batch(
+    clusters: list[CandidateCluster], llm_fn: LLMFn,
+) -> list[ReviewDecision]:
+    """Review one context-bounded batch of clusters in a single LLM call.
 
-    Clusters whose diff-inventory already says ``mergeable=False`` are auto-
-    skipped without consulting the LLM (the gate already vetoed them, spec §6.4).
+    A batch that fails (e.g. the provider rejects an over-long prompt) or
+    returns malformed output defers ONLY its own clusters — never the whole
+    pass. This is the per-batch isolation that batching buys us (#499).
     """
     decisions: list[ReviewDecision] = []
-    review_clusters: list[CandidateCluster] = []
-
-    for cluster in plan.clusters:
-        if cluster.kind == KIND_MERGE and cluster.diff is not None and not cluster.diff.mergeable:
-            decisions.append(ReviewDecision(
-                cluster_id=cluster.cluster_id,
-                verdict=VERDICT_SKIP,
-                reason=f"diff-inventory: not mergeable — {cluster.diff.rationale}",
-            ))
-        else:
-            review_clusters.append(cluster)
-
-    if not review_clusters:
-        return decisions
-
-    block = "\n\n".join(_render_cluster_for_review(c) for c in review_clusters)
+    block = "\n\n".join(_render_cluster_for_review(c) for c in clusters)
     messages = [
         {"role": "system", "content": _SELF_REVIEW_SYSTEM},
         {"role": "user", "content": f"Clusters to review:\n\n{block}\n\nReturn the JSON array now."},
@@ -501,19 +489,20 @@ async def self_review(plan: ConsolidationPlan, llm_fn: LLMFn) -> list[ReviewDeci
     try:
         raw = await llm_fn(messages)
     except Exception as exc:
-        logger.warning("[convergent-dream] self_review LLM failed: %s", exc)
-        # Fail safe: if absent self-review, defer everything (never auto-approve).
-        for c in review_clusters:
-            decisions.append(ReviewDecision(
+        logger.warning("[convergent-dream] self_review batch LLM failed: %s", exc)
+        # Fail safe: defer this batch (never auto-approve), let the pass go on.
+        return [
+            ReviewDecision(
                 cluster_id=c.cluster_id, verdict=VERDICT_DEFER,
                 reason=f"self-review unavailable — deferred: {exc}",
-            ))
-        return decisions
+            )
+            for c in clusters
+        ]
 
     parsed = _parse_json_array(raw)
     id_counts = Counter(str(d.get("cluster_id")) for d in parsed if isinstance(d, dict))
     by_id = {str(d.get("cluster_id")): d for d in parsed if isinstance(d, dict)}
-    for c in review_clusters:
+    for c in clusters:
         # A repeated id is malformed output (Codex review #493). Never let a
         # later verdict silently overwrite an earlier one — last-wins would
         # let a bogus "approve" bury a real "skip"/"defer" and weaken the
@@ -537,6 +526,63 @@ async def self_review(plan: ConsolidationPlan, llm_fn: LLMFn) -> list[ReviewDeci
                 cluster_id=c.cluster_id, verdict=verdict,
                 reason=str(d.get("reason", "")) if d else "",
             ))
+    return decisions
+
+
+async def self_review(
+    plan: ConsolidationPlan,
+    llm_fn: LLMFn,
+    *,
+    batch_size: int = 10,
+    max_review_clusters: int = 40,
+) -> list[ReviewDecision]:
+    """絲絲 reviews each cluster offline and returns hard-boundary verdicts.
+
+    Clusters whose diff-inventory already says ``mergeable=False`` are auto-
+    skipped without consulting the LLM (the gate already vetoed them, spec §6.4)
+    and do NOT consume the review budget.
+
+    The remaining clusters are reviewed in batches of ``batch_size`` — one
+    context-bounded LLM call each — rather than one mega-prompt. Real-run
+    finding (#499): a single all-clusters prompt blew the context window at
+    scale → 2013 → everything fell back to defer. ``max_review_clusters`` caps
+    how many clusters one pass reviews; the overflow is deferred to the next
+    pass via ``plan.deferred_to_next_pass`` (no silent truncation).
+    """
+    decisions: list[ReviewDecision] = []
+    review_clusters: list[CandidateCluster] = []
+
+    for cluster in plan.clusters:
+        if cluster.kind == KIND_MERGE and cluster.diff is not None and not cluster.diff.mergeable:
+            decisions.append(ReviewDecision(
+                cluster_id=cluster.cluster_id,
+                verdict=VERDICT_SKIP,
+                reason=f"diff-inventory: not mergeable — {cluster.diff.rationale}",
+            ))
+        else:
+            review_clusters.append(cluster)
+
+    if not review_clusters:
+        return decisions
+
+    # Per-pass cap — overflow deferred to next pass, never silently dropped.
+    if max_review_clusters is not None and len(review_clusters) > max_review_clusters:
+        overflow = review_clusters[max_review_clusters:]
+        review_clusters = review_clusters[:max_review_clusters]
+        for c in overflow:
+            decisions.append(ReviewDecision(
+                cluster_id=c.cluster_id, verdict=VERDICT_DEFER,
+                reason="self-review cap reached this pass — deferred to next pass",
+            ))
+        plan.deferred_to_next_pass += len(overflow)
+        plan.notes.append(
+            f"self-review cap {max_review_clusters} reached; "
+            f"{len(overflow)} clusters deferred to next pass (no silent truncation)."
+        )
+
+    for start in range(0, len(review_clusters), batch_size):
+        batch = review_clusters[start:start + batch_size]
+        decisions.extend(await _review_batch(batch, llm_fn))
     return decisions
 
 
@@ -625,6 +671,8 @@ async def run_convergent_dream(
     corpus_limit: int = 2000,
     min_similarity: float = 0.85,
     max_clusters: int = 20,
+    review_batch_size: int = 10,
+    max_review_clusters: int = 40,
     execute: bool = False,
 ) -> tuple[ConsolidationPlan, str]:
     """Run one convergent-dream pass.
@@ -647,7 +695,11 @@ async def run_convergent_dream(
         if cluster.kind == KIND_MERGE:
             cluster.diff = await diff_inventory(cluster, llm_fn)
 
-    plan.decisions = await self_review(plan, llm_fn)
+    plan.decisions = await self_review(
+        plan, llm_fn,
+        batch_size=review_batch_size,
+        max_review_clusters=max_review_clusters,
+    )
 
     execute_result = None
     if execute:

--- a/loom/core/cognition/consolidation.py
+++ b/loom/core/cognition/consolidation.py
@@ -534,7 +534,7 @@ async def self_review(
     llm_fn: LLMFn,
     *,
     batch_size: int = 10,
-    max_review_clusters: int = 40,
+    max_review_clusters: int | None = 40,
 ) -> list[ReviewDecision]:
     """絲絲 reviews each cluster offline and returns hard-boundary verdicts.
 
@@ -546,9 +546,24 @@ async def self_review(
     context-bounded LLM call each — rather than one mega-prompt. Real-run
     finding (#499): a single all-clusters prompt blew the context window at
     scale → 2013 → everything fell back to defer. ``max_review_clusters`` caps
-    how many clusters one pass reviews; the overflow is deferred to the next
-    pass via ``plan.deferred_to_next_pass`` (no silent truncation).
+    how many clusters one pass reviews (``None`` = no cap); the overflow is
+    deferred to the next pass via ``plan.deferred_to_next_pass`` (no silent
+    truncation).
+
+    ``batch_size`` and ``max_review_clusters`` must be positive — a
+    non-positive ``batch_size`` would crash ``range(step=0)`` or silently
+    review nothing (empty range), and a non-positive cap would defer or
+    mis-slice the whole set. These are public tool knobs (#502 review), so a
+    bad value is rejected outright rather than honoured.
     """
+    if batch_size < 1:
+        raise ValueError(f"batch_size must be a positive integer, got {batch_size}")
+    if max_review_clusters is not None and max_review_clusters < 1:
+        raise ValueError(
+            f"max_review_clusters must be a positive integer or None, "
+            f"got {max_review_clusters}"
+        )
+
     decisions: list[ReviewDecision] = []
     review_clusters: list[CandidateCluster] = []
 
@@ -672,7 +687,7 @@ async def run_convergent_dream(
     min_similarity: float = 0.85,
     max_clusters: int = 20,
     review_batch_size: int = 10,
-    max_review_clusters: int = 40,
+    max_review_clusters: int | None = 40,
     execute: bool = False,
 ) -> tuple[ConsolidationPlan, str]:
     """Run one convergent-dream pass.

--- a/loom/core/memory/maintenance.py
+++ b/loom/core/memory/maintenance.py
@@ -213,18 +213,18 @@ def make_convergent_dream_tool(
     llm_fn: LLMFn,
     *,
     timezone: str = "Asia/Taipei",
-    journal_dir=None,
+    dreams_dir=None,
 ) -> ToolDefinition:
     """Build the ``convergent_dream`` ToolDefinition (#488, P1).
 
     The convergent counterpart to ``dream_cycle``: scans the semantic store,
     proposes merge / reconcile / clean clusters, runs the diff-inventory gate
-    and 絲絲's self-review, then writes a 夢境鞏固 report to the circadian
-    journal. **Read-only** — this phase never writes to the DB; execution of
-    the approved clusters lands in P2 (#489).
+    and 絲絲's self-review, then writes a 夢境鞏固 report to its own dated
+    ``dreams/`` file. **Read-only** — this phase never writes to the DB;
+    execution of the approved clusters lands in P2 (#489).
 
     Parameters mirror ``make_journal_append_tool`` (``timezone`` /
-    ``journal_dir``) so tests can redirect the report IO.
+    ``dreams_dir``) so tests can redirect the report IO.
     """
     from loom.core.cognition.consolidation import (
         KIND_CLEAN, KIND_MERGE, KIND_RECONCILE, run_convergent_dream,
@@ -235,16 +235,20 @@ def make_convergent_dream_tool(
         corpus_limit = int(call.args.get("corpus_limit", 2000))
         max_clusters = int(call.args.get("max_clusters", 20))
         min_similarity = float(call.args.get("min_similarity", 0.85))
+        review_batch_size = int(call.args.get("review_batch_size", 10))
+        max_review_clusters = int(call.args.get("max_review_clusters", 40))
 
         plan, report = await run_convergent_dream(
             semantic, llm_fn,
             corpus_limit=corpus_limit,
             min_similarity=min_similarity,
             max_clusters=max_clusters,
+            review_batch_size=review_batch_size,
+            max_review_clusters=max_review_clusters,
         )
 
         path = append_consolidation_report(
-            report, timezone=timezone, journal_dir=journal_dir,
+            report, timezone=timezone, dreams_dir=dreams_dir,
         )
 
         counts = plan.counts()
@@ -297,6 +301,16 @@ def make_convergent_dream_tool(
                     "type": "number",
                     "description": "Cosine threshold for near-duplicate merge candidates (default 0.85).",
                     "default": 0.85,
+                },
+                "review_batch_size": {
+                    "type": "integer",
+                    "description": "Clusters per self-review LLM call; keeps each prompt context-bounded (default 10).",
+                    "default": 10,
+                },
+                "max_review_clusters": {
+                    "type": "integer",
+                    "description": "Cap on clusters self-reviewed per pass; overflow is deferred to the next pass (default 40).",
+                    "default": 40,
                 },
             },
         },

--- a/loom/core/memory/maintenance.py
+++ b/loom/core/memory/maintenance.py
@@ -238,6 +238,20 @@ def make_convergent_dream_tool(
         review_batch_size = int(call.args.get("review_batch_size", 10))
         max_review_clusters = int(call.args.get("max_review_clusters", 40))
 
+        # The batch/cap knobs feed range() steps and slice bounds; a
+        # non-positive value would crash the pass or silently leave every
+        # cluster unreviewed (#502 review). Reject before any work runs so the
+        # SAFE tool returns a friendly error and writes no report.
+        if review_batch_size < 1 or max_review_clusters < 1:
+            return ToolResult(
+                call_id=call.id, tool_name=call.tool_name, success=False,
+                error=(
+                    "review_batch_size and max_review_clusters must be positive "
+                    f"integers; got review_batch_size={review_batch_size}, "
+                    f"max_review_clusters={max_review_clusters}."
+                ),
+            )
+
         plan, report = await run_convergent_dream(
             semantic, llm_fn,
             corpus_limit=corpus_limit,
@@ -304,11 +318,13 @@ def make_convergent_dream_tool(
                 },
                 "review_batch_size": {
                     "type": "integer",
+                    "minimum": 1,
                     "description": "Clusters per self-review LLM call; keeps each prompt context-bounded (default 10).",
                     "default": 10,
                 },
                 "max_review_clusters": {
                     "type": "integer",
+                    "minimum": 1,
                     "description": "Cap on clusters self-reviewed per pass; overflow is deferred to the next pass (default 40).",
                     "default": 40,
                 },

--- a/tests/test_convergent_dream_review_batching.py
+++ b/tests/test_convergent_dream_review_batching.py
@@ -1,0 +1,147 @@
+"""
+Tests for self_review batching + per-pass cap (#499, slice 2c).
+
+Real-run finding (2026-06-01): self_review rendered ALL pending clusters into a
+single LLM prompt. At scale (the reconcile-noise blowup, #497) that prompt
+exceeded the context limit → the provider returned 2013 → every cluster fell
+back to ``defer``. The fail-safe was correct (defer, never auto-approve) but
+self_review was effectively dead at scale.
+
+The fix: review in batches of N clusters per prompt (one context-bounded call
+each), with a per-pass total cap whose overflow is deferred to the next pass
+via the existing ``deferred_to_next_pass`` accounting — never silently dropped.
+A batch that fails defers only its own clusters, never the whole pass.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from loom.core.memory.semantic import SemanticEntry
+from loom.core.cognition.consolidation import (
+    CandidateCluster,
+    ConsolidationPlan,
+    DiffInventory,
+    KIND_MERGE,
+    KIND_RECONCILE,
+    VERDICT_APPROVE,
+    VERDICT_DEFER,
+    VERDICT_SKIP,
+    self_review,
+)
+
+
+def _cluster(i: int, kind: str = KIND_RECONCILE) -> CandidateCluster:
+    return CandidateCluster(
+        cluster_id=f"c{i}",
+        kind=kind,
+        members=[
+            SemanticEntry(key=f"k{i}a", value="x", source="manual"),
+            SemanticEntry(key=f"k{i}b", value="y", source="manual"),
+        ],
+    )
+
+
+def _plan(n: int) -> ConsolidationPlan:
+    return ConsolidationPlan(clusters=[_cluster(i) for i in range(n)])
+
+
+class _RecordingLLM:
+    """Approves every cluster_id present in the prompt; records each call's ids."""
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    async def __call__(self, messages):
+        ids = re.findall(r'cluster_id="([^"]+)"', messages[1]["content"])
+        self.calls.append(ids)
+        return json.dumps([{"cluster_id": cid, "verdict": "approve"} for cid in ids])
+
+
+class TestBatching:
+    async def test_splits_into_batches_of_batch_size(self):
+        plan = _plan(25)
+        llm = _RecordingLLM()
+        decisions = await self_review(plan, llm, batch_size=10, max_review_clusters=100)
+        # 25 clusters / 10 per batch → three calls of sizes 10, 10, 5
+        assert [len(c) for c in llm.calls] == [10, 10, 5]
+        # every cluster reviewed exactly once
+        assert len(decisions) == 25
+        assert all(d.verdict == VERDICT_APPROVE for d in decisions)
+
+    async def test_every_cluster_gets_exactly_one_decision(self):
+        plan = _plan(17)
+        decisions = await self_review(plan, _RecordingLLM(), batch_size=5, max_review_clusters=100)
+        ids = [d.cluster_id for d in decisions]
+        assert sorted(ids) == sorted(c.cluster_id for c in plan.clusters)
+        assert len(ids) == len(set(ids))  # no duplicates
+
+
+class TestBatchFailureIsolation:
+    async def test_failing_batch_defers_only_its_own_clusters(self):
+        # The second batch raises; batches 1 and 3 must still be approved.
+        class _Flaky:
+            def __init__(self):
+                self.n = 0
+
+            async def __call__(self, messages):
+                ids = re.findall(r'cluster_id="([^"]+)"', messages[1]["content"])
+                self.n += 1
+                if self.n == 2:
+                    raise RuntimeError("context window exceeded (2013)")
+                return json.dumps([{"cluster_id": cid, "verdict": "approve"} for cid in ids])
+
+        plan = _plan(15)  # batch_size 5 → 3 batches
+        decisions = await self_review(plan, _Flaky(), batch_size=5, max_review_clusters=100)
+        by_id = {d.cluster_id: d for d in decisions}
+        # batch 1 (c0-c4) + batch 3 (c10-c14) approved; batch 2 (c5-c9) deferred
+        assert all(by_id[f"c{i}"].verdict == VERDICT_APPROVE for i in range(0, 5))
+        assert all(by_id[f"c{i}"].verdict == VERDICT_DEFER for i in range(5, 10))
+        assert all(by_id[f"c{i}"].verdict == VERDICT_APPROVE for i in range(10, 15))
+        assert len(decisions) == 15
+
+
+class TestPerPassCap:
+    async def test_overflow_deferred_to_next_pass(self):
+        plan = _plan(30)
+        llm = _RecordingLLM()
+        decisions = await self_review(plan, llm, batch_size=10, max_review_clusters=20)
+        approved = [d for d in decisions if d.verdict == VERDICT_APPROVE]
+        deferred = [d for d in decisions if d.verdict == VERDICT_DEFER]
+        assert len(approved) == 20
+        assert len(deferred) == 10
+        # accounting borrows the existing no-silent-truncation channel
+        assert plan.deferred_to_next_pass == 10
+        assert any("cap" in n for n in plan.notes)
+        # only the first 20 clusters were actually sent to the LLM
+        assert sum(len(c) for c in llm.calls) == 20
+
+    async def test_under_cap_reviews_all(self):
+        plan = _plan(8)
+        decisions = await self_review(plan, _RecordingLLM(), batch_size=10, max_review_clusters=40)
+        assert all(d.verdict == VERDICT_APPROVE for d in decisions)
+        assert plan.deferred_to_next_pass == 0
+
+
+class TestAutoSkipNotCounted:
+    async def test_non_mergeable_autoskip_does_not_consume_cap(self):
+        # A merge cluster vetoed by the diff-inventory gate is auto-skipped
+        # without an LLM call — it must not eat into the review cap budget.
+        plan = ConsolidationPlan(clusters=[
+            CandidateCluster(
+                cluster_id="m0", kind=KIND_MERGE,
+                members=[SemanticEntry(key="a", value="x", source="manual"),
+                         SemanticEntry(key="b", value="y", source="manual")],
+                diff=DiffInventory(mergeable=False, rationale="distinct insights"),
+            ),
+            *[_cluster(i) for i in range(20)],
+        ])
+        llm = _RecordingLLM()
+        decisions = await self_review(plan, llm, batch_size=10, max_review_clusters=20)
+        skip = [d for d in decisions if d.verdict == VERDICT_SKIP]
+        approved = [d for d in decisions if d.verdict == VERDICT_APPROVE]
+        assert len(skip) == 1  # the auto-skipped merge cluster
+        # all 20 reconcile clusters still fit under the cap (autoskip not counted)
+        assert len(approved) == 20
+        assert plan.deferred_to_next_pass == 0

--- a/tests/test_convergent_dream_review_batching.py
+++ b/tests/test_convergent_dream_review_batching.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import json
 import re
 
+import pytest
+
 from loom.core.memory.semantic import SemanticEntry
 from loom.core.cognition.consolidation import (
     CandidateCluster,
@@ -120,6 +122,39 @@ class TestPerPassCap:
     async def test_under_cap_reviews_all(self):
         plan = _plan(8)
         decisions = await self_review(plan, _RecordingLLM(), batch_size=10, max_review_clusters=40)
+        assert all(d.verdict == VERDICT_APPROVE for d in decisions)
+        assert plan.deferred_to_next_pass == 0
+
+
+class TestInvalidKnobs:
+    """#502 review (Codex P2): the batch/cap knobs are now public tool args, so
+    they must be validated. ``batch_size=0`` crashes ``range(step=0)``;
+    ``batch_size=-1`` silently reviews nothing (empty range) yet the pass still
+    'succeeds' with every cluster left unreviewed and deferred_to_next_pass==0.
+    Both must be rejected, not coerced, so the bad value is never honoured.
+    """
+
+    async def test_batch_size_zero_raises(self):
+        with pytest.raises(ValueError):
+            await self_review(_plan(3), _RecordingLLM(), batch_size=0)
+
+    async def test_batch_size_negative_raises(self):
+        with pytest.raises(ValueError):
+            await self_review(_plan(3), _RecordingLLM(), batch_size=-1)
+
+    async def test_max_review_clusters_zero_raises(self):
+        with pytest.raises(ValueError):
+            await self_review(_plan(3), _RecordingLLM(), max_review_clusters=0)
+
+    async def test_max_review_clusters_negative_raises(self):
+        with pytest.raises(ValueError):
+            await self_review(_plan(3), _RecordingLLM(), max_review_clusters=-1)
+
+    async def test_none_max_review_clusters_means_no_cap(self):
+        # None remains a valid sentinel for "review everything, no cap".
+        plan = _plan(12)
+        decisions = await self_review(
+            plan, _RecordingLLM(), batch_size=5, max_review_clusters=None)
         assert all(d.verdict == VERDICT_APPROVE for d in decisions)
         assert plan.deferred_to_next_pass == 0
 

--- a/tests/test_convergent_dream_tool.py
+++ b/tests/test_convergent_dream_tool.py
@@ -73,12 +73,12 @@ class TestConvergentDreamTool:
             key="user:pref:tone:b", value="reply short blunt fragments only", source="manual"))
 
         tool = make_convergent_dream_tool(
-            semantic, _combined_llm, timezone="Asia/Taipei", journal_dir=tmp_path)
+            semantic, _combined_llm, timezone="Asia/Taipei", dreams_dir=tmp_path)
         result = await tool.executor(_make_call({}))
 
         assert result.success is True
         assert "scanned" in result.output.lower() or "掃描" in result.output
-        # report file written to the journal dir
+        # report file written to the dreams dir
         md_files = list(tmp_path.glob("*.md"))
         assert len(md_files) == 1
         assert "夢境鞏固" in md_files[0].read_text(encoding="utf-8")
@@ -92,7 +92,7 @@ class TestConvergentDreamTool:
 
         before = await _snapshot(db_conn)
         tool = make_convergent_dream_tool(
-            semantic, _combined_llm, journal_dir=tmp_path)
+            semantic, _combined_llm, dreams_dir=tmp_path)
         await tool.executor(_make_call({}))
         after = await _snapshot(db_conn)
         assert before == after

--- a/tests/test_convergent_dream_tool.py
+++ b/tests/test_convergent_dream_tool.py
@@ -96,3 +96,36 @@ class TestConvergentDreamTool:
         await tool.executor(_make_call({}))
         after = await _snapshot(db_conn)
         assert before == after
+
+
+class TestInvalidKnobsRejected:
+    """#502 review (Codex P2): the SAFE tool must reject non-positive
+    batch/cap knobs with a friendly error rather than crashing or silently
+    leaving every cluster unreviewed."""
+
+    async def test_zero_batch_size_returns_error_not_crash(self, semantic, tmp_path):
+        from loom.core.memory.maintenance import make_convergent_dream_tool
+        await semantic.upsert(SemanticEntry(
+            key="a:b:c:x", value="zebra ocean mountain", source="manual"))
+        tool = make_convergent_dream_tool(semantic, _combined_llm, dreams_dir=tmp_path)
+        result = await tool.executor(_make_call({"review_batch_size": 0}))
+        assert result.success is False
+        assert "review_batch_size" in result.error
+
+    async def test_negative_max_review_clusters_returns_error(self, semantic, tmp_path):
+        from loom.core.memory.maintenance import make_convergent_dream_tool
+        await semantic.upsert(SemanticEntry(
+            key="a:b:c:x", value="zebra ocean mountain", source="manual"))
+        tool = make_convergent_dream_tool(semantic, _combined_llm, dreams_dir=tmp_path)
+        result = await tool.executor(_make_call({"max_review_clusters": -1}))
+        assert result.success is False
+        assert "max_review_clusters" in result.error
+
+    async def test_invalid_knob_writes_no_report(self, semantic, tmp_path):
+        # rejected before the pass runs → no dream file created
+        from loom.core.memory.maintenance import make_convergent_dream_tool
+        await semantic.upsert(SemanticEntry(
+            key="a:b:c:x", value="zebra ocean mountain", source="manual"))
+        tool = make_convergent_dream_tool(semantic, _combined_llm, dreams_dir=tmp_path)
+        await tool.executor(_make_call({"review_batch_size": 0}))
+        assert list(tmp_path.glob("*.md")) == []

--- a/tests/test_journal_consolidation_report.py
+++ b/tests/test_journal_consolidation_report.py
@@ -1,10 +1,15 @@
 """
-Tests for the convergent-dream report appender (#488, P1, spec §8).
+Tests for the convergent-dream report appender (#488 P1; #499 slice 2d).
 
 The dream report is a SYSTEM-generated artifact written by code, not the agent.
-It lands in the same dated circadian journal so the file becomes "絲絲's
-two-phase dream record" (grep-able), but it must NOT pollute the agent-facing
-``journal_append`` tool's ``kind`` enum (which is for daily life-texture only).
+
+#499 finding (real run, 2026-06-01): the report originally landed in the SAME
+dated file as the agent's life journal (``autonomy/circadian/journal/``). At
+real volume the report dwarfed the day's journal entries and drowned them out
+(DK had to hand-restore the file). The two-phase-same-file decision (spec §8)
+was falsified under load, so the report now writes to its OWN dated path,
+``autonomy/circadian/dreams/YYYY-MM-DD.md``, parallel to journal/. It still must
+NOT pollute the agent-facing ``journal_append`` tool's ``kind`` enum.
 """
 
 from __future__ import annotations
@@ -13,9 +18,11 @@ from datetime import datetime
 from zoneinfo import ZoneInfo
 
 from loom.autonomy.circadian.journal import (
+    DEFAULT_DREAMS_DIR,
+    DEFAULT_JOURNAL_DIR,
     KIND_LABELS,
     append_consolidation_report,
-    journal_path_for,
+    dream_path_for,
 )
 
 
@@ -26,27 +33,28 @@ def _today(tz: str = "Asia/Taipei") -> str:
 class TestAppendConsolidationReport:
     def test_writes_dated_entry_with_label(self, tmp_path):
         path = append_consolidation_report(
-            "### 摘要\n- nothing merged\n", timezone="Asia/Taipei", journal_dir=tmp_path,
+            "### 摘要\n- nothing merged\n", timezone="Asia/Taipei", dreams_dir=tmp_path,
         )
-        assert path == journal_path_for(_today(), tmp_path)
+        assert path == dream_path_for(_today(), tmp_path)
         text = path.read_text(encoding="utf-8")
         assert "· 夢境鞏固" in text
         assert "### 摘要" in text
         assert "nothing merged" in text
 
     def test_lazy_h1_header_on_first_write(self, tmp_path):
-        path = append_consolidation_report("body", journal_dir=tmp_path)
+        path = append_consolidation_report("body", dreams_dir=tmp_path)
         text = path.read_text(encoding="utf-8")
-        assert text.startswith(f"# {_today()} Journal")
+        # dreams file carries its own header, not the life-journal "Journal" one
+        assert text.startswith(f"# {_today()} Dream Consolidation")
 
     def test_appends_without_clobbering(self, tmp_path):
-        append_consolidation_report("first pass body", journal_dir=tmp_path)
-        path = append_consolidation_report("second pass body", journal_dir=tmp_path)
+        append_consolidation_report("first pass body", dreams_dir=tmp_path)
+        path = append_consolidation_report("second pass body", dreams_dir=tmp_path)
         text = path.read_text(encoding="utf-8")
         assert "first pass body" in text
         assert "second pass body" in text
         # H1 header written exactly once
-        assert text.count("Journal") == 1
+        assert text.count("Dream Consolidation") == 1
 
     def test_does_not_pollute_agent_kind_enum(self):
         # The agent-facing journal_append tool must not gain a system kind.
@@ -54,5 +62,17 @@ class TestAppendConsolidationReport:
         assert set(KIND_LABELS) == {"moment", "finding", "keepsake", "tomorrow"}
 
     def test_returns_path(self, tmp_path):
-        path = append_consolidation_report("x", journal_dir=tmp_path)
+        path = append_consolidation_report("x", dreams_dir=tmp_path)
         assert path.exists()
+
+
+class TestSeparateFromLifeJournal:
+    """2d: the dream report must not share a file with the life journal."""
+
+    def test_default_dreams_dir_distinct_from_journal_dir(self):
+        assert DEFAULT_DREAMS_DIR != DEFAULT_JOURNAL_DIR
+        assert DEFAULT_DREAMS_DIR.name == "dreams"
+        assert DEFAULT_JOURNAL_DIR.name == "journal"
+
+    def test_dream_path_for_uses_dreams_dir_by_default(self):
+        assert dream_path_for("2026-06-01") == DEFAULT_DREAMS_DIR / "2026-06-01.md"


### PR DESCRIPTION
Two robustness/isolation fixes surfaced by the first real run of `convergent_dream` (2026-06-01), plus the round-2 analysis that validated them. Epic #491.

## slice 2c — self_review batching + per-pass cap
`self_review` rendered **all** pending clusters into a single LLM prompt. At scale (the reconcile-noise blowup, #497/#500) that prompt exceeded the context window → provider returned 2013 → every cluster fell back to `defer`. The fail-safe was correct, but self_review was effectively dead at scale.

- reviews in batches of `batch_size` (default 10) — one context-bounded LLM call each
- `max_review_clusters` per-pass cap (default 40); overflow deferred to next pass via the existing `deferred_to_next_pass` accounting (**no silent truncation**)
- a batch that fails defers **only its own** clusters, never the whole pass
- extracted `_review_batch()`; `run_convergent_dream` / the `convergent_dream` tool expose both knobs
- diff-inventory auto-skips (non-mergeable merge clusters) do **not** consume the review budget

## slice 2d — dream report gets its own file
The report shared the dated life-journal file (`autonomy/circadian/journal/`). At real volume it dwarfed and drowned the day's journal entries (had to be hand-restored).

- now writes to `autonomy/circadian/dreams/YYYY-MM-DD.md` (`DEFAULT_DREAMS_DIR` + `dream_path_for()`, header `# {date} Dream Consolidation`), parallel to `journal/`
- `_append_dated_entry()` stays shared via a new `header_title` param; the agent `journal_append` path is **unchanged**
- renamed report-appender / tool param `journal_dir` → `dreams_dir`

## docs
- #56 §8 — the "two phases, one file" decision (falsified under load) updated to the as-built separate-file design
- #56 §12 — 2c/2d marked landed; **§12.1** records the round-2 trust analysis: the 34 reconcile candidates are 100% trust-symmetric with 0 genuine contradictions → #497 tier-3 deferred, #501 opened (structured-namespace prefix-sibling exclusion) as the higher-value next step

## tests
TDD red→green. New `tests/test_convergent_dream_review_batching.py` (batching / failure-isolation / per-pass cap / autoskip-not-counted). Reworked the journal report tests for the `dreams/` path. Full suite **2357 passed**, 4 skipped.

## verification on the real run
The report's "34 deferred" decomposes correctly to 31 (build_plan merge cap) + 3 (self_review cap) — both caps count independently and each logs a note; no silent truncation. Report landed cleanly in `dreams/2026-06-01.md`; the life journal was untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)