### PR TITLE
feat(harness): auto-betting mouth — implicit tool_success bets (#528 P0.5-a, #537)

### DIFF
--- a/loom.toml.example
+++ b/loom.toml.example
@@ -327,6 +327,14 @@ corpus_limit  = 5000
 # the consolidation ``execute`` above — consolidation execute merges facts
 # (destructive); reconcile execute only records observation-derived scores
 # (benign), so you can flip reconcile on while consolidation stays read-only.
+# Auto-betting "mouth" (epic #528 P0.5-a / #537): co-write an implicit
+# "this tool will succeed" bet for every tool action that actually executed,
+# settled later by reconcile. This is the spine's INPUT — without it the
+# reconcile schedule chews an empty table. Session-level (per tool call), not a
+# dream activity, but grouped here so the whole observation ramp is in one place.
+# Observation ramp (flip top-down, watch dreams/ reports between each):
+#   auto_predict_enabled → reconcile_enabled → reconcile_execute → calibration_write_enabled
+auto_predict_enabled = false  # opt-in: start making implicit per-tool bets
 reconcile_enabled = false   # opt-in: run prediction reconciliation each weekly pass
 reconcile_execute = false   # P4a read-only; set true to commit scores (mark_reconciled)
 # Calibration residue (epic #528 slice 4.5): rolls reconciled bets into a

--- a/loom/core/harness/auto_predict.py
+++ b/loom/core/harness/auto_predict.py
@@ -54,9 +54,17 @@ def implicit_bet_for(record: ActionRecord, *, enabled: bool) -> PredictionRecord
     if not executed:
         return None
 
+    # No session → no bet. A session-less bet would reconcile fine (it settles by
+    # call_id) but be an orphan to any per-session audit — and this writes
+    # autonomously at volume, so "don't bet rather than write orphan data" keeps
+    # the spine's own hygiene clean (絲絲 PR #538 P3). Drops the empty fallback.
+    session_id = record.call.session_id
+    if not session_id:
+        return None
+
     tool = record.call.tool_name
     return PredictionRecord(
-        session_id=record.call.session_id or "",
+        session_id=session_id,
         claim=f"{tool} will succeed",
         due_condition={"kind": "after_action", "call_id": record.call.id},
         resolver={"kind": "tool_success", "expect": True},

--- a/loom/core/harness/auto_predict.py
+++ b/loom/core/harness/auto_predict.py
@@ -1,0 +1,84 @@
+"""
+Prediction Spine — auto-betting "mouth" (epic #528 P0.5-a slice B, issue #537).
+
+P0 built the spine's metabolism (store → reconcile → calibrate) but nothing made
+bets, so the reconcile schedule had an empty table to chew on. This module gives
+the spine its *involuntary heartbeat*: every tool action that actually executed
+leaves behind a flat implicit bet — "this tool will succeed" — which the existing
+reconcile settles against the very ``action_record`` the action produced.
+
+It is the harness-layer bridge (harness may import memory — the one-way arrow
+Platform → Cognition → Harness → Memory holds): an :class:`ActionRecord` in,
+a :class:`PredictionRecord` out. Pure and side-effect free; the session's
+``_on_lifecycle`` seam does the actual write so this stays trivially testable.
+
+The two contract decisions live here, not at the call site:
+
+* **executed-only.** Only an action whose history reached ``EXECUTING`` is bet
+  on. A permission-denied or precondition-aborted action never *tried* — its
+  "failure" is not a world-model miss, and betting on it would pollute
+  calibration with permission noise (calibration measures capability, not
+  whether the user allowed the act).
+* **flat bet, per-tool grain.** ``resolver=tool_success``, ``domain=tool_name``,
+  born ``pending``, due ``after_action(call_id)``. The signal it yields is a
+  per-tool success rate — a low-calibration / high-uncertainty tool is one whose
+  actions often fail, exactly what the exploration arm (P2) should later be drawn
+  to. Richer, confidence-varying bets are slice A's job.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from loom.core.harness.lifecycle import ActionRecord, ActionState
+from loom.core.memory.prediction import PredictionRecord, PredictionStore
+
+logger = logging.getLogger(__name__)
+
+# Provenance tag on auto-generated bets — lets later analysis (and slice A's
+# explicit bets) tell the involuntary heartbeat apart from deliberate wagers.
+_AUTO_CONTEXT = "auto:implicit_tool_success"
+
+
+def implicit_bet_for(record: ActionRecord, *, enabled: bool) -> PredictionRecord | None:
+    """Return the implicit ``tool_success`` bet for a terminal action, or ``None``.
+
+    ``None`` when betting is disabled, the record carries no call, or the action
+    never reached ``EXECUTING`` (it didn't try — see module docstring). Otherwise
+    a flat, pending, per-tool bet the existing reconcile pipeline will settle.
+    """
+    if not enabled or record.call is None:
+        return None
+
+    executed = any(t.to_state == ActionState.EXECUTING for t in record.state_history)
+    if not executed:
+        return None
+
+    tool = record.call.tool_name
+    return PredictionRecord(
+        session_id=record.call.session_id or "",
+        claim=f"{tool} will succeed",
+        due_condition={"kind": "after_action", "call_id": record.call.id},
+        resolver={"kind": "tool_success", "expect": True},
+        domain=tool,
+        context=_AUTO_CONTEXT,
+    )
+
+
+async def co_write_implicit_bet(db, record: ActionRecord, *, enabled: bool) -> bool:
+    """Persist the implicit bet for a terminal action; return whether one landed.
+
+    The IO half, kept here (not inlined in the session) so it stays testable
+    without a Session. **Isolated**: a betting failure is swallowed + logged and
+    returns ``False`` — it must never crash the lifecycle persistence it rides
+    on, exactly like the action_record write it sits beside.
+    """
+    bet = implicit_bet_for(record, enabled=enabled)
+    if bet is None:
+        return False
+    try:
+        await PredictionStore(db).write(bet)
+        return True
+    except Exception:  # noqa: BLE001 — betting must never crash the pipeline
+        logger.debug("implicit bet write failed (suppressed)", exc_info=True)
+        return False

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -952,6 +952,13 @@ class LoomSession:
 
         # Issue #43: Memory Governance — always-on
         _memory_cfg = _load_loom_config().get("memory", {})
+        # Prediction Spine (#537) — the auto-betting "mouth". Grouped under
+        # [memory.consolidation_dream] with the reconcile/calibration gates so the
+        # whole observation ramp lives in one place, though betting itself is a
+        # session-level (per-tool) input, not a dream activity. Off by default.
+        self._auto_predict_enabled = bool(
+            _memory_cfg.get("consolidation_dream", {}).get("auto_predict_enabled", False)
+        )
         _gov_cfg = dict(_memory_cfg.get("governance", {}))
         # Issue #281 P3: lifecycle throttle is owned by [memory.lifecycle]
         # but also gates session.stop()'s run_decay_cycle path, so plumb
@@ -4009,6 +4016,15 @@ class LoomSession:
             await self._db.commit()
         except Exception:
             pass  # DB write must never crash the pipeline
+
+        # Prediction Spine (#537): co-write the implicit "this tool will succeed"
+        # bet for the action just persisted. Gated (auto_predict_enabled) and
+        # executed-only + self-isolated inside co_write_implicit_bet, so a betting
+        # failure never crashes the lifecycle persistence it rides beside.
+        from loom.core.harness.auto_predict import co_write_implicit_bet
+        await co_write_implicit_bet(
+            self._db, record, enabled=self._auto_predict_enabled
+        )
 
     async def _on_state_change(
         self, record: ActionRecord, old_state: str, new_state: str

--- a/tests/test_auto_predict.py
+++ b/tests/test_auto_predict.py
@@ -82,6 +82,12 @@ class TestExecutedOnly:
         rec = _record(states=_EXECUTED, call=False)
         assert implicit_bet_for(rec, enabled=True) is None
 
+    def test_sessionless_call_is_not_bet_on(self):
+        """絲絲 PR #538 P3: no session → no bet. A session-less bet would be an
+        orphan to per-session audit; don't write orphan data at volume."""
+        assert implicit_bet_for(_record(states=_EXECUTED, session=""), enabled=True) is None
+        assert implicit_bet_for(_record(states=_EXECUTED, session=None), enabled=True) is None
+
 
 class TestBetShape:
     def test_flat_tool_success_bet(self):

--- a/tests/test_auto_predict.py
+++ b/tests/test_auto_predict.py
@@ -1,0 +1,155 @@
+"""
+Prediction Spine — P0.5-a slice B: the auto-betting "mouth" (epic #528, #537).
+
+P0 built the metabolism (store → reconcile → calibrate) but nothing *made* bets,
+so the dry-run schedule reconciles an empty table. This slice gives the spine its
+involuntary heartbeat: every tool action that actually *executed* leaves behind a
+flat implicit bet — "this tool will succeed" — co-written at the lifecycle
+persistence seam (``_on_lifecycle``), settled later by the existing reconcile.
+
+``implicit_bet_for`` is the pure half — given a terminal ``ActionRecord`` it
+returns the bet to write, or ``None``. TDD-first contract:
+
+* **gated** — ``enabled=False`` makes no bet (consistent with the spine's
+  opt-in discipline; nothing flows until DK flips it).
+* **executed-only** — only an action whose history reached ``EXECUTING`` is bet
+  on. A permission-denied / precondition-aborted action never *tried*, so its
+  "failure" is not a world-model miss; betting on it would pollute calibration
+  with permission noise (I6-adjacent: calibration measures capability, not
+  whether the user allowed the act).
+* **shape** — a flat ``tool_success`` bet, ``domain=tool_name``, born
+  ``pending``, due ``after_action(call_id)`` so the existing reconcile settles it
+  against the very action_record being persisted.
+"""
+
+from datetime import datetime, UTC
+
+import pytest
+import pytest_asyncio
+
+from loom.core.harness.lifecycle import ActionRecord, ActionState, StateTransition
+from loom.core.harness.middleware import ToolCall
+from loom.core.harness.permissions import TrustLevel
+from loom.core.harness.auto_predict import implicit_bet_for, co_write_implicit_bet
+from loom.core.memory.store import SQLiteStore
+from loom.core.memory.prediction import PredictionStore
+
+
+def _record(*, tool="run_bash", session="s1", states, call=True):
+    call_obj = (
+        ToolCall(id="c1", tool_name=tool, args={},
+                 trust_level=TrustLevel.SAFE, session_id=session)
+        if call else None
+    )
+    rec = ActionRecord(call=call_obj)
+    prev = ActionState.DECLARED
+    for s in states:
+        nxt = ActionState(s)
+        rec.state_history.append(
+            StateTransition(from_state=prev, to_state=nxt,
+                            timestamp=datetime.now(UTC), reason=None)
+        )
+        prev = nxt
+    rec.state = prev
+    return rec
+
+
+_EXECUTED = ("authorized", "prepared", "executing", "observed", "committed", "memorialized")
+_DENIED = ("awaiting_confirm", "denied")
+
+
+class TestGate:
+    def test_disabled_makes_no_bet(self):
+        rec = _record(states=_EXECUTED)
+        assert implicit_bet_for(rec, enabled=False) is None
+
+    def test_enabled_executed_makes_a_bet(self):
+        rec = _record(states=_EXECUTED)
+        assert implicit_bet_for(rec, enabled=True) is not None
+
+
+class TestExecutedOnly:
+    def test_denied_action_is_not_bet_on(self):
+        """Permission-denied never executed — not a world-model miss."""
+        rec = _record(states=_DENIED)
+        assert implicit_bet_for(rec, enabled=True) is None
+
+    def test_aborted_before_executing_is_not_bet_on(self):
+        rec = _record(states=("authorized", "prepared", "aborted"))
+        assert implicit_bet_for(rec, enabled=True) is None
+
+    def test_callless_record_is_skipped(self):
+        rec = _record(states=_EXECUTED, call=False)
+        assert implicit_bet_for(rec, enabled=True) is None
+
+
+class TestBetShape:
+    def test_flat_tool_success_bet(self):
+        rec = _record(tool="fetch_url", session="sess-9", states=_EXECUTED)
+        bet = implicit_bet_for(rec, enabled=True)
+        assert bet.resolver == {"kind": "tool_success", "expect": True}
+        assert bet.due_condition == {"kind": "after_action", "call_id": "c1"}
+        assert bet.domain == "fetch_url"            # per-tool calibration grain
+        assert bet.session_id == "sess-9"
+        assert "fetch_url" in bet.claim
+        assert bet.status == "pending"              # born pending; reconcile settles
+        assert bet.score is None
+        assert bet.context and bet.context.startswith("auto:")  # provenance tag
+
+    def test_failed_execution_still_makes_a_bet(self):
+        """An action that ran and *failed* (executed then aborted) is exactly the
+        signal we want — a world-model miss. It still gets a bet; the resolver
+        scores it 1.0 at reconcile time."""
+        rec = _record(states=("authorized", "prepared", "executing", "aborted"))
+        assert implicit_bet_for(rec, enabled=True) is not None
+
+
+# ---------------------------------------------------------------------------
+# co_write_implicit_bet — the isolated IO half (no Session needed)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test_auto_predict.db")
+
+
+@pytest_asyncio.fixture
+async def store(tmp_db):
+    s = SQLiteStore(tmp_db)
+    await s.initialize()
+    return s
+
+
+class TestCoWrite:
+    async def test_executed_action_persists_one_pending_bet(self, store):
+        async with store.connect() as db:
+            rec = _record(tool="run_bash", states=_EXECUTED)
+            wrote = await co_write_implicit_bet(db, rec, enabled=True)
+            assert wrote is True
+            pending = await PredictionStore(db).list_by_status("pending")
+            assert len(pending) == 1
+            assert pending[0].domain == "run_bash"
+            assert pending[0].context.startswith("auto:")
+
+    async def test_disabled_persists_nothing(self, store):
+        async with store.connect() as db:
+            rec = _record(states=_EXECUTED)
+            wrote = await co_write_implicit_bet(db, rec, enabled=False)
+            assert wrote is False
+            assert await PredictionStore(db).list_by_status("pending") == []
+
+    async def test_denied_action_persists_nothing(self, store):
+        async with store.connect() as db:
+            rec = _record(states=_DENIED)
+            assert await co_write_implicit_bet(db, rec, enabled=True) is False
+            assert await PredictionStore(db).list_by_status("pending") == []
+
+    async def test_write_failure_is_swallowed(self, store, monkeypatch):
+        """A betting failure must never crash the lifecycle persistence."""
+        async def _boom(self, rec):
+            raise RuntimeError("db went sideways")
+        monkeypatch.setattr(PredictionStore, "write", _boom)
+        async with store.connect() as db:
+            rec = _record(states=_EXECUTED)
+            # must NOT raise
+            assert await co_write_implicit_bet(db, rec, enabled=True) is False


### PR DESCRIPTION
## 什麼

Prediction Spine **P0.5-a slice B** — 補「嘴」。P0 建好代謝(store→reconcile→calibrate)但**沒人下注**,所以對帳排程對著空表跑。這刀給 spine **不隨意志的心跳**:每個**真的執行過**的 tool action 留一筆 flat 隱式賭「this tool will succeed」,靠既有 reconcile 結算。

closes 部分 #537(B;A 待續)。

## 收斂目標(回應 DK 的 EventTrigger 直覺)

接縫調查有意外收穫:production 寫 action_records 是 `session.py` 的 `INSERT OR REPLACE`(grep `INSERT INTO` 漏抓),在 `_on_lifecycle(record)` 持久化 callback。所以 **B 不碰 middleware 熱路徑內部**,只在這個 callback 旁 co-write = additive。

**收斂在 harness lifecycle,不是 autonomy `EventTrigger`**——後者是「具名事件→跑 agent run」的重量級觸發器,對 per-tool 下注是大砲打蚊子。EventTrigger.emit() 留給 slice A 的**事件結算型賭注**(接 slice 3 已建的 `DUE_CONDITION_KINDS` dispatch 擴充點)。

## 兩半(純/IO 分離,沿用 slice 3/4 節奏)

- **`implicit_bet_for(record, *, enabled) -> PredictionRecord|None`** — 純函式。
  - **gated**:`enabled=False`→None。
  - **executed-only**:state_history 沒到 `EXECUTING`→None。**permission-denied / precondition-aborted 不下注**——它沒「試」,失敗不是 world-model miss,下注會用權限雜訊污染 calibration。
  - flat `tool_success` bet,`domain=tool_name`,born pending,due `after_action(call_id)`。
- **`co_write_implicit_bet(db, record, *, enabled) -> bool`** — IO 半,**自我隔離**(下注失敗 swallow+log、回 False,絕不 crash 它寄生的 lifecycle 持久化)。不必建 Session 即可測。
- **`session._on_lifecycle`** 在 action_record 寫入後呼叫,gated on `auto_predict_enabled`(新,預設 false)。

## 觀察期 ramp 變 4 步

`auto_predict.py` 是 input 階段,補上後 DK 的 ramp:

```
1. auto_predict_enabled    → 開始下注(沒它後面對空表)  ← 本 PR 新增
2. reconcile_enabled       → 每週對帳只產報告(DK 已翻)
3. reconcile_execute       → 對帳寫 score
4. calibration_write_enabled → 滾 calibration residue
```

`loom.toml.example` dual-write;live loom.toml 已加(預設 false,留 DK 親翻)。

## 已知設計張力(#537 追蹤,**非本 PR 缺陷**)

flat 賭給「心跳」但訊號多半平凡(多數 tool 成功 → calibration 趨平)。**非平凡訊號**(P0 acceptance gate 的 bar)來自 slice A 信心會變動的顯式賭。B 只讓它呼吸。

## Review 焦點

1. **executed-only filter** 對不對(權限雜訊該不該排除 / EXECUTING 是不是對的門檻)。
2. **隔離**:`co_write_implicit_bet` 的失敗吞掉 + lifecycle 不受影響(`test_write_failure_is_swallowed`)。
3. **gate 預設 off** + 沒偷接行為。

## 測試

11 contract tests TDD red→green(gate ×2、executed-only ×3、bet shape ×2、co-write IO ×4);全 suite **2659 passed / 4 skipped**。`gitnexus detect_changes`:0 affected process,low risk。

## 待續

- **slice A**:顯式 `predict` 工具 + 事件結算型賭注(深度 / 非平凡訊號)。
- **P0.5-b**:calibration 自我監測。

🤖 Generated with [Claude Code](https://claude.com/claude-code)