### PR TITLE
feat(circadian): reload rhythm table at dawn (#477)

### DIFF
--- a/loom/autonomy/circadian/lifecycle.py
+++ b/loom/autonomy/circadian/lifecycle.py
@@ -393,6 +393,12 @@ def register_triggers(daemon: Any, platform: CircadianPlatform, config: Circadia
     close_cron = local_hhmm_to_utc_cron(config.sleep, config.timezone)
 
     async def _dawn_handler(_trigger: Any, _context: dict[str, Any]) -> None:
+        # Re-read the rhythm table at the top of each day so edits made since
+        # the daemon started take effect today without a restart (issue #477).
+        # The Discord daemon is long-lived; without this, a changed rhythm.toml
+        # would never be picked up. Runs before spawning today's session so the
+        # day opens with the current anchor set.
+        reload_rhythm_anchors(daemon, config)
         await ensure_today_session(
             datetime.now(timezone.utc), platform, config, evaluator=evaluator
         )
@@ -598,6 +604,44 @@ def register_rhythm_anchors(
             ", ".join(f"{a.name}@{a.time}" for a in anchors),
         )
     return len(anchors)
+
+
+# Prefix shared by every rhythm-anchor trigger (rhythm.py ``Anchor.trigger_name``
+# builds ``circadian:phase_<name>``). The dawn/close lifecycle triggers use
+# ``circadian:dawn_spawn`` / ``circadian:nightly_close`` and so are never matched
+# — letting reload reconcile anchors without touching the day's bookends.
+_PHASE_ANCHOR_PREFIX = "circadian:phase_"
+
+
+def reload_rhythm_anchors(daemon: Any, config: CircadianConfig) -> int:
+    """Re-read the rhythm table and reconcile the registered phase anchors.
+
+    Called at each dawn (issue #477) so edits to ``rhythm.toml`` take effect
+    the next day without restarting the daemon — the Discord daemon is a
+    long-lived process that would otherwise never pick up a changed table.
+
+    This is reconciliation, not a blind re-register: an anchor *removed* from
+    the table has its ``CronTrigger`` and direct handler torn down, so a deleted
+    phase stops firing instead of lingering as an orphan trigger. New or changed
+    anchors are (re)registered idempotently by :func:`register_rhythm_anchors`.
+    Only ``circadian:phase_*`` triggers are reconciled; the dawn/close triggers
+    are left untouched. A missing/malformed table yields zero anchors, which
+    simply retires every phase anchor — same tolerant contract as PR2.
+
+    Returns the number of anchors registered after reconciliation.
+    """
+    anchors = load_rhythm()
+    desired = {a.trigger_name for a in anchors}
+    stale = [
+        t.name
+        for t in daemon.evaluator.list()
+        if t.name.startswith(_PHASE_ANCHOR_PREFIX) and t.name not in desired
+    ]
+    for name in stale:
+        daemon.evaluator.unregister(name)
+        daemon.unregister_direct_handler(name)
+        logger.info("[circadian] rhythm reload — retired anchor no longer in table: %s", name)
+    return register_rhythm_anchors(daemon, config, anchors)
 
 
 async def setup_circadian(

--- a/loom/autonomy/daemon.py
+++ b/loom/autonomy/daemon.py
@@ -195,6 +195,15 @@ class AutonomyDaemon:
         to the planner's EXECUTE/SKIP/NOTIFY decision."""
         self._direct_handlers[name] = handler
 
+    def unregister_direct_handler(self, name: str) -> None:
+        """Drop the direct handler for trigger ``name`` (no-op if absent).
+
+        Symmetric with :meth:`register_direct_handler`. Used when a trigger is
+        torn down for good — e.g. circadian's dawn reload retires a rhythm
+        anchor that disappeared from the table — so the handler map doesn't
+        accumulate dead entries across renames."""
+        self._direct_handlers.pop(name, None)
+
     async def _on_trigger_fire(self, trigger, context):
         handler = self._direct_handlers.get(trigger.name)
         if handler is not None:

--- a/tests/test_circadian_phase_chime.py
+++ b/tests/test_circadian_phase_chime.py
@@ -23,6 +23,8 @@ from loom.autonomy.circadian.lifecycle import (
     CircadianConfig,
     ensure_today_session,
     register_rhythm_anchors,
+    register_triggers,
+    reload_rhythm_anchors,
     setup_circadian,
 )
 from loom.autonomy.circadian.rhythm import Anchor
@@ -559,3 +561,114 @@ class TestDawnRevisionReport:
 
         intent = deliveries[0].intent
         assert "昨夜" not in intent
+
+
+class TestReloadRhythmAnchors:
+    """Dawn-time reconciliation so rhythm.toml edits take effect next day
+    without restarting the long-lived daemon (issue #477)."""
+
+    def test_reload_registers_a_newly_added_anchor(self):
+        _write_rhythm('''
+            [[anchors]]
+            time = "10:00"
+            name = "pet"
+            meaning = "喵吉"
+        ''')
+        daemon, _, _ = _make_daemon()
+        reload_rhythm_anchors(daemon, CFG)
+        # Author adds a second anchor and the day turns over.
+        _write_rhythm('''
+            [[anchors]]
+            time = "10:00"
+            name = "pet"
+            meaning = "喵吉"
+
+            [[anchors]]
+            time = "14:00"
+            name = "deep_weave"
+            meaning = "深入"
+        ''')
+        count = reload_rhythm_anchors(daemon, CFG)
+        assert count == 2
+        names = {t.name for t in daemon.evaluator.list()}
+        assert {"circadian:phase_pet", "circadian:phase_deep_weave"} <= names
+
+    def test_reload_retires_a_removed_anchor(self):
+        # The invariant that justified this issue: a removed anchor must stop
+        # firing, not linger as an orphan trigger + dead handler.
+        _write_rhythm('''
+            [[anchors]]
+            time = "10:00"
+            name = "pet"
+            meaning = "喵吉"
+
+            [[anchors]]
+            time = "11:00"
+            name = "curiosity"
+            meaning = "散步"
+        ''')
+        daemon, _, _ = _make_daemon()
+        reload_rhythm_anchors(daemon, CFG)
+        assert "circadian:phase_curiosity" in daemon._direct_handlers
+        # Author drops the curiosity walk.
+        _write_rhythm('''
+            [[anchors]]
+            time = "10:00"
+            name = "pet"
+            meaning = "喵吉"
+        ''')
+        reload_rhythm_anchors(daemon, CFG)
+        names = {t.name for t in daemon.evaluator.list()}
+        assert "circadian:phase_curiosity" not in names
+        assert "circadian:phase_pet" in names
+        # Handler torn down too — no dead entry left behind.
+        assert "circadian:phase_curiosity" not in daemon._direct_handlers
+
+    def test_reload_leaves_dawn_close_triggers_untouched(self):
+        daemon, _, _ = _make_daemon()
+        register_triggers(daemon, FakePlatform(), CFG)
+        _write_rhythm('''
+            [[anchors]]
+            time = "10:00"
+            name = "pet"
+            meaning = "喵吉"
+        ''')
+        reload_rhythm_anchors(daemon, CFG)
+        names = {t.name for t in daemon.evaluator.list()}
+        assert {"circadian:dawn_spawn", "circadian:nightly_close"} <= names
+
+    def test_reload_with_no_table_retires_all_anchors(self):
+        _write_rhythm('''
+            [[anchors]]
+            time = "10:00"
+            name = "pet"
+            meaning = "喵吉"
+        ''')
+        daemon, _, _ = _make_daemon()
+        reload_rhythm_anchors(daemon, CFG)
+        # Table vanishes (deleted / unreadable) — tolerant contract: zero
+        # anchors, every phase anchor retired, no crash.
+        from pathlib import Path
+        Path("autonomy/circadian/rhythm.toml").unlink()
+        count = reload_rhythm_anchors(daemon, CFG)
+        assert count == 0
+        names = {t.name for t in daemon.evaluator.list()}
+        assert [n for n in names if n.startswith("circadian:phase_")] == []
+
+    async def test_dawn_fire_reloads_the_rhythm_table(self):
+        # End-to-end: the dawn trigger's direct handler runs reload, so a table
+        # edited while the daemon was up is live the moment the new day opens.
+        daemon, _, _ = _make_daemon()
+        register_triggers(daemon, FakePlatform(), CFG_ALWAYS)
+        _write_rhythm('''
+            [[anchors]]
+            time = "10:00"
+            name = "pet"
+            meaning = "喵吉"
+        ''')
+        dawn = next(
+            t for t in daemon.evaluator.list() if t.name == "circadian:dawn_spawn"
+        )
+        await daemon._on_trigger_fire(dawn, {})
+        names = {t.name for t in daemon.evaluator.list()}
+        assert "circadian:phase_pet" in names


### PR DESCRIPTION
## 動機

`autonomy/circadian/rhythm.toml` 只在 `setup_circadian`(daemon 啟動)被讀一次。長壽的 Discord daemon 不會天天重啟,所以絲絲改了節律表也不生效。這是 #477 唯一真有重量的缺口——其餘規劃的「guarded self-scheduling 工具」屬過度規格化(絲絲本來就能用通用檔案工具編輯 rhythm.toml)。

## 做法 — dawn-time reconciliation

- **`reload_rhythm_anchors(daemon, config)`**:每天 dawn 重讀表。是 **reconciliation 不是盲目 re-register**:
  - 表裡**被移除**的 anchor → 連 `CronTrigger` + direct handler 一起拆掉(否則留孤兒喚醒點繼續觸發)
  - 新增/變更 → idempotent 重註冊
  - 只動 `circadian:phase_*`,**dawn/close bookend 不碰**
  - 表缺/壞 → 退化成零 anchor(沿用 PR2 容錯契約)
- 接進 `_dawn_handler`,spawn 當日 session 前先 reload。
- daemon 補對稱的 **`unregister_direct_handler()`**,避免 rename 累積死 handler。

## 測試

5 個契約測試守命脈不變式:新增 anchor / 移除 anchor(trigger+handler 雙拆)/ bookend 不動 / 無表全退 / dawn-fire 整圈。

- `test_circadian_phase_chime.py` 24 passed
- circadian + lifecycle 全套 96 passed

## 影響面

全 additive(新函式 + 新 daemon method + `_dawn_handler` 一行)。gitnexus impact = LOW;detect_changes 的 "high" 是 `setup_circadian` 流程鏈的機械標記,無既有行為路徑變更。

Closes #477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)