### PR TITLE
fix(memory): wire _strip_vision_blocks into log_message (#506 follow-up)

### DIFF
--- a/loom/core/memory/session_log.py
+++ b/loom/core/memory/session_log.py
@@ -163,7 +163,7 @@ class SessionLog:
         session_id: str,
         turn_index: int,
         role: str,
-        content: str,
+        content: str | list[dict[str, Any]],
         metadata: dict[str, Any] | None = None,
         raw_json: str | None = None,
     ) -> None:
@@ -178,6 +178,18 @@ class SessionLog:
             ``load_messages()`` will prefer this column for assistant-message replay.
         """
         try:
+            # Vision turns arrive as canonical *list* content
+            # (``[{type:text...}, {type:image...}]``). SQLite cannot bind
+            # a list, so reduce it to a text summary + image refs in
+            # metadata before the INSERT — no base64 ever reaches disk.
+            # #506 added ``_strip_vision_blocks`` for exactly this but
+            # never wired it in here, so the list hit the bind and the
+            # write was silently dropped ("type 'list' is not supported").
+            # Kept inside the try so a malformed block can't break the
+            # method's "never blocks the loop" contract.
+            if isinstance(content, list):
+                content, metadata = _strip_vision_blocks(content, metadata)
+
             # #335 — secret redaction is applied at read time in
             # ``load_messages``. Keeping the raw text on disk lets
             # future regex improvements re-redact older rows accurately

--- a/tests/test_vision_input.py
+++ b/tests/test_vision_input.py
@@ -559,6 +559,10 @@ class TestStripVisionBlocks:
 # ---------------------------------------------------------------------------
 
 
+# NOTE: kept in sync by hand with the production schema in
+# loom/core/memory/store.py (CREATE TABLE session_log). If that schema
+# gains a column or changes a type, update this block too — there is no
+# shared single-source, so a mismatch would be silent (#509 review P2-3).
 _SESSION_LOG_SCHEMA = """
 CREATE TABLE sessions (
     session_id TEXT, model TEXT, title TEXT,

--- a/tests/test_vision_input.py
+++ b/tests/test_vision_input.py
@@ -552,3 +552,74 @@ class TestStripVisionBlocks:
         ], {})
         assert text == "[vision input: 1 image(s)]"
         assert len(md["vision_inputs"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Wiring: log_message must actually call _strip_vision_blocks
+# ---------------------------------------------------------------------------
+
+
+_SESSION_LOG_SCHEMA = """
+CREATE TABLE sessions (
+    session_id TEXT, model TEXT, title TEXT,
+    started_at TEXT, last_active TEXT, turn_count INTEGER DEFAULT 0
+);
+CREATE TABLE session_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL, turn_index INTEGER NOT NULL,
+    role TEXT NOT NULL, content TEXT NOT NULL, raw_json TEXT,
+    metadata TEXT NOT NULL DEFAULT '{}', created_at TEXT NOT NULL
+);
+"""
+
+
+class TestSessionLogVisionPersistence:
+    """#506 added _strip_vision_blocks but never wired it into log_message.
+
+    A real vision turn arrives at log_message as canonical *list* content;
+    SQLite cannot bind a list, so the write was silently dropped with
+    "Error binding parameter 4: type 'list' is not supported" (caught by
+    log_message's broad except). The earlier unit test exercised the
+    helper in isolation and never went through log_message — the same
+    "test the unit, skip the wiring" gap as the #508 dead-import bug.
+
+    This test drives the real write path.
+    """
+
+    async def test_list_content_persists_as_text_summary(self, tmp_path: Path) -> None:
+        import aiosqlite
+        from loom.core.memory.session_log import SessionLog
+
+        conn = await aiosqlite.connect(str(tmp_path / "s.db"))
+        await conn.executescript(_SESSION_LOG_SCHEMA)
+        log = SessionLog(conn)
+        await log.create_session("s1", "test-model")
+
+        vi = vision.load_vision_input(png_path_for(tmp_path))
+        content = vision.build_user_content("看下這張", [vi])
+        # This is the exact shape stream_turn appends + logs for a vision
+        # turn. Before the fix it raised inside log_message and dropped
+        # the row.
+        await log.log_message("s1", 4, "user", content)
+
+        cur = await conn.execute(
+            "SELECT content, metadata FROM session_log WHERE turn_index = 4"
+        )
+        row = await cur.fetchone()
+        assert row is not None, "vision turn row was dropped (list hit the SQL bind)"
+        text, meta_raw = row
+        assert isinstance(text, str)
+        assert "看下這張" in text
+        # No base64 / raw image bytes ever reach disk.
+        assert "base64" not in text
+        assert "iVBORw" not in text
+        meta = json.loads(meta_raw)
+        assert len(meta["vision_inputs"]) == 1
+        assert meta["vision_inputs"][0]["digest"] == vi.digest
+        await conn.close()
+
+
+def png_path_for(tmp_path: Path) -> Path:
+    p = tmp_path / "fixture.png"
+    p.write_bytes(_make_png_bytes())
+    return p


### PR DESCRIPTION
## Summary

Fixes the `Session log write failed (turn=N): Error binding parameter 4: type 'list' is not supported` error seen on a real vision turn. Follow-up to #506 / #508.

A vision turn reaches `SessionLog.log_message` as canonical **list** content (`[{type:text...}, {type:image...}]`). SQLite cannot bind a Python list, so the INSERT raised — and `log_message`'s broad `except` swallowed it, **silently dropping that turn's row from the persistent session log**.

#506 added `_strip_vision_blocks` to reduce list content to a text summary + image refs in metadata (no base64 on disk), but **never called it from `log_message`**:

```
$ grep -rn _strip_vision_blocks loom/
loom/core/memory/session_log.py:37:def _strip_vision_blocks(content, metadata):   # defined…
# …and never called anywhere.
```

The helper had a direct unit test (`TestStripVisionBlocks`); the write path that was supposed to use it did not. This is the **third instance of the same "test the unit, skip the wiring" gap in the vision feature**:

| | bug | shared root cause |
|---|---|---|
| #506 | `build_user_content` `ref=None` crash | tests drove `vision.*` directly, never the session/persistence wiring |
| #508 | `session.py` never imported `vision` → CLI vision fully dead | same |
| **this** | `_strip_vision_blocks` never wired into `log_message` | acceptance #6 ("no base64 in history") tested the helper, not `log_message` calling it |

## Fix

* `log_message` calls `_strip_vision_blocks` when `content` is a list, before the bind. Kept **inside** the `try` so a malformed block can't break the method's documented "never blocks the loop" contract.
* `content` type widened to `str | list[dict[str, Any]]`.

## Impact

Non-fatal in the moment — the write was swallowed and vision still reached the wire (the model saw the image). But **vision-turn rows were lost from `session_log`**, so a resumed session would be missing those turns from its history. This also makes #506's acceptance criterion #6 ("no base64 in session history") *actually* hold — it was previously claimed-but-unwired.

## Tests

* New `TestSessionLogVisionPersistence` drives the **real `log_message` write path** (not the helper in isolation) and reproduced the exact `type 'list' is not supported` error before the fix — red on first run.
* Asserts: list content persists as a text summary (no `base64` / no PNG header on disk), and `metadata.vision_inputs` carries ref + digest.
* Vision tests 43 → 44; full suite **2419 passed, 4 skipped**.

## Risk

LOW. `gitnexus detect_changes`: only `SessionLog.log_message` touched, no affected processes. Behaviour for non-list (str) content is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
