### PR TITLE
feat(vision): rehydrate vision turns on session resume (#510)

### DIFF
--- a/loom/core/cognition/vision.py
+++ b/loom/core/cognition/vision.py
@@ -35,6 +35,30 @@ Provider-neutral canonical block (used inside ``content`` list):
         "media_type": "image/png" | ...,
         "digest": "sha256:<hex>",
     }}
+
+Wiring touchpoints (keep this list current — it is the antidote to the
+#506 → #508 → #509 → #510 pattern, where the same feature shipped a
+"tested the unit, skipped the wiring" bug at four different seams in a
+row). Every place an image enters or leaves the harness, plus the test
+that drives that *seam end-to-end* (not the underlying module function
+in isolation):
+
+  1. CLI entry        session._detect_vision_paths_in_text → build_user_content
+                      test_vision_input.py::TestSessionVisionDetection,
+                      ::TestBuildUserContentRoundTrips
+  2. Discord entry    bot._handle_message → build_user_content
+                      ::TestBuildUserContentRoundTrips::test_discord_origin_round_trip
+  3. Single builder   make_image_block (the only canonical-block builder)
+                      ::TestMakeImageBlock
+  4. Provider wire    _to_anthropic_messages / _build_responses_content
+                      ::TestAnthropicMessages, ::TestResponsesContent
+  5. Persist (write)  session_log.log_message → _strip_vision_blocks + raw_json
+                      ::TestSessionLogVisionPersistence
+  6. Replay (read)    session_log.load_messages → _drop_unreadable_image_refs
+                      ::TestVisionResumeReplay (incl. full persist→replay→wire)
+
+When you add a new image source/sink, add its row here AND a test that
+exercises the real entry point, not just the helper it delegates to.
 """
 
 from __future__ import annotations

--- a/loom/core/memory/session_log.py
+++ b/loom/core/memory/session_log.py
@@ -23,6 +23,7 @@ import json
 import logging
 import re
 from datetime import datetime, UTC
+from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -59,6 +60,52 @@ def _strip_vision_blocks(content, metadata):
     if image_refs:
         md["vision_inputs"] = image_refs
     return text_summary, md
+
+
+def _drop_unreadable_image_refs(msg):
+    """#510: on replay, drop file-backed image blocks whose file is gone.
+
+    A vision turn is rehydrated from ``raw_json`` with its canonical
+    image blocks intact (``source.kind == "file"``, ``ref`` a path). If
+    the file no longer exists (workspace cleaned, ``.discord_downloads``
+    pruned), re-feeding that block to the wire would make the provider's
+    ``load_vision_input`` raise and crash the whole turn — the same
+    failure class as #506. So we degrade gracefully here instead: drop
+    the dead image block, keep the text. When no image survives, collapse
+    to a plain text string so the message looks like an ordinary text
+    turn. ``url``/``raw`` blocks are left untouched (no local file to
+    check).
+    """
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return msg
+    kept: list = []
+    dropped = 0
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "image":
+            src = block.get("source", {}) or {}
+            if src.get("kind") == "file":
+                ref = src.get("ref")
+                if not ref or not Path(ref).is_file():
+                    dropped += 1
+                    continue
+        kept.append(block)
+    if not dropped:
+        return msg
+    has_image = any(
+        isinstance(b, dict) and b.get("type") == "image" for b in kept
+    )
+    out = dict(msg)
+    if has_image:
+        out["content"] = kept
+    else:
+        texts = [
+            b.get("text", "") for b in kept
+            if isinstance(b, dict) and b.get("type") == "text"
+        ]
+        text = "\n".join(t for t in texts if t)
+        out["content"] = text or "[vision input no longer available]"
+    return out
 
 
 
@@ -188,6 +235,15 @@ class SessionLog:
             # Kept inside the try so a malformed block can't break the
             # method's "never blocks the loop" contract.
             if isinstance(content, list):
+                # #510: persist the canonical structure to raw_json so a
+                # resumed session can rehydrate the image (load_messages
+                # Priority 1). Canonical blocks carry only ref+digest,
+                # never base64, so this is disk-safe. Don't clobber a
+                # raw_json the caller already supplied.
+                if raw_json is None:
+                    raw_json = json.dumps(
+                        {"role": role, "content": content}, ensure_ascii=False
+                    )
                 content, metadata = _strip_vision_blocks(content, metadata)
 
             # #335 — secret redaction is applied at read time in
@@ -474,6 +530,10 @@ class SessionLog:
             if raw_json:
                 try:
                     parsed = json.loads(raw_json)
+                    # #510 — a rehydrated vision turn may reference image
+                    # files that no longer exist; drop those blocks before
+                    # they reach the wire (degrade to text, never crash).
+                    parsed = _drop_unreadable_image_refs(parsed)
                     # #335 — redact at the leaf level after parse so
                     # patterns can't accidentally chew through escaped
                     # quotes and break JSON.

--- a/tests/test_vision_input.py
+++ b/tests/test_vision_input.py
@@ -683,6 +683,44 @@ class TestVisionResumeReplay:
             assert all(b.get("type") != "image" for b in m["content"])
         await conn.close()
 
+    async def test_resume_keeps_live_images_drops_dead(self, tmp_path: Path) -> None:
+        # #511 review P2-1: partial death — two images, only one file
+        # survives. The live one is kept (content stays a list), the dead
+        # one is dropped. Exercises the `has_image = any(...)` branch.
+        conn, log = await _fresh_log(tmp_path)
+        p1 = tmp_path / "a.png"
+        p1.write_bytes(_make_png_bytes(width=2))
+        p2 = tmp_path / "b.png"
+        p2.write_bytes(_make_png_bytes(width=8))
+        vi1 = vision.load_vision_input(p1)
+        vi2 = vision.load_vision_input(p2)
+        content = vision.build_user_content("兩張", [vi1, vi2])
+        await log.log_message("s1", 4, "user", content)
+        p1.unlink()  # kill only the first
+
+        m = _user_msg(await log.load_messages("s1"))
+        assert isinstance(m["content"], list)
+        imgs = [b for b in m["content"] if b.get("type") == "image"]
+        assert len(imgs) == 1
+        assert imgs[0]["source"]["digest"] == vi2.digest  # the survivor
+        await conn.close()
+
+    async def test_resume_redacts_secrets_in_rehydrated_text(self, tmp_path: Path) -> None:
+        # #511 review P2-4: a secret in a vision turn's text block must be
+        # redacted on replay, exactly like a plain-text turn — the
+        # raw_json rehydrate path must not bypass _redact_in_place.
+        conn, log = await _fresh_log(tmp_path)
+        p = png_path_for(tmp_path)
+        vi = vision.load_vision_input(p)
+        content = vision.build_user_content("token Bearer abcd1234efgh5678", [vi])
+        await log.log_message("s1", 4, "user", content)
+
+        m = _user_msg(await log.load_messages("s1"))
+        flat = json.dumps(m["content"], ensure_ascii=False)
+        assert "abcd1234efgh5678" not in flat
+        assert "[REDACTED]" in flat
+        await conn.close()
+
     async def test_full_persist_replay_wire_roundtrip(self, tmp_path: Path) -> None:
         # The end-to-end seam #506/#508/#509 never covered together:
         # build -> persist -> load_messages -> wire, file present.

--- a/tests/test_vision_input.py
+++ b/tests/test_vision_input.py
@@ -627,3 +627,77 @@ def png_path_for(tmp_path: Path) -> Path:
     p = tmp_path / "fixture.png"
     p.write_bytes(_make_png_bytes())
     return p
+
+
+async def _fresh_log(tmp_path: Path):
+    import aiosqlite
+    from loom.core.memory.session_log import SessionLog
+
+    conn = await aiosqlite.connect(str(tmp_path / "s.db"))
+    await conn.executescript(_SESSION_LOG_SCHEMA)
+    log = SessionLog(conn)
+    await log.create_session("s1", "test-model")
+    return conn, log
+
+
+def _user_msg(msgs: list) -> dict:
+    return [m for m in msgs if m["role"] == "user"][0]
+
+
+class TestVisionResumeReplay:
+    """#510: a vision turn must survive session resume.
+
+    The write side persists the canonical list to ``raw_json`` (refs +
+    digests, no base64); ``load_messages`` Priority-1 rehydrates it so the
+    image re-attaches on resume. When the referenced file is gone, replay
+    degrades to text instead of crashing the wire build.
+    """
+
+    async def test_vision_turn_survives_resume(self, tmp_path: Path) -> None:
+        conn, log = await _fresh_log(tmp_path)
+        p = png_path_for(tmp_path)
+        vi = vision.load_vision_input(p)
+        content = vision.build_user_content("看下這張", [vi])
+        await log.log_message("s1", 4, "user", content)
+
+        m = _user_msg(await log.load_messages("s1"))
+        assert isinstance(m["content"], list), "vision turn replayed as plain text, image lost"
+        img = [b for b in m["content"] if b.get("type") == "image"][0]
+        assert img["source"]["digest"] == vi.digest
+        assert img["source"]["ref"] == str(p)
+        await conn.close()
+
+    async def test_resume_degrades_when_file_missing(self, tmp_path: Path) -> None:
+        conn, log = await _fresh_log(tmp_path)
+        p = png_path_for(tmp_path)
+        vi = vision.load_vision_input(p)
+        content = vision.build_user_content("看下這張", [vi])
+        await log.log_message("s1", 4, "user", content)
+        p.unlink()  # file gone before resume (workspace cleaned, etc.)
+
+        m = _user_msg(await log.load_messages("s1"))
+        # Image dropped; text preserved; no dead file ref remains.
+        flat = json.dumps(m["content"], ensure_ascii=False)
+        assert "看下這張" in flat
+        if isinstance(m["content"], list):
+            assert all(b.get("type") != "image" for b in m["content"])
+        await conn.close()
+
+    async def test_full_persist_replay_wire_roundtrip(self, tmp_path: Path) -> None:
+        # The end-to-end seam #506/#508/#509 never covered together:
+        # build -> persist -> load_messages -> wire, file present.
+        conn, log = await _fresh_log(tmp_path)
+        p = png_path_for(tmp_path)
+        vi = vision.load_vision_input(p)
+        content = vision.build_user_content("看下這張", [vi])
+        await log.log_message("s1", 4, "user", content)
+
+        m = _user_msg(await log.load_messages("s1"))
+        _, anth = _to_anthropic_messages([{"role": "user", "content": m["content"]}])
+        blocks = anth[0]["content"]
+        assert any(
+            isinstance(b, dict) and b.get("type") == "image"
+            and b["source"]["type"] == "base64"
+            for b in blocks
+        ), "image did not survive persist->replay->wire"
+        await conn.close()


### PR DESCRIPTION
## Summary

Closes #510. Completes the **read half** of vision persistence. After #509 a vision turn's row was written to `session_log` (image reduced to `metadata.vision_inputs`), but `load_messages` replayed user turns as plain text — so on resume the image silently vanished. This makes the image survive resume, and degrade safely when the file is gone.

## Write side

`log_message` now persists the canonical list content to the `raw_json` column for vision (list-content) turns, alongside the text summary in `content`. Canonical blocks carry only `ref`+`digest` (never base64), so this is disk-safe. Guarded by `raw_json is None` so a caller-supplied `raw_json` is never clobbered.

## Read side

`load_messages` already prefers `raw_json` (Priority 1) for replay, so the canonical list — image block included — rehydrates **for free**. The one addition is `_drop_unreadable_image_refs`:

> a rehydrated turn may reference an image file that no longer exists (workspace cleaned, `.discord_downloads` pruned). Re-feeding that block to the wire would make the provider's `load_vision_input` raise and crash the turn — the **#506 failure class**. So replay drops dead file-backed image blocks and keeps the text, collapsing to a plain string when no image survives. `url`/`raw` blocks are untouched.

`ref` stays a `str` end-to-end (`make_image_block` coerces it) and `vision.load_vision_input` accepts `str | PathLike`, so no `Path` round-trip coercion is needed — **review #509 P2-2 turned out to be a non-issue**.

## Wiring checklist (review #509 P2-4)

Added a **"Wiring touchpoints"** table to the `vision.py` module docstring listing all six image entry/exit seams (CLI, Discord, builder, provider wire, persist, replay) and the test that drives each one *end-to-end*. This is the structural antidote to the #506 → #508 → #509 → #510 pattern — a "tested the unit, skipped the wiring" bug at a new seam each time.

## Tests

* New `TestVisionResumeReplay` (3 tests):
  * `test_vision_turn_survives_resume` — image rehydrates as canonical list with correct digest/ref (red before this PR: replayed as plain text).
  * `test_resume_degrades_when_file_missing` — file deleted before resume → image dropped, text kept, no crash.
  * `test_full_persist_replay_wire_roundtrip` — `build → persist → load_messages → _to_anthropic_messages` ends in a `base64` block. The end-to-end seam the prior PRs never covered together.
* Vision tests 44 → 47; full suite **2422 passed, 4 skipped**.

## Risk

LOW–MEDIUM. `gitnexus detect_changes`: confined to `session_log.py` + the `vision.py` docstring + tests; affected process is the `load_messages → _redact` replay path. Resumed vision turns now yield **list** content for user messages — the same shape a live vision session already puts in `self.messages`, so history processing tolerates it by construction (it would already break live otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
