### PR TITLE
feat(harness): self-heal when a provider rejects an image as sensitive

### DIFF
--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -52,6 +52,33 @@ logger = logging.getLogger(__name__)
 _RETRYABLE_STATUSES = {429, 500, 502, 503, 504, 529}
 
 
+class SensitiveContentError(RuntimeError):
+    """A provider rejected input as sensitive/disallowed content.
+
+    Distinct from a transient 5xx: retrying the identical payload can
+    never succeed, so this is non-retryable. The session layer catches
+    it to self-heal (strip the offending image from history and retry
+    text-only) rather than wedging the conversation.
+
+    Kept a ``RuntimeError`` subclass so existing broad handlers that
+    don't know about it still degrade gracefully.
+    """
+
+
+def _is_sensitive_content_rejection(exc: BaseException) -> bool:
+    """True when *exc* is a provider content-moderation rejection.
+
+    Conservative on purpose — a generic 5xx, timeout, or rate limit must
+    NOT match, or we'd wrongly skip retries on transient failures. Keys
+    off the MiniMax signature: the word ``sensitive`` (as in
+    ``"... image is sensitive ..."``) or its error code ``1026``. The
+    provider mislabels this as HTTP 500, so status alone can't classify
+    it — the message text is the only reliable signal.
+    """
+    msg = (str(exc) or "").lower()
+    return "sensitive" in msg or "(1026)" in msg
+
+
 async def _retry_async(
     coro_fn,
     *,
@@ -72,6 +99,11 @@ async def _retry_async(
             return await coro_fn()
         except BaseException as exc:
             last_exc = exc
+            # Content-moderation rejection: never retryable (the payload
+            # is deterministically refused). Re-raise typed so the session
+            # layer can self-heal instead of wedging.
+            if _is_sensitive_content_rejection(exc):
+                raise SensitiveContentError(str(exc)) from exc
             status = getattr(exc, "status_code", None) or getattr(exc, "status", None)
             exc_name = type(exc).__name__.lower()
             retryable = (
@@ -490,6 +522,14 @@ class AnthropicProvider(LLMProvider):
                     _forensics_dumped = True
                 if _yielded_any:
                     raise  # mid-stream failure — can't retry safely
+                # Content-moderation rejection (e.g. MiniMax 1026 image is
+                # sensitive, mislabeled as 500): never retryable. Re-raise
+                # typed so the session layer self-heals (strip the image)
+                # instead of burning retries on a deterministically refused
+                # payload. Safe here because it fires before any token is
+                # yielded (_yielded_any is False).
+                if _is_sensitive_content_rejection(_exc):
+                    raise SensitiveContentError(str(_exc)) from _exc
                 exc_name = type(_exc).__name__.lower()
                 status = getattr(_exc, "status_code", None) or getattr(_exc, "status", None)
                 retryable = (

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -58,7 +58,7 @@ from loom.core.ledger import (
 from loom.core.memory.facade import MemoryFacade
 from loom.core.cognition.context import ContextBudget
 from loom.core.cognition.prompt_stack import PromptStack
-from loom.core.cognition.providers import AnthropicProvider
+from loom.core.cognition.providers import AnthropicProvider, SensitiveContentError
 from loom.core.cognition import vision as _vision
 from loom.core.cognition.responses_sse import ResponsesProviderError
 from loom.core.cognition.counter_factual import CounterFactualReflector
@@ -1985,6 +1985,12 @@ class LoomSession:
             _stream_retry = 0         # counts back-to-back stream_none retries
             _MAX_STREAM_RETRIES = 2  # auto-retry up to 2 times on response=None
             _stop_reason = "complete"  # tracks why the loop exits
+            # Self-heal guard: a provider may reject an image as sensitive
+            # (SensitiveContentError). We strip the image from history and
+            # retry text-only at most once per turn so a moderation refusal
+            # can't wedge the conversation (the persisted image would
+            # otherwise re-trigger the rejection every turn).
+            _vision_sensitive_healed = False
 
             # Issue #205: TaskList self-check. On end_turn we inject a reminder
             # at most once per stream_turn if the list still has active nodes,
@@ -2036,78 +2042,106 @@ class LoomSession:
                 # self.model (legacy behavior preserved).
                 _active_model = self._active_model()
 
-                async for chunk, final in self.router.stream_chat(
-                    model=_active_model,
-                    messages=self.messages,
-                    tools=tools,
-                    max_tokens=_resolve_output_max_tokens(
-                        self._loom_config, _active_model, router=self.router,
-                    ),
-                    abort_signal=abort_signal,
-                ):
-                    if final is None:
-                        if chunk:
-                            _tbuf += chunk
-                            out_parts: list[str] = []
-                            while _tbuf:
-                                if _think_in:
-                                    close_idx = _tbuf.find("</think>")
-                                    if close_idx >= 0:
-                                        _think_parts.append(_tbuf[:close_idx])
-                                        _think_in = False
-                                        _tbuf = _tbuf[close_idx + len("</think>"):]
-                                        if not _think_shown:
-                                            # Flush text accumulated before the think block,
-                                            # then emit a dedicated ThinkCollapsed event so
-                                            # each platform can render it in its own style.
-                                            if out_parts:
-                                                yield TextChunk(text="".join(out_parts))
-                                                out_parts = []
-                                            _think_full = "".join(
-                                                _think_parts[_current_think_start:]
-                                            ).strip()
-                                            _think_summary = _think_full[:120].replace("\n", " ")
-                                            yield ThinkCollapsed(
-                                                summary=_think_summary,
-                                                full=_think_full,
-                                            )
-                                            _think_shown = True
-                                    else:
-                                        # Partial </think> at end? Accumulate up to lookahead.
-                                        partial = _find_partial_tag_suffix(_tbuf, "</think>")
-                                        if partial:
-                                            _think_parts.append(_tbuf[: len(_tbuf) - partial])
-                                            _tbuf = _tbuf[len(_tbuf) - partial :]
+                try:
+                    async for chunk, final in self.router.stream_chat(
+                        model=_active_model,
+                        messages=self.messages,
+                        tools=tools,
+                        max_tokens=_resolve_output_max_tokens(
+                            self._loom_config, _active_model, router=self.router,
+                        ),
+                        abort_signal=abort_signal,
+                    ):
+                        if final is None:
+                            if chunk:
+                                _tbuf += chunk
+                                out_parts: list[str] = []
+                                while _tbuf:
+                                    if _think_in:
+                                        close_idx = _tbuf.find("</think>")
+                                        if close_idx >= 0:
+                                            _think_parts.append(_tbuf[:close_idx])
+                                            _think_in = False
+                                            _tbuf = _tbuf[close_idx + len("</think>"):]
+                                            if not _think_shown:
+                                                # Flush text accumulated before the think block,
+                                                # then emit a dedicated ThinkCollapsed event so
+                                                # each platform can render it in its own style.
+                                                if out_parts:
+                                                    yield TextChunk(text="".join(out_parts))
+                                                    out_parts = []
+                                                _think_full = "".join(
+                                                    _think_parts[_current_think_start:]
+                                                ).strip()
+                                                _think_summary = _think_full[:120].replace("\n", " ")
+                                                yield ThinkCollapsed(
+                                                    summary=_think_summary,
+                                                    full=_think_full,
+                                                )
+                                                _think_shown = True
                                         else:
-                                            _think_parts.append(_tbuf)
-                                            _tbuf = ""
-                                        break
-                                else:
-                                    open_idx = _tbuf.find("<think>")
-                                    if open_idx >= 0:
-                                        before = _tbuf[:open_idx]
-                                        if before:
-                                            out_parts.append(before)
-                                        _think_in = True
-                                        _current_think_start = len(_think_parts)
-                                        _tbuf = _tbuf[open_idx + len("<think>"):]
+                                            # Partial </think> at end? Accumulate up to lookahead.
+                                            partial = _find_partial_tag_suffix(_tbuf, "</think>")
+                                            if partial:
+                                                _think_parts.append(_tbuf[: len(_tbuf) - partial])
+                                                _tbuf = _tbuf[len(_tbuf) - partial :]
+                                            else:
+                                                _think_parts.append(_tbuf)
+                                                _tbuf = ""
+                                            break
                                     else:
-                                        # Partial <think> at end? Keep lookahead.
-                                        partial = _find_partial_tag_suffix(_tbuf, "<think>")
-                                        if partial:
-                                            before = _tbuf[: len(_tbuf) - partial]
+                                        open_idx = _tbuf.find("<think>")
+                                        if open_idx >= 0:
+                                            before = _tbuf[:open_idx]
                                             if before:
                                                 out_parts.append(before)
-                                            _tbuf = _tbuf[len(_tbuf) - partial :]
+                                            _think_in = True
+                                            _current_think_start = len(_think_parts)
+                                            _tbuf = _tbuf[open_idx + len("<think>"):]
                                         else:
-                                            out_parts.append(_tbuf)
-                                            _tbuf = ""
-                                        break
-                            text = "".join(out_parts)
-                            if text:
-                                yield TextChunk(text=text)
-                    else:
-                        response = final
+                                            # Partial <think> at end? Keep lookahead.
+                                            partial = _find_partial_tag_suffix(_tbuf, "<think>")
+                                            if partial:
+                                                before = _tbuf[: len(_tbuf) - partial]
+                                                if before:
+                                                    out_parts.append(before)
+                                                _tbuf = _tbuf[len(_tbuf) - partial :]
+                                            else:
+                                                out_parts.append(_tbuf)
+                                                _tbuf = ""
+                                            break
+                                text = "".join(out_parts)
+                                if text:
+                                    yield TextChunk(text=text)
+                        else:
+                            response = final
+                except SensitiveContentError as _sc_exc:
+                    # Provider refused an image as sensitive content.
+                    # Strip images from history and retry text-only,
+                    # at most once per turn, so the refusal can't wedge
+                    # the session (the persisted image would otherwise
+                    # re-trigger the rejection every turn).
+                    if not _vision_sensitive_healed:
+                        _removed = _strip_images_from_messages(self.messages)
+                        if _removed:
+                            _vision_sensitive_healed = True
+                            logger.warning(
+                                "provider rejected image as sensitive; stripped "
+                                "%d image block(s), retrying text-only: %s",
+                                _removed, _sc_exc,
+                            )
+                            self.messages.append({
+                                "role": "user",
+                                "content": _VISION_SENSITIVE_NOTE,
+                            })
+                            self._sanitize_history()
+                            yield TurnDropped(
+                                stop_reason="sensitive_image_stripped",
+                                retry_count=0,
+                                tool_count=tool_count,
+                            )
+                            continue
+                    raise
 
                 # Flush any buffered non-think content after each streaming call ends.
                 if _tbuf and not _think_in:
@@ -4648,6 +4682,44 @@ def _annotate_user_input(user_input, timestamp: str):
     if isinstance(user_input, str):
         return f"[{timestamp}]\n{user_input}"
     return [{"type": "text", "text": f"[{timestamp}]"}, *user_input]
+
+
+_VISION_SENSITIVE_NOTE = (
+    "[系統通知：剛才訊息中的圖片被模型供應商判定為敏感內容而拒絕，已從本次對話"
+    "移除，本輪改以純文字繼續。若你先前已觀察過該圖，可依記憶向使用者說明；否則"
+    "請告知使用者該圖無法被處理。]"
+)
+
+
+def _strip_images_from_messages(messages: list) -> int:
+    """Replace every image block in ``messages`` with a text marker.
+
+    Used by the session self-heal when a provider rejects an image as
+    sensitive content (see ``SensitiveContentError``). Mutates list
+    content in place, swapping each ``{"type": "image", ...}`` block for a
+    short text marker so the turn can be retried text-only and — because
+    the image is gone from history — subsequent turns don't re-trigger
+    the same rejection (the wedge). ``str`` content is left untouched.
+
+    Returns the number of image blocks removed.
+    """
+    removed = 0
+    for msg in messages:
+        content = msg.get("content") if isinstance(msg, dict) else None
+        if not isinstance(content, list):
+            continue
+        new_blocks: list = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "image":
+                removed += 1
+                new_blocks.append({
+                    "type": "text",
+                    "text": "[圖片已移除：供應商判定為敏感內容]",
+                })
+            else:
+                new_blocks.append(block)
+        msg["content"] = new_blocks
+    return removed
 
 
 def _detect_vision_paths_in_text(user_input: str, base_dir=None) -> list:

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -1693,10 +1693,17 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                     console.print()
                     at_line_start = True
                 detail = event.provider_error_detail.strip()
-                message = f"turn dropped: stop_reason={event.stop_reason}"
-                if detail:
-                    message += f"; {detail}"
-                harness.inline(message, level="error")
+                if event.stop_reason == "sensitive_image_stripped":
+                    # Self-heal, not a failure — frame as recovery.
+                    harness.inline(
+                        "圖片被供應商判定為敏感、已移除，正以純文字重試…",
+                        level="warning",
+                    )
+                else:
+                    message = f"turn dropped: stop_reason={event.stop_reason}"
+                    if detail:
+                        message += f"; {detail}"
+                    harness.inline(message, level="error")
                 if (loom_app := getattr(session, "_loom_app", None)) is not None:
                     loom_app.stop_heartbeat(force=True)
 

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -1802,6 +1802,14 @@ class LoomDiscordBot:
                                 drop_msg = (
                                     f"-# ⚠️ 連線中斷，正在重試（第 {event.retry_count} 次）…"
                                 )
+                        elif event.stop_reason == "sensitive_image_stripped":
+                            # Self-heal, not a failure: the image was rejected by
+                            # the provider as sensitive; we removed it and retry
+                            # text-only. Frame it as recovery, not an abort.
+                            drop_msg = (
+                                "-# 🖼️ 圖片被供應商判定為敏感內容、已自動移除，"
+                                "正以純文字重試…"
+                            )
                         else:
                             drop_msg = (
                                 f"-# ⚠️ 任務中止：`stop_reason={event.stop_reason}` "

--- a/tests/test_vision_sensitive_heal.py
+++ b/tests/test_vision_sensitive_heal.py
@@ -1,0 +1,210 @@
+"""Vision self-heal: when a provider rejects an image as sensitive content
+(e.g. MiniMax error 1026, surfaced as a 500), Loom must not retry the
+identical payload forever and must un-wedge the session by stripping the
+offending image from history.
+
+These tests pin the two pure helpers:
+
+* ``providers._is_sensitive_content_rejection`` — classify the rejection
+  from the exception, conservatively (a generic 500 / timeout is NOT it).
+* ``session._strip_images_from_messages`` — replace image blocks in
+  history with a text marker so the next turn is text-only.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from loom.core.cognition.providers import (
+    SensitiveContentError,
+    _is_sensitive_content_rejection,
+)
+from loom.core.session import _strip_images_from_messages
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+
+_MINIMAX_SENSITIVE = (
+    "InternalServerError: Error code: 500 - {'type': 'error', 'error': "
+    "{'type': 'api_error', 'message': \"input new_sensitive, messages[152]'s "
+    "content[2] image is sensitive, please check your input (1026)\"}}"
+)
+
+
+class TestSensitiveDetection:
+    def test_detects_minimax_sensitive_image(self) -> None:
+        assert _is_sensitive_content_rejection(RuntimeError(_MINIMAX_SENSITIVE))
+
+    def test_detects_by_error_code_1026(self) -> None:
+        assert _is_sensitive_content_rejection(
+            RuntimeError("rejected: content flagged (1026)")
+        )
+
+    def test_ignores_generic_500(self) -> None:
+        assert not _is_sensitive_content_rejection(
+            RuntimeError("Error code: 500 - internal server error, try again")
+        )
+
+    def test_ignores_timeout(self) -> None:
+        assert not _is_sensitive_content_rejection(TimeoutError("read timeout"))
+
+    def test_ignores_rate_limit(self) -> None:
+        assert not _is_sensitive_content_rejection(
+            RuntimeError("Error code: 429 - rate limit exceeded")
+        )
+
+    def test_sensitive_content_error_is_runtimeerror(self) -> None:
+        # Session-layer catch relies on the typed class; keep it a
+        # RuntimeError subclass so existing broad handlers still work.
+        assert issubclass(SensitiveContentError, RuntimeError)
+
+
+# ---------------------------------------------------------------------------
+# History strip
+# ---------------------------------------------------------------------------
+
+
+def _img_block(ref: str = "/tmp/x.png") -> dict:
+    return {
+        "type": "image",
+        "source": {
+            "kind": "file", "ref": ref,
+            "media_type": "image/png", "digest": "sha256:abc",
+        },
+    }
+
+
+class TestStripImagesFromMessages:
+    def test_replaces_image_keeps_text(self) -> None:
+        msgs = [
+            {"role": "user", "content": "plain"},
+            {"role": "user", "content": [
+                {"type": "text", "text": "看下這張"},
+                _img_block(),
+            ]},
+        ]
+        removed = _strip_images_from_messages(msgs)
+        assert removed == 1
+        # str message untouched
+        assert msgs[0]["content"] == "plain"
+        # image gone, text preserved, no image blocks remain
+        blocks = msgs[1]["content"]
+        assert all(b["type"] == "text" for b in blocks)
+        assert any("看下這張" in b["text"] for b in blocks)
+
+    def test_counts_multiple_images(self) -> None:
+        msgs = [
+            {"role": "user", "content": [
+                {"type": "text", "text": "兩張"}, _img_block("/a.png"), _img_block("/b.png"),
+            ]},
+        ]
+        assert _strip_images_from_messages(msgs) == 2
+        assert all(
+            b["type"] == "text" for b in msgs[0]["content"]
+        )
+
+    def test_no_images_returns_zero(self) -> None:
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        assert _strip_images_from_messages(msgs) == 0
+        assert msgs[0]["content"] == "hi"
+
+    def test_image_only_message_becomes_text_marker(self) -> None:
+        msgs = [{"role": "user", "content": [_img_block()]}]
+        removed = _strip_images_from_messages(msgs)
+        assert removed == 1
+        blocks = msgs[0]["content"]
+        assert len(blocks) == 1 and blocks[0]["type"] == "text"
+        assert blocks[0]["text"]  # non-empty marker
+
+
+# ---------------------------------------------------------------------------
+# Integration: stream_turn self-heals on SensitiveContentError
+# ---------------------------------------------------------------------------
+
+
+async def test_stream_turn_heals_on_sensitive_image(monkeypatch, tmp_path) -> None:
+    """The wiring the unit tests can't reach: a provider raises
+    SensitiveContentError on the first call; stream_turn must strip the
+    image from history, drop a breadcrumb, and retry text-only — landing
+    a normal response on the second call instead of wedging."""
+    from types import SimpleNamespace
+
+    from loom.core import session as session_module
+    from loom.core.cognition.providers import LLMResponse, SensitiveContentError
+    from loom.core.events import TurnDropped
+    from loom.core.session import LoomSession
+
+    calls = {"n": 0}
+
+    async def flaky_stream_chat(**kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise SensitiveContentError(
+                "messages[152]'s content[2] image is sensitive (1026)"
+            )
+            yield "", None  # pragma: no cover (generator marker)
+        # Second call: image is gone from history → succeed text-only.
+        yield "好的，我改用文字繼續。", None
+        yield "", LLMResponse(
+            text="好的，我改用文字繼續。",
+            tool_uses=[],
+            stop_reason="end_turn",
+            input_tokens=10,
+            output_tokens=5,
+            raw_message={"role": "assistant", "content": "好的，我改用文字繼續。"},
+        )
+
+    router = SimpleNamespace(
+        stream_chat=flaky_stream_chat,
+        native_max_tokens=lambda model: None,
+    )
+    monkeypatch.setattr(session_module, "build_router", lambda *a, **k: router)
+    monkeypatch.setattr(session_module, "_load_loom_config", lambda: {})
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    session = LoomSession(
+        model="MiniMax-M3",
+        db_path=str(tmp_path / "loom.db"),
+        workspace=workspace,
+    )
+
+    class FakeEpisodic:
+        async def write(self, entry):
+            return None
+
+    session._memory = SimpleNamespace(episodic=FakeEpisodic())
+
+    # User turn carrying an image (canonical list content).
+    user_input = [
+        {"type": "text", "text": "看下這張"},
+        _img_block("/tmp/portrait.png"),
+    ]
+
+    events = []
+    async for event in session.stream_turn(user_input):
+        events.append(event)
+
+    # Retried exactly once (two provider calls total).
+    assert calls["n"] == 2
+    # The heal emitted its breadcrumb drop event.
+    assert any(
+        isinstance(e, TurnDropped) and e.stop_reason == "sensitive_image_stripped"
+        for e in events
+    )
+    # No image block remains anywhere in history (un-wedged).
+    for m in session.messages:
+        c = m.get("content")
+        if isinstance(c, list):
+            assert all(b.get("type") != "image" for b in c)
+    # The breadcrumb note made it into history so the agent can explain.
+    assert any(
+        isinstance(m.get("content"), str) and "敏感內容" in m["content"]
+        for m in session.messages
+    )


### PR DESCRIPTION
## Summary

A real Discord failure: MiniMax flagged a vision image as **sensitive content** (error `1026`) and returned it as an **HTTP 500**. The anthropic SDK retried the 5xx, Loom's retry layer retried again, and every attempt hit the same deterministic refusal. Worse — the image lives in history and (since #509 / #511 persist + replay it) was re-sent **every turn**, so the moderation refusal **wedged the whole session**.

```
500 - input new_sensitive, messages[152]'s content[2] image is sensitive,
      please check your input (1026)
```

The image is exactly 1 block on the wire (2.5 MB base64 PNG, the latest user turn). Ironically, the persist+replay work we just shipped is what made this wedge reliably reproducible.

## Fix — classify + session self-heal

The chosen scope (over "classify only" and "also consolidate the retry layer"): make the session recover in place.

**Provider layer** (`providers.py`)
- New `SensitiveContentError(RuntimeError)` + `_is_sensitive_content_rejection`, keyed **conservatively** on the MiniMax signature (`"sensitive"` / code `1026`) so a generic 5xx / timeout / 429 is **not** matched (matching those would wrongly skip retries on transient failures). The provider mislabels this as HTTP 500, so status alone can't classify it — the message text is the only reliable signal.
- Both retry loops (`_retry_async` and the `AnthropicProvider` streaming loop) re-raise it typed and treat it as **non-retryable** — no more burning retries on a payload that can never be accepted. Safe in the streaming loop because it fires *before* any token is yielded.

**Session layer** (`session.py`)
- `_strip_images_from_messages` replaces every image block in history with a short text marker — this **un-wedges**: the image can't re-trigger the rejection on later turns.
- `stream_turn` catches `SensitiveContentError` around the stream, strips the images, drops a **breadcrumb note** into history (so the agent can explain to the user from its earlier observation), and retries the turn **text-only** — at most once per turn, reusing the existing `TurnDropped` / `continue` retry pattern.

This follows the harness-invariants principle: fix the root cause in the harness and guide the agent to self-recover, rather than failing the turn and leaving the session stuck.

## Tests (`test_vision_sensitive_heal.py`, 11)

- **detection** — matches the MiniMax 1026 signature; ignores generic 500 / timeout / 429.
- **strip** — replaces images with a marker, preserves text, counts correctly, handles image-only messages.
- **integration** — drives `stream_turn` with a provider that raises `SensitiveContentError` once: asserts it retries exactly once, strips all images from history, emits the breadcrumb, and lands a normal response on the second call. *(The wiring a unit test can't reach — the same "test the seam, not just the unit" lesson from the #506→#511 vision arc.)*

Full suite: **2435 passed, 4 skipped**. `gitnexus detect_changes`: confined to `providers.py` + `session.py` (the large session diff is the mechanical +4 re-indent of the stream block under the new `try:`), no affected processes.

## Scope / deferred

`url`-source images that are *unreachable* (404/timeout) are a separate failure class with no current degradation — deferred until actually hit, per discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
