### PR TITLE
test(memory): cover session log list health

### DIFF
--- a/tests/test_vision_input.py
+++ b/tests/test_vision_input.py
@@ -622,6 +622,29 @@ class TestSessionLogVisionPersistence:
         assert meta["vision_inputs"][0]["digest"] == vi.digest
         await conn.close()
 
+    async def test_list_content_does_not_record_session_log_write_failure(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        import aiosqlite
+        from loom.core.memory.health import MemoryHealthTracker
+        from loom.core.memory.session_log import SessionLog
+
+        conn = await aiosqlite.connect(str(tmp_path / "s.db"))
+        await conn.executescript(_SESSION_LOG_SCHEMA)
+        log = SessionLog(conn)
+        health = MemoryHealthTracker(conn, "s1")
+        log._health = health
+        await log.create_session("s1", "test-model")
+
+        vi = vision.load_vision_input(png_path_for(tmp_path))
+        content = vision.build_user_content("看下這張", [vi])
+        await log.log_message("s1", 4, "user", content)
+
+        report = health.report()
+        assert "session_log_write" not in report.operations
+        await conn.close()
+
 
 def png_path_for(tmp_path: Path) -> Path:
     p = tmp_path / "fixture.png"


### PR DESCRIPTION
## Summary
- investigated #515 against current `master` and traced `session_log_write` failures to `SessionLog.log_message` binding list content as SQL parameter 4 (`content`)
- confirmed current runtime already normalizes canonical vision list content before INSERT via the #509/#511 session_log fixes
- add a health-layer regression test that attaches `MemoryHealthTracker`, writes canonical list content, and asserts no `session_log_write` failure is recorded

## Investigation notes
- The observed `Error binding parameter 4: type 'list' is not supported` signature matches the pre-#509 path where canonical vision user content reached SQLite directly.
- Current `log_message()` converts list content into a text summary + metadata before binding and stores canonical structure in `raw_json`; the exact binding failure no longer reproduces.
- This PR is intentionally evidence-focused: no production code change was needed on current `master`.

## Verification
- `pytest -q tests/test_vision_input.py::TestSessionLogVisionPersistence tests/test_session_log_redaction.py tests/test_pulse_session_log.py` — 24 passed
- `pytest -q tests/test_vision_input.py tests/test_memory_compaction_subscriber.py tests/test_integration.py::TestSessionCompression` — 64 passed
- `python -m py_compile loom/core/memory/session_log.py tests/test_vision_input.py`
- `git diff --check`
- `npx gitnexus impact 'Function:loom/core/memory/session_log.py:SessionLog.log_message' --direction upstream` — LOW, 0 direct callers, 0 affected processes
- `npx gitnexus detect-changes --scope staged` — Risk low, affected processes 0

Refs #515