### PR TITLE
feat(cognition): Prediction Spine slice 3 — reconciliation pipeline (pure functions) (#528)

### DIFF
--- a/loom/core/cognition/prediction_reconcile.py
+++ b/loom/core/cognition/prediction_reconcile.py
@@ -57,9 +57,14 @@ class ReconcileSkip:
     reason ∈ {"not_settled" (no terminal observation yet),
               "observation_gone" (ref row vanished),
               "unresolvable" (resolver cannot read its field — no silent pass)}
+
+    ``domain`` is carried so slice 4 can attribute skips per-domain (e.g.
+    high ``unresolvable`` in one domain = a resolver-spec bug) without re-joining
+    prediction_records (絲絲 review).
     """
     prediction_id: str
     reason: str
+    domain: str = ""
 
 
 @dataclass
@@ -104,18 +109,18 @@ async def run_prediction_reconciliation(
     for pred in candidates:
         ref = await find_settling_observation(db, pred.due_condition)
         if ref is None:
-            skipped.append(ReconcileSkip(pred.id, "not_settled"))
+            skipped.append(ReconcileSkip(pred.id, "not_settled", pred.domain))
             continue
         observation = await resolve_observation_ref(db, ref)
         if observation is None:
-            skipped.append(ReconcileSkip(pred.id, "observation_gone"))
+            skipped.append(ReconcileSkip(pred.id, "observation_gone", pred.domain))
             continue
         try:
             result = resolve(pred.resolver, observation)
         except (KeyError, ValueError):
             # resolver cannot read the field it needs against this observation —
             # unresolvable, not a free 0.0 (no silent pass; pairs with I4).
-            skipped.append(ReconcileSkip(pred.id, "unresolvable"))
+            skipped.append(ReconcileSkip(pred.id, "unresolvable", pred.domain))
             continue
         proposals.append(
             ReconcileProposal(

--- a/loom/core/cognition/prediction_reconcile.py
+++ b/loom/core/cognition/prediction_reconcile.py
@@ -1,0 +1,140 @@
+"""
+Prediction Spine — reconciliation pipeline (epic #528, spec docs/designs/58 §5).
+
+The convergent-dream *sibling*: where ``ConvergentDream`` consolidates semantic
+facts, this closes the spine's loop by judging matured predictions against
+runtime ground truth. It follows the same discipline (spec §5, Codex §14.7):
+
+    pending bet → find settling observation → resolve ref → apply resolver
+                → propose (dry-run)  /  mark_reconciled (execute)
+
+**Read-only by construction in dry-run.** ``execute=False`` walks reads only —
+``list_by_status`` / ``find_settling_observation`` / ``resolve_observation_ref``
+/ ``resolve``. The single write path (``mark_reconciled``) is gated behind
+``execute=True``. This is the function-level half of I3: the surprise the spine
+emits is a projection of observation, never something the dream writes back
+speculatively. The report is inert, auditable data — every proposal names the
+prediction, the observation it was judged against, the resolver, and the score.
+
+**Ground truth only (I2).** Observations come solely from
+``resolve_observation_ref`` (the action_records / session_log whitelist). A
+resolver that cannot see the field it needs leaves the bet *unresolvable* —
+skipped, never silently scored 0.0.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from loom.core.memory.observation import (
+    find_settling_observation,
+    resolve_observation_ref,
+)
+from loom.core.memory.resolvers import resolve
+
+
+# ---------------------------------------------------------------------------
+# Report shape — the auditable projection 絲絲 reviews
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ReconcileProposal:
+    """One matured bet, judged. The unit of audit: *this* prediction was scored
+    against *this* observation by *this* resolver, yielding *this* error."""
+    prediction_id: str
+    domain: str
+    observation_ref: str
+    resolver_kind: str
+    matched: bool
+    error_score: float
+    detail: str = ""
+
+
+@dataclass
+class ReconcileSkip:
+    """A candidate that could not be reconciled this pass, and why.
+
+    reason ∈ {"not_settled" (no terminal observation yet),
+              "observation_gone" (ref row vanished),
+              "unresolvable" (resolver cannot read its field — no silent pass)}
+    """
+    prediction_id: str
+    reason: str
+
+
+@dataclass
+class ReconcileReport:
+    executed: bool
+    proposals: list[ReconcileProposal] = field(default_factory=list)
+    skipped: list[ReconcileSkip] = field(default_factory=list)
+
+    @property
+    def settleable(self) -> int:
+        return len(self.proposals)
+
+    def summary(self) -> str:
+        verb = "reconciled" if self.executed else "would reconcile"
+        tail = "" if self.executed else " (dry-run)"
+        return (
+            f"prediction reconcile: {verb} {len(self.proposals)}, "
+            f"skipped {len(self.skipped)}{tail}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+async def run_prediction_reconciliation(
+    store, db, *, execute: bool = False
+) -> ReconcileReport:
+    """Reconcile every settleable pending/due bet. See module docstring.
+
+    ``store`` is a ``PredictionStore``; ``db`` an open connection. With
+    ``execute=False`` (default) nothing is written — the report says what *would*
+    happen. With ``execute=True`` each proposal is committed via
+    ``mark_reconciled``.
+    """
+    proposals: list[ReconcileProposal] = []
+    skipped: list[ReconcileSkip] = []
+
+    candidates = await store.list_by_status("pending")
+    candidates += await store.list_by_status("due")
+
+    for pred in candidates:
+        ref = await find_settling_observation(db, pred.due_condition)
+        if ref is None:
+            skipped.append(ReconcileSkip(pred.id, "not_settled"))
+            continue
+        observation = await resolve_observation_ref(db, ref)
+        if observation is None:
+            skipped.append(ReconcileSkip(pred.id, "observation_gone"))
+            continue
+        try:
+            result = resolve(pred.resolver, observation)
+        except (KeyError, ValueError):
+            # resolver cannot read the field it needs against this observation —
+            # unresolvable, not a free 0.0 (no silent pass; pairs with I4).
+            skipped.append(ReconcileSkip(pred.id, "unresolvable"))
+            continue
+        proposals.append(
+            ReconcileProposal(
+                prediction_id=pred.id,
+                domain=pred.domain,
+                observation_ref=ref,
+                resolver_kind=pred.resolver["kind"],
+                matched=result.matched,
+                error_score=result.error_score,
+                detail=result.detail,
+            )
+        )
+
+    if execute:
+        for prop in proposals:
+            await store.mark_reconciled(
+                prop.prediction_id,
+                score=prop.error_score,
+                observation_ref=prop.observation_ref,
+            )
+
+    return ReconcileReport(executed=execute, proposals=proposals, skipped=skipped)

--- a/loom/core/memory/observation.py
+++ b/loom/core/memory/observation.py
@@ -41,10 +41,11 @@ OBSERVATION_SOURCES = ("action", "session_log")
 
 _PREFIX_TO_TABLE = {"action": "action_records", "session_log": "session_log"}
 
-# Local mirror of harness ActionState._FAILURE_STATES values (see
-# loom/core/harness/lifecycle.py). Duplicated rather than imported to preserve
-# the one-way memory-layer dependency. Drift-guarded in the test suite.
+# Local mirror of harness ActionState._FAILURE_STATES / _TERMINAL_STATES values
+# (see loom/core/harness/lifecycle.py). Duplicated rather than imported to
+# preserve the one-way memory-layer dependency. Both drift-guarded in the suite.
 _FAILURE_STATE_VALUES = frozenset({"denied", "aborted", "timed_out", "reverted"})
+_TERMINAL_STATE_VALUES = frozenset({"memorialized", "denied", "aborted", "timed_out"})
 
 _REF_RE = re.compile(r"^(?P<prefix>[a-z_]+):(?P<row_id>.+)$")
 
@@ -90,6 +91,34 @@ async def resolve_observation_ref(
     if source == "action":
         return await _resolve_action(db, row_id)
     return await _resolve_session_log(db, row_id)
+
+
+async def find_settling_observation(
+    db: aiosqlite.Connection, due_condition: dict
+) -> str | None:
+    """Find the observation_ref that *settles* a bet, or ``None`` if not yet.
+
+    P0 supports ``after_action``: the bet settles once the named tool call has a
+    **terminal** action_records row. Returns that row's ref (the latest one).
+    An unknown due_condition kind raises (whitelist, like resolvers).
+    """
+    kind = due_condition.get("kind")
+    if kind != "after_action":
+        raise ValueError(
+            f"unknown due_condition kind {kind!r}; P0 supports 'after_action'"
+        )
+    call_id = due_condition.get("call_id")
+    if not call_id:
+        raise ValueError("after_action due_condition requires call_id")
+    placeholders = ",".join("?" * len(_TERMINAL_STATE_VALUES))
+    cur = await db.execute(
+        f"SELECT id FROM action_records WHERE call_id = ? "
+        f"AND final_state IN ({placeholders}) "
+        "ORDER BY created_at DESC LIMIT 1",
+        (call_id, *sorted(_TERMINAL_STATE_VALUES)),
+    )
+    r = await cur.fetchone()
+    return make_observation_ref("action", r[0]) if r else None
 
 
 async def _resolve_action(db: aiosqlite.Connection, row_id: str) -> dict | None:

--- a/loom/core/memory/observation.py
+++ b/loom/core/memory/observation.py
@@ -1,0 +1,133 @@
+"""
+Prediction Spine — observation_ref contract (epic #528, issue #531).
+
+An ``observation_ref`` ties a reconciled prediction's score to the exact
+runtime observation that produced it. It is the auditable backbone of I2:
+ground truth comes only from runtime observation tables, never from an LLM
+self-narrative store, and every score can be reverse-looked-up to the row it
+came from.
+
+Format
+------
+``"<source>:<row_id>"`` where ``source`` is on ``OBSERVATION_SOURCES``. The
+whitelist *is* the I2 boundary — ``action`` → ``action_records`` and
+``session_log`` → ``session_log`` are the only runtime observation tables a
+prediction may be reconciled against.
+
+Reverse lookup
+--------------
+``resolve_observation_ref(db, ref)`` returns a *normalized observation* (the
+dict shape ``loom.core.memory.resolvers.resolve`` consumes), or ``None`` when
+the row is gone — an unreconcilable bet, **not** a correct one.
+
+Layering
+--------
+This module lives in the memory layer (the bottom of
+Platform→Cognition→Harness→Memory) and must **not** import the harness. The
+``ActionState`` failure values are mirrored locally as plain strings; a drift
+guard in ``tests/test_observation_ref.py`` keeps the mirror honest.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import aiosqlite
+
+# I2 boundary: the only sources a prediction may be reconciled against. A ref
+# prefix outside this set is rejected at parse time.
+OBSERVATION_SOURCES = ("action", "session_log")
+
+_PREFIX_TO_TABLE = {"action": "action_records", "session_log": "session_log"}
+
+# Local mirror of harness ActionState._FAILURE_STATES values (see
+# loom/core/harness/lifecycle.py). Duplicated rather than imported to preserve
+# the one-way memory-layer dependency. Drift-guarded in the test suite.
+_FAILURE_STATE_VALUES = frozenset({"denied", "aborted", "timed_out", "reverted"})
+
+_REF_RE = re.compile(r"^(?P<prefix>[a-z_]+):(?P<row_id>.+)$")
+
+
+def make_observation_ref(source: str, row_id: object) -> str:
+    """Build a ``"<source>:<row_id>"`` ref. Rejects non-whitelist sources."""
+    if source not in OBSERVATION_SOURCES:
+        raise ValueError(
+            f"observation source {source!r} not in whitelist {OBSERVATION_SOURCES}"
+        )
+    rid = str(row_id)
+    if not rid.strip():
+        raise ValueError("observation_ref row_id is required")
+    return f"{source}:{rid}"
+
+
+def parse_observation_ref(ref: str) -> tuple[str, str]:
+    """Validate + split a ref into ``(source, row_id)``.
+
+    Raises ``ValueError`` for malformed refs and for any source outside the
+    runtime-observation whitelist (the I2 boundary).
+    """
+    m = _REF_RE.match(ref or "")
+    if not m:
+        raise ValueError(
+            f"malformed observation_ref {ref!r}; expected '<source>:<row_id>'"
+        )
+    prefix = m.group("prefix")
+    if prefix not in OBSERVATION_SOURCES:
+        raise ValueError(
+            f"observation_ref source {prefix!r} not in whitelist "
+            f"{OBSERVATION_SOURCES} (I2: ground truth may only come from "
+            "runtime observation tables, never an LLM-narrative store)"
+        )
+    return prefix, m.group("row_id")
+
+
+async def resolve_observation_ref(
+    db: aiosqlite.Connection, ref: str
+) -> dict | None:
+    """Reverse-look-up a ref to a normalized observation, or ``None`` if gone."""
+    source, row_id = parse_observation_ref(ref)
+    if source == "action":
+        return await _resolve_action(db, row_id)
+    return await _resolve_session_log(db, row_id)
+
+
+async def _resolve_action(db: aiosqlite.Connection, row_id: str) -> dict | None:
+    cur = await db.execute(
+        "SELECT id, tool_name, final_state, duration_ms, state_history "
+        "FROM action_records WHERE id = ?",
+        (row_id,),
+    )
+    r = await cur.fetchone()
+    if r is None:
+        return None
+    history = json.loads(r[4] or "[]")
+    # Terminal-state-hides-failure: a failed action is eventually MEMORIALIZED,
+    # so final_state alone can read as success. Scan the full transition history
+    # for any failure state (feedback_terminal_state_hides_failure).
+    failed = r[2] in _FAILURE_STATE_VALUES or any(
+        t.get("to") in _FAILURE_STATE_VALUES for t in history
+    )
+    return {
+        "observation_ref": make_observation_ref("action", r[0]),
+        "tool_name": r[1],
+        "final_state": r[2],
+        "tool_success": not failed,
+        "duration_ms": r[3],
+    }
+
+
+async def _resolve_session_log(db: aiosqlite.Connection, row_id: str) -> dict | None:
+    cur = await db.execute(
+        "SELECT id, role, content, raw_json FROM session_log WHERE id = ?",
+        (row_id,),
+    )
+    r = await cur.fetchone()
+    if r is None:
+        return None
+    return {
+        "observation_ref": make_observation_ref("session_log", r[0]),
+        "role": r[1],
+        "output": r[2],
+        "raw_json": r[3],
+    }

--- a/tests/test_observation_ref.py
+++ b/tests/test_observation_ref.py
@@ -161,6 +161,10 @@ class TestResolveSessionLog:
 
 class TestFailureStateDriftGuard:
     def test_local_mirror_matches_harness(self):
-        from loom.core.harness.lifecycle import _FAILURE_STATES
-        from loom.core.memory.observation import _FAILURE_STATE_VALUES
+        from loom.core.harness.lifecycle import _FAILURE_STATES, _TERMINAL_STATES
+        from loom.core.memory.observation import (
+            _FAILURE_STATE_VALUES,
+            _TERMINAL_STATE_VALUES,
+        )
         assert _FAILURE_STATE_VALUES == {s.value for s in _FAILURE_STATES}
+        assert _TERMINAL_STATE_VALUES == {s.value for s in _TERMINAL_STATES}

--- a/tests/test_observation_ref.py
+++ b/tests/test_observation_ref.py
@@ -1,0 +1,166 @@
+"""
+Prediction Spine — observation_ref contract (epic #528, issue #531; slice 3 前置).
+
+``observation_ref`` is the auditable pointer that ties a reconciled prediction's
+score to the exact runtime observation that produced it (I2). This module pins
+its contract *before* the reconciliation pipeline (slice 3) consumes it:
+
+* **Format** — ``"<source>:<row_id>"``; ``source`` must be on the whitelist.
+* **I2 boundary** — the whitelist is *only* runtime observation tables
+  (``action`` → action_records, ``session_log`` → session_log). A ref pointing
+  anywhere else (e.g. ``semantic:``) is rejected: ground truth may never come
+  from an LLM self-narrative store.
+* **Reverse lookup** — ``resolve_observation_ref`` reads the ref back to a
+  *normalized* observation (the dict shape resolvers consume). A ref to a
+  missing row returns ``None`` (unreconcilable, **not** miscounted).
+* **Terminal-state-hides-failure** — ``tool_success`` is derived by scanning
+  the full ``state_history``, not the final_state column (a failed action is
+  eventually MEMORIALIZED, masking the failure).
+"""
+
+import json
+
+import pytest
+import pytest_asyncio
+
+from loom.core.memory.store import SQLiteStore
+from loom.core.memory.observation import (
+    OBSERVATION_SOURCES,
+    make_observation_ref,
+    parse_observation_ref,
+    resolve_observation_ref,
+)
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test_observation.db")
+
+
+@pytest_asyncio.fixture
+async def store(tmp_db):
+    s = SQLiteStore(tmp_db)
+    await s.initialize()
+    return s
+
+
+@pytest_asyncio.fixture
+async def db_conn(store):
+    async with store.connect() as db:
+        yield db
+
+
+async def _insert_action(db, *, id, final_state, history_to_states, duration_ms=120.0):
+    history = [{"from": "x", "to": s, "ts": "2026-06-08T00:00:00+00:00"} for s in history_to_states]
+    await db.execute(
+        "INSERT INTO action_records "
+        "(id, envelope_id, session_id, turn_index, tool_name, call_id, "
+        " final_state, duration_ms, state_history, created_at) "
+        "VALUES (?, 'env', 'sess', 0, 'run_bash', 'c1', ?, ?, ?, ?)",
+        (id, final_state, duration_ms, json.dumps(history), "2026-06-08T00:00:00+00:00"),
+    )
+    await db.commit()
+
+
+async def _insert_session_log(db, *, content):
+    cur = await db.execute(
+        "INSERT INTO session_log (session_id, turn_index, role, content, created_at) "
+        "VALUES ('sess', 0, 'tool', ?, '2026-06-08T00:00:00+00:00')",
+        (content,),
+    )
+    await db.commit()
+    return cur.lastrowid
+
+
+# ---------------------------------------------------------------------------
+# Format + I2 whitelist boundary
+# ---------------------------------------------------------------------------
+
+class TestRefFormat:
+    def test_whitelist_is_runtime_observation_tables(self):
+        assert OBSERVATION_SOURCES == ("action", "session_log")
+
+    def test_make_and_parse_roundtrip(self):
+        ref = make_observation_ref("action", "abc-1")
+        assert ref == "action:abc-1"
+        assert parse_observation_ref(ref) == ("action", "abc-1")
+
+    def test_make_rejects_non_whitelist_source(self):
+        with pytest.raises(ValueError):
+            make_observation_ref("semantic", "x")
+
+    def test_make_rejects_empty_row_id(self):
+        with pytest.raises(ValueError):
+            make_observation_ref("action", "  ")
+
+    def test_parse_rejects_malformed(self):
+        with pytest.raises(ValueError):
+            parse_observation_ref("no-colon-here")
+
+    def test_parse_rejects_empty(self):
+        with pytest.raises(ValueError):
+            parse_observation_ref("")
+
+    def test_parse_rejects_non_whitelist_prefix_I2(self):
+        """I2: ground truth may not point at an LLM-narrative store."""
+        with pytest.raises(ValueError):
+            parse_observation_ref("semantic:rel:foo")
+        with pytest.raises(ValueError):
+            parse_observation_ref("episodic:123")
+
+
+# ---------------------------------------------------------------------------
+# Reverse lookup — action_records
+# ---------------------------------------------------------------------------
+
+class TestResolveAction:
+    async def test_success_path_normalizes(self, db_conn):
+        await _insert_action(
+            db_conn, id="a-ok", final_state="memorialized",
+            history_to_states=["authorized", "executing", "observed", "committed", "memorialized"],
+            duration_ms=200.0,
+        )
+        obs = await resolve_observation_ref(db_conn, "action:a-ok")
+        assert obs is not None
+        assert obs["tool_success"] is True
+        assert obs["final_state"] == "memorialized"
+        assert obs["duration_ms"] == 200.0
+
+    async def test_terminal_state_hides_failure(self, db_conn):
+        """final_state='memorialized' but the action passed through 'aborted'."""
+        await _insert_action(
+            db_conn, id="a-fail", final_state="memorialized",
+            history_to_states=["authorized", "executing", "aborted", "memorialized"],
+        )
+        obs = await resolve_observation_ref(db_conn, "action:a-fail")
+        assert obs["tool_success"] is False  # scanned history, not just final_state
+
+    async def test_missing_row_returns_none(self, db_conn):
+        """Unreconcilable, not miscounted — a ref to a gone row is None."""
+        assert await resolve_observation_ref(db_conn, "action:ghost") is None
+
+
+# ---------------------------------------------------------------------------
+# Reverse lookup — session_log
+# ---------------------------------------------------------------------------
+
+class TestResolveSessionLog:
+    async def test_resolves_output(self, db_conn):
+        rid = await _insert_session_log(db_conn, content="16 passed in 0.2s")
+        obs = await resolve_observation_ref(db_conn, f"session_log:{rid}")
+        assert obs is not None
+        assert obs["output"] == "16 passed in 0.2s"
+
+    async def test_missing_row_returns_none(self, db_conn):
+        assert await resolve_observation_ref(db_conn, "session_log:999999") is None
+
+
+# ---------------------------------------------------------------------------
+# Drift guard — local failure-state mirror must match harness
+# ---------------------------------------------------------------------------
+
+class TestFailureStateDriftGuard:
+    def test_local_mirror_matches_harness(self):
+        from loom.core.harness.lifecycle import _FAILURE_STATES
+        from loom.core.memory.observation import _FAILURE_STATE_VALUES
+        assert _FAILURE_STATE_VALUES == {s.value for s in _FAILURE_STATES}

--- a/tests/test_prediction_reconcile.py
+++ b/tests/test_prediction_reconcile.py
@@ -1,0 +1,201 @@
+"""
+Prediction Spine — P0 slice 3: reconciliation pipeline (epic #528, spec §5).
+
+The convergent-dream sibling that closes the spine's loop:
+
+    pending bet → find settling observation → resolve ref → apply resolver
+                → propose (dry-run) / mark_reconciled (execute)
+
+Review focus (絲絲): the **dry-run report shape** and **I3 at the function
+level** — ``execute=False`` must be read-only *by construction* (the only write
+path is gated behind ``execute=True``). The report is an inert, auditable
+projection of "what would happen": each proposal names the prediction, the
+observation it was judged against, the resolver, and the resulting error_score.
+"""
+
+import json
+
+import pytest
+import pytest_asyncio
+
+from loom.core.memory.store import SQLiteStore
+from loom.core.memory.prediction import PredictionRecord, PredictionStore
+from loom.core.cognition.prediction_reconcile import (
+    run_prediction_reconciliation,
+    ReconcileReport,
+    ReconcileProposal,
+)
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test_reconcile.db")
+
+
+@pytest_asyncio.fixture
+async def store(tmp_db):
+    s = SQLiteStore(tmp_db)
+    await s.initialize()
+    return s
+
+
+@pytest_asyncio.fixture
+async def db_conn(store):
+    async with store.connect() as db:
+        yield db
+
+
+async def _insert_action(db, *, id, call_id, final_state, history_to_states, duration_ms=120.0):
+    history = [{"from": "x", "to": s, "ts": "2026-06-08T00:00:00+00:00"} for s in history_to_states]
+    await db.execute(
+        "INSERT INTO action_records "
+        "(id, envelope_id, session_id, turn_index, tool_name, call_id, "
+        " final_state, duration_ms, state_history, created_at) "
+        "VALUES (?, 'env', 'sess', 0, 'run_bash', ?, ?, ?, ?, ?)",
+        (id, call_id, final_state, duration_ms, json.dumps(history), "2026-06-08T00:00:00+00:00"),
+    )
+    await db.commit()
+
+
+def _prediction(call_id="c1", **resolver_over) -> PredictionRecord:
+    resolver = {"kind": "tool_success", "expect": True}
+    resolver.update(resolver_over)
+    return PredictionRecord(
+        session_id="sess",
+        claim="this run_bash will succeed",
+        due_condition={"kind": "after_action", "call_id": call_id},
+        resolver=resolver,
+        domain="cli",
+    )
+
+
+async def _settled_ok_action(db, call_id="c1", id="act-1"):
+    await _insert_action(
+        db, id=id, call_id=call_id, final_state="memorialized",
+        history_to_states=["authorized", "executing", "observed", "committed", "memorialized"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# dry-run report shape  (絲絲 review focus #1)
+# ---------------------------------------------------------------------------
+
+class TestDryRunReportShape:
+    async def test_proposal_is_auditable(self, db_conn):
+        ps = PredictionStore(db_conn)
+        pred = _prediction()
+        await ps.write(pred)
+        await _settled_ok_action(db_conn, id="act-1")
+
+        report = await run_prediction_reconciliation(ps, db_conn, execute=False)
+        assert isinstance(report, ReconcileReport)
+        assert report.executed is False
+        assert len(report.proposals) == 1
+
+        prop = report.proposals[0]
+        assert isinstance(prop, ReconcileProposal)
+        assert prop.prediction_id == pred.id
+        assert prop.domain == "cli"
+        assert prop.observation_ref == "action:act-1"   # auditable, reverse-resolvable
+        assert prop.resolver_kind == "tool_success"
+        assert prop.matched is True
+        assert prop.error_score == 0.0
+        assert prop.detail  # non-empty resolver detail
+
+    async def test_unsettled_bet_is_skipped_with_reason(self, db_conn):
+        ps = PredictionStore(db_conn)
+        await ps.write(_prediction(call_id="never-ran"))
+        report = await run_prediction_reconciliation(ps, db_conn, execute=False)
+        assert report.proposals == []
+        assert len(report.skipped) == 1
+        assert report.skipped[0].reason == "not_settled"
+
+
+# ---------------------------------------------------------------------------
+# I3 at the function level — dry-run is read-only by construction
+# ---------------------------------------------------------------------------
+
+class TestDryRunIsReadOnly:
+    async def test_dry_run_does_not_mutate_prediction(self, db_conn):
+        ps = PredictionStore(db_conn)
+        pred = _prediction()
+        await ps.write(pred)
+        await _settled_ok_action(db_conn)
+
+        await run_prediction_reconciliation(ps, db_conn, execute=False)
+
+        after = await ps.get(pred.id)
+        assert after.status == "pending"      # untouched
+        assert after.score is None
+        assert after.observation_ref is None
+        assert after.reconciled_at is None
+
+    async def test_dry_run_and_execute_propose_the_same(self, db_conn):
+        ps = PredictionStore(db_conn)
+        pred = _prediction()
+        await ps.write(pred)
+        await _settled_ok_action(db_conn)
+
+        dry = await run_prediction_reconciliation(ps, db_conn, execute=False)
+        # re-write so the second pass sees a fresh pending bet
+        wet = await run_prediction_reconciliation(ps, db_conn, execute=True)
+        assert [p.error_score for p in dry.proposals] == [p.error_score for p in wet.proposals]
+
+
+# ---------------------------------------------------------------------------
+# execute path — writes the score + observation_ref
+# ---------------------------------------------------------------------------
+
+class TestExecute:
+    async def test_execute_reconciles(self, db_conn):
+        ps = PredictionStore(db_conn)
+        pred = _prediction()
+        await ps.write(pred)
+        await _settled_ok_action(db_conn, id="act-9")
+
+        report = await run_prediction_reconciliation(ps, db_conn, execute=True)
+        assert report.executed is True
+
+        after = await ps.get(pred.id)
+        assert after.status == "reconciled"
+        assert after.score == 0.0
+        assert after.observation_ref == "action:act-9"
+        assert after.reconciled_at is not None
+
+    async def test_wrong_prediction_scores_one(self, db_conn):
+        ps = PredictionStore(db_conn)
+        pred = _prediction()  # expects success
+        await ps.write(pred)
+        await _insert_action(
+            db_conn, id="act-bad", call_id="c1", final_state="memorialized",
+            history_to_states=["authorized", "executing", "aborted", "memorialized"],
+        )
+        report = await run_prediction_reconciliation(ps, db_conn, execute=True)
+        assert report.proposals[0].error_score == 1.0
+        assert (await ps.get(pred.id)).score == 1.0
+
+    async def test_execute_is_idempotent(self, db_conn):
+        ps = PredictionStore(db_conn)
+        pred = _prediction()
+        await ps.write(pred)
+        await _settled_ok_action(db_conn)
+
+        await run_prediction_reconciliation(ps, db_conn, execute=True)
+        second = await run_prediction_reconciliation(ps, db_conn, execute=True)
+        # already reconciled — nothing left to do, no double-reconcile error
+        assert second.proposals == []
+
+    async def test_resolver_mismatch_is_skipped_not_scored_zero(self, db_conn):
+        """A resolver needing a field the observation lacks is unresolvable,
+        not a free 0.0 (no silent pass)."""
+        ps = PredictionStore(db_conn)
+        pred = _prediction()
+        pred.resolver = {"kind": "output_contains", "needle": "X", "expect": True}
+        await ps.write(pred)
+        await _settled_ok_action(db_conn)  # action obs has no "output" field
+
+        report = await run_prediction_reconciliation(ps, db_conn, execute=True)
+        assert report.proposals == []
+        assert len(report.skipped) == 1
+        assert report.skipped[0].reason == "unresolvable"
+        assert (await ps.get(pred.id)).status == "pending"

--- a/tests/test_prediction_reconcile.py
+++ b/tests/test_prediction_reconcile.py
@@ -109,6 +109,7 @@ class TestDryRunReportShape:
         assert report.proposals == []
         assert len(report.skipped) == 1
         assert report.skipped[0].reason == "not_settled"
+        assert report.skipped[0].domain == "cli"  # carried for slice-4 attribution
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Epic **#528** P0 slice 3。規格 `docs/designs/58` §5 + 前置 issue **#531**（observation_ref 契約）。

> 🪢 **給絲絲 review（按你提的節奏）**：這是 slice 3 的**純函式本體**——對帳管線寫好了，但**還沒接進 dream**（那是 slice 3.5 的 PR）。所以 Loom runtime 行為仍零變化。
>
> 你提的 review 焦點我照做了，請重點看這兩個（不只是行為）：
> 1. **dry-run 報告形狀**——`ReconcileReport` / `ReconcileProposal` / `ReconcileSkip` 是不是「可被看、可被談、可審計」的形狀？
> 2. **I3 在函式層**——`execute=False` 是不是 by construction 唯讀（唯一寫路 `mark_reconciled` 被 `execute=True` 關起來）？
>
> 你說得對：I3 一旦在排程層破了 rollback 政治成本極高，所以這個 PR 先把函式層的唯讀形狀釘死，slice 3.5 再驗「函式層唯讀 → 排程層唯讀」。

## 這個 PR 有什麼

### #531 契約（`memory/observation.py`，slice 3 前置）
- `make/parse_observation_ref`：格式 `<source>:<row_id>`，白名單 `(action, session_log)` **就是 I2 邊界**——指向 LLM 敘事庫（`semantic:`/`episodic:`）一律拒絕
- `resolve_observation_ref(db, ref) → normalized obs | None`：反查回原始 row（None = 不可對帳、不誤算）
- `tool_success` 掃 `state_history` 全歷史，**不信 final_state**（失敗最終也 MEMORIALIZED 會藏失敗 — `feedback_terminal_state_hides_failure`）
- memory 層**不 import harness**（守單向依賴）；失敗/終結狀態字串本地 mirror + drift guard 防漂移
- `find_settling_observation(due_condition)`：P0 `after_action` — 賭注在 tool call 有 terminal action row 時 settle

### Slice 3 對帳管線（`cognition/prediction_reconcile.py`）
- `run_prediction_reconciliation(store, db, *, execute=False)`：`pending/due → 找 settling obs → resolve ref → apply resolver → propose`
- **dry-run 報告形狀**：每個 `ReconcileProposal` 回答「哪條 prediction、對哪個 observation_ref、用哪個 resolver、得到什麼 error_score」——這是審計單元
- **skip 有理由**：`not_settled` / `observation_gone` / `unresolvable`（resolver 看不到欄位 → skip，**不靜默給 0.0**）
- 是 `ConvergentDream` 的 **sibling**（沿用 dry-run→execute 紀律），不塞進它內部

## 這個 PR **沒有**什麼
- ❌ **Slice 3.5** dream maintenance adapter（接線進排程）— 下個 PR，你再 review「I3 排程層唯讀」
- ❌ **Slice 4** calibration residue（`calibration:<domain>` 摘要 + surprise 三量）— issue #530 待拍板 decay tier
- ❌ `due_condition` 只收 `after_action`；`at_time` + session_log 輸出賭注是 slice 3 第二刀

## 想請絲絲特別看
1. **報告形狀夠不夠審計**？`ReconcileProposal` 的欄位（prediction_id / observation_ref / resolver_kind / matched / error_score / detail）夠你「說夢話」式回顧嗎，還是缺了什麼維度？
2. **`unresolvable` skip 的邊界**：resolver 對不上 observation（如 output_contains 配 after_action 的 action obs 沒 output）時我 skip 而非 score——這個「寧可不判也不亂判」對齊 I2/I4 嗎？

## 驗證
- 新增 21 tests（observation 13 + reconcile 8），全綠
- 回歸：spine + memory + convergent dream 套件 **140 passed**
- `gitnexus detect_changes`：medium，唯一 affected process 是新模組內部 flow，**無既有 process 被波及**（管線無 caller、未接線）

🤖 Generated with [Claude Code](https://claude.com/claude-code)