### PR TITLE
feat(vision): add see_image tool — agent-initiated native vision

### DIFF
--- a/loom/core/cognition/codex_responses_provider.py
+++ b/loom/core/cognition/codex_responses_provider.py
@@ -5,7 +5,7 @@ import uuid
 from collections.abc import AsyncIterator
 from typing import Any
 
-from .providers import LLMProvider, LLMResponse, ToolUse
+from .providers import LLMProvider, LLMResponse, ToolUse, _reduce_tool_result_to_text
 from . import vision as _vision
 from .responses_policy import normalize_reasoning_effort
 from .responses_sse import (
@@ -153,20 +153,12 @@ class CodexResponsesProvider(LLMProvider):
                 call_id = msg.get("tool_call_id")
                 if call_id:
                     # A vision tool result carries canonical list content
-                    # ([text, image]). The Responses function_call_output
-                    # can't hold an image, so reduce to the text parts
-                    # rather than emitting a Python repr of the blocks.
-                    if isinstance(content, list):
-                        out = "\n".join(
-                            b.get("text", "") for b in content
-                            if isinstance(b, dict) and b.get("type") == "text"
-                        )
-                    else:
-                        out = str(content)
+                    # ([text, image]); function_call_output can't hold an
+                    # image, so reduce to text (shared helper).
                     input_items.append({
                         "type": "function_call_output",
                         "call_id": call_id,
-                        "output": out,
+                        "output": _reduce_tool_result_to_text(content),
                     })
                 continue
             if role == "assistant":

--- a/loom/core/cognition/codex_responses_provider.py
+++ b/loom/core/cognition/codex_responses_provider.py
@@ -152,10 +152,21 @@ class CodexResponsesProvider(LLMProvider):
             if role == "tool":
                 call_id = msg.get("tool_call_id")
                 if call_id:
+                    # A vision tool result carries canonical list content
+                    # ([text, image]). The Responses function_call_output
+                    # can't hold an image, so reduce to the text parts
+                    # rather than emitting a Python repr of the blocks.
+                    if isinstance(content, list):
+                        out = "\n".join(
+                            b.get("text", "") for b in content
+                            if isinstance(b, dict) and b.get("type") == "text"
+                        )
+                    else:
+                        out = str(content)
                     input_items.append({
                         "type": "function_call_output",
                         "call_id": call_id,
-                        "output": str(content),
+                        "output": out,
                     })
                 continue
             if role == "assistant":

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -79,6 +79,23 @@ def _is_sensitive_content_rejection(exc: BaseException) -> bool:
     return "sensitive" in msg or "(1026)" in msg
 
 
+def _reduce_tool_result_to_text(content: Any) -> str:
+    """Reduce tool_result content to a plain string.
+
+    The Responses API ``function_call_output`` can't carry an image, so a
+    vision tool result (canonical ``[text, image]`` list) is reduced to
+    its text parts; anything else is ``str()``-ed. Shared by the Codex and
+    xAI Responses providers so the degradation lives in one place. Defined
+    above the codex/xai imports below so they can import it at module load.
+    """
+    if isinstance(content, list):
+        return "\n".join(
+            b.get("text", "") for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        )
+    return str(content)
+
+
 async def _retry_async(
     coro_fn,
     *,

--- a/loom/core/cognition/providers.py
+++ b/loom/core/cognition/providers.py
@@ -959,6 +959,49 @@ class LMStudioProvider(_OpenAICompatibleBase):
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _canonical_blocks_to_anthropic(content: list) -> list[dict]:
+    """Convert canonical list content (``[{type:text}, {type:image}, ...]``)
+    to Anthropic wire blocks.
+
+    Shared by the ``user`` and ``tool`` branches of
+    :func:`_to_anthropic_messages` — a user vision turn and a ``see_image``
+    tool result (#510-era vision + agent-initiated viewing) carry the exact
+    same canonical image block, so both go through one converter. ``image``
+    blocks become Anthropic ``image`` blocks (base64 for file/raw, url for
+    url); ``text`` blocks pass through; unknown blocks are kept verbatim.
+    """
+    anth_blocks: list[dict] = []
+    for block in content:
+        btype = block.get("type") if isinstance(block, dict) else None
+        if btype == "text":
+            anth_blocks.append({"type": "text", "text": block.get("text", "")})
+        elif btype == "image":
+            src = block.get("source", {}) or {}
+            if src.get("kind") == "url":
+                anth_blocks.append({
+                    "type": "image",
+                    "source": {"type": "url", "url": src.get("ref")},
+                })
+                continue
+            if src.get("kind") == "raw":
+                raw_bytes = src.get("ref")
+                vision_input = _vision.VisionInput(
+                    source=_vision.VisionSource(kind="raw", ref=raw_bytes),
+                    media_type=src.get("media_type", ""),
+                    size_bytes=len(raw_bytes) if raw_bytes else 0,
+                    digest=src.get("digest", ""),
+                )
+            else:
+                # file: use the ref path; we re-read at wire time.
+                vision_input = _vision.load_vision_input(src.get("ref"))
+            anth_blocks.append(_vision.to_anthropic_image_block(vision_input))
+        else:
+            # Unknown block type — keep verbatim so we don't silently drop
+            # provider-specific extensions.
+            anth_blocks.append(block)
+    return anth_blocks
+
+
 def _to_anthropic_messages(
     messages: list[dict[str, Any]],
 ) -> tuple[str | None, list[dict[str, Any]]]:
@@ -988,48 +1031,12 @@ def _to_anthropic_messages(
         elif role == "user":
             content = msg.get("content")
             if isinstance(content, list):
-                # Canonical list content: [{type, ...}, ...] where ``type`` is
-                # either "text" or "image" (provider-neutral, see
-                # ``loom.core.cognition.vision``). Convert ``image`` blocks to
-                # the Anthropic wire shape; pass ``text`` blocks through.
-                anth_blocks: list[dict] = []
-                for block in content:
-                    btype = block.get("type")
-                    if btype == "text":
-                        anth_blocks.append({"type": "text", "text": block.get("text", "")})
-                    elif btype == "image":
-                        src = block.get("source", {}) or {}
-                        if src.get("kind") == "url":
-                            anth_blocks.append({
-                                "type": "image",
-                                "source": {
-                                    "type": "url",
-                                    "url": src.get("ref"),
-                                },
-                            })
-                            continue
-                        # file / raw: re-validate and embed base64.
-                        if src.get("kind") == "raw":
-                            from io import BytesIO
-                            raw_bytes = src.get("ref")
-                            vision_input = _vision.VisionInput(
-                                source=_vision.VisionSource(kind="raw", ref=raw_bytes),
-                                media_type=src.get("media_type", ""),
-                                size_bytes=len(raw_bytes) if raw_bytes else 0,
-                                digest=src.get("digest", ""),
-                            )
-                        else:
-                            # file: use the ref path; we re-read at wire time.
-                            vision_input = _vision.load_vision_input(
-                                src.get("ref"),
-                                origin=msg.get("_vision_origin", "user"),
-                            )
-                        anth_blocks.append(_vision.to_anthropic_image_block(vision_input))
-                    else:
-                        # Unknown block type — keep the dict verbatim so we
-                        # don't silently drop provider-specific extensions.
-                        anth_blocks.append(block)
-                result.append({"role": "user", "content": anth_blocks})
+                # Canonical list content (text + image blocks) → Anthropic
+                # wire blocks via the shared converter.
+                result.append({
+                    "role": "user",
+                    "content": _canonical_blocks_to_anthropic(content),
+                })
             else:
                 result.append({"role": "user", "content": content})
             i += 1
@@ -1058,10 +1065,18 @@ def _to_anthropic_messages(
             tool_results: list[dict] = []
             while i < len(messages) and messages[i]["role"] == "tool":
                 tr = messages[i]
+                tr_content = tr["content"]
+                # A tool (e.g. see_image) can return canonical list content
+                # carrying an image block. Anthropic accepts a list of
+                # text/image blocks as tool_result content — convert it the
+                # same way as a user vision turn. Plain string content
+                # (the common case) passes through untouched.
+                if isinstance(tr_content, list):
+                    tr_content = _canonical_blocks_to_anthropic(tr_content)
                 tool_results.append({
                     "type": "tool_result",
                     "tool_use_id": tr["tool_call_id"],
-                    "content": tr["content"],
+                    "content": tr_content,
                 })
                 i += 1
             result.append({"role": "user", "content": tool_results})

--- a/loom/core/cognition/xai_responses_provider.py
+++ b/loom/core/cognition/xai_responses_provider.py
@@ -5,7 +5,7 @@ import uuid
 from collections.abc import AsyncIterator
 from typing import Any
 
-from .providers import LLMProvider, LLMResponse, ToolUse
+from .providers import LLMProvider, LLMResponse, ToolUse, _reduce_tool_result_to_text
 from . import vision as _vision
 from .responses_policy import normalize_reasoning_effort
 from .responses_sse import (
@@ -154,18 +154,11 @@ class XAIResponsesProvider(LLMProvider):
                 if call_id:
                     # Vision tool results carry canonical list content
                     # ([text, image]); function_call_output can't hold an
-                    # image, so reduce to text rather than a Python repr.
-                    if isinstance(content, list):
-                        out = "\n".join(
-                            b.get("text", "") for b in content
-                            if isinstance(b, dict) and b.get("type") == "text"
-                        )
-                    else:
-                        out = str(content)
+                    # image, so reduce to text (shared helper).
                     input_items.append({
                         "type": "function_call_output",
                         "call_id": call_id,
-                        "output": out,
+                        "output": _reduce_tool_result_to_text(content),
                     })
                 continue
             if role == "assistant":

--- a/loom/core/cognition/xai_responses_provider.py
+++ b/loom/core/cognition/xai_responses_provider.py
@@ -152,10 +152,20 @@ class XAIResponsesProvider(LLMProvider):
             if role == "tool":
                 call_id = msg.get("tool_call_id")
                 if call_id:
+                    # Vision tool results carry canonical list content
+                    # ([text, image]); function_call_output can't hold an
+                    # image, so reduce to text rather than a Python repr.
+                    if isinstance(content, list):
+                        out = "\n".join(
+                            b.get("text", "") for b in content
+                            if isinstance(b, dict) and b.get("type") == "text"
+                        )
+                    else:
+                        out = str(content)
                     input_items.append({
                         "type": "function_call_output",
                         "call_id": call_id,
-                        "output": str(content),
+                        "output": out,
                     })
                 continue
             if role == "assistant":

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -2427,10 +2427,10 @@ class LoomSession:
                             _tool_msg = self.router.format_tool_result(
                                 self.model, tu.id, tool_output, result.success,
                             )
-                            # see_image (#agent vision): if the tool returned an
+                            # see_image (agent vision): if the tool returned an
                             # image, rewrite content as [text, image_block] so
                             # the model sees it in the tool_result.
-                            _attach_tool_vision(_tool_msg, result, tool_output)
+                            _attach_tool_vision(_tool_msg, result)
                             _tool_msg["_emit_turn"] = self._turn_index
                             _tool_msg["_tool_name"] = tu.name
                             self.messages.append(_tool_msg)
@@ -2516,10 +2516,10 @@ class LoomSession:
                             _tool_msg = self.router.format_tool_result(
                                 self.model, tu.id, tool_output, result.success,
                             )
-                            # see_image (#agent vision): if the tool returned an
+                            # see_image (agent vision): if the tool returned an
                             # image, rewrite content as [text, image_block] so
                             # the model sees it in the tool_result.
-                            _attach_tool_vision(_tool_msg, result, tool_output)
+                            _attach_tool_vision(_tool_msg, result)
                             _tool_msg["_emit_turn"] = self._turn_index
                             _tool_msg["_tool_name"] = tu.name
                             self.messages.append(_tool_msg)
@@ -4730,26 +4730,41 @@ def _strip_images_from_messages(messages: list) -> int:
     return removed
 
 
-def _attach_tool_vision(tool_msg: dict, result, tool_output: str) -> dict:
-    """Rewrite a tool message's content as ``[text, image_block]`` when the
-    tool returned an image via ``result.metadata["vision_image"]``.
+def _attach_tool_vision(tool_msg: dict, result) -> None:
+    """Mutate ``tool_msg`` in place, rewriting its content as
+    ``[text, image_block]`` when the tool returned an image via
+    ``result.metadata["vision_image"]``. Returns ``None`` (mutator).
 
     This is how an agent-initiated ``see_image`` tool injects vision: the
     canonical image block rides the tool_result, and the provider's
     ``_to_anthropic_messages`` tool branch converts it to a wire image
     block (Anthropic accepts image blocks inside tool_result content).
-    Plain (non-vision) tool results are left as a string.
+    Plain (non-vision) tool results are left untouched.
+
+    The image block is validated before attaching — a malformed block
+    (missing ``source.ref``) would otherwise crash far away at wire time
+    inside ``load_vision_input`` (the #506 failure class). If it's bad we
+    log and leave the formatted string content, so the model still gets
+    the tool's text.
     """
-    try:
-        block = (result.metadata or {}).get("vision_image")
-    except Exception:
-        block = None
-    if block:
-        tool_msg["content"] = [
-            {"type": "text", "text": tool_output or ""},
-            block,
-        ]
-    return tool_msg
+    meta = result.metadata if isinstance(result.metadata, dict) else {}
+    block = meta.get("vision_image")
+    if not (
+        isinstance(block, dict)
+        and block.get("type") == "image"
+        and (block.get("source") or {}).get("ref")
+    ):
+        if block is not None:
+            logger.warning("see_image returned a malformed vision block; "
+                           "leaving tool result as text: %r", block)
+        return
+    # Read the *formatted* content from format_tool_result rather than the
+    # raw tool output, so any provider-specific formatting is preserved.
+    existing = tool_msg.get("content")
+    if isinstance(existing, list):
+        tool_msg["content"] = [*existing, block]
+    else:
+        tool_msg["content"] = [{"type": "text", "text": existing or ""}, block]
 
 
 def _detect_vision_paths_in_text(user_input: str, base_dir=None) -> list:

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -2427,6 +2427,10 @@ class LoomSession:
                             _tool_msg = self.router.format_tool_result(
                                 self.model, tu.id, tool_output, result.success,
                             )
+                            # see_image (#agent vision): if the tool returned an
+                            # image, rewrite content as [text, image_block] so
+                            # the model sees it in the tool_result.
+                            _attach_tool_vision(_tool_msg, result, tool_output)
                             _tool_msg["_emit_turn"] = self._turn_index
                             _tool_msg["_tool_name"] = tu.name
                             self.messages.append(_tool_msg)
@@ -2512,6 +2516,10 @@ class LoomSession:
                             _tool_msg = self.router.format_tool_result(
                                 self.model, tu.id, tool_output, result.success,
                             )
+                            # see_image (#agent vision): if the tool returned an
+                            # image, rewrite content as [text, image_block] so
+                            # the model sees it in the tool_result.
+                            _attach_tool_vision(_tool_msg, result, tool_output)
                             _tool_msg["_emit_turn"] = self._turn_index
                             _tool_msg["_tool_name"] = tu.name
                             self.messages.append(_tool_msg)
@@ -4720,6 +4728,28 @@ def _strip_images_from_messages(messages: list) -> int:
                 new_blocks.append(block)
         msg["content"] = new_blocks
     return removed
+
+
+def _attach_tool_vision(tool_msg: dict, result, tool_output: str) -> dict:
+    """Rewrite a tool message's content as ``[text, image_block]`` when the
+    tool returned an image via ``result.metadata["vision_image"]``.
+
+    This is how an agent-initiated ``see_image`` tool injects vision: the
+    canonical image block rides the tool_result, and the provider's
+    ``_to_anthropic_messages`` tool branch converts it to a wire image
+    block (Anthropic accepts image blocks inside tool_result content).
+    Plain (non-vision) tool results are left as a string.
+    """
+    try:
+        block = (result.metadata or {}).get("vision_image")
+    except Exception:
+        block = None
+    if block:
+        tool_msg["content"] = [
+            {"type": "text", "text": tool_output or ""},
+            block,
+        ]
+    return tool_msg
 
 
 def _detect_vision_paths_in_text(user_input: str, base_dir=None) -> list:

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -583,6 +583,8 @@ def make_filesystem_tools(workspace: Path) -> list["ToolDefinition"]:
         # validation stack (magic-byte MIME, size cap, digest); the image
         # rides back as a canonical block in result.metadata and the
         # session attaches it to the tool_result.
+        # Local import: keep the vision module (and any heavy image deps)
+        # off the CLI-startup import path; only paid when see_image runs.
         from loom.core.cognition import vision as _vision
 
         raw = call.args.get("path", "")

--- a/loom/platform/cli/tools.py
+++ b/loom/platform/cli/tools.py
@@ -577,7 +577,59 @@ def make_filesystem_tools(workspace: Path) -> list["ToolDefinition"]:
             return ToolResult(call_id=call.id, tool_name=call.tool_name,
                               success=False, error=str(exc))
 
+    async def _see_image(call: ToolCall) -> ToolResult:
+        # Agent-initiated vision: load a local image so the model can
+        # actually see its pixels (not just the path). Reuses the vision
+        # validation stack (magic-byte MIME, size cap, digest); the image
+        # rides back as a canonical block in result.metadata and the
+        # session attaches it to the tool_result.
+        from loom.core.cognition import vision as _vision
+
+        raw = call.args.get("path", "")
+        path = _resolve_workspace_path(raw, workspace)
+        try:
+            vi = _vision.load_vision_input(path, origin="agent")
+        except _vision.VisionInputError as exc:
+            return ToolResult(call_id=call.id, tool_name=call.tool_name,
+                              success=False, error=f"無法載入圖片：{exc}")
+        except Exception as exc:
+            return ToolResult(call_id=call.id, tool_name=call.tool_name,
+                              success=False, error=f"讀取圖片失敗：{exc}")
+        block = _vision.make_image_block(vi)
+        kb = vi.size_bytes / 1024
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name, success=True,
+            output=(
+                f"已載入圖片 {raw}（{vi.media_type}, {kb:.0f} KB）。"
+                f"圖片內容現在可被你直接看見——請描述或分析你所見。"
+            ),
+            metadata={"vision_image": block},
+        )
+
     return [
+        ToolDefinition(
+            name="see_image",
+            description=(
+                "View a local image file with your native multimodal vision — "
+                "you SEE the actual pixels, not just the path. Use this when "
+                "you need to look at an image you found, were given a path to, "
+                "or generated yourself (rather than routing through an external "
+                "image-understanding tool). Relative paths resolve inside the "
+                "workspace. Requires a vision-capable model (e.g. MiniMax-M3)."
+            ),
+            trust_level=TrustLevel.SAFE,
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string",
+                             "description": "Image path (relative to workspace or absolute)"},
+                },
+                "required": ["path"],
+            },
+            executor=_see_image,
+            tags=["filesystem", "vision", "read"],
+            impact_scope="filesystem",
+        ),
         ToolDefinition(
             name="read_file",
             description=(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -241,7 +241,7 @@ class TestBuiltinTools:
         bash_tool = make_run_bash_tool(tmp_workspace)
         assert bash_tool.name == "run_bash"
         fs_names = {t.name for t in make_filesystem_tools(tmp_workspace)}
-        assert fs_names == {"read_file", "write_file", "list_dir"}
+        assert fs_names == {"read_file", "write_file", "list_dir", "see_image"}
 
     def test_trust_levels_correct(self, tmp_workspace):
         from loom.core.harness.permissions import ToolCapability

--- a/tests/test_see_image_tool.py
+++ b/tests/test_see_image_tool.py
@@ -1,0 +1,116 @@
+"""Agent-initiated vision: the `see_image` tool lets the agent view an
+image it found or generated (not only images the user supplies). The
+image rides back as a canonical block in the tool result and reaches the
+wire as a base64 image inside the Anthropic tool_result content.
+"""
+
+from __future__ import annotations
+
+import base64
+import struct
+import zlib
+from pathlib import Path
+from types import SimpleNamespace
+
+from loom.core.harness.middleware import ToolCall
+from loom.core.harness.permissions import TrustLevel
+from loom.core.cognition.providers import _to_anthropic_messages
+from loom.core.session import _attach_tool_vision
+from loom.platform.cli.tools import make_filesystem_tools
+
+
+def _png_bytes(w: int = 4, h: int = 4) -> bytes:
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return (struct.pack(">I", len(data)) + tag + data
+                + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF))
+    raw = b"".join(b"\x00" + b"\xff\x00\x00" * w for _ in range(h))
+    return (b"\x89PNG\r\n\x1a\n"
+            + chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0))
+            + chunk(b"IDAT", zlib.compress(raw)) + chunk(b"IEND", b""))
+
+
+def _see_tool(workspace: Path):
+    return next(t for t in make_filesystem_tools(workspace) if t.name == "see_image")
+
+
+def _call(path: str) -> ToolCall:
+    return ToolCall(tool_name="see_image", args={"path": path},
+                    trust_level=TrustLevel.SAFE, session_id="s1")
+
+
+class TestSeeImageTool:
+    async def test_loads_image_returns_vision_block(self, tmp_path: Path) -> None:
+        (tmp_path / "shot.png").write_bytes(_png_bytes())
+        res = await _see_tool(tmp_path).executor(_call("shot.png"))
+        assert res.success
+        block = res.metadata["vision_image"]
+        assert block["type"] == "image"
+        assert block["source"]["kind"] == "file"
+        assert block["source"]["media_type"] == "image/png"
+        assert "已載入" in res.output
+
+    async def test_rejects_non_image(self, tmp_path: Path) -> None:
+        (tmp_path / "notes.txt").write_text("hi")
+        res = await _see_tool(tmp_path).executor(_call("notes.txt"))
+        assert not res.success
+        assert "vision_image" not in (res.metadata or {})
+
+    async def test_rejects_missing_file(self, tmp_path: Path) -> None:
+        res = await _see_tool(tmp_path).executor(_call("nope.png"))
+        assert not res.success
+
+    def test_tool_is_safe(self, tmp_path: Path) -> None:
+        # SAFE → pre-authorized like read_file; reading an image is read-only.
+        assert _see_tool(tmp_path).trust_level == TrustLevel.SAFE
+
+
+class TestToolVisionWire:
+    def test_attach_rewrites_content_as_list(self) -> None:
+        block = {"type": "image", "source": {
+            "kind": "file", "ref": "/x.png",
+            "media_type": "image/png", "digest": "sha256:a"}}
+        tool_msg = {"role": "tool", "tool_call_id": "t1", "content": "loaded"}
+        _attach_tool_vision(tool_msg, SimpleNamespace(metadata={"vision_image": block}), "loaded")
+        assert tool_msg["content"][0] == {"type": "text", "text": "loaded"}
+        assert tool_msg["content"][1] == block
+
+    def test_attach_noop_for_plain_tool(self) -> None:
+        tool_msg = {"role": "tool", "tool_call_id": "t1", "content": "ok"}
+        _attach_tool_vision(tool_msg, SimpleNamespace(metadata={}), "ok")
+        assert tool_msg["content"] == "ok"
+
+    def test_tool_result_image_reaches_wire_as_base64(self, tmp_path: Path) -> None:
+        # The seam #506→#512 never had: an image inside a tool_result.
+        p = tmp_path / "shot.png"
+        p.write_bytes(_png_bytes())
+        block = {"type": "image", "source": {
+            "kind": "file", "ref": str(p),
+            "media_type": "image/png", "digest": "sha256:a"}}
+        messages = [
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"id": "t1", "type": "function",
+                 "function": {"name": "see_image", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "t1",
+             "content": [{"type": "text", "text": "已載入"}, block]},
+        ]
+        _, anth = _to_anthropic_messages(messages)
+        tr_msg = anth[-1]
+        assert tr_msg["role"] == "user"
+        tr = tr_msg["content"][0]
+        assert tr["type"] == "tool_result"
+        img = [b for b in tr["content"] if b["type"] == "image"][0]
+        assert img["source"]["type"] == "base64"
+        assert base64.b64decode(img["source"]["data"]) == p.read_bytes()
+
+    def test_plain_string_tool_result_unchanged(self) -> None:
+        # Regression: ordinary (non-vision) tool results still pass through
+        # as a plain string, not a block list.
+        messages = [
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"id": "t1", "type": "function",
+                 "function": {"name": "read_file", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "t1", "content": "file contents"},
+        ]
+        _, anth = _to_anthropic_messages(messages)
+        tr = anth[-1]["content"][0]
+        assert tr["content"] == "file contents"

--- a/tests/test_see_image_tool.py
+++ b/tests/test_see_image_tool.py
@@ -69,14 +69,30 @@ class TestToolVisionWire:
         block = {"type": "image", "source": {
             "kind": "file", "ref": "/x.png",
             "media_type": "image/png", "digest": "sha256:a"}}
+        # Reads the already-formatted tool content ("loaded"), not a raw arg.
         tool_msg = {"role": "tool", "tool_call_id": "t1", "content": "loaded"}
-        _attach_tool_vision(tool_msg, SimpleNamespace(metadata={"vision_image": block}), "loaded")
+        out = _attach_tool_vision(tool_msg, SimpleNamespace(metadata={"vision_image": block}))
+        assert out is None  # mutator, not transformer
         assert tool_msg["content"][0] == {"type": "text", "text": "loaded"}
         assert tool_msg["content"][1] == block
 
     def test_attach_noop_for_plain_tool(self) -> None:
         tool_msg = {"role": "tool", "tool_call_id": "t1", "content": "ok"}
-        _attach_tool_vision(tool_msg, SimpleNamespace(metadata={}), "ok")
+        _attach_tool_vision(tool_msg, SimpleNamespace(metadata={}))
+        assert tool_msg["content"] == "ok"
+
+    def test_attach_skips_malformed_block(self) -> None:
+        # A block missing source.ref must NOT be attached — otherwise it
+        # would crash at wire time in load_vision_input(None). Degrade to
+        # the text string instead.
+        bad = {"type": "image", "source": {}}
+        tool_msg = {"role": "tool", "tool_call_id": "t1", "content": "loaded"}
+        _attach_tool_vision(tool_msg, SimpleNamespace(metadata={"vision_image": bad}))
+        assert tool_msg["content"] == "loaded"
+
+    def test_attach_tolerates_non_dict_metadata(self) -> None:
+        tool_msg = {"role": "tool", "tool_call_id": "t1", "content": "ok"}
+        _attach_tool_vision(tool_msg, SimpleNamespace(metadata=None))
         assert tool_msg["content"] == "ok"
 
     def test_tool_result_image_reaches_wire_as_base64(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Until now the vision path only fired from **user** input — CLI free-text path detection and Discord attachments (#506→#512). The agent itself had no way to look at an image it found or generated: it could read the *path* via `run_bash`/`ls`, but not see the pixels — so it still had to fall back to the external `minimax__understand_image` MCP tool, the very workaround this whole vision arc set out to replace.

This closes that gap: **絲絲 can now look at an image on her own initiative.**

## New tool: `see_image(path)`

- SAFE (read-only, pre-authorized like `read_file`), lives in `make_filesystem_tools`.
- Loads a local image through the **existing** vision stack — magic-byte MIME, 10 MB cap, sha256 digest — via `load_vision_input(origin="agent")`.
- Returns the canonical image block in `result.metadata["vision_image"]`.

## How the image reaches the model

Anthropic (and M3 via its Anthropic-compatible endpoint) accept image blocks **inside `tool_result` content**. So:

- `_attach_tool_vision` (session) rewrites the tool message content as `[text, image_block]` when the result carries a vision image — applied at both the parallel and sequential tool-result append sites.
- `_to_anthropic_messages`' tool branch now converts canonical image blocks in `tool_result` content to Anthropic image blocks. The user-branch converter was extracted into a shared `_canonical_blocks_to_anthropic` so the user-vision path and the tool-vision path use **one** converter (same convergence discipline as #508).

## Graceful degradation (codex / xai)

A vision tool result on a Responses-API provider reduces to its **text** parts in `function_call_output` (which can't carry an image), instead of emitting a Python repr of the blocks. `see_image`'s native vision targets vision-capable models (M3); on others the agent gets the text description, not the pixels. No crash.

## Tests (`test_see_image_tool.py`, 8)

- Tool loads an image → `vision_image` metadata; rejects non-image / missing file.
- `_attach_tool_vision` rewrites content; no-op for plain tool results.
- **End-to-end seam** (the one #506→#512 never had — an image inside a `tool_result`): the block reaches the Anthropic wire as a `base64` image; a plain string tool result is unchanged (regression guard).
- `test_integration` builtin-tools set updated to include `see_image`.

Full suite: **2443 passed, 4 skipped**. `gitnexus detect_changes`: affected processes are the codex/xai `_build_payload` tool-result paths (the degradation edit), as expected.

## Notes / deferred

- `see_image` is always registered; on a non-vision model it degrades to text (above) rather than being hidden. Provider-capability gating is a possible follow-up but out of scope here.
- Tool-result images are session-scoped (not persisted to `session_log` like user vision turns) — the agent's text reasoning is the durable record, consistent with the existing design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
