### PR TITLE
feat(cli): sustained-action pips + remove dead LONG_TOOLING (#521 v1)

### DIFF
--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -430,6 +430,11 @@ class LoomApp:
         Called from the tool ToolBegin path only — thinking beats are not
         fed, so a run of same-family tools survives the think gaps between
         them. Read-only: nothing consumes this but the footer pip display.
+
+        No ``invalidate()`` here on purpose: the caller (``_start_tool_
+        heartbeat``) calls ``start_heartbeat`` immediately before this, and
+        that already invalidated. Keep this call ordered after it — that's
+        the invariant that lets this stay a pure state fold with no redraw.
         """
         self._engagement = advance_engagement(self._engagement, family)
 

--- a/loom/platform/cli/app.py
+++ b/loom/platform/cli/app.py
@@ -59,7 +59,11 @@ from loom.platform.cli.ui import (
     SlashCompleter,
     cli_animation_frame,
 )
-from loom.platform.interaction_language import LivenessSensor
+from loom.platform.interaction_language import (
+    Engagement,
+    LivenessSensor,
+    advance_engagement,
+)
 
 _CLI_PALETTE = active_palette()
 _CLI_BG = _CLI_PALETTE["bg"]
@@ -121,7 +125,7 @@ class FooterState:
     compacting: bool = False
     # Runtime heartbeat — single liveness signal that replaced the raw
     # ``▸ run_bash`` envelope label (#418). States: idle / thinking /
-    # tooling / long_tooling / stalled / paused_blocking. Written by
+    # tooling / stalled / paused_blocking. Written by
     # stream-event handlers via ``LoomApp.start_heartbeat`` and friends.
     # ``heartbeat_last_event_monotonic`` is touched on every observable
     # stream event; ``stale_after_s`` controls when the footer adds the
@@ -310,6 +314,9 @@ class LoomApp:
         # Monotonic counter advancing one step per animated heartbeat, used
         # to rotate variants within an action family for visual freshness.
         self._anim_rotation = 0
+        # Read-only 'sustained action' signal (#521): consecutive same-family
+        # tool runs, folded at each tool ToolBegin, reset at turn end.
+        self._engagement = Engagement()
 
         # Runtime-liveness sensor (#418/#419) — shared stall-DECISION logic
         # with the Discord watchdog (#422). The footer owns the CLI
@@ -416,6 +423,19 @@ class LoomApp:
         if self.footer.heartbeat_state != "idle":
             self.footer.heartbeat_last_event_monotonic = monotonic()
             self.invalidate()
+
+    def note_tool_engagement(self, family: str) -> None:
+        """Fold one *tool* beat into the sustained-action signal (#521).
+
+        Called from the tool ToolBegin path only — thinking beats are not
+        fed, so a run of same-family tools survives the think gaps between
+        them. Read-only: nothing consumes this but the footer pip display.
+        """
+        self._engagement = advance_engagement(self._engagement, family)
+
+    def reset_engagement(self) -> None:
+        """Clear the sustained-action signal at a turn boundary."""
+        self._engagement = Engagement()
 
     def linger_heartbeat(self, seconds: float) -> None:
         """Re-arm the min-dwell window from *now*.
@@ -882,12 +902,19 @@ class LoomApp:
             stalled = (
                 s.heartbeat_state == "stalled"
                 or (
-                    s.heartbeat_state in ("tooling", "long_tooling")
+                    s.heartbeat_state == "tooling"
                     and self._liveness.is_stalled(now=now)
                 )
             )
             prefix = "still waiting · " if stalled else ""
             label = f"{prefix}{s.heartbeat_label}"
+            # Sustained-action pips (#521): once the same family has run ≥3
+            # tools in a row, grow ⟫ pips so "lots happening / still going"
+            # reads at a glance — even without a TaskList. Tooling beats only
+            # (think gaps don't carry pips); capped so the footer can't grow
+            # unbounded — exact count is for the agent, the user wants "many".
+            if s.heartbeat_state == "tooling" and self._engagement.run_length >= 3:
+                label += " " + "⟫" * min(self._engagement.run_length, 10)
             if s.heartbeat_subject:
                 label += f" · {s.heartbeat_subject}"
             label += f" · {format_elapsed(elapsed)}"

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -591,6 +591,10 @@ async def _chat(
             finally:
                 current_turn_task = None
                 app.stop_heartbeat(force=True)
+                # Sustained-action signal is per-turn (#521): a new user
+                # turn is a fresh context, so the run-length resets here
+                # regardless of how the turn ended (done / error / cancel).
+                app.reset_engagement()
 
             # Update footer token budget + grants at each turn boundary
             # (per doc/49 decision: TTL refresh on turn edge, not per-
@@ -1181,6 +1185,10 @@ def _start_tool_heartbeat(loom_app: Any, name: str, args: dict[str, Any]) -> Non
         stale_after_s=action.stale_after_s,
         family=action.family,
     )
+    # Fold this tool beat into the sustained-action signal (#521). Tool
+    # beats only — the thinking heartbeat never calls this, so a run of
+    # same-family tools survives the think gaps between them.
+    loom_app.note_tool_engagement(action.family)
 
 
 async def _run_streaming_turn(session: "LoomSession", user_input: str) -> None:

--- a/loom/platform/interaction_language.py
+++ b/loom/platform/interaction_language.py
@@ -46,7 +46,6 @@ class HeartbeatState(str, Enum):
     IDLE = "idle"
     THINKING = "thinking"
     TOOLING = "tooling"
-    LONG_TOOLING = "long_tooling"
     STALLED = "stalled"
     PAUSED_BLOCKING = "paused_blocking"
 
@@ -96,6 +95,37 @@ FAMILY_FPS: dict[str, float] = {
 def family_fps(family: str) -> float:
     """Playback fps for a family (default snappy 10 fps)."""
     return FAMILY_FPS.get(family, _DEFAULT_FPS)
+
+
+@dataclass(frozen=True)
+class Engagement:
+    """Read-only 'sustained action' signal (#521 v1).
+
+    Session-level, computed live from the stream of *tool* beats — its
+    essence is "this moment" (in a flow of same-kind work vs scattered),
+    not a history readout. ``run_length`` is the number of consecutive
+    same-family tool calls; ``dominant_family`` is which family that is.
+    Frontend-agnostic on purpose so any surface (CLI footer today, Discord
+    later) can compute it the same way.
+    """
+
+    dominant_family: str = ""
+    run_length: int = 0
+
+
+def advance_engagement(prev: Engagement, family: str) -> Engagement:
+    """Fold one tool beat into the engagement signal.
+
+    Same family → run extends; a different family → run resets to 1 on the
+    new family; an empty family → reset to default. Thinking beats are NOT
+    fed here (callers only advance on tool ToolBegin), so a sustained run
+    survives the think gaps that naturally sit between tool calls.
+    """
+    if not family:
+        return Engagement()
+    if family == prev.dominant_family:
+        return Engagement(family, prev.run_length + 1)
+    return Engagement(family, 1)
 
 
 class ParallelReason(str, Enum):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -381,6 +381,78 @@ class TestFooterRender:
 # ---------------------------------------------------------------------------
 
 
+class TestEngagementPips:
+    """#521 v1: a read-only session-level 'sustained action' signal. The
+    footer grows ⟫ pips once the same action family runs ≥3 times in a row
+    so the user sees 'lots happening / still going' at a glance — even when
+    the agent never opened a TaskList. Pips only show on a tooling beat
+    (thinking gaps between tools don't carry them) and are capped."""
+
+    _PIP = "⟫"
+
+    def _write(self, app: LoomApp) -> None:
+        from loom.platform.interaction_language import ActionFamily
+        app.note_tool_engagement(ActionFamily.WRITE.value)
+
+    def test_engagement_accumulates_same_family(self, app: LoomApp) -> None:
+        from loom.platform.interaction_language import ActionFamily
+        for _ in range(3):
+            self._write(app)
+        assert app._engagement.run_length == 3
+        assert app._engagement.dominant_family == ActionFamily.WRITE.value
+
+    def test_engagement_resets_run_on_family_change(self, app: LoomApp) -> None:
+        from loom.platform.interaction_language import ActionFamily
+        self._write(app)
+        self._write(app)
+        app.note_tool_engagement(ActionFamily.PROBE.value)
+        assert app._engagement.run_length == 1
+        assert app._engagement.dominant_family == ActionFamily.PROBE.value
+
+    def test_reset_engagement_clears(self, app: LoomApp) -> None:
+        self._write(app)
+        app.reset_engagement()
+        assert app._engagement.run_length == 0
+        assert app._engagement.dominant_family == ""
+
+    def _tooling(self, app: LoomApp) -> None:
+        from loom.platform.interaction_language import ActionFamily
+        app.start_heartbeat(
+            state=HeartbeatState.TOOLING.value, label="編輯檔案",
+            subject="a.py", family=ActionFamily.WRITE.value,
+        )
+
+    def test_pips_appear_at_threshold(self, app: LoomApp) -> None:
+        self._tooling(app)
+        for _ in range(3):
+            self._write(app)
+        assert self._PIP * 3 in _flat_text(app._render_footer())
+
+    def test_no_pips_below_threshold(self, app: LoomApp) -> None:
+        self._tooling(app)
+        self._write(app)
+        self._write(app)  # run_length 2 — below the 3 threshold
+        assert self._PIP not in _flat_text(app._render_footer())
+
+    def test_pips_capped_at_ten(self, app: LoomApp) -> None:
+        self._tooling(app)
+        for _ in range(20):
+            self._write(app)
+        assert _flat_text(app._render_footer()).count(self._PIP) == 10
+
+    def test_no_pips_during_thinking_beat(self, app: LoomApp) -> None:
+        from loom.platform.interaction_language import ActionFamily
+        for _ in range(5):
+            self._write(app)
+        # Same session, but the current beat is thinking (between tools):
+        # the sustained-action signal is for tool work, not think gaps.
+        app.start_heartbeat(
+            state=HeartbeatState.THINKING.value, label="Loom is thinking",
+            family=ActionFamily.THINK.value,
+        )
+        assert self._PIP not in _flat_text(app._render_footer())
+
+
 class TestHeartbeatMinDwell:
     """Regression: short tool calls (< 1 s) were producing labels that
     appeared and disappeared before the user could read them. The dwell

--- a/tests/test_interaction_language.py
+++ b/tests/test_interaction_language.py
@@ -171,6 +171,14 @@ def test_advance_engagement_empty_family_resets_to_default() -> None:
     assert advance_engagement(Engagement(ActionFamily.WRITE.value, 5), "") == Engagement()
 
 
+def test_advance_engagement_empty_then_real_starts_fresh() -> None:
+    # An empty family fully resets, so the next real family starts a new
+    # run at 1 (not a continuation of the pre-empty run).
+    e = advance_engagement(Engagement(ActionFamily.WRITE.value, 5), "")
+    e = advance_engagement(e, ActionFamily.WRITE.value)
+    assert e == Engagement(ActionFamily.WRITE.value, 1)
+
+
 def test_heartbeat_state_names_are_stable() -> None:
     assert HeartbeatState.THINKING.value == "thinking"
     assert HeartbeatState.STALLED.value == "stalled"

--- a/tests/test_interaction_language.py
+++ b/tests/test_interaction_language.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from loom.platform.interaction_language import (
     ANIMATION_FAMILIES,
     ActionFamily,
+    Engagement,
     HeartbeatState,
     LivenessSensor,
     _LABELS_ZH_TW,
+    advance_engagement,
     derive_envelope_outcome,
     family_fps,
     family_variants,
@@ -143,6 +145,30 @@ def test_action_family_names_are_stable() -> None:
     assert ActionFamily.EXECUTE.value == "execute"
     assert ActionFamily.TIDY.value == "tidy"
     assert ActionFamily.TOOL.value == "tool"
+
+
+def test_long_tooling_state_removed() -> None:
+    # #521 Gap A: LONG_TOOLING was never assigned anywhere (dead branch);
+    # rising_columns moved to the WRITE family in #520. Removed.
+    assert not hasattr(HeartbeatState, "LONG_TOOLING")
+
+
+def test_advance_engagement_increments_same_family() -> None:
+    e = Engagement()
+    e = advance_engagement(e, ActionFamily.WRITE.value)
+    assert e == Engagement(ActionFamily.WRITE.value, 1)
+    e = advance_engagement(e, ActionFamily.WRITE.value)
+    e = advance_engagement(e, ActionFamily.WRITE.value)
+    assert e == Engagement(ActionFamily.WRITE.value, 3)
+
+
+def test_advance_engagement_resets_run_on_family_change() -> None:
+    prior = Engagement(ActionFamily.WRITE.value, 5)
+    assert advance_engagement(prior, ActionFamily.PROBE.value) == Engagement(ActionFamily.PROBE.value, 1)
+
+
+def test_advance_engagement_empty_family_resets_to_default() -> None:
+    assert advance_engagement(Engagement(ActionFamily.WRITE.value, 5), "") == Engagement()
 
 
 def test_heartbeat_state_names_are_stable() -> None:


### PR DESCRIPTION
Closes the v1 scope of #521.

## Why
Loom's heartbeat is **single-action granularity** — each tool / think is its own beat, reset to idle after. There was no signal for "the agent is in a *sustained* activity". The concrete pain (DK): when the agent does a long run of work **without opening a TaskList**, the user's only cue is messages piling up — no glanceable "still going".

絲絲's framing that settled the design: this is an **immediacy** signal ("am I in a flow right now"), not history — so it lives as a live session field computed at tool time, not recalled from the ledger.

## What (v1 = read-only + display, deliberately minimal)
- **Engagement signal** (`interaction_language.py`): `Engagement{dominant_family, run_length}` + pure `advance_engagement(prev, family)`. Frontend-agnostic; state on `LoomApp` for v1 (CLI-only — promoted to core `session_state` only when a 2nd consumer actually appears, per 純粹精練 / no speculative abstraction).
- **Folded at *tool* ToolBegin only** — thinking beats don't feed it, so a run of same-family tools survives the think gaps naturally sitting between tool calls. Reset at the turn boundary (done / error / cancel).
- **Display = ⟫ pips**: once the same family runs **≥3 tools in a row**, the footer grows `⟫` pips after the label (capped at 10). Below threshold: nothing (no clutter). Tooling beats only — think gaps don't carry pips.

```
 below threshold (<3):  ⣀ 編輯檔案 · loom/core/session.py · 2s
 at/above (≥3):         ⣀ 編輯檔案 ⟫⟫⟫⟫⟫ · loom/core/session.py · 2s
```

The exact count is for the agent; the user just wants to see "many = sustained". Read-only — nothing consumes engagement but this display. Whether engagement should ever *influence behaviour* (mood / pacing) is explicitly deferred (not built).

## Gap A — removed dead `LONG_TOOLING`
`HeartbeatState.LONG_TOOLING` was never assigned anywhere (dead since #519); #520 moved its `rising_columns` animation to the WRITE family. Dropped the enum entry + the `long_tooling` arm of the footer stall gate.

## Verification
- `pytest -q tests/test_app.py tests/test_cache_display.py tests/test_transient_footer_hints.py tests/test_interaction_language.py` — **130 passed**
- `py_compile` on the 3 edited modules — OK
- `gitnexus detect_changes` — **risk low, 0 affected processes**

## Tests (TDD)
`advance_engagement` increment / family-change reset / empty reset; `LONG_TOOLING` removed; pip threshold (2 hides, 3 shows); cap at 10; no pips on a thinking beat; engagement reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)