### PR TITLE
feat(autonomy): Prediction Spine slice 3.5 — dream schedule 接線 (#528)

### DIFF
--- a/loom.toml.example
+++ b/loom.toml.example
@@ -321,6 +321,14 @@ execute       = false   # P4a read-only; set true for autonomous writes (P4b)
 # count for full coverage. LLM cost is bounded by max_clusters regardless; only
 # local embedding work scales with this number. Raise it as your corpus grows.
 corpus_limit  = 5000
+# Prediction Spine reconciliation (epic #528 slice 3.5). The convergent dream's
+# sibling: judges matured predictions against runtime observation and writes a
+# reconcile report to the same dreams file. Its execute gate is INDEPENDENT of
+# the consolidation ``execute`` above — consolidation execute merges facts
+# (destructive); reconcile execute only records observation-derived scores
+# (benign), so you can flip reconcile on while consolidation stays read-only.
+reconcile_enabled = false   # opt-in: run prediction reconciliation each weekly pass
+reconcile_execute = false   # P4a read-only; set true to commit scores (mark_reconciled)
 
 # ─────────────────────────────────────────────
 # Reflection (Issue #120 PR1) — Skill diagnostic layer

--- a/loom/autonomy/daemon.py
+++ b/loom/autonomy/daemon.py
@@ -708,6 +708,31 @@ class AutonomyDaemon:
                 "[consolidation] pass=%s execute=%s clusters=%s deferred=%d",
                 plan.pass_id, execute, plan.counts(), plan.deferred_to_next_pass,
             )
+
+            # Epic #528 slice 3.5: the Prediction Spine reconciliation parasitizes
+            # the same weekly cadence. Its execute gate is INDEPENDENT of the
+            # consolidation one — consolidation execute merges facts (destructive),
+            # reconcile execute only records observation-derived scores (benign), so
+            # reconcile can go execute=true while consolidation stays read-only.
+            # Both default False (P4a): the schedule never writes the spine until
+            # reconcile_execute is deliberately set.
+            if cfg.get("reconcile_enabled", False):
+                from loom.core.cognition.prediction_reconcile import (
+                    run_prediction_reconciliation,
+                )
+                from loom.core.memory.prediction import PredictionStore
+
+                reconcile_execute = bool(cfg.get("reconcile_execute", False))
+                rreport = await run_prediction_reconciliation(
+                    PredictionStore(db), db, execute=reconcile_execute,
+                )
+                append_consolidation_report(rreport.render())
+                logger.info(
+                    "[consolidation] prediction reconcile execute=%s "
+                    "proposed=%d skipped=%d",
+                    reconcile_execute, len(rreport.proposals), len(rreport.skipped),
+                )
+
             return plan
 
         loop = ConvergentDreamLoop(

--- a/loom/autonomy/daemon.py
+++ b/loom/autonomy/daemon.py
@@ -144,6 +144,39 @@ def _check_config_integrity(sched_cfg: dict) -> bool:
         return True  # fail-open
 
 
+async def _run_scheduled_reconcile(db, *, enabled: bool, execute: bool) -> None:
+    """Run the Prediction Spine reconciliation step of the weekly dream (#528 3.5).
+
+    Additive to the consolidation pass, and **isolated**: a reconcile failure
+    must not abort ``_consolidate_once`` — that would roll back the consolidation
+    that already ran (its ``last_run`` would go unmarked and re-fire next check).
+    So failures are swallowed + logged and the weekly loop continues (絲絲 review
+    PR #533 P2). No-op when ``enabled`` is False — the schedule default.
+    """
+    if not enabled:
+        return
+    try:
+        from loom.core.cognition.prediction_reconcile import (
+            run_prediction_reconciliation,
+        )
+        from loom.core.memory.prediction import PredictionStore
+        from loom.autonomy.circadian.journal import append_consolidation_report
+
+        report = await run_prediction_reconciliation(
+            PredictionStore(db), db, execute=execute,
+        )
+        append_consolidation_report(report.render())
+        logger.info(
+            "[consolidation] prediction reconcile execute=%s proposed=%d skipped=%d",
+            execute, len(report.proposals), len(report.skipped),
+        )
+    except Exception as exc:  # noqa: BLE001 — schedule isolation, never veto the loop
+        logger.exception(
+            "[consolidation] prediction reconcile failed; continuing weekly loop: %s",
+            exc,
+        )
+
+
 class AutonomyDaemon:
     """
     Manages the full autonomy lifecycle:
@@ -710,28 +743,13 @@ class AutonomyDaemon:
             )
 
             # Epic #528 slice 3.5: the Prediction Spine reconciliation parasitizes
-            # the same weekly cadence. Its execute gate is INDEPENDENT of the
-            # consolidation one — consolidation execute merges facts (destructive),
-            # reconcile execute only records observation-derived scores (benign), so
-            # reconcile can go execute=true while consolidation stays read-only.
-            # Both default False (P4a): the schedule never writes the spine until
-            # reconcile_execute is deliberately set.
-            if cfg.get("reconcile_enabled", False):
-                from loom.core.cognition.prediction_reconcile import (
-                    run_prediction_reconciliation,
-                )
-                from loom.core.memory.prediction import PredictionStore
-
-                reconcile_execute = bool(cfg.get("reconcile_execute", False))
-                rreport = await run_prediction_reconciliation(
-                    PredictionStore(db), db, execute=reconcile_execute,
-                )
-                append_consolidation_report(rreport.render())
-                logger.info(
-                    "[consolidation] prediction reconcile execute=%s "
-                    "proposed=%d skipped=%d",
-                    reconcile_execute, len(rreport.proposals), len(rreport.skipped),
-                )
+            # the same weekly cadence (isolated so its failure can't poison the
+            # consolidation pass — see _run_scheduled_reconcile).
+            await _run_scheduled_reconcile(
+                db,
+                enabled=cfg.get("reconcile_enabled", False),
+                execute=bool(cfg.get("reconcile_execute", False)),
+            )
 
             return plan
 

--- a/loom/core/cognition/prediction_reconcile.py
+++ b/loom/core/cognition/prediction_reconcile.py
@@ -77,6 +77,28 @@ class ReconcileReport:
     def settleable(self) -> int:
         return len(self.proposals)
 
+    def render(self) -> str:
+        """Render as a 夢境鞏固-style body for the dream journal (slice 3.5).
+
+        Both the ``prediction_reconcile`` tool and the daemon's weekly loop
+        write this to the circadian dreams file.
+        """
+        lines = [self.summary(), ""]
+        if self.proposals:
+            lines.append("Proposals:")
+            verb = "reconciled" if self.executed else "would reconcile"
+            for p in self.proposals:
+                lines.append(
+                    f"  - [{p.domain}] {verb} {p.prediction_id} vs "
+                    f"{p.observation_ref} ({p.resolver_kind}): "
+                    f"error={p.error_score:.3f} — {p.detail}"
+                )
+        if self.skipped:
+            lines.append("Skipped:")
+            for s in self.skipped:
+                lines.append(f"  - [{s.domain}] {s.prediction_id}: {s.reason}")
+        return "\n".join(lines)
+
     def to_dict(self) -> dict:
         """Serialize for logging by the dream maintenance adapter (slice 3.5)."""
         return {

--- a/loom/core/cognition/prediction_reconcile.py
+++ b/loom/core/cognition/prediction_reconcile.py
@@ -24,7 +24,7 @@ skipped, never silently scored 0.0.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 
 from loom.core.memory.observation import (
     find_settling_observation,
@@ -76,6 +76,18 @@ class ReconcileReport:
     @property
     def settleable(self) -> int:
         return len(self.proposals)
+
+    def to_dict(self) -> dict:
+        """Serialize for logging by the dream maintenance adapter (slice 3.5)."""
+        return {
+            "executed": self.executed,
+            "counts": {
+                "proposed": len(self.proposals),
+                "skipped": len(self.skipped),
+            },
+            "proposals": [asdict(p) for p in self.proposals],
+            "skipped": [asdict(s) for s in self.skipped],
+        }
 
     def summary(self) -> str:
         verb = "reconciled" if self.executed else "would reconcile"

--- a/loom/core/memory/maintenance.py
+++ b/loom/core/memory/maintenance.py
@@ -333,3 +333,72 @@ def make_convergent_dream_tool(
         executor=_executor,
         trust_level=TrustLevel.SAFE,
     )
+
+
+def make_prediction_reconcile_tool(
+    db: "aiosqlite.Connection",
+    *,
+    timezone: str = "Asia/Taipei",
+    dreams_dir=None,
+) -> ToolDefinition:
+    """Build the ``prediction_reconcile`` ToolDefinition (epic #528, slice 3.5).
+
+    The convergent-dream sibling that closes the Prediction Spine loop on the
+    dream schedule: matured bets are judged against runtime ground truth and a
+    reconcile report is written to the dreams journal.
+
+    **Read-only by default (I3 at the schedule level).** ``dry_run`` defaults to
+    True — the scheduled/triggered pass proposes and reports without writing the
+    spine. Only ``dry_run=false`` commits scores via ``mark_reconciled``, the
+    single write path. This mirrors the convergent dream's P4a discipline so the
+    spine is never written speculatively by a schedule.
+    """
+    from loom.core.cognition.prediction_reconcile import run_prediction_reconciliation
+    from loom.core.memory.prediction import PredictionStore
+    from loom.autonomy.circadian.journal import append_consolidation_report
+
+    async def _executor(call) -> ToolResult:
+        dry_run = bool(call.args.get("dry_run", True))  # P4a: read-only default
+
+        store = PredictionStore(db)
+        report = await run_prediction_reconciliation(store, db, execute=not dry_run)
+
+        path = append_consolidation_report(
+            report.render(),
+            timezone=timezone, dreams_dir=dreams_dir,
+        )
+
+        verb = "reconciled" if report.executed else "would reconcile (dry-run)"
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name, success=True,
+            output=(
+                f"prediction reconcile: {verb} {len(report.proposals)}, "
+                f"skipped {len(report.skipped)}\n  Report: {path}"
+            ),
+        )
+
+    return ToolDefinition(
+        name="prediction_reconcile",
+        description=(
+            "Reconcile matured predictions against runtime observation and write "
+            "a report to the circadian dream journal. Read-only by default "
+            "(dry_run=true): proposes scores without writing the spine. Set "
+            "dry_run=false to commit reconciliation. Counterpart to "
+            "convergent_dream (which consolidates facts)."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "dry_run": {
+                    "type": "boolean",
+                    "description": (
+                        "Propose without writing the spine (default true). "
+                        "Set false to commit scores via mark_reconciled."
+                    ),
+                    "default": True,
+                },
+            },
+        },
+        executor=_executor,
+        trust_level=TrustLevel.SAFE,
+    )

--- a/loom/core/memory/observation.py
+++ b/loom/core/memory/observation.py
@@ -93,20 +93,11 @@ async def resolve_observation_ref(
     return await _resolve_session_log(db, row_id)
 
 
-async def find_settling_observation(
+async def _find_after_action(
     db: aiosqlite.Connection, due_condition: dict
 ) -> str | None:
-    """Find the observation_ref that *settles* a bet, or ``None`` if not yet.
-
-    P0 supports ``after_action``: the bet settles once the named tool call has a
-    **terminal** action_records row. Returns that row's ref (the latest one).
-    An unknown due_condition kind raises (whitelist, like resolvers).
-    """
-    kind = due_condition.get("kind")
-    if kind != "after_action":
-        raise ValueError(
-            f"unknown due_condition kind {kind!r}; P0 supports 'after_action'"
-        )
+    """Settle once the named tool call has a **terminal** action_records row.
+    Returns the latest such row's ref, or ``None`` if not settled yet."""
     call_id = due_condition.get("call_id")
     if not call_id:
         raise ValueError("after_action due_condition requires call_id")
@@ -119,6 +110,32 @@ async def find_settling_observation(
     )
     r = await cur.fetchone()
     return make_observation_ref("action", r[0]) if r else None
+
+
+# due_condition kind → finder. The extension point: adding ``at_time`` /
+# ``within_window`` (slice 3 second cut) is a registry entry, not an if/elif
+# chain (絲絲 review, PR #532 OQ1).
+DUE_CONDITION_KINDS = {
+    "after_action": _find_after_action,
+}
+
+
+async def find_settling_observation(
+    db: aiosqlite.Connection, due_condition: dict
+) -> str | None:
+    """Find the observation_ref that *settles* a bet, or ``None`` if not yet.
+
+    Dispatches on ``due_condition['kind']`` via ``DUE_CONDITION_KINDS``. An
+    unknown kind raises (whitelist, like resolvers).
+    """
+    kind = due_condition.get("kind")
+    finder = DUE_CONDITION_KINDS.get(kind)
+    if finder is None:
+        raise ValueError(
+            f"unknown due_condition kind {kind!r}; "
+            f"P0 supports {sorted(DUE_CONDITION_KINDS)}"
+        )
+    return await finder(db, due_condition)
 
 
 async def _resolve_action(db: aiosqlite.Connection, row_id: str) -> dict | None:

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1161,6 +1161,7 @@ class LoomSession:
             make_convergent_dream_tool,
             make_dream_cycle_tool,
             make_memory_prune_tool,
+            make_prediction_reconcile_tool,
         )
 
         async def _dream_llm_fn(messages: list[dict]) -> str:
@@ -1181,6 +1182,10 @@ class LoomSession:
         self.registry.register(
             make_convergent_dream_tool(self._memory.semantic, _dream_llm_fn)
         )
+        # Epic #528 (slice 3.5): prediction_reconcile — convergent-dream sibling
+        # that closes the Prediction Spine loop. Read-only by default (dry_run);
+        # judges matured bets against runtime observation, writes a report.
+        self.registry.register(make_prediction_reconcile_tool(db=self._db))
 
         if self._telemetry is not None:
             self.registry.register(make_agent_health_tool(self._telemetry))

--- a/tests/test_observation_ref.py
+++ b/tests/test_observation_ref.py
@@ -159,6 +159,33 @@ class TestResolveSessionLog:
 # Drift guard — local failure-state mirror must match harness
 # ---------------------------------------------------------------------------
 
+class TestDueConditionDispatch:
+    """OQ1 (絲絲): due_condition kinds resolve via a dispatch table, so adding
+    at_time / within_window later is a registry entry, not another if/elif."""
+
+    def test_dispatch_table_is_the_extension_point(self):
+        from loom.core.memory.observation import DUE_CONDITION_KINDS
+        assert "after_action" in DUE_CONDITION_KINDS
+        assert callable(DUE_CONDITION_KINDS["after_action"])
+
+    async def test_unknown_kind_raises(self, db_conn):
+        from loom.core.memory.observation import find_settling_observation
+        with pytest.raises(ValueError):
+            await find_settling_observation(db_conn, {"kind": "at_time", "iso": "2026-01-01"})
+
+    async def test_after_action_dispatches(self, db_conn):
+        from loom.core.memory.observation import find_settling_observation
+        await _insert_action(
+            db_conn, id="a1", final_state="memorialized",
+            history_to_states=["committed", "memorialized"],
+        )
+        # call_id matched below
+        await db_conn.execute("UPDATE action_records SET call_id = 'cx' WHERE id = 'a1'")
+        await db_conn.commit()
+        ref = await find_settling_observation(db_conn, {"kind": "after_action", "call_id": "cx"})
+        assert ref == "action:a1"
+
+
 class TestFailureStateDriftGuard:
     def test_local_mirror_matches_harness(self):
         from loom.core.harness.lifecycle import _FAILURE_STATES, _TERMINAL_STATES

--- a/tests/test_prediction_reconcile.py
+++ b/tests/test_prediction_reconcile.py
@@ -113,6 +113,30 @@ class TestDryRunReportShape:
 
 
 # ---------------------------------------------------------------------------
+# Report serialization  (OQ3 — the dream adapter logs this)
+# ---------------------------------------------------------------------------
+
+class TestReportSerialization:
+    async def test_to_dict_shape(self, db_conn):
+        ps = PredictionStore(db_conn)
+        good = _prediction(call_id="c-ok")
+        bad = _prediction(call_id="c-none")  # never settles
+        await ps.write(good)
+        await ps.write(bad)
+        await _settled_ok_action(db_conn, call_id="c-ok", id="act-ok")
+
+        report = await run_prediction_reconciliation(ps, db_conn, execute=False)
+        d = report.to_dict()
+        assert d["executed"] is False
+        assert d["counts"] == {"proposed": 1, "skipped": 1}
+        assert isinstance(d["proposals"], list)
+        assert d["proposals"][0]["observation_ref"] == "action:act-ok"
+        assert isinstance(d["skipped"], list)
+        assert d["skipped"][0]["reason"] == "not_settled"
+        assert d["skipped"][0]["domain"] == "cli"
+
+
+# ---------------------------------------------------------------------------
 # I3 at the function level — dry-run is read-only by construction
 # ---------------------------------------------------------------------------
 

--- a/tests/test_prediction_reconcile_tool.py
+++ b/tests/test_prediction_reconcile_tool.py
@@ -1,0 +1,110 @@
+"""
+Prediction Spine — slice 3.5: prediction_reconcile tool adapter (epic #528).
+
+The ToolDefinition that lets the reconciliation pipeline run on the convergent
+dream's schedule (and be triggered manually). Mirrors make_convergent_dream_tool.
+
+Review focus (絲絲): **I3 at the schedule level**. The function-level read-only
+guarantee (slice 3) must survive being wired into a scheduled/triggerable tool.
+The adapter enforces it the same way the convergent dream does — ``dry_run``
+defaults to **True**, so the schedule produces a report without writing the
+spine until ``dry_run=false`` is deliberately set.
+"""
+
+import json
+
+import pytest
+import pytest_asyncio
+
+from loom.core.harness.middleware import ToolCall
+from loom.core.harness.permissions import TrustLevel
+from loom.core.memory.store import SQLiteStore
+from loom.core.memory.prediction import PredictionRecord, PredictionStore
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test_reconcile_tool.db")
+
+
+@pytest_asyncio.fixture
+async def store(tmp_db):
+    s = SQLiteStore(tmp_db)
+    await s.initialize()
+    return s
+
+
+@pytest_asyncio.fixture
+async def db_conn(store):
+    async with store.connect() as db:
+        yield db
+
+
+def _make_call(args: dict) -> ToolCall:
+    return ToolCall(id="t1", tool_name="prediction_reconcile", args=args,
+                    trust_level=TrustLevel.SAFE, session_id="s1")
+
+
+async def _seed_settleable(db):
+    """One pending bet whose tool call has settled successfully."""
+    ps = PredictionStore(db)
+    pred = PredictionRecord(
+        session_id="s1",
+        claim="run_bash will succeed",
+        due_condition={"kind": "after_action", "call_id": "c1"},
+        resolver={"kind": "tool_success", "expect": True},
+        domain="cli",
+    )
+    await ps.write(pred)
+    history = [{"from": "x", "to": s, "ts": "2026-06-08T00:00:00+00:00"}
+               for s in ("executing", "committed", "memorialized")]
+    await db.execute(
+        "INSERT INTO action_records "
+        "(id, envelope_id, session_id, turn_index, tool_name, call_id, "
+        " final_state, duration_ms, state_history, created_at) "
+        "VALUES ('act-1', 'env', 's1', 0, 'run_bash', 'c1', 'memorialized', 50.0, ?, ?)",
+        (json.dumps(history), "2026-06-08T00:00:00+00:00"),
+    )
+    await db.commit()
+    return pred
+
+
+class TestReconcileTool:
+    def test_tool_is_safe(self):
+        from loom.core.memory.maintenance import make_prediction_reconcile_tool
+        tool = make_prediction_reconcile_tool(object())
+        assert tool.trust_level == TrustLevel.SAFE
+        assert tool.name == "prediction_reconcile"
+
+    async def test_dry_run_default_is_read_only(self, db_conn, tmp_path):
+        """I3 at the schedule level: the default scheduled pass writes nothing."""
+        from loom.core.memory.maintenance import make_prediction_reconcile_tool
+        pred = await _seed_settleable(db_conn)
+
+        tool = make_prediction_reconcile_tool(db_conn, dreams_dir=tmp_path)
+        result = await tool.executor(_make_call({}))  # no dry_run → defaults True
+        assert result.success is True
+
+        after = await PredictionStore(db_conn).get(pred.id)
+        assert after.status == "pending"     # untouched
+        assert after.score is None
+
+    async def test_report_is_written(self, db_conn, tmp_path):
+        from loom.core.memory.maintenance import make_prediction_reconcile_tool
+        await _seed_settleable(db_conn)
+        tool = make_prediction_reconcile_tool(db_conn, dreams_dir=tmp_path)
+        await tool.executor(_make_call({}))
+        assert list(tmp_path.glob("*.md"))  # a dated report landed
+
+    async def test_execute_reconciles(self, db_conn, tmp_path):
+        from loom.core.memory.maintenance import make_prediction_reconcile_tool
+        pred = await _seed_settleable(db_conn)
+
+        tool = make_prediction_reconcile_tool(db_conn, dreams_dir=tmp_path)
+        result = await tool.executor(_make_call({"dry_run": False}))
+        assert result.success is True
+
+        after = await PredictionStore(db_conn).get(pred.id)
+        assert after.status == "reconciled"
+        assert after.score == 0.0
+        assert after.observation_ref == "action:act-1"

--- a/tests/test_scheduled_reconcile.py
+++ b/tests/test_scheduled_reconcile.py
@@ -1,0 +1,92 @@
+"""
+Prediction Spine — slice 3.5 scheduled reconcile isolation (epic #528, PR #533).
+
+``_run_scheduled_reconcile`` is the daemon's hook that runs the reconciliation
+pipeline on the weekly dream cadence. Two properties matter at the schedule
+level (絲絲 review):
+
+* **P3 — config default is no-run.** ``enabled=False`` (the shipped default)
+  must not touch the spine at all.
+* **P2 — failure isolation.** A reconcile that raises must NOT propagate out of
+  the weekly loop (which would roll back the consolidation pass that already
+  ran). Failures are swallowed + logged; the loop continues.
+"""
+
+import json
+
+import pytest
+import pytest_asyncio
+
+from loom.core.memory.store import SQLiteStore
+from loom.core.memory.prediction import PredictionRecord, PredictionStore
+from loom.autonomy.daemon import _run_scheduled_reconcile
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test_sched_reconcile.db")
+
+
+@pytest_asyncio.fixture
+async def store(tmp_db):
+    s = SQLiteStore(tmp_db)
+    await s.initialize()
+    return s
+
+
+@pytest_asyncio.fixture
+async def db_conn(store):
+    async with store.connect() as db:
+        yield db
+
+
+async def _seed_settleable(db):
+    ps = PredictionStore(db)
+    pred = PredictionRecord(
+        session_id="s1",
+        claim="run_bash will succeed",
+        due_condition={"kind": "after_action", "call_id": "c1"},
+        resolver={"kind": "tool_success", "expect": True},
+        domain="cli",
+    )
+    await ps.write(pred)
+    history = [{"from": "x", "to": s, "ts": "2026-06-08T00:00:00+00:00"}
+               for s in ("executing", "committed", "memorialized")]
+    await db.execute(
+        "INSERT INTO action_records "
+        "(id, envelope_id, session_id, turn_index, tool_name, call_id, "
+        " final_state, duration_ms, state_history, created_at) "
+        "VALUES ('act-1', 'env', 's1', 0, 'run_bash', 'c1', 'memorialized', 50.0, ?, ?)",
+        (json.dumps(history), "2026-06-08T00:00:00+00:00"),
+    )
+    await db.commit()
+    return pred
+
+
+class TestConfigDefaultIsNoRun:
+    async def test_disabled_does_not_touch_spine(self, db_conn):
+        pred = await _seed_settleable(db_conn)
+        await _run_scheduled_reconcile(db_conn, enabled=False, execute=True)
+        # even with execute=True, disabled means nothing ran
+        assert (await PredictionStore(db_conn).get(pred.id)).status == "pending"
+
+    async def test_enabled_execute_reconciles(self, db_conn):
+        pred = await _seed_settleable(db_conn)
+        await _run_scheduled_reconcile(db_conn, enabled=True, execute=True)
+        after = await PredictionStore(db_conn).get(pred.id)
+        assert after.status == "reconciled"
+        assert after.score == 0.0
+
+
+class TestFailureIsolation:
+    async def test_reconcile_raise_is_swallowed(self, db_conn, monkeypatch):
+        """A raising reconcile must not propagate — the weekly loop continues."""
+        async def _boom(*a, **k):
+            raise RuntimeError("schema went sideways")
+
+        monkeypatch.setattr(
+            "loom.core.cognition.prediction_reconcile.run_prediction_reconciliation",
+            _boom,
+        )
+        # must NOT raise
+        await _run_scheduled_reconcile(db_conn, enabled=True, execute=False)


### PR DESCRIPTION
Epic **#528** P0 slice 3.5。把 slice 3 的純函式對帳管線**接進排程**——第一個真正進 autonomy daemon、會週期性跑的 PR。

> 🪢 **給絲絲 review（你提的節奏第 4 步）**：這就是「**I3 從函式層唯讀 → 排程層唯讀**」的驗收 PR。slice 3 證明了函式層 `execute=False` by construction 唯讀；這個 PR 要證明那個保證**被排程包起來後沒破**。
>
> 你上一輪的擔憂——「一旦夢開始寫 spine，rollback 政治成本極高」——我用跟 convergent dream 同款的 **P4a 紀律**頂住：**排程預設 read-only，夢不會自動寫 spine，要人為 flip config 才寫**。

## I3 排程層怎麼守住（請重點看這個）

兩道預設 read-only 的閘，都要人為才會寫 spine：

1. **Tool 層**：`make_prediction_reconcile_tool` 的 `dry_run` **預設 True**。手動觸發 / agent 呼叫，預設只產報告不寫。
2. **排程層**：daemon 的 `reconcile_enabled` 預設 **False**（整個對帳在排程裡預設不跑），`reconcile_execute` 預設 **False**（就算跑也 read-only）。

→ 測試 `test_dry_run_default_is_read_only` 釘死：預設 call 跑完，prediction 仍 `pending`、`score is None`。**無論未來實作怎麼改，這個 test 綠 = 排程層 I3 破不了。**

## 這個 PR 有什麼

### 純的（OQ1/OQ3，承上一輪 review）
- `find_settling_observation` → `DUE_CONDITION_KINDS` dispatch table（加 kind 是 registry entry）
- `ReconcileReport.to_dict()` + `render()`（排程/tool log 報告用）

### 接線
- **`make_prediction_reconcile_tool`**（`memory/maintenance.py`）：convergent_dream 的 sibling ToolDefinition，`dry_run` 預設 True，寫 report 到 dreams journal。註冊進 session。
- **daemon**：對帳寄生進 weekly `ConvergentDreamLoop`，**獨立 execute gate**（`reconcile_execute`）——理由：consolidation execute 是破壞性（merge 事實），reconcile execute 是良性（只 mark_reconciled 記 observation-derived score），分開能讓對帳先上 execute、consolidation 仍 read-only 觀察。**DK 拍板分開。**
- `loom.toml.example`：`reconcile_enabled`/`reconcile_execute` 補進 `[memory.consolidation_dream]`（config dual-write）

## 這個 PR **沒有**什麼
- ❌ Slice 3 第二刀（`at_time` + session_log 賭注）— dispatch table 已備好接點
- ❌ Slice 4 calibration residue（`calibration:<domain>` 摘要 + surprise 三量）— issue #530 待拍板 decay tier

## 想請絲絲特別看
1. **兩道閘夠不夠**？tool `dry_run=True` + 排程 `reconcile_enabled=False`/`reconcile_execute=False`——三個預設都 read-only。你覺得 I3 排程層守住了嗎，還是想要再加一道（例如排程寫 spine 前先強制產一次 dry-run report）？
2. **獨立 execute gate** 的語義：reconcile execute 是良性、可獨立先上——你以 end-user 身分同意「夢可以開始寫我的 prediction log（記分），但 consolidation 仍 read-only」這個不對稱嗎？

## 驗證
- 新增 4 tests（tool: SAFE / dry-run 預設唯讀 / 報告寫出 / execute path）
- **全套件 2608 passed, 4 skipped**（動了 session.py + daemon.py 核心，跑全量確認）
- `gitnexus detect_changes`：medium，affected 僅 weekly loop 啟動流程（對帳 additive 進 `_consolidate_once`，gated 預設 off）

🤖 Generated with [Claude Code](https://claude.com/claude-code)