### PR TITLE
feat(memory): Prediction Spine P0 foundation — record store + resolver whitelist (#528)

### DIFF
--- a/loom/core/memory/prediction.py
+++ b/loom/core/memory/prediction.py
@@ -1,0 +1,207 @@
+"""
+Prediction Spine — episodic prediction log (epic #528, spec docs/designs/58 §3.1).
+
+A ``PredictionRecord`` is a bet the agent makes about the world: *I expect this
+command to succeed / this PR to merge / this output to contain X*. Bets are
+reconciled against **runtime observation** (never LLM self-narrative — I2) in
+the convergent dream, producing a per-domain calibration residue that lives in
+semantic memory. Individual records decay like any episodic entry; the rolled-up
+``calibration:<domain-or-resolver>`` summary is what persists (§3.2).
+
+This module is the data layer only — slice 1. The reconciliation pipeline
+(``run_prediction_reconciliation``) and the resolver whitelist land in later
+slices. Everything here enforces the structural seeds of the lifeline
+invariants:
+
+* **I1** — the ``(claim, due_condition, resolver)`` triple is mandatory; a
+  record missing any leg cannot be written.
+* **I4** — ``status`` is an explicit state machine. A bet is born ``pending``;
+  only a *reconciled* record carries a ``score`` and an ``observation_ref``.
+  Reconcile and stale are terminal-aware transitions, so a verified bet cannot
+  be re-scored (idempotency seed) and an unverified bet cannot masquerade as
+  verified.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, UTC
+from typing import Any
+
+import aiosqlite
+
+# I4 — the only legal status values, and which ones are terminal.
+VALID_STATUSES = ("pending", "due", "reconciled", "stale")
+_TERMINAL = ("reconciled", "stale")
+
+
+@dataclass
+class PredictionRecord:
+    session_id: str
+    claim: str                                  # what is predicted
+    due_condition: dict[str, Any]               # when it can be reconciled
+    resolver: dict[str, Any]                     # how to mechanically judge
+    domain: str = "knowledge"
+    context: str | None = None
+    status: str = "pending"
+    observation_ref: str | None = None          # set at reconcile
+    score: float | None = None                  # error_score, None until reconciled
+    metadata: dict[str, Any] = field(default_factory=dict)
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    reconciled_at: datetime | None = None
+
+
+def _row_to_record(r: Any) -> PredictionRecord:
+    return PredictionRecord(
+        id=r[0],
+        session_id=r[1],
+        claim=r[2],
+        due_condition=json.loads(r[3]),
+        resolver=json.loads(r[4]),
+        status=r[5],
+        domain=r[6],
+        context=r[7],
+        observation_ref=r[8],
+        score=r[9],
+        metadata=json.loads(r[10]),
+        created_at=datetime.fromisoformat(r[11]),
+        reconciled_at=datetime.fromisoformat(r[12]) if r[12] else None,
+    )
+
+
+_COLUMNS = (
+    "id, session_id, claim, due_condition, resolver, status, domain, "
+    "context, observation_ref, score, metadata, created_at, reconciled_at"
+)
+
+
+class PredictionStore:
+    """Read/write access to the prediction_records table."""
+
+    def __init__(self, db: aiosqlite.Connection) -> None:
+        self._db = db
+
+    # -- write -------------------------------------------------------------
+
+    async def write(self, rec: PredictionRecord) -> None:
+        """Persist a fresh bet. Enforces I1 (full triple) and I4 (born pending).
+
+        Raises ``ValueError`` when any leg of the ``(claim, due_condition,
+        resolver)`` triple is empty, or when the record claims a non-``pending``
+        status at birth (a bet cannot be verified before it has been observed).
+        """
+        if not rec.claim or not rec.claim.strip():
+            raise ValueError("prediction.claim is required (I1)")
+        if not rec.due_condition:
+            raise ValueError("prediction.due_condition is required (I1)")
+        if not rec.resolver:
+            raise ValueError("prediction.resolver is required (I1)")
+        if rec.status != "pending":
+            raise ValueError(
+                f"a prediction is born 'pending', not {rec.status!r} (I4)"
+            )
+        await self._db.execute(
+            f"INSERT INTO prediction_records ({_COLUMNS}) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                rec.id,
+                rec.session_id,
+                rec.claim,
+                json.dumps(rec.due_condition, ensure_ascii=False),
+                json.dumps(rec.resolver, ensure_ascii=False),
+                rec.status,
+                rec.domain,
+                rec.context,
+                rec.observation_ref,
+                rec.score,
+                json.dumps(rec.metadata, ensure_ascii=False),
+                rec.created_at.isoformat(),
+                rec.reconciled_at.isoformat() if rec.reconciled_at else None,
+            ),
+        )
+        await self._db.commit()
+
+    # -- read --------------------------------------------------------------
+
+    async def get(self, prediction_id: str) -> PredictionRecord | None:
+        cur = await self._db.execute(
+            f"SELECT {_COLUMNS} FROM prediction_records WHERE id = ?",
+            (prediction_id,),
+        )
+        row = await cur.fetchone()
+        return _row_to_record(row) if row else None
+
+    async def list_by_status(
+        self, status: str, *, limit: int = 200
+    ) -> list[PredictionRecord]:
+        if status not in VALID_STATUSES:
+            raise ValueError(f"unknown status {status!r}; expected {VALID_STATUSES}")
+        cur = await self._db.execute(
+            f"SELECT {_COLUMNS} FROM prediction_records "
+            "WHERE status = ? ORDER BY created_at ASC LIMIT ?",
+            (status, limit),
+        )
+        return [_row_to_record(r) for r in await cur.fetchall()]
+
+    # -- transitions (I4 state machine) -----------------------------------
+
+    async def mark_due(self, prediction_id: str) -> None:
+        """pending → due. The bet's due_condition has been met; it awaits reconcile."""
+        await self._transition(prediction_id, frm=("pending",), to="due")
+
+    async def mark_reconciled(
+        self, prediction_id: str, *, score: float, observation_ref: str
+    ) -> None:
+        """pending/due → reconciled. Requires a ground-truth ``observation_ref``.
+
+        The ``observation_ref`` requirement is the structural seed of I2: a
+        score can only exist alongside a pointer to the observation that
+        produced it. Reconcile is terminal — re-reconciling raises (idempotency).
+        """
+        if not observation_ref or not observation_ref.strip():
+            raise ValueError(
+                "mark_reconciled requires an observation_ref (I2 seed): a score "
+                "must point at the observation that produced it"
+            )
+        await self._transition(
+            prediction_id,
+            frm=("pending", "due"),
+            to="reconciled",
+            score=score,
+            observation_ref=observation_ref,
+            stamp_reconciled=True,
+        )
+
+    async def mark_stale(self, prediction_id: str) -> None:
+        """pending/due → stale. The bet expired unverified; it never carries a score."""
+        await self._transition(prediction_id, frm=("pending", "due"), to="stale")
+
+    async def _transition(
+        self,
+        prediction_id: str,
+        *,
+        frm: tuple[str, ...],
+        to: str,
+        score: float | None = None,
+        observation_ref: str | None = None,
+        stamp_reconciled: bool = False,
+    ) -> None:
+        rec = await self.get(prediction_id)
+        if rec is None:
+            raise ValueError(f"no prediction {prediction_id!r}")
+        if rec.status not in frm:
+            raise ValueError(
+                f"cannot move prediction from {rec.status!r} to {to!r} "
+                f"(allowed from {frm})"
+            )
+        stamp = datetime.now(UTC).isoformat() if stamp_reconciled else None
+        await self._db.execute(
+            "UPDATE prediction_records SET status = ?, score = ?, "
+            "observation_ref = COALESCE(?, observation_ref), reconciled_at = ? "
+            "WHERE id = ?",
+            (to, score, observation_ref, stamp, prediction_id),
+        )
+        await self._db.commit()

--- a/loom/core/memory/prediction.py
+++ b/loom/core/memory/prediction.py
@@ -43,7 +43,7 @@ class PredictionRecord:
     claim: str                                  # what is predicted
     due_condition: dict[str, Any]               # when it can be reconciled
     resolver: dict[str, Any]                     # how to mechanically judge
-    domain: str = "knowledge"
+    domain: str = "knowledge"   # "knowledge"|"cli"|"git"|... — enum/normalize in slice 4
     context: str | None = None
     status: str = "pending"
     observation_ref: str | None = None          # set at reconcile

--- a/loom/core/memory/resolvers.py
+++ b/loom/core/memory/resolvers.py
@@ -67,7 +67,12 @@ def resolve(resolver: dict, observation: dict) -> ResolverResult:
 
     if kind == "final_state":
         actual = observation["final_state"]
-        expect_in = resolver.get("expect_in", [])
+        expect_in = resolver.get("expect_in") or []
+        if not expect_in:
+            # Fail-fast: an empty expect_in would silently judge every state
+            # wrong (x in [] is always False). A resolver spec that forgot its
+            # set is a write-time mistake, not a 100%-error prediction (絲絲 review).
+            raise ValueError("final_state resolver requires a non-empty expect_in")
         return _binary(actual in expect_in, f"final_state={actual}")
 
     if kind == "output_contains":

--- a/loom/core/memory/resolvers.py
+++ b/loom/core/memory/resolvers.py
@@ -1,0 +1,98 @@
+"""
+Prediction Spine — resolver whitelist (epic #528, spec docs/designs/58 §4/§6).
+
+A resolver mechanically judges whether a prediction came true, given a
+*normalized observation* extracted from runtime ground truth (action_records /
+session_log — slice 3 does the extraction). Each resolver is a pure function
+of ``(resolver_spec, observation)`` returning a deterministic ``ResolverResult``.
+
+P0 admits **only mechanical** resolvers (this whitelist). Free-text "vibe"
+judging is deliberately excluded: it would let ground truth slip back to LLM
+self-narrative and break I2. An unknown resolver kind raises — P0 refuses to
+score what it cannot judge mechanically.
+
+A resolver whose observation is missing the field it needs raises ``KeyError``
+rather than silently scoring 0.0 — an unobservable bet is *unresolved*, not
+*correct* (no-silent-pass; pairs with I4's "unreconciled ≠ verified").
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+KNOWN_RESOLVERS = {
+    "tool_success",
+    "final_state",
+    "output_contains",
+    "output_regex",
+    "file_digest_changed",
+    "row_count",
+    "duration_bucket",
+}
+
+# duration_bucket thresholds (ms). A bet names the bucket it expects.
+_DURATION_BUCKETS = (("fast", 1_000.0), ("medium", 10_000.0))  # else "slow"
+
+
+@dataclass
+class ResolverResult:
+    matched: bool          # did the prediction come true?
+    error_score: float     # 0.0 = perfectly predicted, 1.0 = fully wrong
+    detail: str = ""
+
+
+def _binary(matched: bool, detail: str = "") -> ResolverResult:
+    return ResolverResult(matched=matched, error_score=0.0 if matched else 1.0, detail=detail)
+
+
+def _bucket_for(duration_ms: float) -> str:
+    for name, ceiling in _DURATION_BUCKETS:
+        if duration_ms < ceiling:
+            return name
+    return "slow"
+
+
+def resolve(resolver: dict, observation: dict) -> ResolverResult:
+    """Judge a prediction mechanically. See module docstring for contract."""
+    kind = resolver.get("kind")
+    if kind not in KNOWN_RESOLVERS:
+        raise ValueError(
+            f"unknown resolver kind {kind!r}; P0 whitelist is {sorted(KNOWN_RESOLVERS)}"
+        )
+
+    if kind == "tool_success":
+        actual = observation["tool_success"]  # KeyError if unobserved
+        return _binary(actual == resolver.get("expect", True), f"tool_success={actual}")
+
+    if kind == "final_state":
+        actual = observation["final_state"]
+        expect_in = resolver.get("expect_in", [])
+        return _binary(actual in expect_in, f"final_state={actual}")
+
+    if kind == "output_contains":
+        output = observation["output"]
+        present = resolver["needle"] in output
+        return _binary(present == resolver.get("expect", True), f"present={present}")
+
+    if kind == "output_regex":
+        output = observation["output"]
+        hit = re.search(resolver["pattern"], output) is not None
+        return _binary(hit == resolver.get("expect", True), f"regex_hit={hit}")
+
+    if kind == "file_digest_changed":
+        changed = observation["digest_before"] != observation["digest_after"]
+        return _binary(changed == resolver.get("expect", True), f"changed={changed}")
+
+    if kind == "row_count":
+        expect = resolver["expect"]
+        actual = observation["row_count"]
+        tolerance = resolver.get("tolerance", 0)
+        delta = abs(actual - expect)
+        matched = delta <= tolerance
+        error_score = 0.0 if matched else min(1.0, delta / max(1, abs(expect)))
+        return ResolverResult(matched, error_score, f"expect={expect} actual={actual}")
+
+    # duration_bucket
+    actual_bucket = _bucket_for(observation["duration_ms"])
+    return _binary(actual_bucket == resolver["expect"], f"bucket={actual_bucket}")

--- a/loom/core/memory/store.py
+++ b/loom/core/memory/store.py
@@ -137,6 +137,34 @@ CREATE INDEX IF NOT EXISTS idx_action_session ON action_records(session_id);
 CREATE INDEX IF NOT EXISTS idx_action_state   ON action_records(final_state);
 CREATE INDEX IF NOT EXISTS idx_action_env     ON action_records(envelope_id);
 
+-- Prediction Spine P0 (epic #528, spec docs/designs/58 §3.1): episodic
+-- prediction log. A bet the agent makes about the world; reconciled against
+-- runtime observation in the convergent dream. Individual records decay like
+-- episodic memory — the per-domain calibration *residue* lives in
+-- semantic_entries under key `calibration:<domain-or-resolver>` (§3.2).
+-- I1: (claim, due_condition, resolver) are mandatory (enforced in PredictionStore).
+-- I4: status is a state machine (pending → due → reconciled / stale); only a
+--     reconciled record carries a score + observation_ref.
+CREATE TABLE IF NOT EXISTS prediction_records (
+    id              TEXT PRIMARY KEY,
+    session_id      TEXT NOT NULL,
+    claim           TEXT NOT NULL,        -- what is predicted (structured/text)
+    due_condition   TEXT NOT NULL,        -- JSON: when it can be reconciled
+    resolver        TEXT NOT NULL,        -- JSON: how to mechanically judge
+    status          TEXT NOT NULL DEFAULT 'pending',  -- pending|due|reconciled|stale
+    domain          TEXT NOT NULL DEFAULT 'knowledge',
+    context         TEXT,                 -- optional free context label
+    observation_ref TEXT,                 -- ground-truth pointer, set at reconcile
+    score           REAL,                 -- error_score, NULL until reconciled
+    metadata        TEXT NOT NULL DEFAULT '{}',
+    created_at      TEXT NOT NULL,
+    reconciled_at   TEXT                  -- NULL until reconciled
+);
+
+CREATE INDEX IF NOT EXISTS idx_prediction_status ON prediction_records(status);
+CREATE INDEX IF NOT EXISTS idx_prediction_domain ON prediction_records(domain);
+CREATE INDEX IF NOT EXISTS idx_prediction_session ON prediction_records(session_id);
+
 -- Issue #142: Agent self-observability snapshots (one row per dimension per session)
 CREATE TABLE IF NOT EXISTS agent_telemetry (
     dimension   TEXT NOT NULL,

--- a/tests/test_prediction_resolvers.py
+++ b/tests/test_prediction_resolvers.py
@@ -1,0 +1,165 @@
+"""
+Prediction Spine — P0 slice 2: resolver whitelist (epic #528, spec §4/§6).
+
+P0 only admits **mechanically reconcilable** resolvers — given a resolver spec
+and a normalized observation, each returns a deterministic verdict
+(``matched`` + ``error_score``). No LLM, no free-text "vibe" judging (those are
+deferred so I2's ground-truth guarantee cannot slip back to self-narrative).
+
+A resolver kind that is not on the whitelist must raise — P0 refuses to score
+anything it cannot judge mechanically.
+"""
+
+import pytest
+
+from loom.core.memory.resolvers import resolve, ResolverResult, KNOWN_RESOLVERS
+
+
+class TestWhitelist:
+    def test_known_resolvers_are_the_p0_set(self):
+        assert KNOWN_RESOLVERS == {
+            "tool_success",
+            "final_state",
+            "output_contains",
+            "output_regex",
+            "file_digest_changed",
+            "row_count",
+            "duration_bucket",
+        }
+
+    def test_unknown_kind_raises(self):
+        with pytest.raises(ValueError):
+            resolve({"kind": "vibe_check"}, {"output": "anything"})
+
+    def test_missing_kind_raises(self):
+        with pytest.raises(ValueError):
+            resolve({}, {})
+
+
+class TestToolSuccess:
+    def test_correct_prediction_scores_zero(self):
+        r = resolve({"kind": "tool_success", "expect": True}, {"tool_success": True})
+        assert isinstance(r, ResolverResult)
+        assert r.matched is True
+        assert r.error_score == 0.0
+
+    def test_wrong_prediction_scores_one(self):
+        r = resolve({"kind": "tool_success", "expect": True}, {"tool_success": False})
+        assert r.matched is False
+        assert r.error_score == 1.0
+
+
+class TestFinalState:
+    def test_state_in_expected_set(self):
+        r = resolve(
+            {"kind": "final_state", "expect_in": ["completed", "ok"]},
+            {"final_state": "completed"},
+        )
+        assert r.matched is True
+        assert r.error_score == 0.0
+
+    def test_state_not_in_expected_set(self):
+        r = resolve(
+            {"kind": "final_state", "expect_in": ["completed"]},
+            {"final_state": "denied"},
+        )
+        assert r.matched is False
+        assert r.error_score == 1.0
+
+
+class TestOutputContains:
+    def test_needle_present_as_expected(self):
+        r = resolve(
+            {"kind": "output_contains", "needle": "PASS", "expect": True},
+            {"output": "all tests PASS"},
+        )
+        assert r.matched is True
+
+    def test_needle_absent_when_expected_present(self):
+        r = resolve(
+            {"kind": "output_contains", "needle": "PASS", "expect": True},
+            {"output": "1 failed"},
+        )
+        assert r.matched is False
+
+    def test_expect_absent(self):
+        r = resolve(
+            {"kind": "output_contains", "needle": "ERROR", "expect": False},
+            {"output": "clean run"},
+        )
+        assert r.matched is True
+
+
+class TestOutputRegex:
+    def test_pattern_matches(self):
+        r = resolve(
+            {"kind": "output_regex", "pattern": r"\d+ passed", "expect": True},
+            {"output": "16 passed in 0.1s"},
+        )
+        assert r.matched is True
+
+    def test_pattern_does_not_match(self):
+        r = resolve(
+            {"kind": "output_regex", "pattern": r"\d+ passed", "expect": True},
+            {"output": "collection error"},
+        )
+        assert r.matched is False
+
+
+class TestFileDigestChanged:
+    def test_changed_as_expected(self):
+        r = resolve(
+            {"kind": "file_digest_changed", "expect": True},
+            {"digest_before": "aaa", "digest_after": "bbb"},
+        )
+        assert r.matched is True
+
+    def test_unchanged_when_change_expected(self):
+        r = resolve(
+            {"kind": "file_digest_changed", "expect": True},
+            {"digest_before": "aaa", "digest_after": "aaa"},
+        )
+        assert r.matched is False
+
+
+class TestRowCount:
+    def test_exact_match_scores_zero(self):
+        r = resolve({"kind": "row_count", "expect": 10}, {"row_count": 10})
+        assert r.matched is True
+        assert r.error_score == 0.0
+
+    def test_within_tolerance_matches(self):
+        r = resolve(
+            {"kind": "row_count", "expect": 10, "tolerance": 2},
+            {"row_count": 12},
+        )
+        assert r.matched is True
+
+    def test_graded_error_score_outside_tolerance(self):
+        r = resolve({"kind": "row_count", "expect": 10}, {"row_count": 15})
+        assert r.matched is False
+        assert 0.0 < r.error_score <= 1.0
+
+
+class TestDurationBucket:
+    def test_bucket_matches_expectation(self):
+        r = resolve(
+            {"kind": "duration_bucket", "expect": "fast"},
+            {"duration_ms": 200},
+        )
+        assert r.matched is True
+
+    def test_bucket_misses_expectation(self):
+        r = resolve(
+            {"kind": "duration_bucket", "expect": "fast"},
+            {"duration_ms": 60_000},
+        )
+        assert r.matched is False
+        assert r.error_score == 1.0
+
+
+class TestMissingObservationField:
+    def test_missing_field_is_unresolvable_not_a_silent_pass(self):
+        """A resolver that can't see its field must not silently score 0."""
+        with pytest.raises(KeyError):
+            resolve({"kind": "tool_success", "expect": True}, {})

--- a/tests/test_prediction_resolvers.py
+++ b/tests/test_prediction_resolvers.py
@@ -66,6 +66,13 @@ class TestFinalState:
         assert r.matched is False
         assert r.error_score == 1.0
 
+    def test_empty_expect_in_raises(self):
+        """絲絲 review: a forgotten expect_in is a write-time bug, not 100% error."""
+        with pytest.raises(ValueError):
+            resolve({"kind": "final_state"}, {"final_state": "completed"})
+        with pytest.raises(ValueError):
+            resolve({"kind": "final_state", "expect_in": []}, {"final_state": "ok"})
+
 
 class TestOutputContains:
     def test_needle_present_as_expected(self):
@@ -139,6 +146,12 @@ class TestRowCount:
         r = resolve({"kind": "row_count", "expect": 10}, {"row_count": 15})
         assert r.matched is False
         assert 0.0 < r.error_score <= 1.0
+
+    def test_expect_zero_outside_tolerance_caps_at_one(self):
+        """絲絲 review: pin the expect=0 boundary — delta/max(1,0) caps at 1.0."""
+        r = resolve({"kind": "row_count", "expect": 0}, {"row_count": 5})
+        assert r.matched is False
+        assert r.error_score == 1.0
 
 
 class TestDurationBucket:

--- a/tests/test_prediction_store.py
+++ b/tests/test_prediction_store.py
@@ -1,0 +1,197 @@
+"""
+Prediction Spine — P0 slice 1 contract tests (epic #528, spec docs/designs/58 §2/§3/§8).
+
+Covers the lifeline invariants the data model must hold *before* any
+reconciliation pipeline exists:
+
+* **I1** — every prediction must carry the ``(claim, due_condition, resolver)``
+  triple; a record missing any leg cannot be written.
+* **I4 (seed)** — status is an explicit state machine; a prediction is born
+  ``pending`` and only a *reconciled* record carries a score. You cannot fake
+  a verified bet at birth, and reconciling requires an ``observation_ref``
+  (the structural seed of I2: a score must point at a ground-truth observation).
+
+These are red-first: ``loom.core.memory.prediction`` does not exist yet.
+"""
+
+import pytest
+import pytest_asyncio
+
+from loom.core.memory.store import SQLiteStore
+from loom.core.memory.prediction import PredictionRecord, PredictionStore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — fresh temp DB per test (mirrors tests/test_memory.py)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test_prediction.db")
+
+
+@pytest_asyncio.fixture
+async def store(tmp_db):
+    s = SQLiteStore(tmp_db)
+    await s.initialize()
+    return s
+
+
+@pytest_asyncio.fixture
+async def db_conn(store):
+    async with store.connect() as db:
+        yield db
+
+
+def _record(**overrides) -> PredictionRecord:
+    """A fully-populated, writable prediction (all three legs present)."""
+    base = dict(
+        session_id="sess-1",
+        claim="loom test suite will exit 0",
+        due_condition={"kind": "after_action", "call_id": "call-42"},
+        resolver={"kind": "tool_success", "expect": True},
+        domain="cli",
+    )
+    base.update(overrides)
+    return PredictionRecord(**base)
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+class TestSchema:
+    async def test_initialize_creates_prediction_table(self, db_conn):
+        cur = await db_conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='prediction_records'"
+        )
+        assert await cur.fetchone() is not None
+
+
+# ---------------------------------------------------------------------------
+# I1 — the (claim, due_condition, resolver) triple is mandatory
+# ---------------------------------------------------------------------------
+
+class TestI1RequiredTriple:
+    async def test_full_triple_writes_and_reads_back(self, db_conn):
+        ps = PredictionStore(db_conn)
+        rec = _record()
+        await ps.write(rec)
+
+        got = await ps.get(rec.id)
+        assert got is not None
+        assert got.claim == rec.claim
+        assert got.due_condition == rec.due_condition
+        assert got.resolver == rec.resolver
+        assert got.domain == "cli"
+
+    @pytest.mark.parametrize("missing", ["claim", "due_condition", "resolver"])
+    async def test_missing_leg_is_rejected(self, db_conn, missing):
+        ps = PredictionStore(db_conn)
+        empty = "" if missing == "claim" else {}
+        rec = _record(**{missing: empty})
+        with pytest.raises(ValueError):
+            await ps.write(rec)
+
+    async def test_whitespace_only_claim_is_rejected(self, db_conn):
+        ps = PredictionStore(db_conn)
+        with pytest.raises(ValueError):
+            await ps.write(_record(claim="   "))
+
+
+# ---------------------------------------------------------------------------
+# I4 (seed) — status state machine; only reconciled carries a score
+# ---------------------------------------------------------------------------
+
+class TestStatusLifecycle:
+    async def test_fresh_record_is_pending_with_no_score(self, db_conn):
+        ps = PredictionStore(db_conn)
+        rec = _record()
+        await ps.write(rec)
+        got = await ps.get(rec.id)
+        assert got.status == "pending"
+        assert got.score is None
+        assert got.observation_ref is None
+        assert got.reconciled_at is None
+
+    async def test_cannot_be_born_reconciled(self, db_conn):
+        """I4: a bet cannot be 'verified' at birth — no ground truth yet."""
+        ps = PredictionStore(db_conn)
+        with pytest.raises(ValueError):
+            await ps.write(_record(status="reconciled"))
+
+    async def test_invalid_status_rejected(self, db_conn):
+        ps = PredictionStore(db_conn)
+        with pytest.raises(ValueError):
+            await ps.write(_record(status="bogus"))
+
+    async def test_mark_due_pending_to_due(self, db_conn):
+        ps = PredictionStore(db_conn)
+        rec = _record()
+        await ps.write(rec)
+        await ps.mark_due(rec.id)
+        assert (await ps.get(rec.id)).status == "due"
+
+    async def test_reconcile_requires_observation_ref(self, db_conn):
+        """Structural seed of I2: a score must point at an observation."""
+        ps = PredictionStore(db_conn)
+        rec = _record()
+        await ps.write(rec)
+        with pytest.raises(ValueError):
+            await ps.mark_reconciled(rec.id, score=0.0, observation_ref="")
+
+    async def test_reconcile_sets_score_ref_and_timestamp(self, db_conn):
+        ps = PredictionStore(db_conn)
+        rec = _record()
+        await ps.write(rec)
+        await ps.mark_reconciled(
+            rec.id, score=0.25, observation_ref="action:call-42"
+        )
+        got = await ps.get(rec.id)
+        assert got.status == "reconciled"
+        assert got.score == 0.25
+        assert got.observation_ref == "action:call-42"
+        assert got.reconciled_at is not None
+
+    async def test_double_reconcile_is_rejected(self, db_conn):
+        """Idempotency seed — a reconciled bet is terminal."""
+        ps = PredictionStore(db_conn)
+        rec = _record()
+        await ps.write(rec)
+        await ps.mark_reconciled(rec.id, score=0.1, observation_ref="action:x")
+        with pytest.raises(ValueError):
+            await ps.mark_reconciled(rec.id, score=0.9, observation_ref="action:y")
+
+    async def test_mark_stale_pending_to_stale(self, db_conn):
+        ps = PredictionStore(db_conn)
+        rec = _record()
+        await ps.write(rec)
+        await ps.mark_stale(rec.id)
+        got = await ps.get(rec.id)
+        assert got.status == "stale"
+        assert got.score is None  # stale never carries a score
+
+    async def test_cannot_stale_a_reconciled_record(self, db_conn):
+        ps = PredictionStore(db_conn)
+        rec = _record()
+        await ps.write(rec)
+        await ps.mark_reconciled(rec.id, score=0.0, observation_ref="action:x")
+        with pytest.raises(ValueError):
+            await ps.mark_stale(rec.id)
+
+    async def test_list_by_status_filters(self, db_conn):
+        ps = PredictionStore(db_conn)
+        a, b, c = _record(), _record(), _record()
+        await ps.write(a)
+        await ps.write(b)
+        await ps.write(c)
+        await ps.mark_due(b.id)
+        await ps.mark_reconciled(c.id, score=0.0, observation_ref="action:x")
+
+        pending = await ps.list_by_status("pending")
+        due = await ps.list_by_status("due")
+        reconciled = await ps.list_by_status("reconciled")
+        assert {r.id for r in pending} == {a.id}
+        assert {r.id for r in due} == {b.id}
+        assert {r.id for r in reconciled} == {c.id}


### PR DESCRIPTION
Epic **#528** Prediction Spine 的 P0 第一刀（slices 1+2）。規格依據：`docs/designs/58` §3/§4/§6。

> 🪢 **給絲絲 review**：這是「spine 本體」的地基。**純積木、零 runtime 接線**——能產資料/判定，但沒有任何東西消費它，Loom 外在行為完全不變。這正是 P0「先讓器官會分泌、確認分泌物為真，最後才接神經」的前半。你最該看的是**不變式有沒有被正確編碼**（尤其 I2 的 ground-truth 種子），而不是行為——因為還沒有行為。

## 這個 PR 有什麼

### Slice 1 — 資料模型 + store（`prediction.py` + `prediction_records` 表）
- `PredictionRecord` / `PredictionStore`：write / get / list_by_status / mark_due / mark_reconciled / mark_stale
- **I1**：`(claim, due_condition, resolver)` 三元缺一不可寫
- **I4**：status 狀態機 `pending → due → reconciled / stale`
  - 出生即 `pending`（不能一出生就 `reconciled`——還沒被觀察過，不能假裝已驗證）
  - 只有 `reconciled` 帶 `score`
  - `mark_reconciled` 強制要 `observation_ref`（**I2 的結構種子**：score 一定要指向產生它的那個 observation）
  - terminal-aware：不可重複對帳、reconciled 後不可轉 stale

### Slice 2 — resolver 白名單（`resolvers.py`）
- `resolve(spec, observation) → ResolverResult`，7 種**機械可對帳** resolver：`tool_success` / `final_state` / `output_contains` / `output_regex` / `file_digest_changed` / `row_count` / `duration_bucket`
- 白名單外的 kind → `ValueError`（P0 拒絕判定它無法機械判定的東西）
- observation 缺欄位 → `KeyError`（**不靜默放水**：看不到的賭注是「未解析」不是「猜對了」，呼應 I4「未對帳 ≠ 已驗證」）

## 這個 PR **沒有**什麼（後續 slice）
- ❌ **Slice 3** 對帳管線 `run_prediction_reconciliation()`：寄生 convergent dream、dry-run→execute、從 `action_records`/`session_log` 抽 observation（**I2 的真正落實**）
- ❌ **Slice 4** calibration residue（`calibration:<domain>` semantic 摘要）+ surprise 三量唯讀廣播（**I3**）+ sentiment 不可更新（**I6**）
- ❌ **I5**（surprise 無直達 output）屬 affect 臂（P1 / #487）

## 想請絲絲特別看
1. **I2 種子夠不夠硬**？`observation_ref` 在 store 層強制，但「ground truth 不得來自 LLM 自我敘事」要到 slice 3 抽取層才真正鎖死——你覺得地基這層的約束方向對嗎？
2. **resolver 白名單範圍**：P0 只收機械可對帳、自由文字下注排除（§4）。這個 minimal subset 你 ok 嗎，還是有哪種「機械但我會想下」的賭注漏了？

## 驗證
- 新增 36 tests（store 16 + resolvers 20），全綠
- 回歸：memory / convergent dream / lifecycle 套件無破（86 passed）
- `gitnexus detect_changes`：只 `SCHEMA` 被動到，risk low、0 affected processes

Closes 無（epic #528 P0 尚未完成，這是第一刀）

🤖 Generated with [Claude Code](https://claude.com/claude-code)