### PR TITLE
feat(cli): action-family animations with per-call variant rotation

### DIFF
--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -83,10 +83,6 @@ Mode = Literal["input", "confirm", "pause", "redirect"]
 # to override instantly, which feels like a clean "replaced" transition.
 _HEARTBEAT_MIN_DWELL_S = 1.0
 
-# Pulse/breathing-style loops read better at a gentler cadence; every other
-# animation gets the snappy spinner fps. Names refer to ``ui._ANIMATION_FRAMES``.
-_GENTLE_ANIMATIONS = frozenset({"breathing_focus", "dots_grow"})
-
 
 # ---------------------------------------------------------------------------
 # Footer state
@@ -901,10 +897,11 @@ class LoomApp:
                 # family); here we only advance its frame. Frame index is
                 # sampled from wall-clock so the loop runs smoothly as long
                 # as the footer_ticker invalidates at ≥2× the fps (it runs
-                # ~20 Hz while a heartbeat is live). Pulse-style loops read
-                # better slower; everything else gets a snappy spinner fps.
+                # ~20 Hz while a heartbeat is live). Cadence travels with the
+                # family (pulse-style families read slower) — see family_fps.
+                from loom.platform.interaction_language import family_fps
                 animation = s.heartbeat_animation or "classic_spinner"
-                fps = 6.0 if animation in _GENTLE_ANIMATIONS else 10.0
+                fps = family_fps(s.heartbeat_family)
                 label = f"{cli_animation_frame(animation, int(now * fps))} {label}"
             parts.append(("class:footer", "  "))
             style = "class:footer.budget.warn" if stalled else "class:footer.envelope"

--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -83,6 +83,10 @@ Mode = Literal["input", "confirm", "pause", "redirect"]
 # to override instantly, which feels like a clean "replaced" transition.
 _HEARTBEAT_MIN_DWELL_S = 1.0
 
+# Pulse/breathing-style loops read better at a gentler cadence; every other
+# animation gets the snappy spinner fps. Names refer to ``ui._ANIMATION_FRAMES``.
+_GENTLE_ANIMATIONS = frozenset({"breathing_focus", "dots_grow"})
+
 
 # ---------------------------------------------------------------------------
 # Footer state
@@ -131,6 +135,13 @@ class FooterState:
     heartbeat_state: str = "idle"
     heartbeat_label: str = ""
     heartbeat_subject: str = ""
+    # Animation identity for this beat. ``heartbeat_family`` is the action
+    # family (think / probe / write / execute / tidy / tool);
+    # ``heartbeat_animation`` is the specific variant picked from that
+    # family's pool at start (held for the beat's duration so only the
+    # frame advances, not the variant). Empty when no animated beat.
+    heartbeat_family: str = ""
+    heartbeat_animation: str = ""
     heartbeat_started_monotonic: float = 0.0
     heartbeat_last_event_monotonic: float = 0.0
     heartbeat_stale_after_s: float = 30.0
@@ -300,6 +311,9 @@ class LoomApp:
 
         # Footer state
         self.footer = FooterState()
+        # Monotonic counter advancing one step per animated heartbeat, used
+        # to rotate variants within an action family for visual freshness.
+        self._anim_rotation = 0
 
         # Runtime-liveness sensor (#418/#419) — shared stall-DECISION logic
         # with the Discord watchdog (#422). The footer owns the CLI
@@ -368,11 +382,25 @@ class LoomApp:
         label: str,
         subject: str = "",
         stale_after_s: float = 30.0,
+        family: str | None = None,
     ) -> None:
         now = monotonic()
         self.footer.heartbeat_state = state
         self.footer.heartbeat_label = label
         self.footer.heartbeat_subject = subject
+        # Pick the animation variant for this beat. Within a family the
+        # pool rotates per call (the global counter advances every beat
+        # that names a family), so consecutive same-family actions don't
+        # look identical, while the family-level "feel" stays recognisable.
+        if family:
+            from loom.platform.interaction_language import family_variants
+            pool = family_variants(family)
+            self.footer.heartbeat_family = family
+            self.footer.heartbeat_animation = pool[self._anim_rotation % len(pool)]
+            self._anim_rotation += 1
+        else:
+            self.footer.heartbeat_family = ""
+            self.footer.heartbeat_animation = ""
         self.footer.heartbeat_started_monotonic = now
         self.footer.heartbeat_last_event_monotonic = now
         self.footer.heartbeat_stale_after_s = stale_after_s
@@ -392,6 +420,22 @@ class LoomApp:
         if self.footer.heartbeat_state != "idle":
             self.footer.heartbeat_last_event_monotonic = monotonic()
             self.invalidate()
+
+    def linger_heartbeat(self, seconds: float) -> None:
+        """Re-arm the min-dwell window from *now*.
+
+        Confirm-gated writes (write_file / edit_file) burn the original
+        dwell — armed at ``start_heartbeat`` on ToolBegin — while the user
+        reads the diff, so the actual write completes instantly and a plain
+        ``stop_heartbeat`` at ToolEnd would clear the label before the eye
+        registers it. Calling this just before the stop holds the
+        pen-stroke beat open for ``seconds`` so "wrote X" stays legible.
+
+        No-op when idle — there is nothing to hold open.
+        """
+        if self.footer.heartbeat_state == "idle":
+            return
+        self.footer.heartbeat_min_alive_until = monotonic() + seconds
 
     def stop_heartbeat(self, *, force: bool = False) -> None:
         """Clear the heartbeat. By default respects ``_HEARTBEAT_MIN_DWELL_S``
@@ -414,6 +458,8 @@ class LoomApp:
         self.footer.heartbeat_state = "idle"
         self.footer.heartbeat_label = ""
         self.footer.heartbeat_subject = ""
+        self.footer.heartbeat_family = ""
+        self.footer.heartbeat_animation = ""
         self.footer.heartbeat_started_monotonic = 0.0
         self.footer.heartbeat_last_event_monotonic = 0.0
         self.footer.heartbeat_min_alive_until = 0.0
@@ -773,7 +819,7 @@ class LoomApp:
         # If compacting: replace the middle area with the spinner
         # message so the user doesn't think the agent has hung
         if s.compacting:
-            frame = cli_animation_frame("cascade_drop", int(monotonic() * 2))
+            frame = cli_animation_frame("cascade_drop", int(monotonic() * 8))
             parts.append(("class:footer", "  "))
             parts.append(("class:footer.compaction", f"{frame} ⚡ 壓縮中…"))
             return FormattedText(parts)
@@ -822,7 +868,6 @@ class LoomApp:
             from loom.platform.interaction_language import format_elapsed
 
             now = _t.monotonic()
-            frame_index = int(now * 2)
             elapsed = max(0.0, now - s.heartbeat_started_monotonic)
             # The stall DECISION delegates to the shared sensor's
             # non-latching ``is_stalled`` (threshold + observation timeline).
@@ -851,14 +896,16 @@ class LoomApp:
                 label += f" · {s.heartbeat_subject}"
             label += f" · {format_elapsed(elapsed)}"
             if not stalled and s.heartbeat_state != "paused_blocking":
-                if s.heartbeat_state == "thinking":
-                    animation = "breathing_focus"
-                elif s.heartbeat_state == "long_tooling":
-                    animation = "rising_columns"
-                    frame_index //= 2
-                else:
-                    animation = "classic_spinner"
-                label = f"{cli_animation_frame(animation, frame_index)} {label}"
+                # Animation variant was picked per-call into
+                # ``heartbeat_animation`` (rotated within the action
+                # family); here we only advance its frame. Frame index is
+                # sampled from wall-clock so the loop runs smoothly as long
+                # as the footer_ticker invalidates at ≥2× the fps (it runs
+                # ~20 Hz while a heartbeat is live). Pulse-style loops read
+                # better slower; everything else gets a snappy spinner fps.
+                animation = s.heartbeat_animation or "classic_spinner"
+                fps = 6.0 if animation in _GENTLE_ANIMATIONS else 10.0
+                label = f"{cli_animation_frame(animation, int(now * fps))} {label}"
             parts.append(("class:footer", "  "))
             style = "class:footer.budget.warn" if stalled else "class:footer.envelope"
             parts.append((style, label))
@@ -955,7 +1002,7 @@ class LoomApp:
             and self.footer.heartbeat_state not in ("idle", "paused_blocking", "stalled")
         )
         active_frame = (
-            cli_animation_frame("breathing_focus", int(monotonic() * 2))
+            cli_animation_frame("breathing_focus", int(monotonic() * 6))
             if tasklist_animated else "▸"
         )
         for t in todos:

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -572,11 +572,12 @@ async def _chat(
             # _run_streaming_turn transition it to TOOLING / PAUSED /
             # back to idle. If the turn crashes / aborts before any
             # event lands, the finally below still returns to idle.
-            from loom.platform.interaction_language import HeartbeatState
+            from loom.platform.interaction_language import ActionFamily, HeartbeatState
             app.start_heartbeat(
                 state=HeartbeatState.THINKING.value,
                 label="Loom is thinking",
                 stale_after_s=30.0,
+                family=ActionFamily.THINK.value,
             )
             current_turn_task = asyncio.create_task(
                 _run_streaming_turn(session, text)
@@ -623,18 +624,24 @@ async def _chat(
             app.invalidate()
 
     async def footer_ticker() -> None:
-        """Tick the footer at 2 Hz so live fields (heartbeat elapsed,
-        compaction spinner, transient hint expiry — #284) progress
-        visibly. Also promotes deferred heartbeat stops once the
-        min-dwell window elapses so short-lived tool labels finish
-        their reading time before fading."""
+        """Drive the footer's live fields (heartbeat elapsed, braille
+        animations, compaction spinner, transient hint expiry — #284) and
+        promote deferred heartbeat stops once the min-dwell elapses.
+
+        Cadence is adaptive: ~20 Hz while something is animating so the
+        braille loops (8–10 fps) render smoothly — sampling at <2× the fps
+        is what made the old fixed 2 Hz tick visibly choppy — and a lazy
+        2 Hz when idle so a quiet prompt isn't waking the loop 20×/s."""
         while not shutdown.is_set():
             app.maybe_finalize_pending_stop()
-            if (app.footer.heartbeat_state != "idle"
-                    or app.footer.compacting
-                    or app.footer.transient_hint is not None):
+            animating = (
+                app.footer.heartbeat_state != "idle"
+                or app.footer.compacting
+                or app.footer.transient_hint is not None
+            )
+            if animating:
                 app.invalidate()
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(0.05 if animating else 0.5)
 
     # patch_stdout makes console.print flow above the app's persistent
     # bottom region. raw=True passes escape sequences through so the
@@ -1158,14 +1165,13 @@ async def _handle_slash(cmd: str, session: "LoomSession") -> None:
 
 
 def _start_tool_heartbeat(loom_app: Any, name: str, args: dict[str, Any]) -> None:
-    """Resolve action-language label for ``name`` + ``args`` and push it
-    into the footer heartbeat as TOOLING. Stale threshold falls out of
-    ``resolve_tool_action`` (long-runners get 90s; everything else 30s).
+    """Resolve action-language label + animation family for ``name`` +
+    ``args`` and push it into the footer heartbeat as TOOLING. Stale
+    threshold falls out of ``resolve_tool_action`` (long-runners get 90s;
+    everything else 30s). The family (probe / write / execute / …) picks
+    which animation the footer rotates to for this call.
     """
-    from loom.platform.interaction_language import (
-        HeartbeatState,
-        resolve_tool_action,
-    )
+    from loom.platform.interaction_language import HeartbeatState, resolve_tool_action
 
     action = resolve_tool_action(name, args)
     loom_app.start_heartbeat(
@@ -1173,6 +1179,7 @@ def _start_tool_heartbeat(loom_app: Any, name: str, args: dict[str, Any]) -> Non
         label=action.label,
         subject=action.subject,
         stale_after_s=action.stale_after_s,
+        family=action.family,
     )
 
 
@@ -1588,6 +1595,14 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 loom_app = getattr(session, "_loom_app", None)
                 if loom_app is not None:
                     loom_app.touch_heartbeat()
+                    # Confirm-gated writes burn the dwell while the user
+                    # reads the diff, so the actual write finishes
+                    # instantly and the pen-stroke beat would never show.
+                    # Re-arm the dwell at apply time so "wrote X" lingers.
+                    from loom.platform.interaction_language import ActionFamily
+                    from loom.platform.cli.app import _HEARTBEAT_MIN_DWELL_S
+                    if loom_app.footer.heartbeat_family == ActionFamily.WRITE.value:
+                        loom_app.linger_heartbeat(_HEARTBEAT_MIN_DWELL_S)
                     loom_app.stop_heartbeat()
 
             elif isinstance(event, TurnPaused):

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -1214,7 +1214,18 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
     def _print_spinner() -> None:
         nonlocal frame_index
         clear_line()
-        console.print(tool_running_line(active_tool or "", frame_index), end="")
+        # Match the footer's resolved family variant so the inline running
+        # line animates in the same language as the heartbeat (probe scans,
+        # write strokes, …); fall back to the classic spinner if no app.
+        _la = getattr(session, "_loom_app", None)
+        animation = (
+            (_la.footer.heartbeat_animation or "classic_spinner")
+            if _la is not None else "classic_spinner"
+        )
+        console.print(
+            tool_running_line(active_tool or "", frame_index, animation=animation),
+            end="",
+        )
         frame_index += 1
 
     async def _spin_loop() -> None:
@@ -1595,10 +1606,14 @@ async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:
                 loom_app = getattr(session, "_loom_app", None)
                 if loom_app is not None:
                     loom_app.touch_heartbeat()
-                    # Confirm-gated writes burn the dwell while the user
-                    # reads the diff, so the actual write finishes
-                    # instantly and the pen-stroke beat would never show.
-                    # Re-arm the dwell at apply time so "wrote X" lingers.
+                    # This fires at ToolEnd — i.e. right after the write
+                    # applied. Confirm-gated writes (write_file/edit_file)
+                    # burn the 1s dwell while the user reads the diff, so the
+                    # instant write would otherwise flash by with no beat;
+                    # re-arming here keeps "寫入檔案 X" legible. Non-gated
+                    # WRITE-family tools (memorize / task_write) don't burn
+                    # the dwell, so this just grants them the same ~1s
+                    # "done" courtesy — an accepted side effect, not a bug.
                     from loom.platform.interaction_language import ActionFamily
                     from loom.platform.cli.app import _HEARTBEAT_MIN_DWELL_S
                     if loom_app.footer.heartbeat_family == ActionFamily.WRITE.value:

--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -623,15 +623,17 @@ def tool_spinner_line(
     the args body wraps with a hanging indent so continuation lines
     align under the tool name instead of restarting at column 0.
     """
-    spinner = cli_animation_frame("classic_spinner", frame_index)
     args_preview = _format_args(args)
     body_plain = f"{name}{f'({args_preview})' if args_preview else ''}"
-    prefix_visual = "  [·] "  # 6 cells; spinner glyph is always 1 wide
+    prefix_visual = "  [·] "  # 6 cells; marker glyph is always 1 wide
     indent = " " * len(prefix_visual)
 
+    # Neutral · seed at begin — the live animation plays on the separate
+    # running line, and a frozen spinner frame here read as "stuck" once
+    # the tool finished. ``frame_index`` is kept for signature stability.
     out = Text()
     out.append("  [", style="loom.muted")
-    out.append(spinner, style="loom.warning")
+    out.append("·", style="loom.muted")
     out.append("] ", style="loom.muted")
 
     if width is None:
@@ -702,7 +704,7 @@ def tool_begin_line(
 
     out = Text()
     out.append("  [", style="loom.muted")
-    out.append(cli_animation_frame("classic_spinner", 0), style="loom.warning")
+    out.append("·", style="loom.muted")  # neutral seed; see tool_spinner_line
     out.append("] ", style="loom.muted")
     out.append(justification, style="loom.text")
     out.append("\n")
@@ -729,12 +731,18 @@ def tool_begin_line(
     return out
 
 
-def tool_running_line(name: str, frame_index: int = 0) -> Text:
+def tool_running_line(
+    name: str, frame_index: int = 0, animation: str = "classic_spinner"
+) -> Text:
     """
     Rich Text for a tool that is currently executing.
-    Shows animated spinner without args (args already shown at begin).
+    Shows the animated spinner without args (args already shown at begin).
+
+    ``animation`` selects which family loop to play — the caller passes the
+    footer's resolved variant so the inline running line stays in sync with
+    the heartbeat (probe scans, write strokes, execute churns, …).
     """
-    spinner = cli_animation_frame("classic_spinner", frame_index)
+    spinner = cli_animation_frame(animation, frame_index)
     return Text.from_markup(
         f"  [loom.muted][[/loom.muted][loom.warning]{spinner}[/loom.warning][loom.muted]][/loom.muted] "
         f"[loom.muted]{name} running...[/loom.muted]"
@@ -757,7 +765,7 @@ def tool_end_line(
       below the row (doc/49 §2 "完成即蒸發").
     """
     if frozen:
-        icon_word = "ok" if success else "!!"
+        icon_word = "✓" if success else "✗"
         status_word = "done" if success else "failed"
         # Build with Text.append rather than from_markup — bare ``[ok]``
         # in a markup string gets parsed as an (unknown) style tag and
@@ -768,7 +776,7 @@ def tool_end_line(
             style="loom.muted",
         )
         return out
-    icon = "[loom.success]ok[/loom.success]" if success else "[loom.error]!![/loom.error]"
+    icon = "[loom.success]✓[/loom.success]" if success else "[loom.error]✗[/loom.error]"
     status = "[loom.success]done[/loom.success]" if success else "[loom.error]failed[/loom.error]"
     return Text.from_markup(
         f"  [loom.muted][[/loom.muted]{icon}[loom.muted]][/loom.muted] "

--- a/loom/platform/cli/ui.py
+++ b/loom/platform/cli/ui.py
@@ -576,14 +576,31 @@ def response_panel(
 # Unicode Braille animation frames. Loom's live CLI surface already assumes a
 # UTF-8 terminal; keep these frames one terminal cell wide so running rows and
 # footer labels do not jitter.
+#
+# Each entry is one self-contained 1-cell loop. Loops are grouped into action
+# *families* by ``ANIMATION_FAMILIES`` in interaction_language.py — a family
+# shares a recognisable motion "feel" (so the user learns "scanning = 探查"),
+# while the variants inside it rotate per tool call for freshness. Most loops
+# are lifted from the battle-tested ``cli-spinners`` braille set, which keeps
+# every frame one terminal cell wide.
 _ANIMATION_FRAMES: dict[str, tuple[str, ...]] = {
-    "classic_spinner": (
-        "⠋", "⠙", "⠹", "⠸", "⠼",
-        "⠴", "⠦", "⠧", "⠇", "⠏",
-    ),
+    # ── think: gentle pulse ────────────────────────────────────────────
     "breathing_focus": ("⠂", "⠆", "⠇", "⠿", "⠇", "⠆"),
-    "cascade_drop": ("⠁", "⠂", "⠄", "⡀", "⢀", "⠠", "⠐", "⠈"),
+    "dots_grow": ("⠄", "⠆", "⠇", "⠋", "⠙", "⠸", "⠰", "⠠", "⠰", "⠸", "⠙", "⠋", "⠇", "⠆"),
+    # ── probe: scanning / searching ────────────────────────────────────
+    "classic_spinner": ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"),
+    "dots_wobble": ("⠋", "⠙", "⠚", "⠞", "⠖", "⠦", "⠴", "⠲", "⠳", "⠓"),
+    "dots_corner": ("⢄", "⢂", "⢁", "⡁", "⡈", "⡐", "⡠"),
+    # ── write: pen stroke / filling in ─────────────────────────────────
+    # Pen stroke sweeping up the left column then lifting off down the right
+    # — "writing a file" reads differently from the read spinner.
+    "pen_stroke": ("⡀", "⡄", "⡆", "⡇", "⢸", "⠸", "⠘", "⠈"),
     "rising_columns": ("⣀", "⣤", "⣶", "⣿", "⣶", "⣤"),
+    # ── execute: heavy churn ───────────────────────────────────────────
+    "dots_heavy": ("⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"),
+    "dots_edge": ("⢹", "⢺", "⢼", "⣸", "⣇", "⡧", "⡗", "⡏"),
+    # ── tidy: settle / drop into place ─────────────────────────────────
+    "cascade_drop": ("⠁", "⠂", "⠄", "⡀", "⢀", "⠠", "⠐", "⠈"),
 }
 _SPINNER_FRAMES = _ANIMATION_FRAMES["classic_spinner"]
 

--- a/loom/platform/interaction_language.py
+++ b/loom/platform/interaction_language.py
@@ -51,6 +51,38 @@ class HeartbeatState(str, Enum):
     PAUSED_BLOCKING = "paused_blocking"
 
 
+# Action families: the animation identity axis, orthogonal to HeartbeatState
+# (which drives stall/suppression semantics). ``resolve_tool_action`` tags
+# each tool with a family; the footer picks one variant from the family pool
+# per tool call (rotating for freshness) and holds it for that call's
+# duration. Family names are stable contract values — the CLI footer and
+# tests key off them.
+class ActionFamily(str, Enum):
+    THINK = "think"        # reasoning between tool calls
+    PROBE = "probe"        # read / search / inspect (read-only)
+    WRITE = "write"        # file + memory + task mutation
+    EXECUTE = "execute"    # run_bash and shell-shaped work
+    TIDY = "tidy"          # compaction / housekeeping
+    TOOL = "tool"          # generic fallback (MCP, unknown tools)
+
+
+# family -> ordered pool of animation names defined in
+# ``loom.platform.cli.ui._ANIMATION_FRAMES``. Order is the rotation order.
+ANIMATION_FAMILIES: dict[str, tuple[str, ...]] = {
+    ActionFamily.THINK.value:   ("breathing_focus", "dots_grow"),
+    ActionFamily.PROBE.value:   ("classic_spinner", "dots_wobble", "dots_corner"),
+    ActionFamily.WRITE.value:   ("pen_stroke", "rising_columns"),
+    ActionFamily.EXECUTE.value: ("dots_heavy", "dots_edge"),
+    ActionFamily.TIDY.value:    ("cascade_drop",),
+    ActionFamily.TOOL.value:    ("classic_spinner",),
+}
+
+
+def family_variants(family: str) -> tuple[str, ...]:
+    """Animation pool for a family, falling back to the generic TOOL pool."""
+    return ANIMATION_FAMILIES.get(family, ANIMATION_FAMILIES[ActionFamily.TOOL.value])
+
+
 class ParallelReason(str, Enum):
     SERIAL = "serial"
     FAN_OUT_REPLICAS = "fan_out_replicas"
@@ -66,6 +98,9 @@ class ToolAction:
     subject: str = ""
     stale_after_s: float = 30.0
     long_after_s: float = 30.0
+    # Animation family this action belongs to (drives the footer's
+    # variant pick). Defaults to the generic TOOL pool.
+    family: str = ActionFamily.TOOL.value
 
 
 _LONG_RUNNER_THRESHOLD_S = 90.0
@@ -150,30 +185,36 @@ def resolve_tool_action(tool_name: str, args: dict[str, Any] | None = None) -> T
     args = args or {}
     stale_after = stale_threshold_for_tool(tool_name)
 
+    _PROBE = ActionFamily.PROBE.value
+    _WRITE = ActionFamily.WRITE.value
+
     if tool_name == "read_file":
-        return ToolAction(_LABELS_ZH_TW["read_file"][0], _truncate(args.get("path")), stale_after)
+        return ToolAction(_LABELS_ZH_TW["read_file"][0], _truncate(args.get("path")), stale_after, family=_PROBE)
     if tool_name == "write_file":
-        return ToolAction(_LABELS_ZH_TW["write_file"][0], _truncate(args.get("path")), stale_after)
+        return ToolAction(_LABELS_ZH_TW["write_file"][0], _truncate(args.get("path")), stale_after, family=_WRITE)
     if tool_name in {"edit_file", "edit"}:
-        return ToolAction(_LABELS_ZH_TW[tool_name][0], _truncate(args.get("path")), stale_after)
+        return ToolAction(_LABELS_ZH_TW[tool_name][0], _truncate(args.get("path")), stale_after, family=_WRITE)
     if tool_name == "run_bash":
-        return ToolAction(_LABELS_ZH_TW["run_bash"][0], _command_root(str(args.get("command") or "")), stale_after)
+        return ToolAction(
+            _LABELS_ZH_TW["run_bash"][0], _command_root(str(args.get("command") or "")), stale_after,
+            family=ActionFamily.EXECUTE.value,
+        )
     if tool_name in {"grep", "ripgrep"}:
-        return ToolAction(_LABELS_ZH_TW[tool_name][0], _truncate(args.get("pattern")), stale_after)
+        return ToolAction(_LABELS_ZH_TW[tool_name][0], _truncate(args.get("pattern")), stale_after, family=_PROBE)
     if tool_name in {"find", "glob"}:
-        return ToolAction(_LABELS_ZH_TW[tool_name][0], _truncate(args.get("pattern")), stale_after)
+        return ToolAction(_LABELS_ZH_TW[tool_name][0], _truncate(args.get("pattern")), stale_after, family=_PROBE)
     if tool_name == "list_dir":
-        return ToolAction(_LABELS_ZH_TW["list_dir"][0], _truncate(args.get("path")), stale_after)
+        return ToolAction(_LABELS_ZH_TW["list_dir"][0], _truncate(args.get("path")), stale_after, family=_PROBE)
     if tool_name.startswith("gitnexus_"):
-        return ToolAction(_LABELS_ZH_TW["gitnexus"][0], tool_name.removeprefix("gitnexus_"), stale_after)
+        return ToolAction(_LABELS_ZH_TW["gitnexus"][0], tool_name.removeprefix("gitnexus_"), stale_after, family=_PROBE)
     if tool_name in {"memorize", "governed_write"}:
-        return ToolAction(_LABELS_ZH_TW[tool_name][0], _truncate(args.get("type")), stale_after)
+        return ToolAction(_LABELS_ZH_TW[tool_name][0], _truncate(args.get("type")), stale_after, family=_WRITE)
     if tool_name == "task_write":
-        return ToolAction(_LABELS_ZH_TW["task_write"][0], "", stale_after)
+        return ToolAction(_LABELS_ZH_TW["task_write"][0], "", stale_after, family=_WRITE)
     if tool_name == "impact_analysis":
-        return ToolAction(_LABELS_ZH_TW["impact_analysis"][0], _truncate(args.get("target")), stale_after)
+        return ToolAction(_LABELS_ZH_TW["impact_analysis"][0], _truncate(args.get("target")), stale_after, family=_PROBE)
     if tool_name == "compact":
-        return ToolAction(_LABELS_ZH_TW["compact"][0], "", stale_after)
+        return ToolAction(_LABELS_ZH_TW["compact"][0], "", stale_after, family=ActionFamily.TIDY.value)
     if "__" in tool_name:
         return ToolAction(tool_name, _first_string_arg(args), stale_after)
     return ToolAction(tool_name, "", stale_after)

--- a/loom/platform/interaction_language.py
+++ b/loom/platform/interaction_language.py
@@ -83,6 +83,21 @@ def family_variants(family: str) -> tuple[str, ...]:
     return ANIMATION_FAMILIES.get(family, ANIMATION_FAMILIES[ActionFamily.TOOL.value])
 
 
+# Playback cadence (fps) per family — pulse-style families read better
+# slower, everything else gets a snappy spinner. Carried on the family (the
+# identity unit) rather than per-animation-name so a new variant added to a
+# family inherits its cadence automatically.
+_DEFAULT_FPS = 10.0
+FAMILY_FPS: dict[str, float] = {
+    ActionFamily.THINK.value: 6.0,
+}
+
+
+def family_fps(family: str) -> float:
+    """Playback fps for a family (default snappy 10 fps)."""
+    return FAMILY_FPS.get(family, _DEFAULT_FPS)
+
+
 class ParallelReason(str, Enum):
     SERIAL = "serial"
     FAN_OUT_REPLICAS = "fan_out_replicas"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -515,6 +515,23 @@ class TestHeartbeatMinDwell:
         # PROBE has 3 variants — three consecutive picks are all distinct.
         assert len(set(seen)) == 3
 
+    def test_family_rotation_wraps_around_pool(self, app: LoomApp) -> None:
+        # The rotation counter is mod the pool length, so the 4th PROBE
+        # beat returns to the first variant (rotation algorithm contract).
+        from loom.platform.interaction_language import ActionFamily, family_variants
+
+        picks = []
+        for _ in range(4):
+            app.start_heartbeat(
+                state=HeartbeatState.TOOLING.value,
+                label="搜尋",
+                family=ActionFamily.PROBE.value,
+            )
+            picks.append(app.footer.heartbeat_animation)
+        pool = family_variants(ActionFamily.PROBE.value)  # 3 variants
+        assert picks[3] == picks[0]
+        assert picks[:3] == list(pool)
+
     def test_write_linger_rearms_dwell_consumed_by_confirm(self, app: LoomApp) -> None:
         # Confirm-gated writes burn the original min-dwell while the user
         # reads the diff, so a plain ToolEnd stop would clear instantly —

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -484,6 +484,69 @@ class TestHeartbeatMinDwell:
         assert app.footer.heartbeat_pending_stop is False
         assert app.footer.heartbeat_label == ""
 
+    def test_write_family_renders_a_write_animation(self, app: LoomApp) -> None:
+        # A write-family beat resolves to one of the write pool variants
+        # (pen_stroke / rising_columns), so "writing a file" reads
+        # differently from the probe spinner.
+        from loom.platform.interaction_language import ActionFamily, family_variants
+
+        app.start_heartbeat(
+            state=HeartbeatState.TOOLING.value,
+            label="寫入檔案",
+            subject="loom/core/session.py",
+            family=ActionFamily.WRITE.value,
+        )
+        assert app.footer.heartbeat_animation in family_variants(ActionFamily.WRITE.value)
+        assert app.footer.heartbeat_family == ActionFamily.WRITE.value
+
+    def test_family_variants_rotate_across_calls(self, app: LoomApp) -> None:
+        # Two consecutive probe beats pick different pool variants — the
+        # rotation that gives repeated same-family actions freshness.
+        from loom.platform.interaction_language import ActionFamily
+
+        seen = []
+        for _ in range(3):
+            app.start_heartbeat(
+                state=HeartbeatState.TOOLING.value,
+                label="搜尋",
+                family=ActionFamily.PROBE.value,
+            )
+            seen.append(app.footer.heartbeat_animation)
+        # PROBE has 3 variants — three consecutive picks are all distinct.
+        assert len(set(seen)) == 3
+
+    def test_write_linger_rearms_dwell_consumed_by_confirm(self, app: LoomApp) -> None:
+        # Confirm-gated writes burn the original min-dwell while the user
+        # reads the diff, so a plain ToolEnd stop would clear instantly —
+        # the actual write moment would have no beat. ``linger_heartbeat``
+        # re-arms the dwell at apply time so the write beat lingers.
+        import time as _t
+
+        from loom.platform.interaction_language import ActionFamily
+
+        app.start_heartbeat(
+            state=HeartbeatState.TOOLING.value,
+            label="寫入檔案",
+            subject="loom/core/session.py",
+            family=ActionFamily.WRITE.value,
+        )
+        # Simulate the confirm dialog eating the dwell window.
+        app.footer.heartbeat_min_alive_until = _t.monotonic() - 5.0
+
+        # Apply-time re-arm (keyed off the write family), then the stop.
+        assert app.footer.heartbeat_family == ActionFamily.WRITE.value
+        app.linger_heartbeat(1.0)
+        app.stop_heartbeat()
+
+        assert app.footer.heartbeat_pending_stop is True
+        assert "寫入檔案" in _flat_text(app._render_footer())
+
+    def test_linger_heartbeat_is_noop_when_idle(self, app: LoomApp) -> None:
+        # Nothing to hold open when the footer is already idle.
+        app.linger_heartbeat(1.0)
+        assert app.footer.heartbeat_state == HeartbeatState.IDLE.value
+        assert app.footer.heartbeat_min_alive_until == 0.0
+
     def test_first_text_hard_boundary_clears_thinking_immediately(self, app: LoomApp) -> None:
         class _Session:
             _loom_app = app

--- a/tests/test_cache_display.py
+++ b/tests/test_cache_display.py
@@ -141,5 +141,11 @@ class TestCLIAnimationFrames:
     def test_unknown_animation_falls_back_to_classic_spinner(self):
         assert cli_animation_frame("not-a-real-animation", 0) == "⠋"
 
+    def test_pen_stroke_animation_registered(self):
+        # The file-writing identity (chosen pen-stroke sweep). First frame
+        # is the bottom-left dot; the loop wraps after 8 frames.
+        assert cli_animation_frame("pen_stroke", 0) == "⡀"
+        assert cli_animation_frame("pen_stroke", 8) == cli_animation_frame("pen_stroke", 0)
+
     def test_tool_running_line_uses_braille_spinner(self):
         assert "[⠋] pytest running..." in tool_running_line("pytest", 0).plain

--- a/tests/test_cache_display.py
+++ b/tests/test_cache_display.py
@@ -149,3 +149,41 @@ class TestCLIAnimationFrames:
 
     def test_tool_running_line_uses_braille_spinner(self):
         assert "[⠋] pytest running..." in tool_running_line("pytest", 0).plain
+
+    def test_tool_running_line_accepts_family_animation(self):
+        # The inline running line uses the resolved family variant so it
+        # matches the footer heartbeat (pen_stroke frame 0 = ⡀).
+        out = tool_running_line("write_file", 0, animation="pen_stroke").plain
+        assert "[⡀] write_file running..." in out
+
+
+class TestToolLineMarkers:
+    """The per-tool block reads as a start → done arc: a neutral · seed at
+    begin (not a frozen spinner frame, which looked 'stuck' after the tool
+    finished), and a ✓/✗ completion marker."""
+
+    def test_begin_line_uses_neutral_seed_not_frozen_spinner(self):
+        from loom.platform.cli.ui import tool_begin_line
+
+        out = tool_begin_line("run_bash", {"command": "ls"}).plain
+        assert "[·]" in out
+        assert "⠋" not in out  # no frozen start-frame snapshot
+
+    def test_begin_line_with_justification_uses_neutral_seed(self):
+        from loom.platform.cli.ui import tool_begin_line
+
+        out = tool_begin_line("run_bash", {"command": "ls", "justification": "檢查"}).plain
+        assert "[·]" in out
+        assert "⠋" not in out
+
+    def test_end_line_uses_check_and_cross(self):
+        from loom.platform.cli.ui import tool_end_line
+
+        assert "[✓]" in tool_end_line("run_bash", True, 526.0).plain
+        assert "[✗]" in tool_end_line("run_bash", False, 120.0).plain
+
+    def test_end_line_frozen_stage_uses_check_and_cross(self):
+        from loom.platform.cli.ui import tool_end_line
+
+        assert "[✓]" in tool_end_line("run_bash", True, 526.0, frozen=True).plain
+        assert "[✗]" in tool_end_line("run_bash", False, 120.0, frozen=True).plain

--- a/tests/test_interaction_language.py
+++ b/tests/test_interaction_language.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from loom.platform.interaction_language import (
+    ANIMATION_FAMILIES,
+    ActionFamily,
     HeartbeatState,
     LivenessSensor,
     _LABELS_ZH_TW,
     derive_envelope_outcome,
+    family_variants,
     format_elapsed,
     format_parallel_reason,
     resolve_tool_action,
@@ -64,6 +67,45 @@ def test_resolve_tool_action_for_read_file_uses_path_subject() -> None:
     action = resolve_tool_action("read_file", {"path": "loom/platform/cli/app.py"})
     assert action.label == "查詢檔案"
     assert action.subject == "loom/platform/cli/app.py"
+    # Reading is a read-only probe — the scanning family.
+    assert action.family == ActionFamily.PROBE.value
+
+
+def test_resolve_tool_action_families_by_category() -> None:
+    # Each action category maps to a distinct animation family so the
+    # footer reads differently for writing vs searching vs executing.
+    assert resolve_tool_action("write_file", {"path": "a.py"}).family == ActionFamily.WRITE.value
+    assert resolve_tool_action("edit_file", {"path": "a.py"}).family == ActionFamily.WRITE.value
+    assert resolve_tool_action("edit", {"path": "a.py"}).family == ActionFamily.WRITE.value
+    assert resolve_tool_action("memorize", {"type": "x"}).family == ActionFamily.WRITE.value
+    assert resolve_tool_action("task_write", {}).family == ActionFamily.WRITE.value
+    assert resolve_tool_action("grep", {"pattern": "x"}).family == ActionFamily.PROBE.value
+    assert resolve_tool_action("glob", {"pattern": "x"}).family == ActionFamily.PROBE.value
+    assert resolve_tool_action("list_dir", {"path": "."}).family == ActionFamily.PROBE.value
+    assert resolve_tool_action("gitnexus_query", {}).family == ActionFamily.PROBE.value
+    assert resolve_tool_action("impact_analysis", {"target": "x"}).family == ActionFamily.PROBE.value
+    assert resolve_tool_action("run_bash", {"command": "ls"}).family == ActionFamily.EXECUTE.value
+    assert resolve_tool_action("compact", {}).family == ActionFamily.TIDY.value
+
+
+def test_resolve_tool_action_unknown_falls_back_to_tool_family() -> None:
+    assert resolve_tool_action("new_tool", {"v": "1"}).family == ActionFamily.TOOL.value
+    assert resolve_tool_action("server__mcp_thing", {"v": "1"}).family == ActionFamily.TOOL.value
+
+
+def test_animation_families_pools_are_registered() -> None:
+    from loom.platform.cli.ui import _ANIMATION_FRAMES
+
+    # Every family resolves to a non-empty pool of real animation names.
+    for family, pool in ANIMATION_FAMILIES.items():
+        assert pool, f"family {family} has an empty pool"
+        for name in pool:
+            assert name in _ANIMATION_FRAMES, f"{name} missing from _ANIMATION_FRAMES"
+
+
+def test_family_variants_unknown_falls_back_to_tool_pool() -> None:
+    assert family_variants("not-a-family") == ANIMATION_FAMILIES[ActionFamily.TOOL.value]
+    assert family_variants(ActionFamily.PROBE.value) == ANIMATION_FAMILIES[ActionFamily.PROBE.value]
 
 
 def test_labels_use_locale_registry_shape() -> None:
@@ -81,6 +123,16 @@ def test_stale_threshold_defaults_and_long_runner_override() -> None:
     assert stale_threshold_for_tool("read_file") == 30.0
     assert stale_threshold_for_tool("run_bash") == 90.0
     assert stale_threshold_for_tool("gitnexus_query") == 90.0
+
+
+def test_action_family_names_are_stable() -> None:
+    # These are contract values the CLI footer + tests key off.
+    assert ActionFamily.THINK.value == "think"
+    assert ActionFamily.PROBE.value == "probe"
+    assert ActionFamily.WRITE.value == "write"
+    assert ActionFamily.EXECUTE.value == "execute"
+    assert ActionFamily.TIDY.value == "tidy"
+    assert ActionFamily.TOOL.value == "tool"
 
 
 def test_heartbeat_state_names_are_stable() -> None:

--- a/tests/test_interaction_language.py
+++ b/tests/test_interaction_language.py
@@ -7,6 +7,7 @@ from loom.platform.interaction_language import (
     LivenessSensor,
     _LABELS_ZH_TW,
     derive_envelope_outcome,
+    family_fps,
     family_variants,
     format_elapsed,
     format_parallel_reason,
@@ -106,6 +107,15 @@ def test_animation_families_pools_are_registered() -> None:
 def test_family_variants_unknown_falls_back_to_tool_pool() -> None:
     assert family_variants("not-a-family") == ANIMATION_FAMILIES[ActionFamily.TOOL.value]
     assert family_variants(ActionFamily.PROBE.value) == ANIMATION_FAMILIES[ActionFamily.PROBE.value]
+
+
+def test_family_fps_pulse_is_gentle_rest_snappy() -> None:
+    # Cadence travels with the family: THINK pulses gently, everything
+    # else (and unknown families) gets the snappy default.
+    assert family_fps(ActionFamily.THINK.value) == 6.0
+    assert family_fps(ActionFamily.PROBE.value) == 10.0
+    assert family_fps(ActionFamily.WRITE.value) == 10.0
+    assert family_fps("not-a-family") == 10.0
 
 
 def test_labels_use_locale_registry_shape() -> None:


### PR DESCRIPTION
## Summary

Builds on #519. Today every tool collapses into a single `classic_spinner` — reading, searching, running shell, writing memory all look identical. This gives each **action family** its own animated identity, while keeping freshness via per-call variant rotation.

### Action families (identity axis, orthogonal to `HeartbeatState`)
`resolve_tool_action` now tags every tool with an `ActionFamily`:

| Family | Tools | Feel |
|--------|-------|------|
| 🧠 `think` | (reasoning between calls) | breathing / pulse |
| 🔍 `probe` | read_file, grep, find, glob, list_dir, gitnexus_*, impact_analysis | scanning |
| ✍️ `write` | write_file, edit_file, edit, memorize, governed_write, task_write | pen-stroke / fill |
| ⚙️ `execute` | run_bash | heavy churn |
| 🗜 `tidy` | compact | settle / drop |
| `tool` | MCP + unknown | generic spinner (fallback) |

Each family maps to a **pool** of braille variants (`ANIMATION_FAMILIES`). The footer picks one variant at `ToolBegin` via a rotating counter and holds it for the call's duration — so the family "feel" stays recognisable (intuitive) while consecutive same-family actions don't look identical (fresh). Rotation cadence = **per tool call** (the design choice confirmed with the user).

### Write beat is now legible
`write_file`/`edit_file` are confirm-gated, so the 1s min-dwell is consumed while the user reads the diff; the actual write then completes instantly and used to flash by with no animation. `linger_heartbeat()` re-arms the dwell at apply time (keyed off the `write` family) so "寫入檔案 X" + pen-stroke stays on screen for a beat after authorization.

### Smoothness
The previous fixed **2 Hz** `footer_ticker` sampled the braille loops below their frame rate → visibly choppy. Cadence is now **adaptive**: ~20 Hz while a heartbeat is animating (≥2× the 8–10 fps loops → smooth), lazy 2 Hz when idle (no wasted wakeups at a quiet prompt).

Variant frames are lifted from the battle-tested `cli-spinners` braille set, all guaranteed one terminal cell wide.

## Architecture notes
- `HeartbeatState` stays coarse (drives stall/suppression); the **family** drives animation — clean separation, no state-enum explosion per action type.
- `_ANIMATION_FRAMES` (ui.py) is the single frame registry; `ANIMATION_FAMILIES` (interaction_language.py) is the single family→pool map. Adding a new animation or remapping a family is a one-line change in one place.

## Verification
- `pytest -q tests/test_app.py tests/test_cache_display.py tests/test_transient_footer_hints.py tests/test_interaction_language.py` — **112 passed**
- `py_compile` on all four edited modules — OK
- `gitnexus detect_changes` — **risk low, 0 affected processes**

## Tests added (TDD, red→green)
- family classification per tool category + unknown→`tool` fallback
- `family_variants` pool registration + fallback
- footer renders a write-family variant; **3 consecutive probe calls pick 3 distinct variants** (rotation)
- write-beat dwell re-arm after confirm consumes the original dwell
- `pen_stroke` registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)