### PR TITLE
fix(memory): exclude structured-namespace prefix siblings from reconcile (#501)

### DIFF
--- a/docs/designs/56-記憶鞏固夢-收斂相規格.md
+++ b/docs/designs/56-記憶鞏固夢-收斂相規格.md
@@ -308,6 +308,8 @@ trust 分佈：`session_compress × session_compress` 佔 98%(2490)、same-sessi
 prefix 在此是 **provenance 命名空間（主語 / 技能 / 日期桶）**，非語義子題——與 same-session 兄弟**同一失敗模式**。
 → **決策**：高價值下一步 = 把 2a 的修法推廣到「結構化 namespace prefix 兄弟排除」（follow-up issue，epic #491），預期把 34 → 趨近 0，detector 只在真 same-key / 真衝突時響。**優先於 tier-3**。
 
+> **#501 as-built**：`_is_session_sibling`(2a) 推廣為 `_is_namespace_sibling(key_a, key_b)`，在 `build_plan` reconcile loop 排除。關鍵張力是**不能**用「凡共用 prefix 即排除」——`user:pref:tone:formal` × `:casual`(同屬性對立值)是真矛盾、#500 測試明確要求保留。純 key 結構無法通則區分「不同謂語/不同記事」(排除)與「同屬性對立值」(保留)，故用 **namespace-aware 啟發式**：① `rel:<S>::<P>` 關係三元組 ② 任一 key 帶 `YYYY-MM-DD` date 段(time-bucketed log = 歷史非矛盾) ③ 含 `eval`/`diagnostic`/`diagnosis` log 段 ④ session 兄弟(2a 保留)。**刻意不排除**:相同 key(真 tier-1 衝突)、provenance namespace 外的同 prefix 對立值。偏誤刻意偏向「多排除」——reconcile 是破壞性臂，over-skip 是安全錯誤。實測:34 個候選全排除、`user:pref:tone` 真矛盾仍保留。
+
 ---
 
 ## 實作追蹤

--- a/loom/core/cognition/consolidation.py
+++ b/loom/core/cognition/consolidation.py
@@ -171,6 +171,56 @@ def _is_session_sibling(key_a: str, key_b: str) -> bool:
     return key_a.split(":")[:3] == key_b.split(":")[:3]
 
 
+_DATE_SEGMENT = re.compile(r"\d{4}-\d{2}-\d{2}")
+# Key segments that mark an append-only log namespace (per-round / per-session
+# evaluation or diagnostic records) rather than a single-valued attribute.
+_LOG_MARKER_SEGMENTS = {"eval", "diagnostic", "diagnosis"}
+
+
+def _is_namespace_sibling(key_a: str, key_b: str) -> bool:
+    """True if two DISTINCT keys are sibling facts under a structured provenance
+    namespace — different leaves of one grouping, not competing claims (#501).
+
+    Generalises ``_is_session_sibling`` (2a). Real-run round 2 (#56 §12.1)
+    showed the same false-positive pattern across more namespaces: the tier-2
+    prefix detector flags two keys that merely share a provenance prefix as a
+    "contradiction" when they are actually distinct facts of a collection. The
+    families, all confirmed on the real corpus:
+
+      - session compression siblings (``session:<id>:<ts>:fact:<n>``);
+      - relational triples (``rel:<S>::<P>``) — distinct predicates are
+        distinct relations about the subject, never a conflict;
+      - time-bucketed log records — either key carries a ``YYYY-MM-DD`` date
+        segment (diary / self_check / integration / *:updated / diagnostic
+        logs); facts stamped at different times are a history, not a conflict;
+      - evaluation / diagnostic log namespaces (an ``eval`` / ``diagnostic`` /
+        ``diagnosis`` segment) — distinct rounds / cases / facets.
+
+    Deliberately does NOT exclude:
+      - identical keys — a same-key value change is a genuine tier-1
+        contradiction and must still surface;
+      - same-prefix keys outside a provenance namespace whose leaves are
+        opposing values of one attribute (e.g. ``user:pref:tone:formal`` vs
+        ``user:pref:tone:casual``) — those stay reconcile candidates.
+
+    Bias is intentionally conservative toward *excluding* from reconcile: the
+    reconcile arm is the destructive path, so over-skipping is the safe error,
+    under-skipping is the noise we are removing.
+    """
+    if key_a == key_b:
+        return False
+    if _is_session_sibling(key_a, key_b):
+        return True
+    if key_a.startswith("rel:") and key_b.startswith("rel:"):
+        return True
+    if _DATE_SEGMENT.search(key_a) or _DATE_SEGMENT.search(key_b):
+        return True
+    segments = set(key_a.split(":")) | set(key_b.split(":"))
+    if segments & _LOG_MARKER_SEGMENTS:
+        return True
+    return False
+
+
 def _union_find_clusters(pairs: list[tuple[str, str]]) -> list[set[str]]:
     """Group keys into connected components from a list of (key_a, key_b) edges."""
     parent: dict[str, str] = {}
@@ -294,8 +344,8 @@ async def build_plan(
         for c in contradictions:
             if _is_dreaming(c.existing) or _is_stub(c.existing):
                 continue
-            if _is_session_sibling(entry.key, c.existing.key):
-                continue  # provenance-namespace siblings, not contradictions (#497)
+            if _is_namespace_sibling(entry.key, c.existing.key):
+                continue  # structured-namespace siblings, not contradictions (#497/#501)
             pair = frozenset((entry.key, c.existing.key))
             if entry.key == c.existing.key or pair in seen_pairs:
                 continue

--- a/tests/test_convergent_dream_reconcile.py
+++ b/tests/test_convergent_dream_reconcile.py
@@ -26,6 +26,7 @@ from loom.core.cognition.consolidation import (
     ReviewDecision,
     KIND_RECONCILE,
     VERDICT_APPROVE,
+    _is_namespace_sibling,
     build_plan,
     classify_reconcile,
     execute_plan,
@@ -141,6 +142,81 @@ class TestSameSessionExclusion:
             source="manual"))
         plan = await build_plan(semantic)
         assert len([c for c in plan.clusters if c.kind == KIND_RECONCILE]) == 1
+
+
+class TestNamespaceSiblingHelper:
+    """#501: _is_namespace_sibling generalises 2a's session-only check to the
+    structured provenance namespaces surfaced by real-run round 2 (#56 §12.1).
+    Different leaves of one grouping are different facts, never contradictions —
+    but a same-attribute opposing pair (user:pref:tone) must still pass through.
+    """
+
+    def test_identical_key_is_not_sibling(self):
+        # a same-key value conflict is a genuine tier-1 contradiction
+        assert _is_namespace_sibling("a:b:c:d", "a:b:c:d") is False
+
+    def test_relational_triples_are_siblings(self):
+        # rel:<S>::<P> — distinct predicates about the subject, not a conflict
+        assert _is_namespace_sibling("rel:self::role", "rel:self::complements") is True
+
+    def test_date_bucketed_records_are_siblings(self):
+        assert _is_namespace_sibling(
+            "loom:diary:2026-05-11:day_34", "loom:diary:2026-05-11:pet_care") is True
+        assert _is_namespace_sibling(
+            "diary:self_check:daily:2026-04-27",
+            "diary:self_check:daily:2026-05-07") is True
+
+    def test_eval_diagnostic_logs_are_siblings(self):
+        assert _is_namespace_sibling(
+            "skill:code_weaver:eval:r1:summary",
+            "skill:code_weaver:eval:r2:summary") is True
+
+    def test_session_siblings_still_caught(self):
+        assert _is_namespace_sibling(
+            "session:s1:t0:fact:0", "session:s1:t0:fact:1") is True
+
+    def test_opposing_attribute_values_are_not_siblings(self):
+        # user:pref:tone:formal vs :casual — opposing values of one attribute,
+        # a genuine contradiction; must NOT be excluded.
+        assert _is_namespace_sibling(
+            "user:pref:tone:formal", "user:pref:tone:casual") is False
+
+    def test_cross_namespace_is_not_sibling(self):
+        assert _is_namespace_sibling("user:location:home", "profile:city:current") is False
+
+
+class TestNamespaceSiblingExclusion:
+    """#501: the build_plan reconcile loop excludes namespace siblings."""
+
+    async def test_relational_triple_siblings_excluded(self, semantic):
+        await semantic.upsert(SemanticEntry(
+            key="rel:self::role", value="developer building the harness",
+            source="manual"))
+        await semantic.upsert(SemanticEntry(
+            key="rel:self::complements", value="works alongside other agents",
+            source="manual"))
+        plan = await build_plan(semantic)
+        assert [c for c in plan.clusters if c.kind == KIND_RECONCILE] == []
+
+    async def test_eval_log_siblings_excluded(self, semantic):
+        await semantic.upsert(SemanticEntry(
+            key="skill:code_weaver:eval:r1:summary",
+            value="zebra ocean mountain peak glacier", source="manual"))
+        await semantic.upsert(SemanticEntry(
+            key="skill:code_weaver:eval:r2:summary",
+            value="violin guitar drum trumpet flute", source="manual"))
+        plan = await build_plan(semantic)
+        assert [c for c in plan.clusters if c.kind == KIND_RECONCILE] == []
+
+    async def test_date_bucketed_siblings_excluded(self, semantic):
+        await semantic.upsert(SemanticEntry(
+            key="loom:diary:2026-05-11:day_34",
+            value="zebra ocean mountain peak glacier", source="manual"))
+        await semantic.upsert(SemanticEntry(
+            key="loom:diary:2026-05-11:pet_care",
+            value="violin guitar drum trumpet flute", source="manual"))
+        plan = await build_plan(semantic)
+        assert [c for c in plan.clusters if c.kind == KIND_RECONCILE] == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #501. Epic #491. Follows the round-2 real-run analysis recorded in #56 §12.1.

## Why
After the same-session exclusion (#500), the first real run still produced 34 reconcile candidates — and the trust analysis showed they were ~100% **another flavour of the same false positive**. The tier-2 prefix detector (`ContradictionDetector.detect`) flags two keys that merely share a 3-segment provenance prefix as a "contradiction" when they are actually distinct facts of a collection: different relational predicates, eval rounds, diary topics, dated log records. self_review correctly skipped/deferred all 34 (0 genuine contradictions), but they shouldn't reach review in the first place.

## The tension this had to thread
A blanket "same prefix → exclude" rule is wrong: `user:pref:tone:formal` vs `user:pref:tone:casual` are **opposing values of one attribute** — a genuine contradiction, and #500's `test_cross_session_or_semantic_prefix_still_detected` requires it to stay a candidate. Key structure alone can't separate "different predicate / record" (exclude) from "opposing value of one attribute" (keep), so the check is **namespace-aware**.

## What
Generalises `_is_session_sibling` (2a) into `_is_namespace_sibling(key_a, key_b)`, used in the `build_plan` reconcile loop. Excludes (returns True) when the two distinct keys are:

- relational triples (`rel:<S>::<P>`) — distinct predicates are distinct relations, never a conflict
- time-bucketed log records — either key carries a `YYYY-MM-DD` date segment (diary / self_check / integration / `*:updated` / diagnostic logs); facts stamped at different times are a history, not a contradiction
- `eval` / `diagnostic` / `diagnosis` log namespaces — distinct rounds / cases / facets
- session compression siblings (2a, preserved)

Deliberately does **not** exclude identical keys (a genuine tier-1 value conflict) or same-prefix opposing values outside a provenance namespace. Bias is intentionally conservative toward excluding from reconcile — it is the destructive arm, so over-skipping is the safe error, under-skipping is the noise being removed.

## Note for review
The date rule uses **OR** (either key carrying a date segment marks the pair as a time-bucketed log). This is deliberately broad and matches the conservative-skip bias; a genuine "both dated and actually opposing" pair would be skipped, but timestamped facts evolving over time are arguably a history rather than a contradiction. Flagging in case a tighter "date in a shared structural position" rule is preferred.

## Tests
TDD red→green. 7 unit tests on `_is_namespace_sibling` + 3 `build_plan` integration tests (rel / eval-log / date-bucket exclusion). Verified all 34 real candidates excluded and the synthetic `user:pref:tone` contradiction still detected. Full suite **2375 passed**, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)