### PR TITLE
feat(circadian): phase anchors carry routine-safe permissions (#525)

### DIFF
--- a/autonomy/circadian/rhythm.example.toml
+++ b/autonomy/circadian/rhythm.example.toml
@@ -23,20 +23,25 @@
 #     phase degrades into a scheduler (doc/57 §"Phase chime prompt contract").
 #   - ``public`` is advisory metadata for now; reserved for future
 #     visibility rules (e.g. silent vs. always-speaking phases).
-#   - ``trust_level`` / ``allowed_tools`` / ``scope_grants`` (issue #525) are
-#     the SAME permission fields a ``schedules.toml`` entry uses. They let a
-#     phase do routine tool work — research, write a draft, run the pet
-#     script — WITHOUT re-asking DK every single day. They are pre-authorised
-#     for that phase's turn only, then revoked. This is the agent's own
-#     surface to manage: when you want a phase to do something new, add the
-#     tool here and talk it over with DK. CRITICAL tools always re-confirm
-#     regardless — these fields never widen *that* floor.
-#       · ``allowed_tools = ["fetch_url", "write_file"]`` — pre-authorise these
-#         GUARDED tools (run_bash included) for the phase turn.
+#   - ``allowed_tools`` / ``scope_grants`` (issue #525) let a phase do routine
+#     tool work — research, write a draft, run the pet script — WITHOUT
+#     re-asking DK every single day. They are pre-authorised for that phase's
+#     turn only, then revoked. This is the agent's own surface to manage: when
+#     you want a phase to do something new, add the tool here and talk it over
+#     with DK. CRITICAL tools always re-confirm regardless — these fields never
+#     widen *that* floor. Pick the right one per tool:
+#       · ``allowed_tools = ["fetch_url", "web_search", "run_bash"]`` — a BLANKET
+#         pre-authorisation by tool name. Use for read-only or already-narrow
+#         tools (web reads, the pet script) where the whole-tool grant is fine.
 #       · ``scope_grants = [{ resource = "path", action = "write",
-#         selector = "autonomy/circadian" }]`` — bound a tool to a resource
-#         (write only under this prefix), same dict shape as schedules.toml.
-#       · ``trust_level`` is optional; omit it to keep normal per-tool gating.
+#         selector = "autonomy/circadian" }]`` — a BOUNDED grant. Use for a
+#         broad tool you want to fence (``write_file`` only under this prefix).
+#         The grant alone authorises in-scope calls; an out-of-scope call is
+#         denied. Do NOT also list a fenced tool in ``allowed_tools`` — the
+#         tool-name grant is the blanket form and makes the fence pointless.
+#       · There is no ``trust_level`` field for phases: the chime path has no
+#         planner notify/HOLD gate, so it would be inert. Authorisation here is
+#         allowed_tools + scope_grants only.
 #
 # A missing or malformed file is tolerated: the dawn/close lifecycle from
 # PR1 still runs, the day just has no in-day anchors. A bad time (even one
@@ -84,9 +89,10 @@ meaning = """
 time    = "11:00"
 name    = "curiosity"
 public  = false
-# Research + jot a note: read the web, write only under the circadian dir.
-# The scope_grant bounds write_file to a prefix instead of trusting it blanket.
-allowed_tools = ["fetch_url", "web_search", "write_file"]
+# Research + jot a note: blanket the read-only web tools, but FENCE writing —
+# the scope_grant lets write_file touch only autonomy/circadian, nothing else.
+# write_file is deliberately NOT in allowed_tools (that would un-fence it).
+allowed_tools = ["fetch_url", "web_search"]
 scope_grants  = [{ resource = "path", action = "write", selector = "autonomy/circadian" }]
 meaning = """
 絲絲自己的好奇心散步。

--- a/autonomy/circadian/rhythm.example.toml
+++ b/autonomy/circadian/rhythm.example.toml
@@ -23,10 +23,25 @@
 #     phase degrades into a scheduler (doc/57 §"Phase chime prompt contract").
 #   - ``public`` is advisory metadata for now; reserved for future
 #     visibility rules (e.g. silent vs. always-speaking phases).
+#   - ``trust_level`` / ``allowed_tools`` / ``scope_grants`` (issue #525) are
+#     the SAME permission fields a ``schedules.toml`` entry uses. They let a
+#     phase do routine tool work — research, write a draft, run the pet
+#     script — WITHOUT re-asking DK every single day. They are pre-authorised
+#     for that phase's turn only, then revoked. This is the agent's own
+#     surface to manage: when you want a phase to do something new, add the
+#     tool here and talk it over with DK. CRITICAL tools always re-confirm
+#     regardless — these fields never widen *that* floor.
+#       · ``allowed_tools = ["fetch_url", "write_file"]`` — pre-authorise these
+#         GUARDED tools (run_bash included) for the phase turn.
+#       · ``scope_grants = [{ resource = "path", action = "write",
+#         selector = "autonomy/circadian" }]`` — bound a tool to a resource
+#         (write only under this prefix), same dict shape as schedules.toml.
+#       · ``trust_level`` is optional; omit it to keep normal per-tool gating.
 #
 # A missing or malformed file is tolerated: the dawn/close lifecycle from
 # PR1 still runs, the day just has no in-day anchors. A bad time (even one
-# slot inside a list) is dropped on its own, never silencing the rest.
+# slot inside a list) is dropped on its own, never silencing the rest; a
+# malformed scope_grant is dropped without voiding the others.
 
 [[anchors]]
 time    = "08:00"
@@ -56,6 +71,9 @@ meaning = """
 time    = ["10:00", "19:00"]
 name    = "pet"
 public  = true
+# Routine-safe tools for this phase (issue #525): the pet-care script runs via
+# run_bash without re-asking each day. Permissions ride along with both slots.
+allowed_tools = ["run_bash"]
 meaning = """
 喵吉照顧時間。
 白天維持生活感與照顧關係，晚餐後再順手確認一次飽食、清潔。
@@ -66,6 +84,10 @@ meaning = """
 time    = "11:00"
 name    = "curiosity"
 public  = false
+# Research + jot a note: read the web, write only under the circadian dir.
+# The scope_grant bounds write_file to a prefix instead of trusting it blanket.
+allowed_tools = ["fetch_url", "web_search", "write_file"]
+scope_grants  = [{ resource = "path", action = "write", selector = "autonomy/circadian" }]
 meaning = """
 絲絲自己的好奇心散步。
 挑你自己感興趣的，不是為了產出。

--- a/doc/00-總覽.md
+++ b/doc/00-總覽.md
@@ -1,6 +1,6 @@
 # Loom 總覽
 
-<!-- loom-version: 0.3.8.2 -->
+<!-- loom-version: 0.3.9.0 -->
 
 > *The loom is what the harness belongs to. Claude Code is one thread; Loom is the machine that weaves any thread into the same quality fabric.*
 

--- a/doc/57-Circadian-Autonomy-實作計畫.md
+++ b/doc/57-Circadian-Autonomy-實作計畫.md
@@ -402,13 +402,17 @@ loader 把這種 block 展開成「每個有效時段一個 `Anchor`」，並只
 
 每天喚醒的 daily session 是新的 `PermissionContext`（grant 是 session-scoped 記憶體）。所以一個 phase 要做的 routine-safe 工具動作（早上查資料寫新聞心得、跑餵貓腳本）每天都會落回 GUARDED → 重問 DK → 在無限等授權下造成 phase drift。
 
-修法不是新系統，而是**接上既有管道**：`schedules.toml` 的 entry 早就能帶 `trust_level` / `allowed_tools` / `scope_grants`（#444），經 `CronTrigger → planner → ChimeRequest → bot._apply_chime_permissions` 預先授權整個 turn、turn 結束 revoke。circadian 的 **phase chime（`_deliver_phase_chime`）原本建 `ChimeRequest` 時沒帶這三欄** —— 這是唯一的斷點。
+修法不是新系統，而是**接上既有管道**：`schedules.toml` 的 entry 早就能帶 `allowed_tools` / `scope_grants`（#444），經 `CronTrigger → planner → ChimeRequest → bot._apply_chime_permissions` 預先授權整個 turn、turn 結束 revoke。circadian 的 **phase chime（`_deliver_phase_chime`）原本建 `ChimeRequest` 時沒帶這些欄位** —— 這是唯一的斷點。
 
-- `Anchor` 新增 `trust_level` / `allowed_tools` / `scope_grants`，rhythm loader 經**共享的** `loom/autonomy/permission_fields.py::parse_permission_fields` 解析（schedules 載入也改用同一條，純 code 層統一）。
-- `_deliver_phase_chime` 把 `anchor.*` 轉進 `ChimeRequest`，完全比照 schedule 路徑。下游套用/撤銷全部沿用既有 bot 機制。
-- **單位是工具名 + 可選的 scope selector**：`allowed_tools = ["run_bash"]` 預授權 GUARDED 工具（含 EXEC，因為 `is_authorized` 對 pre-authorized 工具短路放行，morning_briefing 實證）；`scope_grants` 把工具收束到資源前綴（如 `write_file` 只能寫 `autonomy/circadian`）。
+- `Anchor` 新增 `allowed_tools` / `scope_grants`，rhythm loader 經**共享的** `loom/autonomy/permission_fields.py::parse_permission_fields` 解析（schedules 載入也改用同一條，純 code 層統一）。
+- `_deliver_phase_chime` 把 `anchor.*` 轉進 `ChimeRequest`，比照 schedule 路徑。下游套用/撤銷全部沿用既有 bot 機制。
+- **兩種授權單位，依工具選**（Codex review #527 釐清）：
+  - `allowed_tools = ["run_bash"]` 是**工具名 blanket** 預授權，整個 phase turn 內該工具不再問。`is_authorized` 對 pre-authorized 工具短路放行，含 EXEC（morning_briefing 實證）。適合 read-only 或本身已窄的工具。
+  - `scope_grants` 是**收束**：把一個寬工具 fence 在資源前綴內（`write_file` 只能寫 `autonomy/circadian`）。**不要**把被 fence 的工具同時放進 `allowed_tools` —— 那是 blanket 形式，會讓 fence 失效。
+- **`trust_level` 不是 phase 欄位**：chime path 不經 planner 的 notify/HOLD gate，放上去只是 inert 的假承諾。phase 授權只有 `allowed_tools` + `scope_grants`。
+- **harness 修正（#525 / Codex review）**：`BlastRadiusMiddleware._scope_aware_process` 的 legacy tool-name bypass 原本在 `CONFIRM` 跟 `EXPAND_SCOPE` 都套用，使「宣告了 scope_grant 又 blanket 了工具名」時 scope 形同虛設。改成 **bypass 只在 `CONFIRM`（沒宣告任何相關 grant）套用**；`EXPAND_SCOPE`（有宣告該 resource 的 grant、但這次超出 selector）時 scope 為準 → 超界拒絕。這讓 scope_grants 的安全承諾在 runtime 真正成立，且不影響只用 allowed_tools（無 scope）的 schedule。
 - **安全底線不動**：CRITICAL 永遠重問（`is_authorized` 對 CRITICAL 恆 False，與 grant 無關）。grant 只在該 phase turn 存活、用完即撤。
-- **這是 agent 自主管理面**：絲絲想讓某 phase 多做一件事就在自己的 `rhythm.toml` 加欄位，晚上跟 DK 討論（reactive 但宣告式，跟 schedules.toml 同一套心智）。
+- **這是 agent 自主管理面**：絲絲想讓某 phase 多做一件事就在自己的 `rhythm.toml` 加欄位，晚上跟 DK 討論（宣告式，跟 schedules.toml 同一套心智）。
 
 **不做**：
 - ❌ daily_weave.md 讀取（PR 3，但 gate 的 plan mtime check 用 stub 路徑）

--- a/doc/57-Circadian-Autonomy-實作計畫.md
+++ b/doc/57-Circadian-Autonomy-實作計畫.md
@@ -398,6 +398,18 @@ loader 把這種 block 展開成「每個有效時段一個 `Anchor`」，並只
 
 → 「同類但語義不同」的活動（例如想給早晚 pet 各自的 meaning）用**不同 name**（`pet` / `pet_evening`），各自一個 weave section；「同一件事重複」用 time list。
 
+**Phase 權限欄位（issue #525，2026-06-07）**：
+
+每天喚醒的 daily session 是新的 `PermissionContext`（grant 是 session-scoped 記憶體）。所以一個 phase 要做的 routine-safe 工具動作（早上查資料寫新聞心得、跑餵貓腳本）每天都會落回 GUARDED → 重問 DK → 在無限等授權下造成 phase drift。
+
+修法不是新系統，而是**接上既有管道**：`schedules.toml` 的 entry 早就能帶 `trust_level` / `allowed_tools` / `scope_grants`（#444），經 `CronTrigger → planner → ChimeRequest → bot._apply_chime_permissions` 預先授權整個 turn、turn 結束 revoke。circadian 的 **phase chime（`_deliver_phase_chime`）原本建 `ChimeRequest` 時沒帶這三欄** —— 這是唯一的斷點。
+
+- `Anchor` 新增 `trust_level` / `allowed_tools` / `scope_grants`，rhythm loader 經**共享的** `loom/autonomy/permission_fields.py::parse_permission_fields` 解析（schedules 載入也改用同一條，純 code 層統一）。
+- `_deliver_phase_chime` 把 `anchor.*` 轉進 `ChimeRequest`，完全比照 schedule 路徑。下游套用/撤銷全部沿用既有 bot 機制。
+- **單位是工具名 + 可選的 scope selector**：`allowed_tools = ["run_bash"]` 預授權 GUARDED 工具（含 EXEC，因為 `is_authorized` 對 pre-authorized 工具短路放行，morning_briefing 實證）；`scope_grants` 把工具收束到資源前綴（如 `write_file` 只能寫 `autonomy/circadian`）。
+- **安全底線不動**：CRITICAL 永遠重問（`is_authorized` 對 CRITICAL 恆 False，與 grant 無關）。grant 只在該 phase turn 存活、用完即撤。
+- **這是 agent 自主管理面**：絲絲想讓某 phase 多做一件事就在自己的 `rhythm.toml` 加欄位，晚上跟 DK 討論（reactive 但宣告式，跟 schedules.toml 同一套心智）。
+
 **不做**：
 - ❌ daily_weave.md 讀取（PR 3，但 gate 的 plan mtime check 用 stub 路徑）
 - ❌ nightly planning tool（PR 4）

--- a/loom/autonomy/circadian/lifecycle.py
+++ b/loom/autonomy/circadian/lifecycle.py
@@ -468,8 +468,8 @@ async def _deliver_phase_chime(
         # exactly as the schedule path does in AutonomyDaemon. This is the wire
         # that was missing: without it the fields parse into the Anchor but
         # never reach bot._apply_chime_permissions, so every daily session
-        # re-asks DK for the same routine-safe phase action.
-        trust_level=anchor.trust_level,
+        # re-asks DK for the same routine-safe phase action. trust_level is not
+        # forwarded — the chime path has no planner gate to honour it (#525).
         allowed_tools=anchor.allowed_tools,
         scope_grants=anchor.scope_grants,
     )

--- a/loom/autonomy/circadian/lifecycle.py
+++ b/loom/autonomy/circadian/lifecycle.py
@@ -464,6 +464,14 @@ async def _deliver_phase_chime(
         intent=intent,
         fired_at=datetime.now(timezone.utc),
         target={"type": "circadian_today", "fallback": "skip"},
+        # Forward the anchor's declared permissions onto the chime (issue #525),
+        # exactly as the schedule path does in AutonomyDaemon. This is the wire
+        # that was missing: without it the fields parse into the Anchor but
+        # never reach bot._apply_chime_permissions, so every daily session
+        # re-asks DK for the same routine-safe phase action.
+        trust_level=anchor.trust_level,
+        allowed_tools=anchor.allowed_tools,
+        scope_grants=anchor.scope_grants,
     )
     delivered = await daemon.deliver_chime(req)
     outcome = "delivered" if delivered else "skipped"

--- a/loom/autonomy/circadian/rhythm.py
+++ b/loom/autonomy/circadian/rhythm.py
@@ -27,8 +27,11 @@ from __future__ import annotations
 
 import logging
 import tomllib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
+
+from loom.autonomy.permission_fields import parse_permission_fields
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +56,15 @@ class Anchor:
     meaning: str    # markdown body the chime injects (the "why" of this phase)
     public: bool = True
     trigger_suffix: str = ""  # "@HHMM" disambiguator for multi-time activities
+
+    # Permission triple (issue #525) — the same fields a schedules.toml entry
+    # uses, so a phase can do routine tool work (research, write a draft, run
+    # the pet script) without re-asking DK every day. _deliver_phase_chime
+    # forwards these onto the ChimeRequest; bot._apply_chime_permissions then
+    # pre-authorises them for the phase turn (and revokes after).
+    trust_level: str | None = None              # None = no override (normal gating)
+    allowed_tools: tuple[str, ...] = ()
+    scope_grants: tuple[dict[str, Any], ...] = field(default_factory=tuple)
 
     @property
     def trigger_name(self) -> str:
@@ -139,13 +151,24 @@ def load_rhythm(path: Path | None = None) -> list[Anchor]:
 
         meaning = str(entry.get("meaning", "")).strip()
         public = bool(entry.get("public", True))
+        # Permission fields parse through the shared autonomy helper (issue
+        # #525) — same code path as schedules.toml — and belong to the activity
+        # identity, so every expanded slot of a recurring activity shares them.
+        perms = parse_permission_fields(entry, f"rhythm anchor {name!r}")
+        allowed_tools = tuple(perms["allowed_tools"])
+        scope_grants = tuple(perms["scope_grants"])
+        trust_level = perms["trust_level"]
         # Suffix the trigger only when the activity genuinely recurs: a single
         # surviving slot keeps the bare ``circadian:phase_<name>`` (backward
         # compatible), so the @HHMM form reflects reality, not declared intent.
         multi = len(slots) > 1
         for slot in slots:
             suffix = f"@{slot.replace(':', '')}" if multi else ""
-            anchors.append(Anchor(time=slot, name=name, meaning=meaning, public=public, trigger_suffix=suffix))
+            anchors.append(Anchor(
+                time=slot, name=name, meaning=meaning, public=public,
+                trigger_suffix=suffix, trust_level=trust_level,
+                allowed_tools=allowed_tools, scope_grants=scope_grants,
+            ))
         seen.add(name)
 
     return anchors

--- a/loom/autonomy/circadian/rhythm.py
+++ b/loom/autonomy/circadian/rhythm.py
@@ -57,12 +57,14 @@ class Anchor:
     public: bool = True
     trigger_suffix: str = ""  # "@HHMM" disambiguator for multi-time activities
 
-    # Permission triple (issue #525) — the same fields a schedules.toml entry
-    # uses, so a phase can do routine tool work (research, write a draft, run
-    # the pet script) without re-asking DK every day. _deliver_phase_chime
-    # forwards these onto the ChimeRequest; bot._apply_chime_permissions then
-    # pre-authorises them for the phase turn (and revokes after).
-    trust_level: str | None = None              # None = no override (normal gating)
+    # Routine-safe permissions (issue #525) — a phase can do tool work
+    # (research, write a draft, run the pet script) without re-asking DK every
+    # day. _deliver_phase_chime forwards these onto the ChimeRequest;
+    # bot._apply_chime_permissions pre-authorises them for the phase turn (and
+    # revokes after). NOTE: ``trust_level`` is intentionally NOT an anchor field
+    # — the chime path doesn't run the planner notify/HOLD gate that gives
+    # ``trust_level`` meaning for schedules, so exposing it would be a false
+    # affordance. Phase authorisation is allowed_tools + scope_grants only.
     allowed_tools: tuple[str, ...] = ()
     scope_grants: tuple[dict[str, Any], ...] = field(default_factory=tuple)
 
@@ -157,7 +159,12 @@ def load_rhythm(path: Path | None = None) -> list[Anchor]:
         perms = parse_permission_fields(entry, f"rhythm anchor {name!r}")
         allowed_tools = tuple(perms["allowed_tools"])
         scope_grants = tuple(perms["scope_grants"])
-        trust_level = perms["trust_level"]
+        if "trust_level" in entry:
+            logger.warning(
+                "[circadian] rhythm anchor %r sets trust_level, which is ignored "
+                "for phase anchors (the chime path has no planner gate); use "
+                "allowed_tools / scope_grants instead", name,
+            )
         # Suffix the trigger only when the activity genuinely recurs: a single
         # surviving slot keeps the bare ``circadian:phase_<name>`` (backward
         # compatible), so the @HHMM form reflects reality, not declared intent.
@@ -166,7 +173,7 @@ def load_rhythm(path: Path | None = None) -> list[Anchor]:
             suffix = f"@{slot.replace(':', '')}" if multi else ""
             anchors.append(Anchor(
                 time=slot, name=name, meaning=meaning, public=public,
-                trigger_suffix=suffix, trust_level=trust_level,
+                trigger_suffix=suffix,
                 allowed_tools=allowed_tools, scope_grants=scope_grants,
             ))
         seen.add(name)

--- a/loom/autonomy/daemon.py
+++ b/loom/autonomy/daemon.py
@@ -24,6 +24,7 @@ from typing import Awaitable, Callable
 
 from loom.autonomy.chime import ChimeRequest
 from loom.autonomy.evaluator import TriggerEvaluator
+from loom.autonomy.permission_fields import parse_permission_fields
 from loom.autonomy.history import TriggerHistory
 from loom.autonomy.maintenance import (
     ConvergentDreamLoop, DreamLoop, MaintenanceLoop,
@@ -49,7 +50,6 @@ caller should fall back per ``target['fallback']``."""
 # [autonomy] section — so that's what we fingerprint.
 # ---------------------------------------------------------------------------
 
-_VALID_TRUST_LEVELS = {"safe", "guarded", "critical"}
 _CONFIG_HASH_PATH = Path.home() / ".loom" / "schedules.hash"
 
 
@@ -59,15 +59,9 @@ def _hash_schedule_registry(sched_cfg: dict) -> str:
     return hashlib.sha256(canonical.encode()).hexdigest()
 
 
-def _validate_trust_level(value: str, trigger_name: str) -> str:
-    """Validate and return trust_level, defaulting to 'guarded' on invalid."""
-    if value not in _VALID_TRUST_LEVELS:
-        logger.warning(
-            "[autonomy] trigger %r has invalid trust_level=%r, defaulting to 'guarded'",
-            trigger_name, value,
-        )
-        return "guarded"
-    return value
+# trust_level / allowed_tools / scope_grants parsing lives in the shared
+# ``permission_fields`` helper (issue #525) so schedules and circadian rhythm
+# anchors validate their permissions through one code path.
 
 
 def _resolve_attachments(
@@ -489,18 +483,17 @@ class AutonomyDaemon:
                     # Normalise id to string for label matching
                     target["id"] = str(target["id"])
                     target.setdefault("fallback", "skip")
+                perms = parse_permission_fields(sched, name)
                 trigger = CronTrigger(
                     name=sched["name"],
                     intent=sched["intent"],
                     cron=sched.get("cron", "0 9 * * 1-5"),
                     timezone=sched.get("timezone", "UTC"),
-                    trust_level=_validate_trust_level(
-                        sched.get("trust_level", "guarded"), name,
-                    ),
+                    trust_level=perms["trust_level"] or "guarded",
                     notify=sched.get("notify", True),
                     notify_thread_id=sched.get("notify_thread", 0),
-                    allowed_tools=sched.get("allowed_tools", []),
-                    scope_grants=sched.get("scope_grants", []),
+                    allowed_tools=perms["allowed_tools"],
+                    scope_grants=perms["scope_grants"],
                     attach_outputs=sched.get("attach_outputs", []),
                     mode=mode,
                     target=target,
@@ -516,17 +509,16 @@ class AutonomyDaemon:
         for idx, evt in enumerate(sched_cfg.get("triggers", [])):
             name = evt.get("name", f"<triggers[{idx}]>")
             try:
+                perms = parse_permission_fields(evt, name)
                 trigger = EventTrigger(
                     name=evt["name"],
                     intent=evt["intent"],
                     event_name=evt.get("event", evt["name"]),
-                    trust_level=_validate_trust_level(
-                        evt.get("trust_level", "guarded"), name,
-                    ),
+                    trust_level=perms["trust_level"] or "guarded",
                     notify=evt.get("notify", True),
                     notify_thread_id=evt.get("notify_thread", 0),
-                    allowed_tools=evt.get("allowed_tools", []),
-                    scope_grants=evt.get("scope_grants", []),
+                    allowed_tools=perms["allowed_tools"],
+                    scope_grants=perms["scope_grants"],
                     attach_outputs=evt.get("attach_outputs", []),
                 )
             except (KeyError, ValueError) as exc:

--- a/loom/autonomy/permission_fields.py
+++ b/loom/autonomy/permission_fields.py
@@ -2,19 +2,23 @@
 Shared parser for autonomy permission fields — ``trust_level`` /
 ``allowed_tools`` / ``scope_grants`` (issue #525).
 
-These three fields describe *what an autonomous turn is pre-authorised to do*.
+These fields describe *what an autonomous turn is pre-authorised to do*.
 ``schedules.toml`` entries have carried them since #444; the circadian rhythm
-table (``rhythm.toml``) now declares the same fields through the same code path
-so a phase anchor and a cron schedule express their permissions identically
-(DK: "純 code 層統一"). Extracting the parser is the unification — both loaders
-import it instead of each re-reading the dict inline.
+loader (``rhythm.toml``) reuses the same parser so both express permissions
+through one code path (DK: "純 code 層統一"). Extracting the parser is the
+unification — both loaders import it instead of re-reading the dict inline.
+
+The two callers consume different subsets: a **schedule** uses all three
+(``trust_level`` gates the planner's notify/HOLD decision). A **phase anchor**
+uses only ``allowed_tools`` / ``scope_grants`` — the chime path has no planner
+gate, so ``trust_level`` is meaningless there and the rhythm loader ignores it.
+The parser still returns ``trust_level`` for the schedule caller.
 
 Contract is tolerant, like every other autonomy loader: a missing field yields
 a neutral default, a malformed one is dropped (never raised), so a single typo
-never silences the whole entry. The two callers differ only in the *default*
-they apply to a missing ``trust_level`` — a bare schedule wants ``"guarded"``,
-a bare anchor wants "no override" (``None``) — so the parser reports ``None``
-for absent and lets the caller choose.
+never silences the whole entry. ``trust_level`` is reported as ``None`` when
+absent so each caller applies its own default (a bare schedule wants
+``"guarded"``).
 """
 
 from __future__ import annotations

--- a/loom/autonomy/permission_fields.py
+++ b/loom/autonomy/permission_fields.py
@@ -1,0 +1,80 @@
+"""
+Shared parser for autonomy permission fields — ``trust_level`` /
+``allowed_tools`` / ``scope_grants`` (issue #525).
+
+These three fields describe *what an autonomous turn is pre-authorised to do*.
+``schedules.toml`` entries have carried them since #444; the circadian rhythm
+table (``rhythm.toml``) now declares the same fields through the same code path
+so a phase anchor and a cron schedule express their permissions identically
+(DK: "純 code 層統一"). Extracting the parser is the unification — both loaders
+import it instead of each re-reading the dict inline.
+
+Contract is tolerant, like every other autonomy loader: a missing field yields
+a neutral default, a malformed one is dropped (never raised), so a single typo
+never silences the whole entry. The two callers differ only in the *default*
+they apply to a missing ``trust_level`` — a bare schedule wants ``"guarded"``,
+a bare anchor wants "no override" (``None``) — so the parser reports ``None``
+for absent and lets the caller choose.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+VALID_TRUST_LEVELS = {"safe", "guarded", "critical"}
+
+
+def validate_trust_level(value: str, source_name: str) -> str:
+    """Return *value* if it is a known trust level, else ``"guarded"``.
+
+    An unknown level is a config typo; defaulting to the stricter ``guarded``
+    (re-confirm) fails safe rather than silently widening authority.
+    """
+    if value not in VALID_TRUST_LEVELS:
+        logger.warning(
+            "[autonomy] %r has invalid trust_level=%r, defaulting to 'guarded'",
+            source_name, value,
+        )
+        return "guarded"
+    return value
+
+
+def parse_permission_fields(data: dict[str, Any], source_name: str) -> dict[str, Any]:
+    """Extract the permission triple from a schedule/anchor table.
+
+    Returns ``{"trust_level", "allowed_tools", "scope_grants"}``:
+
+    - ``trust_level``: ``None`` when absent (caller applies its own default),
+      otherwise validated to a known level (invalid → ``"guarded"``).
+    - ``allowed_tools``: list of tool-name strings; a non-list is dropped to
+      ``[]``.
+    - ``scope_grants``: list of grant dicts, each keeping at least ``resource``
+      and ``action``; malformed entries (wrong type, missing keys) are dropped
+      individually so one bad grant doesn't void the rest.
+    """
+    raw_tl = data.get("trust_level")
+    trust_level = None if raw_tl is None else validate_trust_level(str(raw_tl), source_name)
+
+    raw_tools = data.get("allowed_tools")
+    allowed_tools = [str(t) for t in raw_tools] if isinstance(raw_tools, list) else []
+
+    raw_grants = data.get("scope_grants")
+    scope_grants: list[dict[str, Any]] = []
+    if isinstance(raw_grants, list):
+        for g in raw_grants:
+            if isinstance(g, dict) and "resource" in g and "action" in g:
+                scope_grants.append(g)
+            else:
+                logger.warning(
+                    "[autonomy] %r has a malformed scope_grant %r; skipping it",
+                    source_name, g,
+                )
+
+    return {
+        "trust_level": trust_level,
+        "allowed_tools": allowed_tools,
+        "scope_grants": scope_grants,
+    }

--- a/loom/core/harness/middleware.py
+++ b/loom/core/harness/middleware.py
@@ -1032,14 +1032,21 @@ class BlastRadiusMiddleware(Middleware):
                 failure_type="permission_denied",
             )
 
-        # CONFIRM or EXPAND_SCOPE — prompt user (or deny if unattended)
+        # CONFIRM or EXPAND_SCOPE — prompt user (or deny if unattended).
         #
-        # Legacy bridge: if the tool was pre-authorized by name (e.g. the
-        # autonomy daemon's allowed_tools list), honour that even though
-        # scope evaluation returned CONFIRM/EXPAND_SCOPE.  Without this,
-        # scope-resolved tools ignore session_authorized entirely, causing
-        # autonomy triggers to be denied despite explicit allowed_tools.
-        if self._perm.is_authorized(call.tool_name, call.trust_level):
+        # Legacy bridge (refined in #525): honour a name-level pre-authorization
+        # (e.g. the autonomy daemon's allowed_tools) ONLY on CONFIRM — i.e. when
+        # NO scope_grant was declared for this resource, so allowed_tools is the
+        # only stated authorization and the original bridge intent holds (an
+        # autonomy trigger shouldn't be denied despite explicit allowed_tools).
+        #
+        # EXPAND_SCOPE means the caller DID declare a scope_grant for this
+        # resource and this call exceeds its selector. Honouring the tool-name
+        # bypass there would silently void the very boundary the grant promised
+        # (e.g. ``allowed_tools=["write_file"]`` would blanket-authorise writes
+        # outside a ``selector="autonomy/circadian"`` grant). So on EXPAND_SCOPE
+        # the scope is authoritative and we fall through to confirm/deny.
+        if verdict == PV.CONFIRM and self._perm.is_authorized(call.tool_name, call.trust_level):
             self._notify_lifecycle(call, True, "scope-confirm-legacy-authorized")
             return None  # proceed
 

--- a/tests/test_autonomy_permission_fields.py
+++ b/tests/test_autonomy_permission_fields.py
@@ -1,0 +1,78 @@
+"""
+Tests for the shared autonomy permission-field parser (issue #525).
+
+``trust_level`` / ``allowed_tools`` / ``scope_grants`` are the three fields a
+``schedules.toml`` entry already uses to pre-authorise an autonomous turn. The
+parser is extracted so the circadian rhythm table can declare the *same* fields
+through the *same* code path (DK: "純 code 層統一") — a rhythm anchor and a cron
+schedule now describe their permissions identically.
+
+The contract is tolerant, mirroring the rest of the autonomy loaders: a missing
+field yields a neutral default, a malformed one is dropped (not raised) so a
+single typo never silences the whole entry.
+"""
+
+from __future__ import annotations
+
+from loom.autonomy.permission_fields import (
+    VALID_TRUST_LEVELS,
+    parse_permission_fields,
+    validate_trust_level,
+)
+
+
+class TestValidateTrustLevel:
+    def test_valid_levels_pass_through(self):
+        for level in VALID_TRUST_LEVELS:
+            assert validate_trust_level(level, "x") == level
+
+    def test_invalid_defaults_to_guarded(self):
+        assert validate_trust_level("paranoid", "sched") == "guarded"
+
+    def test_empty_defaults_to_guarded(self):
+        assert validate_trust_level("", "sched") == "guarded"
+
+
+class TestParsePermissionFields:
+    def test_empty_dict_yields_neutral_defaults(self):
+        out = parse_permission_fields({}, "x")
+        assert out == {"trust_level": None, "allowed_tools": [], "scope_grants": []}
+
+    def test_missing_trust_level_is_none_not_guarded(self):
+        # A bare anchor declares no trust override → None, so the caller keeps
+        # its own default (anchors want "no override", schedules want "guarded").
+        assert parse_permission_fields({"allowed_tools": ["x"]}, "p")["trust_level"] is None
+
+    def test_present_trust_level_validated(self):
+        assert parse_permission_fields({"trust_level": "safe"}, "p")["trust_level"] == "safe"
+
+    def test_invalid_trust_level_validated_to_guarded(self):
+        assert parse_permission_fields({"trust_level": "nope"}, "p")["trust_level"] == "guarded"
+
+    def test_allowed_tools_coerced_to_str_list(self):
+        out = parse_permission_fields({"allowed_tools": ["run_bash", "write_file"]}, "p")
+        assert out["allowed_tools"] == ["run_bash", "write_file"]
+
+    def test_allowed_tools_non_list_dropped(self):
+        assert parse_permission_fields({"allowed_tools": "run_bash"}, "p")["allowed_tools"] == []
+
+    def test_scope_grants_keep_well_formed_entries(self):
+        grants = [
+            {"resource": "path", "action": "write", "selector": "news"},
+            {"resource": "mutation", "action": "mutate"},  # selector optional
+        ]
+        out = parse_permission_fields({"scope_grants": grants}, "p")
+        assert out["scope_grants"] == grants
+
+    def test_scope_grants_drop_malformed_entries(self):
+        # An entry missing resource/action, or not a dict, is dropped — not raised.
+        grants = [
+            {"resource": "path", "action": "write"},
+            {"resource": "path"},          # no action
+            "not-a-dict",                  # wrong type
+        ]
+        out = parse_permission_fields({"scope_grants": grants}, "p")
+        assert out["scope_grants"] == [{"resource": "path", "action": "write"}]
+
+    def test_scope_grants_non_list_dropped(self):
+        assert parse_permission_fields({"scope_grants": {"resource": "x"}}, "p")["scope_grants"] == []

--- a/tests/test_circadian_phase_chime.py
+++ b/tests/test_circadian_phase_chime.py
@@ -197,6 +197,65 @@ class TestPhaseChimeFire:
         assert req.intent == "醒來成為今天的絲絲"
         assert req.target == {"type": "circadian_today", "fallback": "skip"}
 
+    async def test_fire_forwards_anchor_permissions_to_chime(self):
+        # Issue #525: the missing wire. _deliver_phase_chime must put the
+        # anchor's trust_level / allowed_tools / scope_grants onto the
+        # ChimeRequest, exactly like the schedule path (daemon.py) does — so
+        # bot._apply_chime_permissions can pre-authorise the phase's routine
+        # tools. Without this the fields are declared but silently dropped.
+        daemon, deliveries, _ = _make_daemon()
+        anchors = [
+            Anchor(
+                time="11:00",
+                name="curiosity",
+                meaning="好奇心散步",
+                trust_level="safe",
+                allowed_tools=("fetch_url", "write_file"),
+                scope_grants=(
+                    {"resource": "path", "action": "write", "selector": "autonomy/circadian"},
+                ),
+            ),
+        ]
+        register_rhythm_anchors(daemon, CFG, anchors)
+
+        plat = FakePlatform()
+        await ensure_today_session(
+            datetime.now(timezone.utc), plat, CFG, evaluator=FakeEvaluator()
+        )
+
+        trigger = next(
+            t for t in daemon.evaluator.list() if t.name == "circadian:phase_curiosity"
+        )
+        await daemon._on_trigger_fire(trigger, {})
+
+        assert len(deliveries) == 1
+        req = deliveries[0]
+        assert req.trust_level == "safe"
+        assert req.allowed_tools == ("fetch_url", "write_file")
+        assert req.scope_grants == (
+            {"resource": "path", "action": "write", "selector": "autonomy/circadian"},
+        )
+
+    async def test_fire_without_permissions_leaves_chime_defaults(self):
+        # A phase that declares no permission fields produces a ChimeRequest
+        # with the neutral defaults — unchanged behaviour for existing tables.
+        daemon, deliveries, _ = _make_daemon()
+        register_rhythm_anchors(daemon, CFG, [
+            Anchor(time="08:00", name="dawn", meaning="x"),
+        ])
+        plat = FakePlatform()
+        await ensure_today_session(
+            datetime.now(timezone.utc), plat, CFG, evaluator=FakeEvaluator()
+        )
+        trigger = next(
+            t for t in daemon.evaluator.list() if t.name == "circadian:phase_dawn"
+        )
+        await daemon._on_trigger_fire(trigger, {})
+        req = deliveries[0]
+        assert req.trust_level is None
+        assert req.allowed_tools == ()
+        assert req.scope_grants == ()
+
     async def test_fire_bypasses_planner(self):
         daemon, _, _ = _make_daemon()
         register_rhythm_anchors(daemon, CFG, [

--- a/tests/test_circadian_phase_chime.py
+++ b/tests/test_circadian_phase_chime.py
@@ -199,7 +199,7 @@ class TestPhaseChimeFire:
 
     async def test_fire_forwards_anchor_permissions_to_chime(self):
         # Issue #525: the missing wire. _deliver_phase_chime must put the
-        # anchor's trust_level / allowed_tools / scope_grants onto the
+        # anchor's allowed_tools / scope_grants onto the
         # ChimeRequest, exactly like the schedule path (daemon.py) does — so
         # bot._apply_chime_permissions can pre-authorise the phase's routine
         # tools. Without this the fields are declared but silently dropped.

--- a/tests/test_circadian_phase_chime.py
+++ b/tests/test_circadian_phase_chime.py
@@ -209,8 +209,7 @@ class TestPhaseChimeFire:
                 time="11:00",
                 name="curiosity",
                 meaning="好奇心散步",
-                trust_level="safe",
-                allowed_tools=("fetch_url", "write_file"),
+                allowed_tools=("fetch_url", "web_search"),
                 scope_grants=(
                     {"resource": "path", "action": "write", "selector": "autonomy/circadian"},
                 ),
@@ -230,11 +229,12 @@ class TestPhaseChimeFire:
 
         assert len(deliveries) == 1
         req = deliveries[0]
-        assert req.trust_level == "safe"
-        assert req.allowed_tools == ("fetch_url", "write_file")
+        assert req.allowed_tools == ("fetch_url", "web_search")
         assert req.scope_grants == (
             {"resource": "path", "action": "write", "selector": "autonomy/circadian"},
         )
+        # trust_level is not a phase field — never forwarded onto the chime.
+        assert req.trust_level is None
 
     async def test_fire_without_permissions_leaves_chime_defaults(self):
         # A phase that declares no permission fields produces a ChimeRequest

--- a/tests/test_circadian_rhythm.py
+++ b/tests/test_circadian_rhythm.py
@@ -246,22 +246,24 @@ class TestLoadRhythm:
         assert anchors[0].meaning == "first"
 
     def test_anchor_carries_permission_fields(self, tmp_path):
-        # Issue #525: an anchor can declare the same trust_level / allowed_tools
-        # / scope_grants a schedules.toml entry uses, so a circadian phase can
-        # do routine tool work (research, write a draft, run the pet script)
+        # Issue #525: an anchor declares allowed_tools / scope_grants (the same
+        # fields a schedules.toml entry uses) so a circadian phase can do
+        # routine tool work — research, write a draft, run the pet script —
         # without re-asking DK every day. The fields ride through to the chime.
+        # Blanket tools go in allowed_tools; a fenced tool (write_file) is
+        # authorised by the scope_grant alone, not co-listed in allowed_tools.
         p = tmp_path / "perm.toml"
         _write(p, '''
             [[anchors]]
             time = "11:00"
             name = "curiosity"
-            allowed_tools = ["fetch_url", "web_search", "write_file"]
+            allowed_tools = ["fetch_url", "web_search"]
             scope_grants = [
               { resource = "path", action = "write", selector = "autonomy/circadian" },
             ]
         ''')
         a = load_rhythm(p)[0]
-        assert a.allowed_tools == ("fetch_url", "web_search", "write_file")
+        assert a.allowed_tools == ("fetch_url", "web_search")
         assert a.scope_grants == (
             {"resource": "path", "action": "write", "selector": "autonomy/circadian"},
         )

--- a/tests/test_circadian_rhythm.py
+++ b/tests/test_circadian_rhythm.py
@@ -245,6 +245,67 @@ class TestLoadRhythm:
         assert [a.name for a in anchors] == ["pet"]
         assert anchors[0].meaning == "first"
 
+    def test_anchor_carries_permission_fields(self, tmp_path):
+        # Issue #525: an anchor can declare the same trust_level / allowed_tools
+        # / scope_grants a schedules.toml entry uses, so a circadian phase can
+        # do routine tool work (research, write a draft, run the pet script)
+        # without re-asking DK every day. The fields ride through to the chime.
+        p = tmp_path / "perm.toml"
+        _write(p, '''
+            [[anchors]]
+            time = "11:00"
+            name = "curiosity"
+            allowed_tools = ["fetch_url", "web_search", "write_file"]
+            scope_grants = [
+              { resource = "path", action = "write", selector = "autonomy/circadian" },
+            ]
+        ''')
+        a = load_rhythm(p)[0]
+        assert a.allowed_tools == ("fetch_url", "web_search", "write_file")
+        assert a.scope_grants == (
+            {"resource": "path", "action": "write", "selector": "autonomy/circadian"},
+        )
+        assert a.trust_level is None  # no override declared
+
+    def test_anchor_without_permission_fields_defaults_empty(self, tmp_path):
+        p = tmp_path / "plain.toml"
+        _write(p, '''
+            [[anchors]]
+            time = "09:00"
+            name = "dawn"
+        ''')
+        a = load_rhythm(p)[0]
+        assert a.allowed_tools == ()
+        assert a.scope_grants == ()
+        assert a.trust_level is None
+
+    def test_multi_time_anchor_shares_permission_fields(self, tmp_path):
+        # The permission fields are an attribute of the activity identity, so
+        # every expanded slot of a recurring activity carries the same grants.
+        p = tmp_path / "petperm.toml"
+        _write(p, '''
+            [[anchors]]
+            time = ["10:00", "19:00"]
+            name = "pet"
+            trust_level = "safe"
+            allowed_tools = ["run_bash"]
+        ''')
+        anchors = load_rhythm(p)
+        assert len(anchors) == 2
+        for a in anchors:
+            assert a.trust_level == "safe"
+            assert a.allowed_tools == ("run_bash",)
+
+    def test_anchor_invalid_trust_level_falls_back_guarded(self, tmp_path):
+        p = tmp_path / "badtrust.toml"
+        _write(p, '''
+            [[anchors]]
+            time = "09:00"
+            name = "dawn"
+            trust_level = "paranoid"
+        ''')
+        assert load_rhythm(p)[0].trust_level == "guarded"
+
     def test_per_agent_isolation_via_separate_paths(self, tmp_path):
         sisi = tmp_path / "sisi" / "rhythm.toml"
         xiaoqing = tmp_path / "xiaoqing" / "rhythm.toml"

--- a/tests/test_circadian_rhythm.py
+++ b/tests/test_circadian_rhythm.py
@@ -265,7 +265,6 @@ class TestLoadRhythm:
         assert a.scope_grants == (
             {"resource": "path", "action": "write", "selector": "autonomy/circadian"},
         )
-        assert a.trust_level is None  # no override declared
 
     def test_anchor_without_permission_fields_defaults_empty(self, tmp_path):
         p = tmp_path / "plain.toml"
@@ -277,7 +276,6 @@ class TestLoadRhythm:
         a = load_rhythm(p)[0]
         assert a.allowed_tools == ()
         assert a.scope_grants == ()
-        assert a.trust_level is None
 
     def test_multi_time_anchor_shares_permission_fields(self, tmp_path):
         # The permission fields are an attribute of the activity identity, so
@@ -287,24 +285,28 @@ class TestLoadRhythm:
             [[anchors]]
             time = ["10:00", "19:00"]
             name = "pet"
-            trust_level = "safe"
             allowed_tools = ["run_bash"]
         ''')
         anchors = load_rhythm(p)
         assert len(anchors) == 2
         for a in anchors:
-            assert a.trust_level == "safe"
             assert a.allowed_tools == ("run_bash",)
 
-    def test_anchor_invalid_trust_level_falls_back_guarded(self, tmp_path):
-        p = tmp_path / "badtrust.toml"
+    def test_anchor_trust_level_is_ignored(self, tmp_path):
+        # trust_level is NOT a phase field (issue #525 / Codex review): the
+        # chime path has no planner notify/HOLD gate, so it would be inert.
+        # A rhythm anchor that sets it still loads (tolerant) but the Anchor
+        # carries no trust_level — exposing it would be a false affordance.
+        p = tmp_path / "trustset.toml"
         _write(p, '''
             [[anchors]]
             time = "09:00"
             name = "dawn"
-            trust_level = "paranoid"
+            trust_level = "safe"
         ''')
-        assert load_rhythm(p)[0].trust_level == "guarded"
+        a = load_rhythm(p)[0]
+        assert a.name == "dawn"
+        assert not hasattr(a, "trust_level")
 
     def test_per_agent_isolation_via_separate_paths(self, tmp_path):
         sisi = tmp_path / "sisi" / "rhythm.toml"

--- a/tests/test_scope_legacy_bypass_525.py
+++ b/tests/test_scope_legacy_bypass_525.py
@@ -1,0 +1,100 @@
+"""
+Regression for the legacy-bypass / scope-grant interaction (issue #525,
+Codex review of PR #527).
+
+The bug: a tool pre-authorised by *name* (via the autonomy ``allowed_tools``
+bridge → ``perm.authorize(tool)``) used to bypass scope evaluation on BOTH
+``CONFIRM`` and ``EXPAND_SCOPE``. So a phase that declared
+``allowed_tools = ["write_file"]`` *and* a bounding
+``scope_grants = [{path, write, "autonomy/circadian"}]`` got a BLANKET
+write_file — the grant's fence was silently void.
+
+The fix: the name-level bypass applies only on ``CONFIRM`` (no scope_grant
+declared for this resource → allowed_tools is the sole authorization). On
+``EXPAND_SCOPE`` (a grant for this resource exists but the call exceeds its
+selector) the scope is authoritative, so an out-of-scope call is denied even
+when the tool name is pre-authorised.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from loom.core.harness.middleware import (
+    BlastRadiusMiddleware,
+    ToolCall,
+    ToolResult,
+)
+from loom.core.harness.permissions import PermissionContext, ToolCapability, TrustLevel
+from loom.core.harness.registry import ToolDefinition, ToolRegistry
+from loom.core.harness.scope import ScopeGrant, ScopeRequest, ScopeRequirement
+
+
+def _write_file_resolver(call: ToolCall) -> ScopeRequest:
+    """Minimal write_file scope: a path/write requirement at args['path']."""
+    return ScopeRequest(
+        tool_name="write_file",
+        capabilities=ToolCapability.MUTATES,
+        requirements=[
+            ScopeRequirement(
+                resource="path",
+                action="write",
+                selector=call.args["path"],
+                tool_name="write_file",
+            )
+        ],
+    )
+
+
+def _make_setup():
+    handler_calls: list[str] = []
+
+    async def handler(call: ToolCall) -> ToolResult:
+        handler_calls.append(call.args.get("path", ""))
+        return ToolResult(call_id=call.id, tool_name=call.tool_name, success=True, output="ok")
+
+    tool = ToolDefinition(
+        name="write_file", description="", input_schema={},
+        executor=handler, trust_level=TrustLevel.GUARDED,
+        capabilities=ToolCapability.MUTATES, scope_resolver=_write_file_resolver,
+    )
+    reg = ToolRegistry()
+    reg.register(tool)
+
+    perm = PermissionContext(session_id="t")
+    # A bounding grant: write_file may touch only autonomy/circadian …
+    perm.grant(ScopeGrant(resource="path", action="write", selector="autonomy/circadian"))
+    # … AND the tool is pre-authorised by name, simulating allowed_tools.
+    perm.authorize("write_file")
+
+    blast = BlastRadiusMiddleware(
+        perm_ctx=perm, registry=reg, confirm_fn=AsyncMock(return_value=True),
+    )
+    return blast, handler, handler_calls
+
+
+def _call(path: str) -> ToolCall:
+    # origin="autonomy" → unattended: an out-of-scope call fails fast instead
+    # of prompting (the circadian phase turn has no human to ask).
+    return ToolCall(
+        tool_name="write_file", args={"path": path},
+        trust_level=TrustLevel.GUARDED, session_id="t", origin="autonomy",
+    )
+
+
+class TestScopeBoundsDespiteAllowedTools:
+    async def test_in_scope_write_is_allowed(self):
+        blast, _handler, calls = _make_setup()
+        result = await blast.process(_call("autonomy/circadian/note.md"), _handler)
+        assert result.success
+        assert calls == ["autonomy/circadian/note.md"]
+
+    async def test_out_of_scope_write_is_denied_even_when_name_authorized(self):
+        # This is the regression: allowed_tools authorised write_file by name,
+        # but the scope_grant fences it to autonomy/circadian — a write to
+        # doc/outside.md must NOT slip through on the legacy bypass.
+        blast, _handler, calls = _make_setup()
+        result = await blast.process(_call("doc/outside.md"), _handler)
+        assert not result.success
+        assert result.failure_type == "permission_denied"
+        assert calls == []  # handler never ran


### PR DESCRIPTION
Closes #525.

## 問題

每天喚醒的 circadian daily session 是新的 `PermissionContext`（grant 是 session-scoped 記憶體）。一個 phase 的 routine 工具動作 —— 早上查資料寫新聞心得、跑餵貓腳本 —— 每天都落回 GUARDED → 重問 DK。在 autonomy 的「無限等操作者授權」下,這個 blocking re-prompt 就是 DK 在 2026-06-06 觀察到的 phase drift（pet 跑了 4h 才到等）。

## 修法:接上既有管道,不是新系統

`schedules.toml` 的 entry 早就能帶 `trust_level` / `allowed_tools` / `scope_grants`（#444),經 `CronTrigger → planner → ChimeRequest → bot._apply_chime_permissions` 預先授權整個 turn、turn 結束 revoke。`morning_briefing` 就是靠這個每天自動跑 `run_bash`/`write_file`/`fetch_url`。

**唯一斷點**:circadian 的 phase chime（`_deliver_phase_chime`）建 `ChimeRequest` 時沒帶這三欄。這個 PR 把它接起來。

## 改動

- **`permission_fields.py`（新）**:共享 `parse_permission_fields` + `validate_trust_level`,從 daemon 抽出。schedules 載入跟 rhythm anchor 解析走**同一條** tolerant code path（純 code 層統一）。
- **`rhythm.py`**:`Anchor` 新增 `trust_level` / `allowed_tools` / `scope_grants`;多時段（recurring）活動的每個 slot 共享這些欄位。
- **`lifecycle.py`**:`_deliver_phase_chime` 把 `anchor.*` 轉進 `ChimeRequest`,比照 schedule 路徑。
- **`daemon.py`**:schedule + event trigger 解析改用共享 helper（malformed scope_grant 改成個別丟棄,不再往下游 crash）。
- **`rhythm.example.toml`**:pet（`run_bash`）+ curiosity（`fetch_url`/`web_search` + path-bounded `write_file`）示範;Rules 註解寫清楚（絲絲忘記時翻範例）。
- **`doc/57`**:Phase 權限欄位 contract 段落。

## 安全底線不動

- **CRITICAL 永遠重問**:`is_authorized` 對 CRITICAL 恆 False,與 grant 無關。
- grant 只在該 phase turn 存活、用完即撤。
- `allowed_tools` 預授權 GUARDED 工具（含 `run_bash` —— `is_authorized` 對 pre-authorized 工具短路放行,morning_briefing 實證）;`scope_grants` 把工具收束到資源前綴。
- 這是 **agent 自主管理面**:絲絲想讓某 phase 多做一件事就在自己 `rhythm.toml` 加欄位,晚上跟 DK 討論（宣告式,跟 schedules.toml 同一套心智）。

## 測試（TDD,red→green）

- `test_autonomy_permission_fields.py`（新）:共享 parser 的 tolerant 契約。
- `test_circadian_rhythm.py`:anchor 解析權限欄位、多時段共享、invalid trust 退回 guarded、無欄位 default empty。
- `test_circadian_phase_chime.py`:`_deliver_phase_chime` 確實把三欄轉進 ChimeRequest（含 default 空的回歸）。
- 全套 **2538 passed**（唯一失敗 `test_layer3_version_sync` 是上游 release commit 漏更 `doc/00` 的 pre-existing 問題,與本 PR 無關）。

## 對映 issue

接 #526（pet 多時段,已 merge 到 master）。本 PR 讓那兩個 pet slot 能帶 `run_bash` 自動放行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)