### PR TITLE
feat(cli): add braille animation language

### DIFF
--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -54,7 +54,11 @@ from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.styles import Style
 
 from loom.platform.cli.theme import active_palette
-from loom.platform.cli.ui import SLASH_COMMANDS, SlashCompleter
+from loom.platform.cli.ui import (
+    SLASH_COMMANDS,
+    SlashCompleter,
+    cli_animation_frame,
+)
 from loom.platform.interaction_language import LivenessSensor
 
 _CLI_PALETTE = active_palette()
@@ -769,8 +773,9 @@ class LoomApp:
         # If compacting: replace the middle area with the spinner
         # message so the user doesn't think the agent has hung
         if s.compacting:
+            frame = cli_animation_frame("cascade_drop", int(monotonic() * 2))
             parts.append(("class:footer", "  "))
-            parts.append(("class:footer.compaction", "⚡ 壓縮中…"))
+            parts.append(("class:footer.compaction", f"{frame} ⚡ 壓縮中…"))
             return FormattedText(parts)
 
         # Context % — always visible. Colour ladder: muted under 60%,
@@ -817,6 +822,7 @@ class LoomApp:
             from loom.platform.interaction_language import format_elapsed
 
             now = _t.monotonic()
+            frame_index = int(now * 2)
             elapsed = max(0.0, now - s.heartbeat_started_monotonic)
             # The stall DECISION delegates to the shared sensor's
             # non-latching ``is_stalled`` (threshold + observation timeline).
@@ -844,6 +850,15 @@ class LoomApp:
             if s.heartbeat_subject:
                 label += f" · {s.heartbeat_subject}"
             label += f" · {format_elapsed(elapsed)}"
+            if not stalled and s.heartbeat_state != "paused_blocking":
+                if s.heartbeat_state == "thinking":
+                    animation = "breathing_focus"
+                elif s.heartbeat_state == "long_tooling":
+                    animation = "rising_columns"
+                    frame_index //= 2
+                else:
+                    animation = "classic_spinner"
+                label = f"{cli_animation_frame(animation, frame_index)} {label}"
             parts.append(("class:footer", "  "))
             style = "class:footer.budget.warn" if stalled else "class:footer.envelope"
             parts.append((style, label))
@@ -935,6 +950,14 @@ class LoomApp:
             ("", "\n"),
             ("class:tasklist.title", f" 📋 task list  {done}/{total}\n"),
         ]
+        tasklist_animated = (
+            self.footer.heartbeat_state
+            and self.footer.heartbeat_state not in ("idle", "paused_blocking", "stalled")
+        )
+        active_frame = (
+            cli_animation_frame("breathing_focus", int(monotonic() * 2))
+            if tasklist_animated else "▸"
+        )
         for t in todos:
             status = (t.get("status") or "pending").lower()
             content = (t.get("content") or "").strip()
@@ -943,7 +966,7 @@ class LoomApp:
             if status == "completed":
                 glyph, cls = "✓", "class:tasklist.done"
             elif status == "in_progress":
-                glyph, cls = "▸", "class:tasklist.active"
+                glyph, cls = active_frame, "class:tasklist.active"
             else:
                 glyph, cls = "○", "class:tasklist.pending"
             parts.append((cls, f"   {glyph} {content}\n"))

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -1208,7 +1208,7 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
         nonlocal frame_index
         clear_line()
         console.print(tool_running_line(active_tool or "", frame_index), end="")
-        frame_index = (frame_index + 1) % 4
+        frame_index += 1
 
     async def _spin_loop() -> None:
         """Background task: animate spinner while tool is running."""

--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -573,8 +573,25 @@ def response_panel(
     )
 
 
-# ASCII spinner frames (cp950 safe, Rich-markup safe — no backslash)
-_SPINNER_FRAMES = ["-", "~", "|", "+"]
+# Unicode Braille animation frames. Loom's live CLI surface already assumes a
+# UTF-8 terminal; keep these frames one terminal cell wide so running rows and
+# footer labels do not jitter.
+_ANIMATION_FRAMES: dict[str, tuple[str, ...]] = {
+    "classic_spinner": (
+        "⠋", "⠙", "⠹", "⠸", "⠼",
+        "⠴", "⠦", "⠧", "⠇", "⠏",
+    ),
+    "breathing_focus": ("⠂", "⠆", "⠇", "⠿", "⠇", "⠆"),
+    "cascade_drop": ("⠁", "⠂", "⠄", "⡀", "⢀", "⠠", "⠐", "⠈"),
+    "rising_columns": ("⣀", "⣤", "⣶", "⣿", "⣶", "⣤"),
+}
+_SPINNER_FRAMES = _ANIMATION_FRAMES["classic_spinner"]
+
+
+def cli_animation_frame(name: str, frame_index: int) -> str:
+    """Return one Braille animation frame by stable animation name."""
+    frames = _ANIMATION_FRAMES.get(name, _SPINNER_FRAMES)
+    return frames[frame_index % len(frames)]
 
 def tool_spinner_line(
     name: str,
@@ -583,17 +600,16 @@ def tool_spinner_line(
     width: int | None = None,
 ) -> Text:
     """
-    Rich Text for a tool-call-in-progress line with ASCII spinner.
-    Frame index 0 shows [- ], 1 shows [\\ ], etc.
+    Rich Text for a tool-call-in-progress line with Braille spinner.
 
     When ``width`` is given and the rendered line would overflow it,
     the args body wraps with a hanging indent so continuation lines
     align under the tool name instead of restarting at column 0.
     """
-    spinner = _SPINNER_FRAMES[frame_index % len(_SPINNER_FRAMES)]
+    spinner = cli_animation_frame("classic_spinner", frame_index)
     args_preview = _format_args(args)
     body_plain = f"{name}{f'({args_preview})' if args_preview else ''}"
-    prefix_visual = "  [-] "  # 6 cells; spinner glyph is always 1 wide
+    prefix_visual = "  [·] "  # 6 cells; spinner glyph is always 1 wide
     indent = " " * len(prefix_visual)
 
     out = Text()
@@ -664,12 +680,12 @@ def tool_begin_line(
     justification = _smart_truncate(justification, 80)
     args_preview = _format_args(display_args)
     body_plain = f"{name}{f'({args_preview})' if args_preview else ''}"
-    prefix_visual = "  [-] "
+    prefix_visual = "  [·] "
     indent = " " * len(prefix_visual)
 
     out = Text()
     out.append("  [", style="loom.muted")
-    out.append("-", style="loom.warning")
+    out.append(cli_animation_frame("classic_spinner", 0), style="loom.warning")
     out.append("] ", style="loom.muted")
     out.append(justification, style="loom.text")
     out.append("\n")
@@ -701,7 +717,7 @@ def tool_running_line(name: str, frame_index: int = 0) -> Text:
     Rich Text for a tool that is currently executing.
     Shows animated spinner without args (args already shown at begin).
     """
-    spinner = _SPINNER_FRAMES[frame_index % len(_SPINNER_FRAMES)]
+    spinner = cli_animation_frame("classic_spinner", frame_index)
     return Text.from_markup(
         f"  [loom.muted][[/loom.muted][loom.warning]{spinner}[/loom.warning][loom.muted]][/loom.muted] "
         f"[loom.muted]{name} running...[/loom.muted]"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -29,6 +29,7 @@ import pytest
 from prompt_toolkit.history import InMemoryHistory
 
 from loom.core.events import TextChunk, TurnDropped
+from loom.platform.cli import app as cli_app_module
 from loom.platform.cli import main as cli_main
 from loom.platform.cli.app import (
     FooterState,
@@ -569,6 +570,24 @@ class TestTaskListPanel:
         assert "✓ first" in text
         assert "▸ second" in text
         assert "○ third" in text
+
+    def test_in_progress_row_breathes_only_while_heartbeat_active(
+        self, app: LoomApp, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(cli_app_module, "monotonic", lambda: 0.0)
+        app.update_tasklist([
+            {"id": "a", "content": "active", "status": "in_progress"},
+        ])
+
+        idle_text = _flat_text(app._render_tasklist())
+        assert "▸ active" in idle_text
+
+        app.start_heartbeat(
+            state=HeartbeatState.THINKING.value,
+            label="Loom is thinking",
+        )
+        active_text = _flat_text(app._render_tasklist())
+        assert "⠂ active" in active_text
 
     def test_all_completed_collapses_to_one_liner(self, app: LoomApp) -> None:
         app.update_tasklist([

--- a/tests/test_cache_display.py
+++ b/tests/test_cache_display.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from loom.core.events import TurnDone
 from loom.core.cognition.providers import LLMResponse
-from loom.platform.cli.ui import status_bar
+from loom.platform.cli.ui import cli_animation_frame, status_bar, tool_running_line
 
 
 # ── TurnDone dataclass ──────────────────────────────────────────────────────
@@ -129,3 +129,17 @@ class TestStatusBarSegments:
         s = status_bar(0.5, 100, 50, 1234.0, 2).plain
         assert "context" in s
         assert "100in / 50out" in s
+
+
+class TestCLIAnimationFrames:
+    def test_known_animation_wraps_frames(self):
+        first = cli_animation_frame("classic_spinner", 0)
+        wrapped = cli_animation_frame("classic_spinner", 10)
+        assert first == "⠋"
+        assert wrapped == first
+
+    def test_unknown_animation_falls_back_to_classic_spinner(self):
+        assert cli_animation_frame("not-a-real-animation", 0) == "⠋"
+
+    def test_tool_running_line_uses_braille_spinner(self):
+        assert "[⠋] pytest running..." in tool_running_line("pytest", 0).plain


### PR DESCRIPTION
## Summary
- add a shared Braille animation frame registry for CLI render surfaces
- use Classic Spinner for running tool rows, Breathing Focus for active TaskList rows, Cascade Drop for compaction, and state-specific heartbeat frames
- keep stalled/paused/completed surfaces static so animation only means active work

## Verification
- `pytest -q tests/test_app.py tests/test_cache_display.py tests/test_transient_footer_hints.py tests/test_interaction_language.py` — 101 passed
- `pytest -q tests/test_app.py tests/test_cache_display.py tests/test_transient_footer_hints.py` — 66 passed
- `python -m py_compile loom/platform/cli/app.py loom/platform/cli/ui.py`
- `git diff --check`
- `npx gitnexus detect-changes --scope staged` — risk low, affected processes 0