### PR TITLE
feat(memory): weekly convergent-dream schedule, read-only (P4a, #495)

### DIFF
--- a/loom.toml.example
+++ b/loom.toml.example
@@ -295,6 +295,29 @@ interval_hours = 12     # cadence (first dream ~5min after daemon start)
 sample_size    = 15     # facts sampled per cycle (matches tool default)
 
 # ─────────────────────────────────────────────
+# Convergent dream (#495 P4) — Weekly memory consolidation
+# ─────────────────────────────────────────────
+# The consolidation counterpart to [memory.dream]'s divergent synthesis. Runs
+# ``run_convergent_dream`` on a *weekly* cadence inside the autonomy daemon:
+# it scans semantic memory for near-duplicate / contradicting / orphaned facts
+# and either reports them (read-only) or fuses them (execute). The cadence is
+# in DAYS, and due-ness is persisted in ``memory_meta``
+# (``consolidation_dream.last_run``) so a restart neither resets the week nor
+# double-runs.
+#
+# Staged rollout:
+#   • execute = false (P4a) — read-only: writes a 夢境鞏固 report to
+#     autonomy/circadian/dreams/YYYY-MM-DD.md, never touches the DB. Use this
+#     to observe report quality on the autonomous schedule first.
+#   • execute = true  (P4b) — autonomous consolidation: the approved, non-stale
+#     clusters are actually fused (self_review veto + the report remain the
+#     safety net). Only flip this once the read-only reports are trusted.
+[memory.consolidation_dream]
+enabled       = true    # set false to disable the weekly convergent dream
+interval_days = 7       # cadence in days (first check ~5min after daemon start)
+execute       = false   # P4a read-only; set true for autonomous writes (P4b)
+
+# ─────────────────────────────────────────────
 # Reflection (Issue #120 PR1) — Skill diagnostic layer
 # ─────────────────────────────────────────────
 # When a skill is activated via ``load_skill`` and the turn completes,

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -316,6 +316,11 @@ sample_size    = 15     # facts sampled per cycle (matches tool default)
 enabled       = true    # set false to disable the weekly convergent dream
 interval_days = 7       # cadence in days (first check ~5min after daemon start)
 execute       = false   # P4a read-only; set true for autonomous writes (P4b)
+# Coverage cap. list_recent is newest-first, so this scans the N most-recent
+# facts — older ones are never looked at. Set it >= your total semantic entry
+# count for full coverage. LLM cost is bounded by max_clusters regardless; only
+# local embedding work scales with this number. Raise it as your corpus grows.
+corpus_limit  = 5000
 
 # ─────────────────────────────────────────────
 # Reflection (Issue #120 PR1) — Skill diagnostic layer

--- a/loom/autonomy/daemon.py
+++ b/loom/autonomy/daemon.py
@@ -25,7 +25,9 @@ from typing import Awaitable, Callable
 from loom.autonomy.chime import ChimeRequest
 from loom.autonomy.evaluator import TriggerEvaluator
 from loom.autonomy.history import TriggerHistory
-from loom.autonomy.maintenance import DreamLoop, MaintenanceLoop
+from loom.autonomy.maintenance import (
+    ConvergentDreamLoop, DreamLoop, MaintenanceLoop,
+)
 from loom.autonomy.planner import ActionPlanner, PlannedAction, ActionDecision
 from loom.autonomy.triggers import CronTrigger, EventTrigger, ConditionTrigger
 from loom.autonomy.schedules import DEFAULT_SCHEDULES_PATH, load_schedules
@@ -559,6 +561,9 @@ class AutonomyDaemon:
         dream_task = self._maybe_start_dream_loop()
         if dream_task is not None:
             wait_set.append(dream_task)
+        consol_task = self._maybe_start_consolidation_loop()
+        if consol_task is not None:
+            wait_set.append(consol_task)
 
         done, pending = await asyncio.wait(
             wait_set, return_when=asyncio.FIRST_COMPLETED
@@ -654,6 +659,67 @@ class AutonomyDaemon:
         logger.info(
             "[autonomy] dream loop started (interval=%.1fh, sample=%d)",
             loop._interval_seconds / 3600.0, sample_size,
+        )
+        return asyncio.ensure_future(loop.run_forever())
+
+    def _maybe_start_consolidation_loop(self) -> asyncio.Task | None:
+        """Read [memory.consolidation_dream] and launch ConvergentDreamLoop (#495).
+
+        The weekly convergent (consolidation) dream — counterpart to the
+        divergent DreamLoop. P4a ships read-only by default (``execute=false``):
+        the schedule produces 夢境鞏固 reports without touching the DB so the
+        autonomous report quality can be observed before ``execute=true`` (P4b)
+        is ever set.
+        """
+        session = self._session
+        db = getattr(session, "_db", None) if session else None
+        if session is None or db is None:
+            return None
+        memory = getattr(session, "_memory", None)
+        if memory is None:
+            return None
+        try:
+            from loom.core.config import load_loom_config  # local import: lazy
+            cfg = load_loom_config().get("memory", {}).get("consolidation_dream", {})
+        except Exception as exc:
+            logger.debug("[autonomy] consolidation config load failed: %s", exc)
+            return None
+        if not cfg.get("enabled", False):  # opt-in: absent section → off
+            return None
+
+        execute = bool(cfg.get("execute", False))  # P4a default: read-only
+        router = session.router
+        model = session.model
+
+        async def _consolidate_once() -> Any:
+            from loom.core.cognition.consolidation import run_convergent_dream
+            from loom.autonomy.circadian.journal import append_consolidation_report
+
+            async def _llm_fn(messages: list[dict]) -> str:
+                response = await router.chat(
+                    model=model, messages=messages, max_tokens=2048,
+                )
+                return response.text or ""
+
+            plan, report = await run_convergent_dream(
+                memory.semantic, _llm_fn, execute=execute,
+            )
+            append_consolidation_report(report)
+            logger.info(
+                "[consolidation] pass=%s execute=%s clusters=%s deferred=%d",
+                plan.pass_id, execute, plan.counts(), plan.deferred_to_next_pass,
+            )
+            return plan
+
+        loop = ConvergentDreamLoop(
+            dream_fn=_consolidate_once,
+            db=db,
+            abort=self._abort,
+            interval_days=float(cfg.get("interval_days", 7.0)),
+        )
+        logger.info(
+            "[autonomy] convergent dream loop started (interval=%.1fd, execute=%s)",
+            loop._interval_seconds / 86400.0, execute,
         )
         return asyncio.ensure_future(loop.run_forever())
 

--- a/loom/autonomy/daemon.py
+++ b/loom/autonomy/daemon.py
@@ -688,6 +688,12 @@ class AutonomyDaemon:
             return None
 
         execute = bool(cfg.get("execute", False))  # P4a default: read-only
+        # list_recent is newest-first, so corpus_limit caps coverage to the N
+        # most-recent facts — older ones are never scanned. Set it >= the total
+        # semantic entry count for full coverage. LLM cost stays bounded by
+        # max_clusters / max_review_clusters regardless; only local embedding
+        # work scales with this number (#524 review).
+        corpus_limit = int(cfg.get("corpus_limit", 2000))
         router = session.router
         model = session.model
 
@@ -702,7 +708,8 @@ class AutonomyDaemon:
                 return response.text or ""
 
             plan, report = await run_convergent_dream(
-                memory.semantic, _llm_fn, execute=execute,
+                memory.semantic, _llm_fn,
+                corpus_limit=corpus_limit, execute=execute,
             )
             append_consolidation_report(report)
             logger.info(
@@ -718,8 +725,9 @@ class AutonomyDaemon:
             interval_days=float(cfg.get("interval_days", 7.0)),
         )
         logger.info(
-            "[autonomy] convergent dream loop started (interval=%.1fd, execute=%s)",
-            loop._interval_seconds / 86400.0, execute,
+            "[autonomy] convergent dream loop started "
+            "(interval=%.1fd, corpus_limit=%d, execute=%s)",
+            loop._interval_seconds / 86400.0, corpus_limit, execute,
         )
         return asyncio.ensure_future(loop.run_forever())
 

--- a/loom/autonomy/maintenance.py
+++ b/loom/autonomy/maintenance.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import datetime, UTC
 from typing import Any, Awaitable, Callable, TYPE_CHECKING
 
 from loom.core.infra import AbortController, wait_aborted
@@ -149,3 +150,109 @@ class DreamLoop:
                     logger.warning("[dream] warnings: %s", "; ".join(errors))
             except Exception as exc:  # never let dreaming crash the daemon
                 logger.warning("[dream] cycle failed: %s", exc)
+
+
+class ConvergentDreamLoop:
+    """Drives ``run_convergent_dream`` on a *weekly*, restart-safe cadence (#495).
+
+    The convergent (consolidation) dream is the counterpart to ``DreamLoop``'s
+    divergent dream, but its cadence is weekly rather than every few hours and
+    must survive restarts: a daemon bounce must neither reset the week nor
+    double-run. So due-ness is decided against a persisted
+    ``consolidation_dream.last_run`` in ``memory_meta`` — not an in-memory timer
+    like ``DreamLoop`` — mirroring ``dreaming.next_themed_domain``'s
+    restart-safe rotation.
+
+    The loop wakes on a short *check* interval and runs the dream only when
+    ``interval_days`` have elapsed since ``last_run``. ``last_run`` is marked
+    **only after a successful pass**, so a failed pass (e.g. LLM outage) retries
+    on the next check rather than silently skipping the week.
+
+    ``dream_fn`` is supplied by the daemon and decides read-only (P4a) vs
+    ``execute=True`` (P4b) — this loop only owns *when*, never *what*.
+    """
+
+    # Defer the first due-check so daemon startup isn't competing for the DB.
+    _FIRST_CHECK_DELAY_SECONDS = 300.0
+    # How often to re-check due-ness. The weekly cadence is enforced by the
+    # persisted last_run, so the check interval only bounds how soon after a
+    # due moment (or a restart) the run actually fires.
+    _CHECK_INTERVAL_SECONDS = 6 * 3600.0
+    _META_KEY_LAST_RUN = "consolidation_dream.last_run"
+
+    def __init__(
+        self,
+        dream_fn: Callable[[], Awaitable[Any]],
+        db: "aiosqlite.Connection",
+        abort: AbortController,
+        interval_days: float = 7.0,
+    ) -> None:
+        self._dream_fn = dream_fn
+        self._db = db
+        self._abort = abort
+        self._interval_seconds = max(60.0, interval_days * 86400.0)
+
+    async def _last_run(self) -> datetime | None:
+        cursor = await self._db.execute(
+            "SELECT value FROM memory_meta WHERE key = ?",
+            (self._META_KEY_LAST_RUN,),
+        )
+        row = await cursor.fetchone()
+        if not row or not row[0]:
+            return None
+        try:
+            return datetime.fromisoformat(row[0])
+        except (ValueError, TypeError):
+            return None  # corrupt value → treat as never-run (re-runs, marks fresh)
+
+    async def _mark_run(self, now: datetime) -> None:
+        stamp = now.isoformat()
+        await self._db.execute(
+            "INSERT INTO memory_meta(key, value, updated_at) VALUES (?, ?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value, "
+            "updated_at = excluded.updated_at",
+            (self._META_KEY_LAST_RUN, stamp, stamp),
+        )
+        await self._db.commit()
+
+    async def maybe_run_once(self, now: datetime) -> bool:
+        """Run one convergent dream iff ``interval_days`` have elapsed.
+
+        Returns True if it ran. ``last_run`` is persisted only after the pass
+        succeeds, so a raising ``dream_fn`` propagates and leaves the week still
+        due (retry next check, never a silent skip).
+        """
+        last = await self._last_run()
+        if last is not None and (now - last).total_seconds() < self._interval_seconds:
+            return False
+        await self._dream_fn()       # may raise → last_run left unmarked
+        await self._mark_run(now)
+        return True
+
+    async def run_forever(self) -> None:
+        """Check due-ness ``_FIRST_CHECK_DELAY_SECONDS`` after start, then every
+        ``_CHECK_INTERVAL_SECONDS``. Returns when the abort signal fires."""
+        first_iter = True
+        while not self._abort.signal.is_set():
+            timeout = (
+                self._FIRST_CHECK_DELAY_SECONDS if first_iter
+                else self._CHECK_INTERVAL_SECONDS
+            )
+            first_iter = False
+            try:
+                await asyncio.wait_for(
+                    wait_aborted(self._abort.signal),
+                    timeout=timeout,
+                )
+                return  # abort signalled
+            except asyncio.TimeoutError:
+                pass  # check interval elapsed
+
+            try:
+                if await self.maybe_run_once(datetime.now(UTC)):
+                    logger.info(
+                        "[consolidation] convergent dream ran (interval=%.1fd)",
+                        self._interval_seconds / 86400.0,
+                    )
+            except Exception as exc:  # never let consolidation crash the daemon
+                logger.warning("[consolidation] cycle failed: %s", exc)

--- a/tests/test_convergent_dream_loop.py
+++ b/tests/test_convergent_dream_loop.py
@@ -1,0 +1,114 @@
+"""
+Tests for ConvergentDreamLoop — the weekly read-only convergent-dream schedule
+(#495, P4a).
+
+Unlike DreamLoop (a simple in-process interval), the convergent dream runs
+weekly and must be **restart-safe**: the due-ness is decided against a
+persisted ``consolidation_dream.last_run`` in ``memory_meta``, not an in-memory
+timer, so a daemon restart neither resets the week nor double-runs. A failed
+pass must NOT mark last_run — it retries next check rather than silently
+skipping the week.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, UTC, timedelta
+
+import pytest
+import pytest_asyncio
+
+from loom.core.memory.store import SQLiteStore
+from loom.core.infra import AbortController
+from loom.autonomy.maintenance import ConvergentDreamLoop
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test.db")
+
+
+@pytest_asyncio.fixture
+async def store(tmp_db):
+    s = SQLiteStore(tmp_db)
+    await s.initialize()
+    return s
+
+
+@pytest_asyncio.fixture
+async def db_conn(store):
+    async with store.connect() as conn:
+        yield conn
+
+
+def _loop(db, dream_fn, *, interval_days=7.0):
+    return ConvergentDreamLoop(
+        dream_fn=dream_fn, db=db, abort=AbortController(), interval_days=interval_days)
+
+
+class TestDueGating:
+    async def test_runs_when_never_run_before(self, db_conn):
+        calls = []
+        async def fn(): calls.append(1)
+        ran = await _loop(db_conn, fn).maybe_run_once(datetime.now(UTC))
+        assert ran is True
+        assert len(calls) == 1
+
+    async def test_skips_within_interval(self, db_conn):
+        calls = []
+        async def fn(): calls.append(1)
+        loop = _loop(db_conn, fn, interval_days=7)
+        now = datetime(2026, 6, 6, tzinfo=UTC)
+        await loop.maybe_run_once(now)                       # runs, marks now
+        ran = await loop.maybe_run_once(now + timedelta(days=3))
+        assert ran is False
+        assert len(calls) == 1
+
+    async def test_runs_again_after_interval(self, db_conn):
+        calls = []
+        async def fn(): calls.append(1)
+        loop = _loop(db_conn, fn, interval_days=7)
+        now = datetime(2026, 6, 6, tzinfo=UTC)
+        await loop.maybe_run_once(now)
+        ran = await loop.maybe_run_once(now + timedelta(days=8))
+        assert ran is True
+        assert len(calls) == 2
+
+    async def test_restart_safe_via_meta(self, db_conn):
+        # a fresh loop instance (simulating a daemon restart) must read the
+        # persisted last_run and stay within the week.
+        calls = []
+        async def fn(): calls.append(1)
+        now = datetime(2026, 6, 6, tzinfo=UTC)
+        await _loop(db_conn, fn).maybe_run_once(now)         # marks
+        ran = await _loop(db_conn, fn).maybe_run_once(now + timedelta(days=2))
+        assert ran is False
+        assert len(calls) == 1
+
+
+class TestFailureRetries:
+    async def test_failure_does_not_mark_last_run(self, db_conn):
+        # a failed pass must retry next check, never silently skip the week.
+        async def boom(): raise RuntimeError("llm down")
+        now = datetime(2026, 6, 6, tzinfo=UTC)
+        with pytest.raises(RuntimeError):
+            await _loop(db_conn, boom).maybe_run_once(now)
+
+        ran_calls = []
+        async def ok(): ran_calls.append(1)
+        # one minute later it is still due (last_run was never written)
+        ran = await _loop(db_conn, ok).maybe_run_once(now + timedelta(minutes=1))
+        assert ran is True
+        assert len(ran_calls) == 1
+
+
+class TestCorruptMeta:
+    async def test_unparseable_last_run_treated_as_due(self, db_conn):
+        await db_conn.execute(
+            "INSERT INTO memory_meta(key, value, updated_at) VALUES (?, ?, ?)",
+            ("consolidation_dream.last_run", "not-a-date", "x"))
+        await db_conn.commit()
+        calls = []
+        async def fn(): calls.append(1)
+        ran = await _loop(db_conn, fn).maybe_run_once(datetime.now(UTC))
+        assert ran is True
+        assert len(calls) == 1


### PR DESCRIPTION
Part of #495 (epic #491). The scheduling layer for the convergent (consolidation) dream — answers "when does it run". P1-P3 made it correct; P4a makes it happen automatically, weekly, **read-only first**.

## What
- **`ConvergentDreamLoop`** (`autonomy/maintenance.py`) — counterpart to `DreamLoop`, but a **weekly, restart-safe** cadence. Due-ness is decided against a persisted `consolidation_dream.last_run` in `memory_meta` (mirroring `dreaming.next_themed_domain`), not an in-memory timer — so a daemon bounce neither resets the week nor double-runs. `last_run` is marked **only after a successful pass**, so a failed pass (e.g. LLM outage) retries next check rather than silently skipping the week. The loop owns *when*, never *what*.
- **`daemon._maybe_start_consolidation_loop`** — mirrors `_maybe_start_dream_loop`: reads `[memory.consolidation_dream]`, builds the dream_fn (`run_convergent_dream` + `append_consolidation_report`), wires into `start()`'s abort-driven `wait_set`.
- **config dual-write** — `[memory.consolidation_dream]` in `loom.toml.example` (`enabled` / `interval_days` / `execute`). Opt-in: absent section → off.

## Staging (why read-only now)
`execute = false` (P4a): the schedule writes a 夢境鞏固 report to `autonomy/circadian/dreams/YYYY-MM-DD.md` without touching the DB, so the autonomous report quality can be observed before `execute = true` (P4b) is ever set. A human-in-the-loop manual `execute=True` verification run is planned before P4b.

## Design notes for review
- **Restart-safety vs DreamLoop**: DreamLoop uses a pure in-memory interval (a restart resets its 12h timer — fine at that cadence). Weekly can't afford that, hence the persisted `last_run` + a short re-check interval (6h) that only *gates*, never itself fires the cadence.
- **Failure semantics**: `maybe_run_once` marks `last_run` only after `dream_fn` returns, by design — a raised `dream_fn` leaves the week due. `run_forever` wraps the call so a failure never crashes the daemon.
- **execute knob lives in config, not the SAFE tool** — consistent with the existing decision that autonomous memory writes are driven by `run_convergent_dream(execute=True)` from the scheduler, never an agent-facing SAFE tool.

## Tests
TDD red→green. New `tests/test_convergent_dream_loop.py`: never-run / within-interval / after-interval / restart-safe / failure-retries / corrupt-meta. Full suite **2513 passed**, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)