### PR TITLE
feat(cognition): calibration residue + surprise three quantities (#528 slice 4)

### DIFF
--- a/loom/core/cognition/calibration.py
+++ b/loom/core/cognition/calibration.py
@@ -1,0 +1,183 @@
+"""
+Prediction Spine — calibration residue + surprise three quantities
+(epic #528, spec docs/designs/58 §3.2/§6; decay tier #530 = Option A).
+
+This is where the spine's loop closes into *residue*. Reconciliation (slice 3)
+scores individual bets against runtime observation; those episodic records decay
+like any other memory. What **persists** is the roll-up: a per-domain
+``calibration:<domain>`` semantic summary — "I'm well-calibrated about CLI
+behaviour, badly calibrated about how DK reacts." That summary is the world-model
+residue (§3.2), and it is the P0 acceptance signal: a frozen-weights agent
+accumulating calibration in the framework layer, no reward, no weight update.
+
+Two halves, deliberately separable so the write can be gated on its own:
+
+* :func:`compute_calibration` — a *pure* aggregation over reconciled records.
+  No I/O, no side effects. Read-only by construction.
+* :func:`write_calibration` — persists the summaries as semantic facts, **only**
+  when ``execute=True``. This gate is the slice-4 half of I3/I5: calibration is
+  written and *nothing else* — no mood change, no Critic call, no surprise push.
+  It is intentionally NOT folded into reconcile's execute gate.
+
+The three surprise quantities (§6) ride along on each summary as inert,
+read-only data. P0 has no consumer for them (Affect arm is P1, Exploration arm
+is P2); they are computed and broadcast, never acted on here.
+
+**Invariants enforced structurally:**
+
+* **I4** — only ``status == "reconciled"`` records with a non-``None`` ``score``
+  contribute. A pending/due/stale bet, or a malformed reconciled-but-unscored
+  one, never counts as a free perfect outcome.
+* **I6** — the only input is prediction records carrying observation-derived
+  scores. There is no parameter through which user sentiment can enter.
+* **#530 (Option A)** — the summary is a *normal* semantic fact
+  (``domain=knowledge``, ``temporal=recent``). Its rolling re-write keeps the
+  decay anchor fresh for any domain still being bet on; an abandoned domain
+  fades through the ordinary half-life. No milestone-permanence hack.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+
+from loom.core.memory.ontology import DOMAIN_KNOWLEDGE, TEMPORAL_RECENT
+from loom.core.memory.semantic import SemanticEntry
+
+# Below this many reconciled bets, a domain is "sample-insufficient": you have
+# not exercised it enough to trust its calibration, regardless of accuracy.
+SAMPLE_FLOOR = 5
+
+# Resolver kinds with a mechanically unambiguous success pole, so a *surprising*
+# outcome can be signed (positive vs negative). P0 keeps this conservative — a
+# resolver without an intrinsic good/bad pole (row_count, duration_bucket) gets
+# valence 0 rather than letting the spine invent a value judgment (I5).
+_POLAR_RESOLVERS = {"tool_success"}
+
+
+@dataclass
+class CalibrationSummary:
+    """Rolled-up calibration for one prediction domain, plus the §6 quantities.
+
+    ``error_score`` / ``calibration_score`` describe *how well* the domain is
+    predicted. ``uncertainty`` describes *how much exploration should be drawn*
+    there (poor calibration OR thin sampling). ``appraisal_valence`` describes
+    whether the domain's surprises have leaned positive or negative.
+    """
+    domain: str
+    n: int
+    error_score: float          # mean error, 0.0 = perfect, 1.0 = always wrong
+    uncertainty: float          # max(mean_error, sample_insufficiency), [0, 1]
+    appraisal_valence: float    # mean signed surprise, [-1, 1]
+    calibration_score: float    # 1 - error_score, [0, 1]
+
+    @property
+    def key(self) -> str:
+        return f"calibration:{self.domain}"
+
+    def to_metadata(self) -> dict:
+        return {
+            "n": self.n,
+            "error_score": round(self.error_score, 4),
+            "uncertainty": round(self.uncertainty, 4),
+            "appraisal_valence": round(self.appraisal_valence, 4),
+            "calibration_score": round(self.calibration_score, 4),
+        }
+
+
+def _record_valence(record) -> float:
+    """Signed surprise for one reconciled bet, computed from the record alone.
+
+    ``valence = polarity × error_score``. Polarity is the factual outcome pole
+    (did the tool actually succeed?), derived from the resolver's ``expect`` and
+    whether the bet ``matched`` (error 0). This is a *factual* polarity, not a
+    value judgment — an unexpected success is +, an unexpected failure is −, and
+    a correctly-predicted outcome is ~0 (no surprise to appraise). The Critic
+    re-appraises in context downstream (I5); the spine only tags direction.
+    """
+    if record.resolver.get("kind") not in _POLAR_RESOLVERS:
+        return 0.0
+    score = record.score
+    expect = record.resolver.get("expect", True)
+    matched = score == 0.0
+    observed_success = expect if matched else (not expect)
+    polarity = 1.0 if observed_success else -1.0
+    return polarity * score
+
+
+def compute_calibration(records) -> list[CalibrationSummary]:
+    """Aggregate reconciled predictions into per-domain calibration summaries.
+
+    Pure and read-only. ``records`` is any iterable of ``PredictionRecord``;
+    only ``reconciled`` records with a real ``score`` contribute (I4). The sole
+    input is prediction-vs-observation scores — no sentiment channel (I6).
+    """
+    scored: dict[str, list[float]] = defaultdict(list)
+    valences: dict[str, list[float]] = defaultdict(list)
+
+    for r in records:
+        if r.status != "reconciled" or r.score is None:
+            continue  # I4 — unreconciled ≠ verified; no silent perfect bet
+        scored[r.domain].append(r.score)
+        valences[r.domain].append(_record_valence(r))
+
+    summaries: list[CalibrationSummary] = []
+    for domain, errs in scored.items():
+        n = len(errs)
+        mean_error = sum(errs) / n
+        sample_insufficiency = max(0.0, (SAMPLE_FLOOR - n) / SAMPLE_FLOOR)
+        uncertainty = max(mean_error, sample_insufficiency)
+        valence = sum(valences[domain]) / n
+        summaries.append(
+            CalibrationSummary(
+                domain=domain,
+                n=n,
+                error_score=mean_error,
+                uncertainty=uncertainty,
+                appraisal_valence=valence,
+                calibration_score=1.0 - mean_error,
+            )
+        )
+    return summaries
+
+
+async def write_calibration(
+    semantic, summaries, *, execute: bool = False
+) -> list[str]:
+    """Persist calibration summaries as semantic facts. Gated on ``execute``.
+
+    With ``execute=False`` (default) nothing is written — the caller still has
+    the computed summaries for its report (I3: read-only by default). With
+    ``execute=True`` each summary is upserted under its stable
+    ``calibration:<domain>`` key as a **normal** semantic fact (``knowledge`` /
+    ``recent`` — #530 Option A). The upsert is what makes the residue *rolling*:
+    re-writing the same key each dream refreshes the decay anchor for any domain
+    still in play, so it never reaches the half-life; an abandoned domain stops
+    being touched and fades through the ordinary path.
+
+    Returns the list of keys written (empty in dry-run). This function writes
+    calibration and nothing else — no mood, no Critic, no surprise push (I5).
+    """
+    if not execute:
+        return []
+
+    written: list[str] = []
+    for s in summaries:
+        value = (
+            f"calibration[{s.domain}]: score={s.calibration_score:.2f} "
+            f"(n={s.n}, error={s.error_score:.2f}, uncertainty={s.uncertainty:.2f}, "
+            f"valence={s.appraisal_valence:+.2f})"
+        )
+        await semantic.upsert(
+            SemanticEntry(
+                key=s.key,
+                value=value,
+                confidence=s.calibration_score,
+                source="prediction_spine",
+                metadata=s.to_metadata(),
+                domain=DOMAIN_KNOWLEDGE,
+                temporal=TEMPORAL_RECENT,
+            )
+        )
+        written.append(s.key)
+    return written

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,331 @@
+"""
+Prediction Spine — P0 slice 4: calibration residue + surprise three quantities
+(epic #528, spec docs/designs/58 §3.2/§6; decay tier #530 = Option A).
+
+Slice 4 turns reconciled bets into the spine's actual *residue*: a rolling
+per-domain ``calibration:<domain>`` semantic summary, plus the three read-only
+surprise quantities (``error_score`` / ``uncertainty`` / ``appraisal_valence``,
+§6). This is the P0 acceptance gate — the first non-trivial, repeatable,
+auditable signal that a frozen-weights agent accumulated world-model calibration
+in the framework layer.
+
+Contract (TDD-first), guarding the lifeline invariants:
+
+* **I4** — only ``reconciled`` predictions (with a real ``score``) feed
+  calibration; ``pending`` / ``due`` / ``stale`` never count (unreconciled ≠
+  verified).
+* **I6** — calibration moves ONLY from prediction-vs-observation scores. There
+  is no parameter, and no path, by which user sentiment can shift it.
+* **I3 / I5** — the three quantities are inert read-only data on the summary.
+  The module writes the calibration fact and *nothing else* (no mood, no Critic,
+  no surprise push). The write is behind its own ``execute`` gate, not smuggled
+  into reconcile's gate.
+* **#530** — calibration is a *normal* semantic fact (``temporal=recent``,
+  ``domain=knowledge`` — the world-model-residue framing of §3.2). Its rolling
+  re-write keeps ``updated_at`` fresh, so an actively-bet domain never reaches
+  the half-life; an abandoned one decays. Dry-run writes nothing.
+"""
+
+from datetime import datetime, UTC, timedelta
+
+import pytest
+import pytest_asyncio
+
+from loom.core.memory.store import SQLiteStore
+from loom.core.memory.semantic import SemanticMemory
+from loom.core.memory.prediction import PredictionRecord
+from loom.core.memory.ontology import DOMAIN_KNOWLEDGE, TEMPORAL_RECENT
+from loom.core.cognition.calibration import (
+    CalibrationSummary,
+    compute_calibration,
+    write_calibration,
+    SAMPLE_FLOOR,
+)
+
+
+# ---------------------------------------------------------------------------
+# helpers — construct reconciled / unreconciled records directly
+# ---------------------------------------------------------------------------
+
+def _reconciled(domain="cli", *, score, expect=True, kind="tool_success"):
+    resolver = {"kind": kind}
+    if kind in ("tool_success", "output_contains", "output_regex", "file_digest_changed"):
+        resolver["expect"] = expect
+    return PredictionRecord(
+        session_id="s",
+        claim="bet",
+        due_condition={"kind": "after_action", "call_id": "c"},
+        resolver=resolver,
+        domain=domain,
+        status="reconciled",
+        score=score,
+        observation_ref="action:a1",
+    )
+
+
+def _pending(domain="cli"):
+    return PredictionRecord(
+        session_id="s", claim="bet",
+        due_condition={"kind": "after_action", "call_id": "c"},
+        resolver={"kind": "tool_success", "expect": True},
+        domain=domain,
+    )
+
+
+# ---------------------------------------------------------------------------
+# I4 — only reconciled predictions feed calibration
+# ---------------------------------------------------------------------------
+
+class TestI4OnlyReconciledCounts:
+    def test_pending_due_stale_excluded(self):
+        records = [
+            _reconciled("cli", score=0.0),
+            _reconciled("cli", score=1.0),
+            _pending("cli"),                                   # excluded
+            PredictionRecord(session_id="s", claim="b",
+                             due_condition={"kind": "after_action", "call_id": "c"},
+                             resolver={"kind": "tool_success"}, domain="cli",
+                             status="due"),                    # excluded
+            PredictionRecord(session_id="s", claim="b",
+                             due_condition={"kind": "after_action", "call_id": "c"},
+                             resolver={"kind": "tool_success"}, domain="cli",
+                             status="stale"),                  # excluded
+        ]
+        summaries = compute_calibration(records)
+        assert len(summaries) == 1
+        assert summaries[0].domain == "cli"
+        assert summaries[0].n == 2          # only the two reconciled
+
+    def test_reconciled_without_score_is_not_counted(self):
+        """A 'reconciled' status but score is None is malformed — never count it
+        as a free perfect bet (no-silent-pass, pairs with I4)."""
+        bad = _reconciled("cli", score=0.0)
+        bad.score = None
+        summaries = compute_calibration([bad])
+        assert summaries == []
+
+    def test_empty_input_is_empty_output(self):
+        assert compute_calibration([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Aggregation — per-domain mean error + calibration score
+# ---------------------------------------------------------------------------
+
+class TestAggregation:
+    def test_grouped_per_domain(self):
+        records = [
+            _reconciled("cli", score=0.0),
+            _reconciled("cli", score=0.0),
+            _reconciled("git", score=1.0),
+        ]
+        by_domain = {s.domain: s for s in compute_calibration(records)}
+        assert set(by_domain) == {"cli", "git"}
+        assert by_domain["cli"].error_score == 0.0
+        assert by_domain["cli"].calibration_score == 1.0
+        assert by_domain["git"].error_score == 1.0
+        assert by_domain["git"].calibration_score == 0.0
+
+    def test_mean_error(self):
+        s = compute_calibration([
+            _reconciled("cli", score=0.0),
+            _reconciled("cli", score=1.0),
+            _reconciled("cli", score=0.5),
+        ])[0]
+        assert s.error_score == pytest.approx(0.5)
+        assert s.calibration_score == pytest.approx(0.5)
+
+    def test_key_is_calibration_prefixed(self):
+        s = compute_calibration([_reconciled("cli", score=0.0)])[0]
+        assert s.key == "calibration:cli"
+
+
+# ---------------------------------------------------------------------------
+# §6 — the three surprise quantities
+# ---------------------------------------------------------------------------
+
+class TestUncertainty:
+    def test_high_when_few_samples(self):
+        """Sample insufficiency: one bet is not enough to know a domain."""
+        s = compute_calibration([_reconciled("cli", score=0.0)])[0]
+        # perfectly calibrated (mean_error 0) but n=1 ⇒ still uncertain
+        expected_insuff = (SAMPLE_FLOOR - 1) / SAMPLE_FLOOR
+        assert s.uncertainty == pytest.approx(expected_insuff)
+
+    def test_high_when_often_wrong(self):
+        """Miscalibration drives uncertainty even with plenty of samples."""
+        records = [_reconciled("cli", score=0.9) for _ in range(SAMPLE_FLOOR + 5)]
+        s = compute_calibration(records)[0]
+        assert s.uncertainty == pytest.approx(0.9)   # mean_error dominates
+
+    def test_low_when_well_sampled_and_accurate(self):
+        records = [_reconciled("cli", score=0.0) for _ in range(SAMPLE_FLOOR + 5)]
+        s = compute_calibration(records)[0]
+        assert s.uncertainty == pytest.approx(0.0)
+
+
+class TestAppraisalValence:
+    def test_negative_on_surprising_failure(self):
+        """Predicted success, got failure (error 1) → negative surprise."""
+        s = compute_calibration([_reconciled("cli", score=1.0, expect=True)])[0]
+        assert s.appraisal_valence == pytest.approx(-1.0)
+
+    def test_positive_on_surprising_success(self):
+        """Bet it would FAIL (expect=False), it succeeded → positive surprise."""
+        s = compute_calibration([_reconciled("cli", score=1.0, expect=False)])[0]
+        assert s.appraisal_valence == pytest.approx(1.0)
+
+    def test_zero_on_expected_outcome(self):
+        """A correctly predicted outcome (error 0) carries no surprise."""
+        s = compute_calibration([_reconciled("cli", score=0.0, expect=True)])[0]
+        assert s.appraisal_valence == pytest.approx(0.0)
+
+    def test_zero_for_non_polar_resolver(self):
+        """P0 valence is conservative: only resolvers with a mechanically
+        unambiguous success pole (tool_success) carry valence. row_count etc.
+        get polarity 0 — the spine does not invent a value judgment (I5)."""
+        s = compute_calibration([
+            _reconciled("db", score=1.0, kind="row_count"),
+        ])[0]
+        assert s.appraisal_valence == pytest.approx(0.0)
+        # ...but it still counts toward error_score / calibration
+        assert s.error_score == pytest.approx(1.0)
+
+
+class TestQuantityRanges:
+    def test_all_quantities_in_range(self):
+        records = [
+            _reconciled("cli", score=0.0, expect=True),
+            _reconciled("cli", score=1.0, expect=True),
+            _reconciled("cli", score=0.3, expect=False),
+        ]
+        s = compute_calibration(records)[0]
+        assert 0.0 <= s.error_score <= 1.0
+        assert 0.0 <= s.uncertainty <= 1.0
+        assert -1.0 <= s.appraisal_valence <= 1.0
+        assert 0.0 <= s.calibration_score <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# I6 — calibration derives ONLY from prediction-vs-observation
+# ---------------------------------------------------------------------------
+
+class TestI6NoSentimentPath:
+    def test_compute_signature_has_no_sentiment_input(self):
+        """Structural I6: the only input is prediction records. There is no
+        parameter through which user sentiment could enter."""
+        import inspect
+        params = list(inspect.signature(compute_calibration).parameters)
+        assert params == ["records"]
+
+    def test_only_observation_scored_records_move_calibration(self):
+        """A domain whose bets are all unreconciled (no observation-derived
+        score) produces no calibration — sentiment about it is irrelevant."""
+        summaries = compute_calibration([_pending("vibes"), _pending("vibes")])
+        assert summaries == []
+
+
+# ---------------------------------------------------------------------------
+# Write gate — I3 / I5 / #530 Option A
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test_calibration.db")
+
+
+@pytest_asyncio.fixture
+async def store(tmp_db):
+    s = SQLiteStore(tmp_db)
+    await s.initialize()
+    return s
+
+
+@pytest_asyncio.fixture
+async def semantic(store):
+    async with store.connect() as db:
+        yield SemanticMemory(db)
+
+
+class TestWriteGate:
+    async def test_dry_run_writes_nothing(self, semantic):
+        """I3: the default pass is read-only — computes but does not persist."""
+        summaries = compute_calibration([_reconciled("cli", score=0.0)])
+        written = await write_calibration(semantic, summaries, execute=False)
+        assert written == []
+        assert await semantic.get("calibration:cli") is None
+
+    async def test_execute_writes_calibration_fact(self, semantic):
+        summaries = compute_calibration([
+            _reconciled("cli", score=0.0),
+            _reconciled("cli", score=0.0),
+        ])
+        written = await write_calibration(semantic, summaries, execute=True)
+        assert written == ["calibration:cli"]
+        entry = await semantic.get("calibration:cli")
+        assert entry is not None
+
+    async def test_written_fact_is_knowledge_recent(self, semantic):
+        """#530 Option A: world-model residue lands as normal semantic
+        (domain=knowledge, temporal=recent) — NOT a milestone permanence hack."""
+        summaries = compute_calibration([_reconciled("cli", score=0.0)])
+        await write_calibration(semantic, summaries, execute=True)
+        entry = await semantic.get("calibration:cli")
+        assert entry.domain == DOMAIN_KNOWLEDGE
+        assert entry.temporal == TEMPORAL_RECENT
+
+    async def test_confidence_reflects_calibration(self, semantic):
+        """A well-calibrated domain is a high-confidence fact; a poorly
+        calibrated one is low-confidence."""
+        good = compute_calibration([_reconciled("cli", score=0.0) for _ in range(6)])
+        bad = compute_calibration([_reconciled("git", score=1.0) for _ in range(6)])
+        await write_calibration(semantic, good + bad, execute=True)
+        assert (await semantic.get("calibration:cli")).confidence == pytest.approx(1.0)
+        assert (await semantic.get("calibration:git")).confidence == pytest.approx(0.0, abs=0.05)
+
+    async def test_quantities_persisted_in_metadata(self, semantic):
+        """The three quantities ride along in metadata so P1/P2 consumers can
+        read them later without recomputing (read-only broadcast, §6)."""
+        summaries = compute_calibration([_reconciled("cli", score=1.0, expect=True)])
+        await write_calibration(semantic, summaries, execute=True)
+        meta = (await semantic.get("calibration:cli")).metadata
+        assert "error_score" in meta
+        assert "uncertainty" in meta
+        assert "appraisal_valence" in meta
+        assert meta["n"] == 1
+
+    async def test_rolling_rewrite_is_stable_key(self, semantic):
+        """The summary is *rolling*: a second pass overwrites the same key
+        rather than accumulating duplicates — this is what keeps an active
+        domain's updated_at fresh (#530 mechanism)."""
+        await write_calibration(
+            semantic, compute_calibration([_reconciled("cli", score=1.0)]), execute=True)
+        await write_calibration(
+            semantic, compute_calibration([_reconciled("cli", score=0.0)]), execute=True)
+        entry = await semantic.get("calibration:cli")
+        # latest pass won; still one row under the stable key
+        assert entry.confidence == pytest.approx(1.0)  # score 0.0 → calibration 1.0
+
+
+# ---------------------------------------------------------------------------
+# #530 — the verifiable decay subtest (Option A)
+# ---------------------------------------------------------------------------
+
+class TestDecayBehaviorOptionA:
+    """The decision: calibration is normal semantic. An *actively* re-written
+    domain never decays (its anchor stays fresh); an *abandoned* one fades.
+    Asserted against the lifecycle mechanism directly."""
+
+    def test_active_domain_survives_abandoned_decays(self):
+        from loom.core.memory.lifecycle import effective_confidence
+        now = datetime.now(UTC)
+        # active: the dream re-wrote it today → anchor fresh
+        active = effective_confidence(
+            0.9, now, now, DOMAIN_KNOWLEDGE, TEMPORAL_RECENT)
+        # abandoned: last written ~300d ago, never recalled since
+        old = now - timedelta(days=300)
+        abandoned = effective_confidence(
+            0.9, old, None, DOMAIN_KNOWLEDGE, TEMPORAL_RECENT)
+        assert active == pytest.approx(0.9, abs=0.01)   # untouched by decay
+        assert abandoned < active
+        assert abandoned < 0.15                          # crossed toward prune


### PR DESCRIPTION
## 什麼

Prediction Spine P0 **slice 4** — 把對帳結果滾成 spine 真正的**殘留物**:per-domain `calibration:<domain>` semantic 摘要 + surprise 三量。這是 **P0 acceptance gate** 的訊號本體:凍結權重的 agent 在框架層累積世界模型校準(no reward / no weight update)。

純模組,**不**接 daemon(slice 4.5 再接,鏡像 slice 3→3.5),讓這個 PR 的 review 面乾淨。

## 兩半(刻意可分離 → 守 gate 條件)

- **`compute_calibration(records)`** — 純聚合,零 I/O。
- **`write_calibration(semantic, summaries, *, execute=False)`** — **自己的 execute gate**,**不**寄生 reconcile_execute。`execute=False` 寫零;`execute=True` 才 upsert `calibration:<domain>`。寫 calibration 而已——**不**碰 mood / Critic / surprise push。

## 不變式對驗

| 不變式 | 怎麼守 | 測試 |
|---|---|---|
| **I4** | 只 `reconciled` + `score is not None` 計入;malformed reconciled-but-unscored 不當免費滿分 | `TestI4OnlyReconciledCounts` |
| **I6** | 唯一入參是 records,簽名無 sentiment 通道(`inspect` 斷言) | `TestI6NoSentimentPath` |
| **I3 / I5** | dry-run 寫零;三量是 inert metadata;write 只寫 calibration | `TestWriteGate` |
| **#530 Option A** | 寫成 `knowledge`/`recent`;rolling re-write 刷新 anchor → 活躍永存、棄用褪色 | `TestDecayBehaviorOptionA` |

## Surprise 三量(§6,value-neutral / P0 保守)

- `error_score` = domain 平均 error。
- `uncertainty` = `max(mean_error, sample_insufficiency)`(校準差 **或** 樣本不足都該被 exploration 吸引)。
- `appraisal_valence` = `polarity × error_score`,polarity **只**對 `tool_success` 給 ±1(其餘 resolver = 0,不讓 spine 自創價值判斷);純從 record 算,**不** re-resolve observation。三量目前無消費者(Affect 臂 P1 / Exploration 臂 P2),只 broadcast。

## #530 拍板落地

calibration 走 **Option A normal tier**(`temporal=recent`)。決定依據與可驗證子測試見 issue #530 close comment。

## Review 焦點(延續上次的把關)

1. **獨立 gate 有沒有被偷塞** — `write_calibration` 的 `execute` 是不是真的只寫 calibration、沒夾帶 mood/surprise 副作用。
2. **三量定義** — 特別是 `appraisal_valence` 的 polarity 取法(只 tool_success)是否同意 P0 保守範圍,還是想要更寬。

## 測試

23 contract tests TDD red→green;全 spine suite 93 綠;memory/cognition 鄰近 518 綠。`gitnexus detect_changes`:0 affected process,low risk(無接線)。

## 待續(不在本 PR)

- **slice 4.5**:daemon 接線 + calibration 自己的 config gate(`calibration_write_enabled`,預設 false)。
- 絲絲先前掛 slice 4 的 OQ(逆觸發、dispatch table registry、journal kind 欄位)+ `to_dict` lossy P3 + `list_overdue`(#531 尾巴)+ slice 3 第二刀(at_time/session_log 賭注)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)