### PR TITLE
feat(autonomy): wire calibration residue into the dream schedule (#528 slice 4.5)

### DIFF
--- a/loom.toml.example
+++ b/loom.toml.example
@@ -329,6 +329,11 @@ corpus_limit  = 5000
 # (benign), so you can flip reconcile on while consolidation stays read-only.
 reconcile_enabled = false   # opt-in: run prediction reconciliation each weekly pass
 reconcile_execute = false   # P4a read-only; set true to commit scores (mark_reconciled)
+# Calibration residue (epic #528 slice 4.5): rolls reconciled bets into a
+# per-domain ``calibration:<domain>`` semantic summary (the spine's world-model
+# residue). Its write gate is INDEPENDENT of reconcile_execute — flipping
+# reconcile on does NOT start writing calibration. Off by default.
+calibration_write_enabled = false  # opt-in: persist calibration residue each weekly pass
 
 # ─────────────────────────────────────────────
 # Reflection (Issue #120 PR1) — Skill diagnostic layer

--- a/loom/autonomy/daemon.py
+++ b/loom/autonomy/daemon.py
@@ -177,6 +177,40 @@ async def _run_scheduled_reconcile(db, *, enabled: bool, execute: bool) -> None:
         )
 
 
+async def _run_scheduled_calibration(db, *, enabled: bool) -> None:
+    """Roll reconciled bets into ``calibration:<domain>`` residue (#528 slice 4.5).
+
+    Gated on ``calibration_write_enabled`` — **independent** of
+    ``reconcile_execute`` (絲絲 PR #534): flipping reconcile's execute must not
+    start writing calibration, and vice versa. It aggregates the standing
+    reconciled corpus, so it is meaningful even on a pass where reconcile scored
+    nothing new. Like the reconcile step it is **isolated**: a failure here is
+    swallowed + logged so it can't roll back the consolidation/reconcile that
+    already ran. No-op when ``enabled`` is False — the schedule default.
+    """
+    if not enabled:
+        return
+    try:
+        from loom.core.cognition.calibration import run_calibration_pass
+        from loom.core.memory.prediction import PredictionStore
+        from loom.core.memory.semantic import SemanticMemory
+        from loom.autonomy.circadian.journal import append_consolidation_report
+
+        report = await run_calibration_pass(
+            PredictionStore(db), SemanticMemory(db), execute=True,
+        )
+        append_consolidation_report(report.render())
+        logger.info(
+            "[consolidation] calibration written=%s domains=%d",
+            report.written, len(report.summaries),
+        )
+    except Exception as exc:  # noqa: BLE001 — schedule isolation, never veto the loop
+        logger.exception(
+            "[consolidation] calibration pass failed; continuing weekly loop: %s",
+            exc,
+        )
+
+
 class AutonomyDaemon:
     """
     Manages the full autonomy lifecycle:
@@ -749,6 +783,14 @@ class AutonomyDaemon:
                 db,
                 enabled=cfg.get("reconcile_enabled", False),
                 execute=bool(cfg.get("reconcile_execute", False)),
+            )
+
+            # Epic #528 slice 4.5: roll reconciled bets into calibration residue.
+            # Its own gate (calibration_write_enabled), independent of reconcile's
+            # execute, and isolated the same way (絲絲 PR #534).
+            await _run_scheduled_calibration(
+                db,
+                enabled=bool(cfg.get("calibration_write_enabled", False)),
             )
 
             return plan

--- a/loom/core/cognition/calibration.py
+++ b/loom/core/cognition/calibration.py
@@ -39,7 +39,7 @@ is P2); they are computed and broadcast, never acted on here.
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from loom.core.memory.ontology import DOMAIN_KNOWLEDGE, TEMPORAL_RECENT
 from loom.core.memory.semantic import SemanticEntry
@@ -82,6 +82,55 @@ class CalibrationSummary:
             "uncertainty": round(self.uncertainty, 4),
             "appraisal_valence": round(self.appraisal_valence, 4),
             "calibration_score": round(self.calibration_score, 4),
+        }
+
+    def to_dict(self) -> dict:
+        """Explicit serialization — every field named, so a future
+        datetime/UUID field can't silently leak through ``asdict`` (絲絲 #532
+        OQ3 carryover). The dream adapter logs this."""
+        return {
+            "domain": self.domain,
+            "key": self.key,
+            "n": self.n,
+            "error_score": round(self.error_score, 4),
+            "uncertainty": round(self.uncertainty, 4),
+            "appraisal_valence": round(self.appraisal_valence, 4),
+            "calibration_score": round(self.calibration_score, 4),
+        }
+
+
+@dataclass
+class CalibrationReport:
+    """Auditable projection of one calibration pass — the dream-journal view.
+
+    ``written`` records whether the residue was actually persisted (execute) or
+    merely computed (dry-run). The per-domain summaries carry the §6 quantities.
+    """
+    written: bool
+    summaries: list = field(default_factory=list)
+
+    def summary(self) -> str:
+        verb = "wrote" if self.written else "would write (dry-run)"
+        return f"calibration: {verb} {len(self.summaries)} domain residue(s)"
+
+    def render(self) -> str:
+        lines = [self.summary()]
+        if self.summaries:
+            lines.append("")
+            verb = "wrote" if self.written else "would write"
+            for s in sorted(self.summaries, key=lambda x: x.domain):
+                lines.append(
+                    f"  - {verb} {s.key}: score={s.calibration_score:.2f} "
+                    f"(n={s.n}, error={s.error_score:.2f}, "
+                    f"uncertainty={s.uncertainty:.2f}, valence={s.appraisal_valence:+.2f})"
+                )
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict:
+        return {
+            "written": self.written,
+            "counts": {"domains": len(self.summaries)},
+            "summaries": [s.to_dict() for s in self.summaries],
         }
 
 
@@ -181,3 +230,28 @@ async def write_calibration(
         )
         written.append(s.key)
     return written
+
+
+# Roll the whole reconciled corpus, not just one pass — calibration is a
+# rolling aggregate. Generous so a low-volume P0 store gets everything; ASC by
+# created_at means oldest-first, which is irrelevant when we take them all.
+_CALIBRATION_CORPUS_LIMIT = 5000
+
+
+async def run_calibration_pass(
+    store, semantic, *, execute: bool = False
+) -> CalibrationReport:
+    """Roll every reconciled bet into per-domain calibration residue.
+
+    The slice-4.5 orchestration that rides the convergent dream's cadence. It is
+    independent of whether *this* dream's reconcile scored anything new (絲絲 PR
+    #534): it aggregates the standing reconciled corpus. ``execute=False`` (the
+    default) computes the summaries for the journal but writes nothing (I3);
+    ``execute=True`` persists them via :func:`write_calibration`.
+    """
+    records = await store.list_by_status(
+        "reconciled", limit=_CALIBRATION_CORPUS_LIMIT
+    )
+    summaries = compute_calibration(records)
+    await write_calibration(semantic, summaries, execute=execute)
+    return CalibrationReport(written=execute and bool(summaries), summaries=summaries)

--- a/loom/core/memory/maintenance.py
+++ b/loom/core/memory/maintenance.py
@@ -354,17 +354,29 @@ def make_prediction_reconcile_tool(
     spine is never written speculatively by a schedule.
     """
     from loom.core.cognition.prediction_reconcile import run_prediction_reconciliation
+    from loom.core.cognition.calibration import run_calibration_pass
     from loom.core.memory.prediction import PredictionStore
+    from loom.core.memory.semantic import SemanticMemory
     from loom.autonomy.circadian.journal import append_consolidation_report
 
     async def _executor(call) -> ToolResult:
         dry_run = bool(call.args.get("dry_run", True))  # P4a: read-only default
+        # Calibration write is gated on its OWN arg, independent of reconcile's
+        # execute (絲絲 PR #534): dry_run=false commits scores but writes no
+        # residue unless write_calibration=true is set deliberately.
+        write_cal = bool(call.args.get("write_calibration", False))
 
         store = PredictionStore(db)
         report = await run_prediction_reconciliation(store, db, execute=not dry_run)
 
+        # Roll reconciled bets into calibration residue. Always computed so the
+        # report shows the landscape; written only when write_calibration=true.
+        cal_report = await run_calibration_pass(
+            store, SemanticMemory(db), execute=write_cal,
+        )
+
         path = append_consolidation_report(
-            report.render(),
+            report.render() + "\n\n" + cal_report.render(),
             timezone=timezone, dreams_dir=dreams_dir,
         )
 
@@ -373,7 +385,8 @@ def make_prediction_reconcile_tool(
             call_id=call.id, tool_name=call.tool_name, success=True,
             output=(
                 f"prediction reconcile: {verb} {len(report.proposals)}, "
-                f"skipped {len(report.skipped)}\n  Report: {path}"
+                f"skipped {len(report.skipped)}; {cal_report.summary()}"
+                f"\n  Report: {path}"
             ),
         )
 
@@ -396,6 +409,15 @@ def make_prediction_reconcile_tool(
                         "Set false to commit scores via mark_reconciled."
                     ),
                     "default": True,
+                },
+                "write_calibration": {
+                    "type": "boolean",
+                    "description": (
+                        "Persist the per-domain calibration residue (default "
+                        "false). Independent of dry_run — calibration always "
+                        "appears in the report, but is only written when true."
+                    ),
+                    "default": False,
                 },
             },
         },

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -35,10 +35,13 @@ from loom.core.memory.store import SQLiteStore
 from loom.core.memory.semantic import SemanticMemory
 from loom.core.memory.prediction import PredictionRecord
 from loom.core.memory.ontology import DOMAIN_KNOWLEDGE, TEMPORAL_RECENT
+from loom.core.memory.prediction import PredictionStore
 from loom.core.cognition.calibration import (
     CalibrationSummary,
+    CalibrationReport,
     compute_calibration,
     write_calibration,
+    run_calibration_pass,
     SAMPLE_FLOOR,
 )
 
@@ -191,6 +194,20 @@ class TestAppraisalValence:
         # ...but it still counts toward error_score / calibration
         assert s.error_score == pytest.approx(1.0)
 
+    def test_boundary_n_one_surprising_failure(self):
+        """絲絲 PR #534 P3: pin the −1.0 extreme — a lone, fully-surprising
+        failure saturates appraisal_valence at the bottom of its range."""
+        s = compute_calibration([_reconciled("cli", score=1.0, expect=True)])[0]
+        assert s.n == 1
+        assert s.appraisal_valence == pytest.approx(-1.0)
+
+    def test_boundary_n_one_surprising_success(self):
+        """絲絲 PR #534 P3: pin the +1.0 extreme — a lone, fully-surprising
+        success saturates appraisal_valence at the top of its range."""
+        s = compute_calibration([_reconciled("cli", score=1.0, expect=False)])[0]
+        assert s.n == 1
+        assert s.appraisal_valence == pytest.approx(1.0)
+
 
 class TestQuantityRanges:
     def test_all_quantities_in_range(self):
@@ -329,3 +346,99 @@ class TestDecayBehaviorOptionA:
         assert active == pytest.approx(0.9, abs=0.01)   # untouched by decay
         assert abandoned < active
         assert abandoned < 0.15                          # crossed toward prune
+
+
+# ---------------------------------------------------------------------------
+# Serialization — CalibrationSummary / CalibrationReport (#532 OQ3 carryover)
+# ---------------------------------------------------------------------------
+
+class TestSerialization:
+    def test_summary_to_dict_is_explicit(self):
+        """絲絲 #532 OQ3: explicit serialization, not asdict — every field is
+        named, so a future datetime/UUID field can't silently leak unserialized."""
+        s = compute_calibration([_reconciled("cli", score=0.25, kind="row_count")])[0]
+        d = s.to_dict()
+        assert d == {
+            "domain": "cli",
+            "key": "calibration:cli",
+            "n": 1,
+            "error_score": pytest.approx(0.25),
+            "uncertainty": pytest.approx(0.8),
+            "appraisal_valence": pytest.approx(0.0),
+            "calibration_score": pytest.approx(0.75),
+        }
+
+    def test_report_to_dict_shape(self):
+        report = CalibrationReport(
+            written=False,
+            summaries=compute_calibration([
+                _reconciled("cli", score=0.0),
+                _reconciled("git", score=1.0),
+            ]),
+        )
+        d = report.to_dict()
+        assert d["written"] is False
+        assert d["counts"]["domains"] == 2
+        assert isinstance(d["summaries"], list)
+        assert {s["domain"] for s in d["summaries"]} == {"cli", "git"}
+
+    def test_report_render_is_nonempty(self):
+        report = CalibrationReport(
+            written=True,
+            summaries=compute_calibration([_reconciled("cli", score=0.0)]),
+        )
+        body = report.render()
+        assert "calibration" in body.lower()
+        assert "cli" in body
+
+
+# ---------------------------------------------------------------------------
+# run_calibration_pass — the rolling pass over the store (slice 4.5)
+# ---------------------------------------------------------------------------
+
+async def _seed_reconciled(store, domain, *, score, n=1):
+    for _ in range(n):
+        pred = PredictionRecord(
+            session_id="s", claim="bet",
+            due_condition={"kind": "after_action", "call_id": "c"},
+            resolver={"kind": "tool_success", "expect": True},
+            domain=domain,
+        )
+        await store.write(pred)
+        await store.mark_reconciled(pred.id, score=score, observation_ref="action:a1")
+
+
+class TestRunCalibrationPass:
+    async def test_dry_run_is_read_only(self, store):
+        async with store.connect() as db:
+            ps = PredictionStore(db)
+            sem = SemanticMemory(db)
+            await _seed_reconciled(ps, "cli", score=0.0, n=2)
+
+            report = await run_calibration_pass(ps, sem, execute=False)
+            assert isinstance(report, CalibrationReport)
+            assert report.written is False
+            assert len(report.summaries) == 1            # computed for the report
+            assert await sem.get("calibration:cli") is None   # but nothing written
+
+    async def test_execute_writes_residue(self, store):
+        async with store.connect() as db:
+            ps = PredictionStore(db)
+            sem = SemanticMemory(db)
+            await _seed_reconciled(ps, "cli", score=0.0, n=2)
+            await _seed_reconciled(ps, "git", score=1.0, n=2)
+
+            report = await run_calibration_pass(ps, sem, execute=True)
+            assert report.written is True
+            assert (await sem.get("calibration:cli")).confidence == pytest.approx(1.0)
+            assert (await sem.get("calibration:git")).confidence == pytest.approx(0.0, abs=0.05)
+
+    async def test_pending_only_store_writes_nothing(self, store):
+        """I4 end-to-end: a store with no reconciled bets yields no residue."""
+        async with store.connect() as db:
+            ps = PredictionStore(db)
+            sem = SemanticMemory(db)
+            await ps.write(_pending("cli"))
+            report = await run_calibration_pass(ps, sem, execute=True)
+            assert report.summaries == []
+            assert await sem.get("calibration:cli") is None

--- a/tests/test_prediction_reconcile_tool.py
+++ b/tests/test_prediction_reconcile_tool.py
@@ -132,3 +132,29 @@ class TestReconcileTool:
         entry = await SemanticMemory(db_conn).get("calibration:cli")
         assert entry is not None
         assert entry.confidence == pytest.approx(1.0)
+
+    async def test_calibration_writes_while_reconcile_stays_dry(self, db_conn, tmp_path):
+        """絲絲 PR #535 P3: the *reverse* independence — reconcile can be a no-op
+        dry-run while calibration still writes, because calibration rolls the
+        *standing* reconciled corpus, not this pass's new scores."""
+        from loom.core.memory.maintenance import make_prediction_reconcile_tool
+        from loom.core.memory.semantic import SemanticMemory
+        # one bet already reconciled in a prior pass (the standing corpus)...
+        prior = PredictionRecord(
+            session_id="s1", claim="bet",
+            due_condition={"kind": "after_action", "call_id": "old"},
+            resolver={"kind": "tool_success", "expect": True}, domain="cli",
+        )
+        await PredictionStore(db_conn).write(prior)
+        await PredictionStore(db_conn).mark_reconciled(
+            prior.id, score=0.0, observation_ref="action:old")
+        # ...plus a fresh settleable bet that this dry-run must NOT score
+        fresh = await _seed_settleable(db_conn)
+
+        tool = make_prediction_reconcile_tool(db_conn, dreams_dir=tmp_path)
+        await tool.executor(_make_call({"dry_run": True, "write_calibration": True}))
+
+        # reconcile stayed read-only: the fresh bet is untouched
+        assert (await PredictionStore(db_conn).get(fresh.id)).status == "pending"
+        # calibration still wrote, from the standing corpus
+        assert (await SemanticMemory(db_conn).get("calibration:cli")) is not None

--- a/tests/test_prediction_reconcile_tool.py
+++ b/tests/test_prediction_reconcile_tool.py
@@ -108,3 +108,27 @@ class TestReconcileTool:
         assert after.status == "reconciled"
         assert after.score == 0.0
         assert after.observation_ref == "action:act-1"
+
+    async def test_calibration_write_is_independent_of_dry_run(self, db_conn, tmp_path):
+        """絲絲 PR #534: the calibration write is gated on its own arg, NOT folded
+        into reconcile's execute. dry_run=false commits scores but writes NO
+        calibration unless write_calibration=true is set deliberately."""
+        from loom.core.memory.maintenance import make_prediction_reconcile_tool
+        from loom.core.memory.semantic import SemanticMemory
+        await _seed_settleable(db_conn)
+
+        tool = make_prediction_reconcile_tool(db_conn, dreams_dir=tmp_path)
+        # reconcile commits, but calibration stays unwritten
+        await tool.executor(_make_call({"dry_run": False}))
+        assert await SemanticMemory(db_conn).get("calibration:cli") is None
+
+    async def test_write_calibration_persists_residue(self, db_conn, tmp_path):
+        from loom.core.memory.maintenance import make_prediction_reconcile_tool
+        from loom.core.memory.semantic import SemanticMemory
+        await _seed_settleable(db_conn)
+
+        tool = make_prediction_reconcile_tool(db_conn, dreams_dir=tmp_path)
+        await tool.executor(_make_call({"dry_run": False, "write_calibration": True}))
+        entry = await SemanticMemory(db_conn).get("calibration:cli")
+        assert entry is not None
+        assert entry.confidence == pytest.approx(1.0)

--- a/tests/test_scheduled_calibration.py
+++ b/tests/test_scheduled_calibration.py
@@ -1,0 +1,80 @@
+"""
+Prediction Spine — slice 4.5 scheduled calibration isolation (epic #528).
+
+``_run_scheduled_calibration`` rolls reconciled bets into the persistent
+``calibration:<domain>`` residue on the weekly dream cadence. Like its
+reconcile sibling (PR #533), two schedule-level properties matter:
+
+* **Independent gate.** Calibration writing is gated on ``calibration_write_enabled``,
+  **separate** from ``reconcile_execute`` (絲絲 PR #534): flipping reconcile's
+  execute must NOT start writing calibration. ``enabled=False`` (the shipped
+  default) writes nothing.
+* **Failure isolation.** A calibration failure must not propagate out of the
+  weekly loop (which would roll back the consolidation + reconcile that already
+  ran). Failures are swallowed + logged; the loop continues.
+"""
+
+import pytest
+import pytest_asyncio
+
+from loom.core.memory.store import SQLiteStore
+from loom.core.memory.semantic import SemanticMemory
+from loom.core.memory.prediction import PredictionRecord, PredictionStore
+from loom.autonomy.daemon import _run_scheduled_calibration
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test_sched_calibration.db")
+
+
+@pytest_asyncio.fixture
+async def store(tmp_db):
+    s = SQLiteStore(tmp_db)
+    await s.initialize()
+    return s
+
+
+@pytest_asyncio.fixture
+async def db_conn(store):
+    async with store.connect() as db:
+        yield db
+
+
+async def _seed_reconciled(db, domain="cli", *, score=0.0):
+    ps = PredictionStore(db)
+    pred = PredictionRecord(
+        session_id="s1", claim="bet",
+        due_condition={"kind": "after_action", "call_id": "c1"},
+        resolver={"kind": "tool_success", "expect": True},
+        domain=domain,
+    )
+    await ps.write(pred)
+    await ps.mark_reconciled(pred.id, score=score, observation_ref="action:a1")
+    return pred
+
+
+class TestGateIndependence:
+    async def test_disabled_writes_no_residue(self, db_conn):
+        await _seed_reconciled(db_conn, "cli", score=0.0)
+        await _run_scheduled_calibration(db_conn, enabled=False)
+        assert await SemanticMemory(db_conn).get("calibration:cli") is None
+
+    async def test_enabled_writes_residue(self, db_conn):
+        await _seed_reconciled(db_conn, "cli", score=0.0)
+        await _run_scheduled_calibration(db_conn, enabled=True)
+        entry = await SemanticMemory(db_conn).get("calibration:cli")
+        assert entry is not None
+        assert entry.confidence == pytest.approx(1.0)
+
+
+class TestFailureIsolation:
+    async def test_calibration_raise_is_swallowed(self, db_conn, monkeypatch):
+        async def _boom(*a, **k):
+            raise RuntimeError("calibration went sideways")
+
+        monkeypatch.setattr(
+            "loom.core.cognition.calibration.run_calibration_pass", _boom,
+        )
+        # must NOT raise — the weekly loop continues past a calibration failure
+        await _run_scheduled_calibration(db_conn, enabled=True)


### PR DESCRIPTION
## 什麼

Prediction Spine P0 **slice 4.5** — 把 slice 4 的 calibration 模組接上 convergent dream 排程(鏡像 slice 3→3.5)。計算保持純函式;本刀加的是 **rolling pass + 排程接線 + 獨立 write gate**。

這之後 P0 epic 的「分泌物」就真的會在每週夢裡被滾出來——但**仍預設零行為**,要人為翻 `calibration_write_enabled` 才寫。

## 接了什麼

- **`run_calibration_pass(store, semantic, *, execute)` + `CalibrationReport`** — 滾「既有 reconciled 全集」成 per-domain residue。**獨立於本 pass 有沒有新計分**(絲絲 PR #534):它聚合所有 reconciled records。`execute=False` 算給報告看、寫零。
- **`CalibrationSummary.to_dict` / `CalibrationReport.to_dict|render`** — 顯式序列化(非 asdict),未來加 datetime/UUID 欄位不會 silent leak(解絲絲 **#532 OQ3** lossy P3)。
- **daemon `_run_scheduled_calibration(db, *, enabled)`** — 跟 reconcile 一樣**隔離**(失敗 swallow+log,絕不回滾已跑完的 consolidation/reconcile)。Gate = `calibration_write_enabled`,**獨立於** `reconcile_execute`:翻 reconcile execute **不會**開始寫 calibration,反之亦然。
- **`prediction_reconcile` tool** 加 `write_calibration` arg(預設 false),也**獨立於 `dry_run`** — calibration 永遠出現在報告裡,只在 set 時才寫。讓手動觸發能「翻 gate 前先預覽 residue」。
- **`loom.toml.example`**:`calibration_write_enabled = false`(dual-write)。

## 三道獨立 gate(回應絲絲對「偷塞」的把關)

| Gate | 管什麼 | 預設 |
|---|---|---|
| `reconcile_enabled` | reconcile 跑不跑 | false |
| `reconcile_execute` | reconcile 寫不寫 `mark_reconciled` | false |
| `calibration_write_enabled` | calibration residue 寫不寫 | false |

三者**互不寄生**。calibration 寫入路徑只 `upsert(SemanticEntry)`——不碰 mood / Critic / dream(I5 by construction,沒 import 沒路走)。

## 順手收掉的絲絲掛單

- ✅ **PR #534 P3 #1**:`appraisal_valence` 在 `n=1` 的 ±1.0 兩個邊界各釘一測試。
- ✅ **#532 OQ3**:顯式 `to_dict` 序列化。
- ✅ **PR #534 OQ3**:`calibration_write_enabled` 沿用 `reconcile_*` 命名慣例、預設 off。
- ✅ **PR #534 OQ2**:report shape(`CalibrationReport.render/to_dict`)給 daemon adapter log。

## Review 焦點(延續上次)

1. **三道 gate 真的獨立** — 特別是 `_run_scheduled_calibration` 的 enabled 沒被 reconcile 的 gate 牽連;tool 的 `write_calibration` 沒被 `dry_run=false` 牽連(`test_calibration_write_is_independent_of_dry_run` 直接釘)。
2. **隔離** — calibration raise 不污染週迴圈(`test_calibration_raise_is_swallowed`)。
3. **三量仍 inert** — calibration 寫入沒偷接 mood push。

## 測試

13 new tests TDD red→green(boundary ×2、to_dict/report ×3、run_calibration_pass ×3、scheduled isolation ×3、tool gate ×2);全 suite **2647 passed / 4 skipped**。`gitnexus detect_changes`:0 affected process,low risk(接線在預設關閉 gate 後)。

## 待續(slice 4.5 之後)

- 絲絲 PR #534 OQ1:消費者 PR(exploration 臂)要釘 `test_consumer_reads_uncertainty_not_calibration_when_choosing_exploration_target`——**屬 P2 消費者 PR,不在本刀**。
- `_POLAR_RESOLVERS` 若日後開新 polar resolver → registry pattern(絲絲 PR #534 OQ4)。
- slice 3 第二刀(at_time/session_log 賭注)、`list_overdue`(#531 尾巴)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)