### PR TITLE
feat(autonomy): extract schedule registry into autonomy/schedules.toml (#444)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,8 @@ Agent.md
 SOUL.md
 loom.toml.bak
 
+# Per-agent schedule registry (issue #444) — copy from schedules.example.toml
+autonomy/schedules.toml
 # Per-agent rhythm table (issue #460) — copy from rhythm.example.toml
 autonomy/circadian/rhythm.toml
 # Per-agent daily weave plan (issue #461) — copy from daily_weave.example.md

--- a/autonomy/schedules.example.toml
+++ b/autonomy/schedules.example.toml
@@ -1,0 +1,89 @@
+# Autonomy schedule registry — example (issue #444)
+#
+# Copy this to ``autonomy/schedules.toml`` in your workspace and edit freely.
+# This file is the *work-item* surface: agents add / remove / tweak schedules
+# here without ever touching ``loom.toml`` (cognition / memory / sandbox /
+# harness). The master on/off switch stays in loom.toml:
+#
+#   [autonomy]
+#   enabled = true        # <- in loom.toml, gates the whole daemon
+#
+# Per-agent isolation is by workspace (cwd), exactly like
+# ``autonomy/circadian/rhythm.toml``: a different agent runs in a different
+# workspace and sees a different registry, one shared daemon.
+#
+# Two table arrays:
+#   [[schedules]]  — cron-fired work items
+#   [[triggers]]   — event-fired work items (emitted via `loom autonomy emit`)
+#
+# Schedules must pre-declare the tools/scopes they need via ``allowed_tools`` /
+# ``scope_grants`` — otherwise a GUARDED run gets denied. ``cron`` strings are
+# UTC (hand-convert from local time); the per-schedule ``timezone`` field is
+# currently a no-op.
+
+# ── 範例 1: 每日記憶整理（dream + housekeeping） ─────────────────
+[[schedules]]
+name          = "memory_housekeeping"
+cron          = "0 19 * * 0"            # 19:00 UTC Sunday = 03:00 Asia/Taipei Monday
+intent        = """Run memory housekeeping. First call memory_prune with
+                   dry_run=true to preview decayed entries. If any qualify,
+                   call again with dry_run=false to delete them. Report:
+                   total examined, pruned, and retained."""
+trust_level   = "safe"
+notify        = false
+notify_thread = 0
+
+# ── 範例 2: 每日 free dream（補 themed 沒覆蓋到的 cross-domain） ────
+[[schedules]]
+name          = "offline_dreaming_free"
+cron          = "0 19 * * *"            # 19:00 UTC = 03:00 Asia/Taipei
+intent        = """Run a free cross-domain dream. Call dream_cycle with
+                   themed=false so the sample spans all four ontology
+                   domains at random."""
+trust_level   = "safe"
+notify        = false
+notify_thread = 0
+allowed_tools = ["dream_cycle", "memorize"]
+
+# ── 範例 3: weekly skill review ────────────────────────────────
+[[schedules]]
+name          = "skill_weekly_review"
+cron          = "0 2 * * 6"             # 02:00 UTC Saturday = 10:00 Asia/Taipei
+intent        = """Run `loom skill weekly` via run_bash, then read the
+                   generated report and surface items in the 該關注清單."""
+trust_level   = "safe"
+notify        = true
+notify_thread = 0
+allowed_tools = ["run_bash", "read_file"]
+scope_grants  = [
+  { resource = "exec", action = "execute", selector = "workspace" },
+  { resource = "path", action = "read",    selector = "outputs"   },
+]
+attach_outputs = ["outputs/self_check/*-skill-weekly.md"]
+
+# ── 範例 4: chime schedule（在既有 Discord 討論串裡發聲，而非獨立 run） ──
+[[schedules]]
+name          = "morning_briefing"
+cron          = "0 1 * * *"
+intent        = "撰寫晨報並發到討論串。"
+trust_level   = "safe"
+mode          = "chime"
+allowed_tools = ["write_file", "web_search"]
+
+  [schedules.target]
+  type     = "discord_thread"
+  id       = "REPLACE_WITH_THREAD_ID"   # 部署細節（非 secret）；放本檔不入 git
+  fallback = "skip"
+
+# ── 範例 5: event trigger（外部訊號觸發） ─────────────────────────
+[[triggers]]
+name          = "deploy_check"
+event         = "deployment_done"        # 用 `loom autonomy emit deployment_done` 觸發
+intent        = "Run smoke tests and post results."
+trust_level   = "guarded"
+notify        = true
+notify_thread = 0
+allowed_tools = ["run_bash"]
+scope_grants  = [
+  { resource = "exec", action = "execute", selector = "workspace" },
+]

--- a/examples/profiles/loom.toml.example.assistant
+++ b/examples/profiles/loom.toml.example.assistant
@@ -14,9 +14,9 @@
 #   • GUARDED 用 session 緩存（預設行為，session 內第一次 prompt）
 #   • Dream cycle 預設開（背景知識整理）
 #
-# 註: autonomy 排程未來會獨立成獨立檔案管理（issue #444），避免
-#     agent 誤改 loom.toml 引發連鎖錯誤；目前先全關。需要時參考
-#     根目錄 loom.toml.example 的 [[autonomy.schedules]] 範例。
+# 註: autonomy 排程已獨立成 autonomy/schedules.toml 管理（issue #444），
+#     避免 agent 誤改 loom.toml 引發連鎖錯誤；本 profile 預設全關。
+#     需要時 `cp autonomy/schedules.example.toml autonomy/schedules.toml`。
 #
 # 完整 per-key 教學註解請看根目錄 loom.toml.example
 # 此檔僅標註 profile-specific 的取捨理由
@@ -120,8 +120,9 @@ allowed_domains = []
 # ─────────────────────────────────────────────
 # Autonomy —— ASSISTANT 預設關（bot 連著就好，不主動排任務）
 # ─────────────────────────────────────────────
-# 想啟用自動排程：把 enabled 改 true，再解註解需要的 schedule 範例
-# （完整範例見根目錄 loom.toml.example 的 [[autonomy.schedules]] 區塊）。
+# 想啟用自動排程：把 enabled 改 true，再
+# `cp autonomy/schedules.example.toml autonomy/schedules.toml` 編輯排程
+# （schedule 清單自 #444 起住在 autonomy/schedules.toml，不在本檔）。
 [autonomy]
 enabled = false
 

--- a/examples/profiles/loom.toml.example.autonomous
+++ b/examples/profiles/loom.toml.example.autonomous
@@ -121,63 +121,17 @@ allowed_domains = []
 # ─────────────────────────────────────────────
 # Autonomy —— AUTONOMOUS 全開
 # ─────────────────────────────────────────────
-# 三類 trigger（cron / event / condition）都通；schedule 必須在
-# allowed_tools / scope_grants 預先宣告權限，否則 GUARDED 會被 deny。
+# 只有總開關住在這裡。實際的 schedule / trigger 清單（cron / event）自
+# issue #444 起搬到獨立檔案 `autonomy/schedules.toml`，把「工作項目」這個
+# agent 會頻繁編輯的 mutation surface 跟系統 config 隔開。
+#
+# 設定 schedules：
+#   cp autonomy/schedules.example.toml autonomy/schedules.toml
+#   # 然後編輯 autonomy/schedules.toml（agents 也只動這個檔，不碰 loom.toml）
+#
+# schedule 必須在 allowed_tools / scope_grants 預先宣告權限，否則 GUARDED 會被 deny。
 [autonomy]
 enabled = true
-
-# ── 範例 1: 每日記憶整理（dream + housekeeping） ─────────────────
-# [[autonomy.schedules]]
-# name          = "memory_housekeeping"
-# cron          = "0 19 * * 0"            # 19:00 UTC Sunday = 03:00 Asia/Taipei Monday
-# intent        = """Run memory housekeeping. First call memory_prune with
-#                    dry_run=true to preview decayed entries. If any qualify,
-#                    call again with dry_run=false to delete them. Report:
-#                    total examined, pruned, and retained."""
-# trust_level   = "safe"
-# notify        = false
-# notify_thread = 0
-
-# ── 範例 2: 每日 free dream（補 themed 沒覆蓋到的 cross-domain） ────
-# [[autonomy.schedules]]
-# name          = "offline_dreaming_free"
-# cron          = "0 19 * * *"            # 19:00 UTC = 03:00 Asia/Taipei
-# intent        = """Run a free cross-domain dream. Call dream_cycle with
-#                    themed=false so the sample spans all four ontology
-#                    domains at random."""
-# trust_level   = "safe"
-# notify        = false
-# notify_thread = 0
-# allowed_tools = ["dream_cycle", "memorize"]
-
-# ── 範例 3: weekly skill review ────────────────────────────────
-# [[autonomy.schedules]]
-# name          = "skill_weekly_review"
-# cron          = "0 2 * * 6"             # 02:00 UTC Saturday = 10:00 Asia/Taipei
-# intent        = """Run `loom skill weekly` via run_bash, then read the
-#                    generated report and surface items in the 該關注清單."""
-# trust_level   = "safe"
-# notify        = true
-# notify_thread = 0
-# allowed_tools = ["run_bash", "read_file"]
-# scope_grants  = [
-#   { resource = "exec", action = "execute", selector = "workspace" },
-#   { resource = "path", action = "read",    selector = "outputs"   },
-# ]
-# attach_outputs = ["outputs/self_check/*-skill-weekly.md"]
-
-# ── 範例 4: event trigger（外部訊號觸發） ─────────────────────────
-# [[autonomy.triggers]]
-# name          = "deploy_check"
-# event         = "deployment_done"        # 用 `loom autonomy emit deployment_done` 觸發
-# intent        = "Run smoke tests and post results."
-# trust_level   = "guarded"
-# notify        = true
-# notify_thread = 0
-# allowed_tools = ["run_bash"]
-# scope_grants  = [
-#   { resource = "exec", action = "execute", selector = "workspace" },
-# ]
 
 [notify]
 default_channel = "discord"

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -588,6 +588,12 @@ backend = "none"   # "none" | "srt"
 [autonomy]
 enabled  = false           # set true to activate daemon
 
+# Schedule registry (cron / event work items) lives in its OWN file since
+# issue #444 — `autonomy/schedules.toml` — so editing a schedule never risks a
+# system-config key. This [autonomy] block holds only posture (the enabled
+# switch + circadian). To add schedules:
+#   cp autonomy/schedules.example.toml autonomy/schedules.toml
+
 # ── Circadian Autonomy — daily-life rhythm (milestone #14, doc/57) ────────────
 # Opens one daily Discord thread at `start` and closes it at `sleep` (close runs
 # the existing memory-finalization path). The thread is opened in the channel

--- a/loom/autonomy/daemon.py
+++ b/loom/autonomy/daemon.py
@@ -459,61 +459,79 @@ class AutonomyDaemon:
                 "Review autonomy/schedules.toml and restart to update the stored hash."
             )
 
+        # Per-entry tolerance: the loader guarantees well-typed tables, but a
+        # *semantically* bad entry (invalid cron -> ValueError, missing required
+        # key -> KeyError) must not abort the whole load. Mirror the schedule
+        # loader's contract — log the bad entry and keep registering siblings.
         count = 0
-        for sched in sched_cfg.get("schedules", []):
-            mode = sched.get("mode", "independent")
-            target = dict(sched.get("target", {}))
-            if mode == "chime":
-                _t_type = target.get("type")
-                if _t_type != "discord_thread":
-                    logger.warning(
-                        "[autonomy] schedule %r mode=chime requires "
-                        "target.type='discord_thread' (got %r); skipping",
-                        sched["name"], _t_type,
-                    )
-                    continue
-                if "id" not in target:
-                    logger.warning(
-                        "[autonomy] schedule %r mode=chime missing target.id; "
-                        "skipping", sched["name"],
-                    )
-                    continue
-                # Normalise id to string for label matching
-                target["id"] = str(target["id"])
-                target.setdefault("fallback", "skip")
-            trigger = CronTrigger(
-                name=sched["name"],
-                intent=sched["intent"],
-                cron=sched.get("cron", "0 9 * * 1-5"),
-                timezone=sched.get("timezone", "UTC"),
-                trust_level=_validate_trust_level(
-                    sched.get("trust_level", "guarded"), sched["name"],
-                ),
-                notify=sched.get("notify", True),
-                notify_thread_id=sched.get("notify_thread", 0),
-                allowed_tools=sched.get("allowed_tools", []),
-                scope_grants=sched.get("scope_grants", []),
-                attach_outputs=sched.get("attach_outputs", []),
-                mode=mode,
-                target=target,
-            )
+        for idx, sched in enumerate(sched_cfg.get("schedules", [])):
+            name = sched.get("name", f"<schedules[{idx}]>")
+            try:
+                mode = sched.get("mode", "independent")
+                target = dict(sched.get("target", {}))
+                if mode == "chime":
+                    _t_type = target.get("type")
+                    if _t_type != "discord_thread":
+                        logger.warning(
+                            "[autonomy] schedule %r mode=chime requires "
+                            "target.type='discord_thread' (got %r); skipping",
+                            name, _t_type,
+                        )
+                        continue
+                    if "id" not in target:
+                        logger.warning(
+                            "[autonomy] schedule %r mode=chime missing target.id; "
+                            "skipping", name,
+                        )
+                        continue
+                    # Normalise id to string for label matching
+                    target["id"] = str(target["id"])
+                    target.setdefault("fallback", "skip")
+                trigger = CronTrigger(
+                    name=sched["name"],
+                    intent=sched["intent"],
+                    cron=sched.get("cron", "0 9 * * 1-5"),
+                    timezone=sched.get("timezone", "UTC"),
+                    trust_level=_validate_trust_level(
+                        sched.get("trust_level", "guarded"), name,
+                    ),
+                    notify=sched.get("notify", True),
+                    notify_thread_id=sched.get("notify_thread", 0),
+                    allowed_tools=sched.get("allowed_tools", []),
+                    scope_grants=sched.get("scope_grants", []),
+                    attach_outputs=sched.get("attach_outputs", []),
+                    mode=mode,
+                    target=target,
+                )
+            except (KeyError, ValueError) as exc:
+                logger.warning(
+                    "[autonomy] schedule %r is malformed (%s); skipping", name, exc
+                )
+                continue
             self._evaluator.register(trigger)
             count += 1
 
-        for evt in sched_cfg.get("triggers", []):
-            trigger = EventTrigger(
-                name=evt["name"],
-                intent=evt["intent"],
-                event_name=evt.get("event", evt["name"]),
-                trust_level=_validate_trust_level(
-                    evt.get("trust_level", "guarded"), evt["name"],
-                ),
-                notify=evt.get("notify", True),
-                notify_thread_id=evt.get("notify_thread", 0),
-                allowed_tools=evt.get("allowed_tools", []),
-                scope_grants=evt.get("scope_grants", []),
-                attach_outputs=evt.get("attach_outputs", []),
-            )
+        for idx, evt in enumerate(sched_cfg.get("triggers", [])):
+            name = evt.get("name", f"<triggers[{idx}]>")
+            try:
+                trigger = EventTrigger(
+                    name=evt["name"],
+                    intent=evt["intent"],
+                    event_name=evt.get("event", evt["name"]),
+                    trust_level=_validate_trust_level(
+                        evt.get("trust_level", "guarded"), name,
+                    ),
+                    notify=evt.get("notify", True),
+                    notify_thread_id=evt.get("notify_thread", 0),
+                    allowed_tools=evt.get("allowed_tools", []),
+                    scope_grants=evt.get("scope_grants", []),
+                    attach_outputs=evt.get("attach_outputs", []),
+                )
+            except (KeyError, ValueError) as exc:
+                logger.warning(
+                    "[autonomy] event trigger %r is malformed (%s); skipping", name, exc
+                )
+                continue
             self._evaluator.register(trigger)
             count += 1
 

--- a/loom/autonomy/daemon.py
+++ b/loom/autonomy/daemon.py
@@ -28,6 +28,7 @@ from loom.autonomy.history import TriggerHistory
 from loom.autonomy.maintenance import DreamLoop, MaintenanceLoop
 from loom.autonomy.planner import ActionPlanner, PlannedAction, ActionDecision
 from loom.autonomy.triggers import CronTrigger, EventTrigger, ConditionTrigger
+from loom.autonomy.schedules import DEFAULT_SCHEDULES_PATH, load_schedules
 from loom.core.infra import AbortController, wait_aborted
 from loom.notify.confirm import ConfirmFlow
 from loom.notify.router import NotificationRouter
@@ -41,16 +42,18 @@ caller should fall back per ``target['fallback']``."""
 
 
 # ---------------------------------------------------------------------------
-# Issue #91: autonomy config tamper detection
+# Issue #91: tamper detection. Since #444 the agent-writable mutation surface
+# is the schedule registry (autonomy/schedules.toml), not the loom.toml
+# [autonomy] section — so that's what we fingerprint.
 # ---------------------------------------------------------------------------
 
 _VALID_TRUST_LEVELS = {"safe", "guarded", "critical"}
-_CONFIG_HASH_PATH = Path.home() / ".loom" / "autonomy_config.hash"
+_CONFIG_HASH_PATH = Path.home() / ".loom" / "schedules.hash"
 
 
-def _hash_autonomy_section(autonomy_cfg: dict) -> str:
-    """Deterministic SHA-256 of the autonomy config section."""
-    canonical = _json.dumps(autonomy_cfg, sort_keys=True, ensure_ascii=False)
+def _hash_schedule_registry(sched_cfg: dict) -> str:
+    """Deterministic SHA-256 of the loaded schedule registry."""
+    canonical = _json.dumps(sched_cfg, sort_keys=True, ensure_ascii=False)
     return hashlib.sha256(canonical.encode()).hexdigest()
 
 
@@ -117,19 +120,19 @@ def _resolve_attachments(
     return results
 
 
-def _check_config_integrity(autonomy_cfg: dict) -> bool:
+def _check_config_integrity(sched_cfg: dict) -> bool:
     """
-    Compare current config hash against stored hash.
+    Compare current schedule-registry hash against stored hash.
     Returns True if first load or match; False if mismatch.
     """
-    current_hash = _hash_autonomy_section(autonomy_cfg)
+    current_hash = _hash_schedule_registry(sched_cfg)
     try:
         if _CONFIG_HASH_PATH.exists():
             stored = _CONFIG_HASH_PATH.read_text().strip()
             if stored != current_hash:
                 logger.warning(
-                    "[autonomy] CONFIG CHANGE DETECTED — autonomy section hash "
-                    "mismatch. Stored=%s, Current=%s. Review loom.toml for tampering.",
+                    "[autonomy] SCHEDULE REGISTRY CHANGE DETECTED — hash mismatch. "
+                    "Stored=%s, Current=%s. Review autonomy/schedules.toml for tampering.",
                     stored[:12], current_hash[:12],
                 )
                 # Update hash after warning — the log entry is the audit trail.
@@ -413,7 +416,11 @@ class AutonomyDaemon:
 
     def load_config(self, config_path: str | Path) -> int:
         """
-        Load triggers from a loom.toml file.
+        Load autonomy triggers. The master switch (``[autonomy] enabled``) is
+        read from *config_path* (loom.toml); the schedule registry itself lives
+        in the sibling ``autonomy/schedules.toml`` (issue #444 — isolating the
+        agent-writable mutation surface from system config).
+
         Returns the number of triggers registered.
         """
         import tomllib
@@ -429,15 +436,31 @@ class AutonomyDaemon:
         if not autonomy_cfg.get("enabled", False):
             return 0
 
-        # Issue #91: tamper detection (fail-open by design — logs warning only)
-        if not _check_config_integrity(autonomy_cfg):
+        # Hard cut (#444): the schedule registry moved out of loom.toml. Inline
+        # [[autonomy.schedules]] / [[autonomy.triggers]] are no longer honoured —
+        # warn so a stale loom.toml doesn't look like it's still driving autonomy.
+        if autonomy_cfg.get("schedules") or autonomy_cfg.get("triggers"):
             logger.warning(
-                "[autonomy] Proceeding despite config change. "
-                "Review loom.toml and restart to update the stored hash."
+                "[autonomy] inline [[autonomy.schedules]]/[[autonomy.triggers]] in %s "
+                "are ignored since #444 — run `python -m loom.autonomy.migrate_schedules %s` "
+                "to move them into autonomy/schedules.toml",
+                path, path,
+            )
+
+        # Resolve the registry relative to loom.toml's directory so launching
+        # from another cwd still finds the right per-workspace file.
+        sched_path = path.resolve().parent / DEFAULT_SCHEDULES_PATH
+        sched_cfg = load_schedules(sched_path)
+
+        # Issue #91: tamper detection on the registry (fail-open — logs only).
+        if not _check_config_integrity(sched_cfg):
+            logger.warning(
+                "[autonomy] Proceeding despite schedule registry change. "
+                "Review autonomy/schedules.toml and restart to update the stored hash."
             )
 
         count = 0
-        for sched in autonomy_cfg.get("schedules", []):
+        for sched in sched_cfg.get("schedules", []):
             mode = sched.get("mode", "independent")
             target = dict(sched.get("target", {}))
             if mode == "chime":
@@ -477,7 +500,7 @@ class AutonomyDaemon:
             self._evaluator.register(trigger)
             count += 1
 
-        for evt in autonomy_cfg.get("triggers", []):
+        for evt in sched_cfg.get("triggers", []):
             trigger = EventTrigger(
                 name=evt["name"],
                 intent=evt["intent"],

--- a/loom/autonomy/migrate_schedules.py
+++ b/loom/autonomy/migrate_schedules.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Migrate inline autonomy schedules out of ``loom.toml`` (issue #444).
+
+Moves every ``[[autonomy.schedules]]`` / ``[[autonomy.triggers]]`` block (and
+their ``[autonomy.schedules.target]`` sub-tables) from ``loom.toml`` into a
+sibling ``autonomy/schedules.toml``, rewriting the table headers to the
+registry's top-level form:
+
+    [[autonomy.schedules]]        ->  [[schedules]]
+    [autonomy.schedules.target]   ->  [schedules.target]
+    [[autonomy.triggers]]         ->  [[triggers]]
+
+The move is a *verbatim text transform*, not a TOML re-serialisation — the giant
+multi-line ``intent = \"\"\"...\"\"\"`` strings survive byte-for-byte. ``loom.toml``
+is backed up to ``loom.toml.bak`` (already gitignored) before it's rewritten.
+
+Idempotent: refuses to overwrite an existing ``autonomy/schedules.toml``; a
+loom.toml with no inline blocks is a no-op.
+
+Usage:
+    python -m loom.autonomy.migrate_schedules [path/to/loom.toml]   # default: ./loom.toml
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# A schedules/triggers region: the block header itself, or any sub-table of it
+# (e.g. ``[autonomy.schedules.target]``, ``[[autonomy.schedules.scope_grants]]``).
+_REGION_HEADER = re.compile(r"^\s*\[\[?autonomy\.(schedules|triggers)\b")
+_ANY_HEADER = re.compile(r"^\s*\[")
+
+
+def _rewrite_header(line: str) -> str:
+    """Strip the leading ``autonomy.`` from a schedules/triggers table header."""
+    return re.sub(r"(\[\[?)autonomy\.(schedules|triggers)", r"\1\2", line, count=1)
+
+
+def extract_blocks(text: str) -> tuple[str, str]:
+    """Split *text* into (remaining loom.toml, extracted registry).
+
+    A line belongs to the registry while we're inside a schedules/triggers
+    region. We enter on a region header and stay until a header that is *not*
+    part of a schedules/triggers table appears (or EOF). Trailing blank lines of
+    a region are left with the registry so loom.toml doesn't accrue dangling gaps.
+    """
+    remaining: list[str] = []
+    registry: list[str] = []
+    in_region = False
+
+    for line in text.splitlines(keepends=True):
+        is_header = bool(_ANY_HEADER.match(line))
+        if is_header:
+            in_region = bool(_REGION_HEADER.match(line))
+        if in_region:
+            registry.append(_rewrite_header(line) if is_header else line)
+        else:
+            remaining.append(line)
+
+    return "".join(remaining), "".join(registry)
+
+
+def migrate(loom_path: Path) -> int:
+    """Perform the migration. Returns the number of blocks moved (0 = no-op)."""
+    if not loom_path.exists():
+        print(f"error: {loom_path} not found", file=sys.stderr)
+        return -1
+
+    text = loom_path.read_text(encoding="utf-8")
+    remaining, registry = extract_blocks(text)
+
+    n_blocks = len(re.findall(r"^\s*\[\[autonomy\.(schedules|triggers)\]\]", text, re.M))
+    if n_blocks == 0:
+        print("nothing to migrate: no inline [[autonomy.schedules]]/[[autonomy.triggers]] blocks")
+        return 0
+
+    out_dir = loom_path.resolve().parent / "autonomy"
+    out_path = out_dir / "schedules.toml"
+    if out_path.exists():
+        print(
+            f"error: {out_path} already exists — refusing to overwrite. "
+            "Merge by hand or remove it first.",
+            file=sys.stderr,
+        )
+        return -1
+
+    header = (
+        "# Autonomy schedule registry — split out of loom.toml (issue #444).\n"
+        "# The master on/off switch ([autonomy] enabled) stays in loom.toml;\n"
+        "# only the work items live here. Agents edit THIS file, not loom.toml.\n"
+        "\n"
+    )
+
+    backup = loom_path.with_suffix(loom_path.suffix + ".bak")
+    backup.write_text(text, encoding="utf-8")
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(header + registry.lstrip("\n"), encoding="utf-8")
+    loom_path.write_text(remaining.rstrip("\n") + "\n", encoding="utf-8")
+
+    print(f"migrated {n_blocks} block(s) -> {out_path}")
+    print(f"backup written -> {backup}")
+    return n_blocks
+
+
+if __name__ == "__main__":
+    target = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("loom.toml")
+    raise SystemExit(0 if migrate(target) >= 0 else 1)

--- a/loom/autonomy/schedules.py
+++ b/loom/autonomy/schedules.py
@@ -1,0 +1,90 @@
+"""
+Schedule registry — the autonomy *work-item* data, split out of ``loom.toml``.
+
+Issue #444: ``[[autonomy.schedules]]`` / ``[[autonomy.triggers]]`` used to live
+inside ``loom.toml`` next to system config (cognition / memory / sandbox /
+harness). That put two very different things on one mutation surface: an agent
+editing a schedule (which it does routinely — it owns the schedule registry)
+could fat-finger a sandbox key and shift Loom's whole startup posture. The
+schedule registry now lives in its own ``autonomy/schedules.toml`` — same
+per-agent, cwd-relative, ``.example``-tracked convention as
+``autonomy/circadian/rhythm.toml``.
+
+The master on/off switch (``[autonomy] enabled``) deliberately *stays* in
+``loom.toml``: it's a system-posture decision, not a work item. Only the
+per-schedule entries move here.
+
+The reader is tolerant by contract (mirrors ``rhythm.load_rhythm``): a missing
+or malformed file yields empty arrays so the daemon still starts; a single bad
+entry is dropped individually, never failing the whole file. Per-entry
+*semantic* validation (chime target shape, trust-level coercion) stays in the
+daemon's builder — this module only guarantees "you get well-typed arrays of
+tables, or empty".
+"""
+
+from __future__ import annotations
+
+import logging
+import tomllib
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Workspace-relative, cwd-anchored — identical isolation model to
+# ``autonomy/circadian/rhythm.toml``: different agent = different workspace =
+# different registry, one daemon. The daemon resolves this against the
+# ``loom.toml`` directory so it survives being launched from elsewhere.
+DEFAULT_SCHEDULES_PATH = Path("autonomy/schedules.toml")
+
+_ARRAY_KEYS = ("schedules", "triggers")
+
+
+def load_schedules(path: Path | None = None) -> dict:
+    """Read the schedule registry, returning ``{"schedules": [...], "triggers": [...]}``.
+
+    Every failure mode the daemon should survive yields *empty* arrays: file
+    absent, unreadable bytes, invalid TOML. A top-level key that isn't a TOML
+    array is coerced to ``[]`` with a warning; non-table entries inside an array
+    are skipped individually so one typo never silences the rest of the file.
+    """
+    p = path or DEFAULT_SCHEDULES_PATH
+    if not p.exists():
+        logger.info(
+            "[autonomy] schedule registry not found at %s — daemon runs with no schedules",
+            p,
+        )
+        return {"schedules": [], "triggers": []}
+    try:
+        raw = tomllib.loads(p.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError, UnicodeDecodeError) as exc:
+        logger.warning(
+            "[autonomy] schedule registry at %s unreadable (%s); no schedules registered",
+            p,
+            exc,
+        )
+        return {"schedules": [], "triggers": []}
+
+    return {key: _coerce_array(raw, key) for key in _ARRAY_KEYS}
+
+
+def _coerce_array(raw: dict, key: str) -> list[dict]:
+    """Return ``raw[key]`` as a list of tables, dropping malformed entries."""
+    entries = raw.get(key)
+    if entries is None:
+        return []
+    if not isinstance(entries, list):
+        logger.warning(
+            "[autonomy] schedule registry: %r must be a TOML array of tables, got %s — ignoring",
+            key,
+            type(entries).__name__,
+        )
+        return []
+    out: list[dict] = []
+    for idx, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            logger.warning(
+                "[autonomy] schedule registry: %s[%d] is not a table; skipping", key, idx
+            )
+            continue
+        out.append(entry)
+    return out

--- a/loom/core/timezone.py
+++ b/loom/core/timezone.py
@@ -40,7 +40,7 @@ or ``user_zone()``)::
     them via the user-zone tools above, never raw
   - Forensics / dreaming / counter_factual / autonomy audit timestamps
   - Cron scheduling: ``CronTrigger.should_fire(datetime.now(UTC))``;
-    cron strings in ``loom.toml [[autonomy.schedules]]`` are always
+    cron strings in ``autonomy/schedules.toml`` ``[[schedules]]`` are always
     written in UTC, the operator hand-converts from local time. The
     per-schedule ``timezone`` field is currently a no-op — do not rely
     on it (tracked separately).

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -2339,7 +2339,7 @@ async def _autonomy_start(config: str, model: str, db: str, interval: int) -> No
     console.print(
         Panel(
             f"[bold loom.accent]Loom Autonomy Daemon[/bold loom.accent]\n"
-            f"Loaded [loom.success]{n}[/loom.success] trigger(s) from [loom.muted]{config}[/loom.muted]\n"
+            f"Loaded [loom.success]{n}[/loom.success] trigger(s) from [loom.muted]autonomy/schedules.toml[/loom.muted]\n"
             f"Poll interval: {interval}s  |  model: {model}\n"
             f"[loom.muted]Press Ctrl-C to stop.[/loom.muted]",
             border_style="cyan",
@@ -2358,7 +2358,7 @@ async def _autonomy_start(config: str, model: str, db: str, interval: int) -> No
 @autonomy.command("status")
 @click.option("--config", default="loom.toml", show_default=True)
 def autonomy_status(config: str) -> None:
-    """Show registered triggers from loom.toml."""
+    """Show registered triggers from autonomy/schedules.toml (gated by loom.toml [autonomy] enabled)."""
     from loom.autonomy.daemon import AutonomyDaemon
     from loom.notify.router import NotificationRouter
     from loom.notify.confirm import ConfirmFlow

--- a/tests/test_autonomy.py
+++ b/tests/test_autonomy.py
@@ -706,6 +706,55 @@ notify = true
         assert count == 1
         assert daemon.registered_triggers()[0]["kind"] == "event"
 
+    def test_bad_cron_schedule_skipped_siblings_still_load(self, tmp_path):
+        # Tolerance must hold at the daemon boundary too (#444 PR review P1):
+        # an invalid cron raises ValueError in CronTrigger — it must drop only
+        # that entry, not abort the load and strand later valid schedules.
+        config_file = self._write_config(
+            tmp_path,
+            schedules_toml="""
+[[schedules]]
+name = "before"
+cron = "0 9 * * 1-5"
+intent = "ok"
+
+[[schedules]]
+name = "bad_cron"
+cron = "not a cron"
+intent = "boom"
+
+[[schedules]]
+name = "after"
+cron = "0 2 * * 0"
+intent = "ok"
+""",
+        )
+        daemon = self._make_daemon()
+        count = daemon.load_config(config_file)
+        assert count == 2
+        names = {t["name"] for t in daemon.registered_triggers()}
+        assert names == {"before", "after"}
+
+    def test_trigger_missing_required_key_skipped(self, tmp_path):
+        # A trigger missing `name` raises KeyError — drop it, keep the sibling.
+        config_file = self._write_config(
+            tmp_path,
+            schedules_toml="""
+[[triggers]]
+event = "no_name_here"
+intent = "missing name"
+
+[[triggers]]
+name = "good"
+event = "fires"
+intent = "ok"
+""",
+        )
+        daemon = self._make_daemon()
+        count = daemon.load_config(config_file)
+        assert count == 1
+        assert daemon.registered_triggers()[0]["name"] == "good"
+
     @pytest.mark.asyncio
     async def test_execute_plan_safe_calls_agent(self):
         from loom.autonomy.daemon import AutonomyDaemon

--- a/tests/test_autonomy.py
+++ b/tests/test_autonomy.py
@@ -594,27 +594,43 @@ class TestAutonomyDaemonConfig:
         flow = ConfirmFlow(send_fn=send)
         return AutonomyDaemon(notify_router=router, confirm_flow=flow)
 
-    def test_load_config_enabled(self, tmp_path):
-        toml_content = """
-[autonomy]
-enabled = true
+    def _write_config(self, tmp_path, *, enabled=True, schedules_toml="", loom_extra=""):
+        """Write a loom.toml (master switch) + autonomy/schedules.toml (registry).
 
-[[autonomy.schedules]]
+        Mirrors the #444 split: the daemon reads ``[autonomy] enabled`` from
+        loom.toml and the actual schedules from the sibling registry file.
+        """
+        config_file = tmp_path / "loom.toml"
+        config_file.write_text(
+            f"[autonomy]\nenabled = {str(enabled).lower()}\n{loom_extra}",
+            encoding="utf-8",
+        )
+        if schedules_toml:
+            (tmp_path / "autonomy").mkdir(exist_ok=True)
+            (tmp_path / "autonomy" / "schedules.toml").write_text(
+                schedules_toml, encoding="utf-8"
+            )
+        return config_file
+
+    def test_load_config_enabled(self, tmp_path):
+        config_file = self._write_config(
+            tmp_path,
+            schedules_toml="""
+[[schedules]]
 name = "daily_review"
 cron = "0 9 * * 1-5"
 intent = "Review progress"
 trust_level = "guarded"
 notify = true
 
-[[autonomy.schedules]]
+[[schedules]]
 name = "weekly_prune"
 cron = "0 2 * * 0"
 intent = "Prune old memories"
 trust_level = "safe"
 notify = false
-"""
-        config_file = tmp_path / "loom.toml"
-        config_file.write_text(toml_content, encoding="utf-8")
+""",
+        )
 
         daemon = self._make_daemon()
         count = daemon.load_config(config_file)
@@ -625,17 +641,16 @@ notify = false
         assert names == {"daily_review", "weekly_prune"}
 
     def test_load_config_disabled_returns_zero(self, tmp_path):
-        toml_content = """
-[autonomy]
-enabled = false
-
-[[autonomy.schedules]]
+        config_file = self._write_config(
+            tmp_path,
+            enabled=False,
+            schedules_toml="""
+[[schedules]]
 name = "never_loaded"
 cron = "* * * * *"
 intent = "x"
-"""
-        config_file = tmp_path / "loom.toml"
-        config_file.write_text(toml_content, encoding="utf-8")
+""",
+        )
 
         daemon = self._make_daemon()
         count = daemon.load_config(config_file)
@@ -647,20 +662,44 @@ intent = "x"
         count = daemon.load_config(tmp_path / "nonexistent.toml")
         assert count == 0
 
-    def test_load_config_with_event_triggers(self, tmp_path):
-        toml_content = """
+    def test_load_config_missing_registry_returns_zero(self, tmp_path):
+        # Enabled in loom.toml but no autonomy/schedules.toml yet → no triggers,
+        # no crash (tolerant-by-contract loader).
+        config_file = self._write_config(tmp_path)
+        daemon = self._make_daemon()
+        assert daemon.load_config(config_file) == 0
+
+    def test_load_config_ignores_inline_schedules(self, tmp_path):
+        # Hard cut (#444): schedules left inline in loom.toml are NOT honoured.
+        config_file = tmp_path / "loom.toml"
+        config_file.write_text(
+            """
 [autonomy]
 enabled = true
 
-[[autonomy.triggers]]
+[[autonomy.schedules]]
+name = "stale_inline"
+cron = "* * * * *"
+intent = "should be ignored"
+""",
+            encoding="utf-8",
+        )
+        daemon = self._make_daemon()
+        assert daemon.load_config(config_file) == 0
+        assert daemon.registered_triggers() == []
+
+    def test_load_config_with_event_triggers(self, tmp_path):
+        config_file = self._write_config(
+            tmp_path,
+            schedules_toml="""
+[[triggers]]
 name = "on_error_spike"
 event = "error_rate_threshold"
 intent = "Analyse errors"
 trust_level = "guarded"
 notify = true
-"""
-        config_file = tmp_path / "loom.toml"
-        config_file.write_text(toml_content, encoding="utf-8")
+""",
+        )
 
         daemon = self._make_daemon()
         count = daemon.load_config(config_file)
@@ -863,19 +902,27 @@ class TestLoadConfigAttachOutputs:
         flow = ConfirmFlow(send_fn=send)
         return AutonomyDaemon(notify_router=router, confirm_flow=flow)
 
-    def test_schedule_attach_outputs_propagates_to_trigger(self, tmp_path):
-        toml_content = """
-[autonomy]
-enabled = true
+    def _write_registry(self, tmp_path, schedules_toml):
+        (tmp_path / "loom.toml").write_text(
+            "[autonomy]\nenabled = true\n", encoding="utf-8"
+        )
+        (tmp_path / "autonomy").mkdir(exist_ok=True)
+        (tmp_path / "autonomy" / "schedules.toml").write_text(
+            schedules_toml, encoding="utf-8"
+        )
+        return tmp_path / "loom.toml"
 
-[[autonomy.schedules]]
+    def test_schedule_attach_outputs_propagates_to_trigger(self, tmp_path):
+        config_file = self._write_registry(
+            tmp_path,
+            """
+[[schedules]]
 name = "morning_briefing"
 cron = "0 9 * * *"
 intent = "News roundup"
 attach_outputs = ["news/*.md", "reports/*.pdf"]
-"""
-        config_file = tmp_path / "loom.toml"
-        config_file.write_text(toml_content, encoding="utf-8")
+""",
+        )
 
         daemon = self._make_daemon()
         daemon.load_config(config_file)
@@ -884,18 +931,16 @@ attach_outputs = ["news/*.md", "reports/*.pdf"]
         assert trigger.attach_outputs == ["news/*.md", "reports/*.pdf"]
 
     def test_event_trigger_attach_outputs_propagates(self, tmp_path):
-        toml_content = """
-[autonomy]
-enabled = true
-
-[[autonomy.triggers]]
+        config_file = self._write_registry(
+            tmp_path,
+            """
+[[triggers]]
 name = "on_render_done"
 event = "render_complete"
 intent = "Upload renders"
 attach_outputs = ["renders/*.png"]
-"""
-        config_file = tmp_path / "loom.toml"
-        config_file.write_text(toml_content, encoding="utf-8")
+""",
+        )
 
         daemon = self._make_daemon()
         daemon.load_config(config_file)

--- a/tests/test_chime.py
+++ b/tests/test_chime.py
@@ -254,24 +254,29 @@ class TestChimeExecution:
 
 
 class TestChimeConfigLoading:
-    def test_loads_chime_schedule(self, tmp_path):
-        toml_content = """
-[autonomy]
-enabled = true
+    def _write(self, tmp_path, schedules_body):
+        """loom.toml master switch + autonomy/schedules.toml registry (#444)."""
+        cfg = tmp_path / "loom.toml"
+        cfg.write_text("[autonomy]\nenabled = true\n", encoding="utf-8")
+        (tmp_path / "autonomy").mkdir(exist_ok=True)
+        (tmp_path / "autonomy" / "schedules.toml").write_text(
+            schedules_body, encoding="utf-8"
+        )
+        return cfg
 
-[[autonomy.schedules]]
+    def test_loads_chime_schedule(self, tmp_path):
+        cfg = self._write(tmp_path, """
+[[schedules]]
 name = "morning_greeting"
 cron = "0 1 * * *"
 intent = "say hi"
 trust_level = "safe"
 mode = "chime"
 
-  [autonomy.schedules.target]
+  [schedules.target]
   type = "discord_thread"
   id = "12345"
-"""
-        cfg = tmp_path / "loom.toml"
-        cfg.write_text(toml_content, encoding="utf-8")
+""")
 
         daemon = _make_daemon()
         n = daemon.load_config(cfg)
@@ -286,21 +291,16 @@ mode = "chime"
         }
 
     def test_chime_without_target_id_is_skipped(self, tmp_path):
-        toml_content = """
-[autonomy]
-enabled = true
-
-[[autonomy.schedules]]
+        cfg = self._write(tmp_path, """
+[[schedules]]
 name = "broken"
 cron = "0 1 * * *"
 intent = "x"
 mode = "chime"
 
-  [autonomy.schedules.target]
+  [schedules.target]
   type = "discord_thread"
-"""
-        cfg = tmp_path / "loom.toml"
-        cfg.write_text(toml_content, encoding="utf-8")
+""")
 
         daemon = _make_daemon()
         # Missing id ⇒ schedule is dropped with a warning, not a crash.
@@ -308,44 +308,34 @@ mode = "chime"
         assert n == 0
 
     def test_chime_wrong_target_type_is_skipped(self, tmp_path):
-        toml_content = """
-[autonomy]
-enabled = true
-
-[[autonomy.schedules]]
+        cfg = self._write(tmp_path, """
+[[schedules]]
 name = "broken"
 cron = "0 1 * * *"
 intent = "x"
 mode = "chime"
 
-  [autonomy.schedules.target]
+  [schedules.target]
   type = "cli"
   id = "whatever"
-"""
-        cfg = tmp_path / "loom.toml"
-        cfg.write_text(toml_content, encoding="utf-8")
+""")
 
         daemon = _make_daemon()
         n = daemon.load_config(cfg)
         assert n == 0
 
     def test_integer_target_id_is_coerced_to_string(self, tmp_path):
-        toml_content = """
-[autonomy]
-enabled = true
-
-[[autonomy.schedules]]
+        cfg = self._write(tmp_path, """
+[[schedules]]
 name = "g"
 cron = "0 1 * * *"
 intent = "x"
 mode = "chime"
 
-  [autonomy.schedules.target]
+  [schedules.target]
   type = "discord_thread"
   id = 99999
-"""
-        cfg = tmp_path / "loom.toml"
-        cfg.write_text(toml_content, encoding="utf-8")
+""")
 
         daemon = _make_daemon()
         daemon.load_config(cfg)

--- a/tests/test_migrate_schedules.py
+++ b/tests/test_migrate_schedules.py
@@ -1,0 +1,131 @@
+"""
+Tests for the #444 schedule-migration script.
+
+The migration is a *text* transform, so the invariant under test is: the moved
+registry round-trips through tomllib to the same data the daemon would have read
+from the inline blocks, multi-line intents survive byte-for-byte, and the
+non-autonomy sections of loom.toml are left untouched.
+"""
+
+import tomllib
+
+from loom.autonomy.migrate_schedules import extract_blocks, migrate
+
+SAMPLE = '''\
+[cognition]
+model = "claude"
+
+[autonomy]
+enabled = true
+
+[autonomy.circadian]
+enabled = true
+
+[[autonomy.schedules]]
+name = "morning_briefing"
+cron = "0 1 * * *"
+intent = """
+Line one.
+
+  Indented line — must survive verbatim.
+"""
+trust_level = "safe"
+mode = "chime"
+allowed_tools = ["write_file"]
+
+  [autonomy.schedules.target]
+  type = "discord_thread"
+  id = "123456789"
+  fallback = "skip"
+
+[[autonomy.schedules]]
+name = "daily_journal"
+cron = "30 15 * * *"
+intent = "Write today's journal."
+trust_level = "safe"
+
+[[autonomy.triggers]]
+name = "on_error"
+event = "error_spike"
+intent = "Investigate."
+'''
+
+
+def test_extract_preserves_non_autonomy_sections():
+    remaining, _ = extract_blocks(SAMPLE)
+    parsed = tomllib.loads(remaining)
+    assert parsed["cognition"]["model"] == "claude"
+    assert parsed["autonomy"]["enabled"] is True
+    assert parsed["autonomy"]["circadian"]["enabled"] is True
+    # The inline schedule arrays must be gone from loom.toml.
+    assert "schedules" not in parsed.get("autonomy", {})
+    assert "triggers" not in parsed.get("autonomy", {})
+
+
+def test_extract_rewrites_headers_to_registry_form():
+    _, registry = extract_blocks(SAMPLE)
+    parsed = tomllib.loads(registry)
+    assert [s["name"] for s in parsed["schedules"]] == [
+        "morning_briefing",
+        "daily_journal",
+    ]
+    assert parsed["triggers"][0]["event"] == "error_spike"
+    # Nested target sub-table rewritten and still bound to its parent block.
+    assert parsed["schedules"][0]["target"]["id"] == "123456789"
+
+
+def test_multiline_intent_survives_verbatim():
+    _, registry = extract_blocks(SAMPLE)
+    parsed = tomllib.loads(registry)
+    intent = parsed["schedules"][0]["intent"]
+    assert "Indented line — must survive verbatim." in intent
+    assert intent.count("\n") >= 3
+
+
+def test_migrate_end_to_end(tmp_path):
+    loom = tmp_path / "loom.toml"
+    loom.write_text(SAMPLE, encoding="utf-8")
+
+    n = migrate(loom)
+    assert n == 3
+
+    registry = tmp_path / "autonomy" / "schedules.toml"
+    assert registry.exists()
+    parsed = tomllib.loads(registry.read_text(encoding="utf-8"))
+    assert len(parsed["schedules"]) == 2
+    assert len(parsed["triggers"]) == 1
+
+    # loom.toml still valid, autonomy master switch intact, inline blocks gone.
+    loom_parsed = tomllib.loads(loom.read_text(encoding="utf-8"))
+    assert loom_parsed["autonomy"]["enabled"] is True
+    assert "schedules" not in loom_parsed["autonomy"]
+
+    # Backup captured the pre-migration file.
+    assert (tmp_path / "loom.toml.bak").exists()
+
+
+def test_migrate_second_run_is_noop(tmp_path):
+    loom = tmp_path / "loom.toml"
+    loom.write_text(SAMPLE, encoding="utf-8")
+    assert migrate(loom) == 3
+    # loom.toml is now clean → second run finds nothing to move (no-op).
+    assert migrate(loom) == 0
+
+
+def test_migrate_refuses_to_clobber_existing_registry(tmp_path):
+    # Registry already present AND loom.toml still has inline blocks (e.g. a
+    # half-finished migration): refuse rather than overwrite the registry.
+    loom = tmp_path / "loom.toml"
+    loom.write_text(SAMPLE, encoding="utf-8")
+    (tmp_path / "autonomy").mkdir()
+    (tmp_path / "autonomy" / "schedules.toml").write_text("# pre-existing\n", encoding="utf-8")
+    assert migrate(loom) == -1
+    # loom.toml left untouched (still has its inline blocks).
+    assert "[[autonomy.schedules]]" in loom.read_text(encoding="utf-8")
+
+
+def test_migrate_noop_when_no_inline_blocks(tmp_path):
+    loom = tmp_path / "loom.toml"
+    loom.write_text("[autonomy]\nenabled = true\n", encoding="utf-8")
+    assert migrate(loom) == 0
+    assert not (tmp_path / "autonomy" / "schedules.toml").exists()

--- a/tests/test_schedules_config.py
+++ b/tests/test_schedules_config.py
@@ -1,0 +1,110 @@
+"""
+Contract tests for the autonomy schedule registry loader (issue #444).
+
+The loader is the seam between ``loom.toml`` (system posture) and
+``autonomy/schedules.toml`` (work items). Its lifeline invariant: it must never
+raise — every failure mode the daemon should survive degrades to empty arrays,
+and a single bad entry is dropped individually rather than failing the file.
+"""
+
+from pathlib import Path
+
+from loom.autonomy.schedules import (
+    DEFAULT_SCHEDULES_PATH,
+    load_schedules,
+)
+
+
+def test_missing_file_returns_empty_arrays(tmp_path):
+    got = load_schedules(tmp_path / "schedules.toml")
+    assert got == {"schedules": [], "triggers": []}
+
+
+def test_default_path_is_workspace_relative():
+    # Same isolation model as the circadian rhythm table: cwd-anchored.
+    assert DEFAULT_SCHEDULES_PATH == Path("autonomy/schedules.toml")
+
+
+def test_parses_schedules_and_triggers(tmp_path):
+    f = tmp_path / "schedules.toml"
+    f.write_text(
+        """
+[[schedules]]
+name = "daily_review"
+cron = "0 9 * * 1-5"
+intent = "Review progress"
+trust_level = "guarded"
+
+[[schedules]]
+name = "weekly_prune"
+cron = "0 2 * * 0"
+intent = "Prune"
+trust_level = "safe"
+
+[[triggers]]
+name = "on_error_spike"
+event = "error_rate_threshold"
+intent = "Analyse errors"
+""",
+        encoding="utf-8",
+    )
+    got = load_schedules(f)
+    assert [s["name"] for s in got["schedules"]] == ["daily_review", "weekly_prune"]
+    assert got["triggers"][0]["event"] == "error_rate_threshold"
+
+
+def test_nested_target_table_preserved(tmp_path):
+    # chime schedules carry a [schedules.target] sub-table — must survive intact.
+    f = tmp_path / "schedules.toml"
+    f.write_text(
+        """
+[[schedules]]
+name = "morning_briefing"
+cron = "0 1 * * *"
+intent = "briefing"
+mode = "chime"
+
+  [schedules.target]
+  type = "discord_thread"
+  id = "1505984613351428196"
+  fallback = "skip"
+""",
+        encoding="utf-8",
+    )
+    got = load_schedules(f)
+    target = got["schedules"][0]["target"]
+    assert target["type"] == "discord_thread"
+    assert target["id"] == "1505984613351428196"
+
+
+def test_invalid_toml_returns_empty(tmp_path):
+    f = tmp_path / "schedules.toml"
+    f.write_text("this is = = not valid toml [[[", encoding="utf-8")
+    assert load_schedules(f) == {"schedules": [], "triggers": []}
+
+
+def test_non_array_key_coerced_to_empty(tmp_path):
+    f = tmp_path / "schedules.toml"
+    f.write_text('schedules = "oops not an array"\n', encoding="utf-8")
+    got = load_schedules(f)
+    assert got["schedules"] == []
+    assert got["triggers"] == []
+
+
+def test_non_table_entry_skipped_individually(tmp_path):
+    # A stray scalar in the array must not nuke the valid sibling entries.
+    # (array-of-tables can't mix scalars in TOML syntax, so build via a raw
+    # inline array to exercise the per-entry guard.)
+    f = tmp_path / "schedules.toml"
+    f.write_text(
+        'schedules = [ { name = "ok", cron = "* * * * *", intent = "x" }, "bogus" ]\n',
+        encoding="utf-8",
+    )
+    got = load_schedules(f)
+    assert [s["name"] for s in got["schedules"]] == ["ok"]
+
+
+def test_empty_file_returns_empty_arrays(tmp_path):
+    f = tmp_path / "schedules.toml"
+    f.write_text("", encoding="utf-8")
+    assert load_schedules(f) == {"schedules": [], "triggers": []}


### PR DESCRIPTION
Closes #444.

## Why

Autonomy schedules/triggers lived inside `loom.toml` next to system config (cognition / memory / sandbox / harness), putting two very different things on one mutation surface. An agent editing a schedule — which it does routinely, it *owns* the schedule registry — could fat-finger a sandbox key and shift Loom's whole startup posture.

## What

Split the work-item registry out into its own **`autonomy/schedules.toml`**, mirroring the existing circadian `rhythm.toml` convention (gitignored personal file + tracked `.example`). The master on/off switch (`[autonomy] enabled`) deliberately stays in `loom.toml` — it's a system-posture decision, not a work item.

- **`loom/autonomy/schedules.py`** — `load_schedules()`, tolerant by contract (missing/malformed file → empty arrays; one bad entry dropped individually, never fails the whole file). Same shape as `rhythm.load_rhythm`.
- **`daemon.load_config` (hard cut)** — reads `enabled` from `loom.toml`, schedules from the sibling registry resolved against the loom.toml dir. Inline `[[autonomy.schedules]]` left in `loom.toml` are **ignored with a warning** pointing at the migrator.
- **#91 tamper-detection re-pointed** at the registry — that's now the agent-writable surface — `~/.loom/schedules.hash`.
- **`python -m loom.autonomy.migrate_schedules`** — verbatim text-block mover (preserves the giant multi-line `intent` strings byte-for-byte), backs up `loom.toml` → `loom.toml.bak`, refuses to clobber an existing registry, no-op when there's nothing to move.
- **`autonomy/schedules.example.toml`** (tracked) + updated example profiles + `.gitignore`.

## Design decisions (per issue's open questions)

| Question | Decision |
|----------|----------|
| File location | `autonomy/schedules.toml` — reuses the existing `autonomy/` folder where circadian config already lives |
| Backward compat | **Hard cut** + migration script; inline blocks ignored with a warning |
| git-tracking | Personal registry gitignored, `.example` tracked (same as `rhythm.toml`) |
| `enabled` flag | Master `[autonomy] enabled` stays in `loom.toml`; per-schedule entries move |
| CLI add/list/remove | **Out of scope by request** — agents edit the registry file directly |

## Tests

- `test_schedules_config.py` — loader contract (missing/invalid/non-array/non-table/nested-target)
- `test_migrate_schedules.py` — migration invariants (verbatim intents, header rewrite, idempotency, no-clobber)
- `test_autonomy.py` / `test_chime.py` — existing `load_config` + chime tests moved to the registry format; added a hard-cut "inline ignored" test

Full suite green: **2469 passed, 4 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)