### PR TITLE
feat(spine): explicit predict tool + next_action due (P0.5-a slice A, #537)

### DIFF
--- a/docs/designs/58-生成認知整合-P0-收斂規格-Prediction-Spine.md
+++ b/docs/designs/58-生成認知整合-P0-收斂規格-Prediction-Spine.md
@@ -182,6 +182,7 @@ expected_info_gain =
 | **P2 — exploration 臂（#464）** | drift 選向接 `uncertainty` landscape；`expected_info_gain` policy；dark-room 護欄定位 | P0 acceptance gate 通過 |
 | **P3 — 自我維持指標** | 把恆定變量從情緒擴到資源（cost / memory 矛盾度 / process 連續性 / trust）；#57 §9-6 指標清單 | P1 + P2 跑出實測 |
 | 軟判層 | 自由文字「氛圍下注」的 Critic 軟對帳（#57 §9-1 上層） | P0 機械對帳穩定後 |
+| **事件結算下注（`on_event` due）** | 對外部事件（CI 完成 / PR merge / 排程觸發）下注 + 結算 | **撞 I2 邊界**，見 §12.3 — 需先決定「事件如何落成 observation row」 |
 
 ---
 
@@ -195,4 +196,40 @@ expected_info_gain =
 
 ---
 
-*收斂：2026-06-07 | 來源：#57 四輪討論（DK / 絲絲 / CC / Codex）| 狀態：P0 拍板規格，issue 開發依據*
+## 12. P0.5-a 補遺 — 下注入口（the mouth）
+
+> **狀態**：slice B ✅ 落地（#538）；slice A 開發中（本節為依據）。
+> **背景**：P0 建好了「胃」（store → reconcile → calibrate），卻**沒有任何東西在下注**——對帳排程在啃空表。P0.5-a 補上「嘴」。issue #537。
+
+### 12.1 slice B — involuntary heartbeat（已落地）
+
+每個**實際執行過**的 tool action 在 lifecycle 持久化縫（`_on_lifecycle`）留下一注平注 `tool_success @ expect=True`，由既有 reconcile 對 `action_records` 結算。`loom/core/harness/auto_predict.py`，gate = `auto_predict_enabled`。
+
+兩條契約決定：**executed-only**（沒到 `EXECUTING` 不下注——權限拒絕不是世界模型失誤，會用 permission 雜訊污染 calibration）；**per-tool grain**（`domain=tool_name`）。
+
+> 侷限：訊號太平。永遠賭成功 → calibration 只量「原始失敗率」,信心不變化。撐不起 §8 acceptance gate 要的**非平凡**訊號。這是 slice A 的事。
+
+### 12.2 slice A — 顯式 `predict` 工具（本次）
+
+讓 Loom **主動**下信心有差異、resolver 有變化的賭：
+
+> 「我預測這個 grep 回 0 行」(`row_count, expect=0`)、「output 含 PASS」(`output_contains`)、「這次會慢」(`duration_bucket`)。
+
+- **新 due-condition kind `next_action`**：顯式賭在「動作執行前」下,此時還沒有 `call_id`。`due_condition = {kind: "next_action", session_id, tool, after}` 在對帳時找該 session 下、該 tool、`after` 之後的**第一筆 terminal** `action_records` row 結算。`DUE_CONDITION_KINDS` 的一筆 registry entry,結算對 `action_records` → **I2 乾淨**。要求具名 `tool`:給乾淨 domain、天然排除 predict 自身那筆 call。
+- **`predict` 工具**（memory 層,`make_predict_tool`,SAFE,與 `prediction_reconcile` 同層）:`claim` + 目標 `tool` + 結構化 `resolver`(寫入前驗 kind ∈ 白名單,fail-fast)。複用完整 7 resolver palette。
+- **gate `predict_tool_enabled`**(預設 false):延續「每道 spine 能力各自 gate、預設關、非寄生」紀律。納入 ramp,`loom.toml.example` dual-write。
+
+成果:calibration 開始吃到**信心會錯**的賭——不只是「會不會成功」,而是「我對這工具的行為猜得準不準」。
+
+### 12.3 為何 event-settled 賭不在 slice A（I2 邊界)
+
+DK 原構想含「接 `EventTrigger` 做事件結算賭」。摸接點查出兩點:
+
+1. **`TriggerEvaluator.emit()` 是幽靈** — 只在 `EventTrigger` docstring 被提及,全 codebase 無實作。autonomy daemon 用別的方式 dispatch EventTrigger。
+2. **`on_event` 撞 I2**:reconcile 每個 score 必須指向 I2 白名單表(`action_records` / `session_log`)的 row。但外部事件(CI 完成、PR merge)**不是這兩張表的 row**。要嘛 (a) 讓事件先落一筆 observation row 再用既有 reconcile 結算,要嘛 (b) 放寬 I2 白名單加 `events` 來源——動到 spec 視為神聖的 I2 邊界。
+
+這是該 DK 刻意決定的取捨,不混進 slice A。→ 獨立 issue,§10 Deferred 已列。
+
+---
+
+*收斂：2026-06-07 | 來源：#57 四輪討論（DK / 絲絲 / CC / Codex）| 狀態：P0 拍板規格，issue 開發依據 | P0.5-a 補遺：2026-06-10*

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -334,7 +334,10 @@ corpus_limit  = 5000
 # dream activity, but grouped here so the whole observation ramp is in one place.
 # Observation ramp (flip top-down, watch dreams/ reports between each):
 #   auto_predict_enabled → reconcile_enabled → reconcile_execute → calibration_write_enabled
+# predict_tool_enabled is orthogonal — flip it whenever you want Loom to make
+# deliberate, confidence-varying wagers (richer signal than the flat heartbeat).
 auto_predict_enabled = false  # opt-in: start making implicit per-tool bets
+predict_tool_enabled = false  # opt-in (slice A #537): expose the explicit `predict` tool
 reconcile_enabled = false   # opt-in: run prediction reconciliation each weekly pass
 reconcile_execute = false   # P4a read-only; set true to commit scores (mark_reconciled)
 # Calibration residue (epic #528 slice 4.5): rolls reconciled bets into a

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -336,6 +336,9 @@ corpus_limit  = 5000
 #   auto_predict_enabled → reconcile_enabled → reconcile_execute → calibration_write_enabled
 # predict_tool_enabled is orthogonal — flip it whenever you want Loom to make
 # deliberate, confidence-varying wagers (richer signal than the flat heartbeat).
+# NOTE: either betting gate ON while reconcile_enabled is OFF means bets pile up
+# pending and never settle — a dead-letter backlog, not learning. When you flip a
+# betting gate to observe, flip reconcile_enabled within the same ramp window.
 auto_predict_enabled = false  # opt-in: start making implicit per-tool bets
 predict_tool_enabled = false  # opt-in (slice A #537): expose the explicit `predict` tool
 reconcile_enabled = false   # opt-in: run prediction reconciliation each weekly pass

--- a/loom/core/memory/maintenance.py
+++ b/loom/core/memory/maintenance.py
@@ -424,3 +424,129 @@ def make_prediction_reconcile_tool(
         executor=_executor,
         trust_level=TrustLevel.SAFE,
     )
+
+
+def make_predict_tool(db: "aiosqlite.Connection") -> ToolDefinition:
+    """Build the ``predict`` ToolDefinition (epic #528, P0.5-a slice A, #537).
+
+    The deliberate counterpart to the involuntary heartbeat (``auto_predict``):
+    where the heartbeat only ever bets ``tool_success @ True``, this lets Loom
+    make confidence-varying, resolver-rich wagers about its *next* use of a named
+    tool — the non-trivial signal the §8 acceptance gate needs.
+
+    SAFE: it writes one ``pending`` meta-memory bet and drives no behaviour. The
+    bet binds by ``next_action`` (session + tool + ``after`` anchor), so the
+    existing reconcile settles it against the next ``action_records`` row — no
+    ``call_id`` needed at bet time. The resolver kind is validated against the
+    P0 whitelist *before* writing: P0 refuses to score what it cannot judge
+    mechanically (I2), and refusing at write time beats persisting an
+    unresolvable bet that silently rots.
+    """
+    from datetime import datetime, UTC
+
+    from loom.core.memory.prediction import PredictionRecord, PredictionStore
+    from loom.core.memory.resolvers import KNOWN_RESOLVERS
+
+    # Provenance — tells a deliberate wager apart from the heartbeat's ``auto:``
+    # bets in later analysis (slice B uses ``auto:implicit_tool_success``).
+    _EXPLICIT_CONTEXT = "explicit:predict_tool"
+
+    def _fail(call, msg: str) -> ToolResult:
+        return ToolResult(call_id=call.id, tool_name=call.tool_name,
+                          success=False, output=f"predict refused: {msg}")
+
+    async def _executor(call) -> ToolResult:
+        claim = (call.args.get("claim") or "").strip()
+        tool = (call.args.get("tool") or "").strip()
+        resolver = call.args.get("resolver")
+        if not claim:
+            return _fail(call, "claim is required (I1)")
+        if not tool:
+            return _fail(call, "tool is required — name the tool you're betting on")
+        if not isinstance(resolver, dict) or not resolver.get("kind"):
+            return _fail(call, "resolver is required (I1): a {kind, ...} object")
+        kind = resolver["kind"]
+        if kind not in KNOWN_RESOLVERS:
+            return _fail(
+                call,
+                f"unknown resolver kind {kind!r}; P0 judges only the mechanical "
+                f"whitelist {sorted(KNOWN_RESOLVERS)} (I2 — no free-text vibe bets)",
+            )
+
+        after = datetime.now(UTC).isoformat()
+        bet = PredictionRecord(
+            session_id=call.session_id,
+            claim=claim,
+            due_condition={
+                "kind": "next_action",
+                "session_id": call.session_id,
+                "tool": tool,
+                "after": after,
+            },
+            resolver=resolver,
+            domain=(call.args.get("domain") or tool),
+            context=call.args.get("context") or _EXPLICIT_CONTEXT,
+        )
+        await PredictionStore(db).write(bet)
+        return ToolResult(
+            call_id=call.id, tool_name=call.tool_name, success=True,
+            output=(
+                f"prediction logged: «{claim}» — settles against the next "
+                f"{tool} action via {kind}. (id={bet.id})"
+            ),
+        )
+
+    return ToolDefinition(
+        name="predict",
+        description=(
+            "Make a falsifiable prediction about the NEXT time a named tool runs "
+            "this session, judged mechanically against the observed action. Use "
+            "to bet on a concrete, checkable outcome — not a vibe. The bet is "
+            "settled later by the reconcile pass and rolled into your per-domain "
+            "calibration. Examples: predict the next run_bash returns 0 rows "
+            "(resolver row_count, expect 0); the next fetch_url output contains "
+            "'200 OK' (output_contains); the next git push will succeed "
+            "(tool_success)."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "claim": {
+                    "type": "string",
+                    "description": "Plain-language statement of what you predict.",
+                },
+                "tool": {
+                    "type": "string",
+                    "description": (
+                        "The tool whose next invocation this bet is about "
+                        "(e.g. 'run_bash', 'fetch_url'). Also the default domain."
+                    ),
+                },
+                "resolver": {
+                    "type": "object",
+                    "description": (
+                        "How to judge the bet mechanically. {kind, ...} where "
+                        "kind ∈ {tool_success, final_state, output_contains, "
+                        "output_regex, file_digest_changed, row_count, "
+                        "duration_bucket}. Carry the kind's params, e.g. "
+                        "{kind:'row_count', expect:0} or "
+                        "{kind:'output_contains', needle:'PASS'}."
+                    ),
+                },
+                "domain": {
+                    "type": "string",
+                    "description": (
+                        "Calibration domain to attribute this bet to "
+                        "(default: the tool name)."
+                    ),
+                },
+                "context": {
+                    "type": "string",
+                    "description": "Optional free-text provenance note.",
+                },
+            },
+            "required": ["claim", "tool", "resolver"],
+        },
+        executor=_executor,
+        trust_level=TrustLevel.SAFE,
+    )

--- a/loom/core/memory/observation.py
+++ b/loom/core/memory/observation.py
@@ -112,11 +112,44 @@ async def _find_after_action(
     return make_observation_ref("action", r[0]) if r else None
 
 
+async def _find_next_action(
+    db: aiosqlite.Connection, due_condition: dict
+) -> str | None:
+    """Settle against the *next* terminal action for a (session, tool) pair.
+
+    The explicit ``predict`` tool (P0.5-a slice A) bets *before* its target runs,
+    so it has no ``call_id`` to key on like ``after_action`` does. It binds by
+    ``session_id`` + ``tool`` + an ``after`` anchor instead, and settles against
+    the **earliest terminal** ``action_records`` row for that pair created
+    *strictly after* the anchor — i.e. the very next time that tool runs. The
+    predicting tool-call's own row is created at/before the anchor, so the
+    ``created_at > after`` guard excludes it. Still I2-clean: ground truth is an
+    ``action_records`` row, never an LLM narrative.
+    """
+    session_id = due_condition.get("session_id")
+    tool = due_condition.get("tool")
+    after = due_condition.get("after")
+    if not session_id or not tool or not after:
+        raise ValueError(
+            "next_action due_condition requires session_id, tool, and after"
+        )
+    placeholders = ",".join("?" * len(_TERMINAL_STATE_VALUES))
+    cur = await db.execute(
+        f"SELECT id FROM action_records WHERE session_id = ? AND tool_name = ? "
+        f"AND created_at > ? AND final_state IN ({placeholders}) "
+        "ORDER BY created_at ASC LIMIT 1",
+        (session_id, tool, after, *sorted(_TERMINAL_STATE_VALUES)),
+    )
+    r = await cur.fetchone()
+    return make_observation_ref("action", r[0]) if r else None
+
+
 # due_condition kind → finder. The extension point: adding ``at_time`` /
-# ``within_window`` (slice 3 second cut) is a registry entry, not an if/elif
-# chain (絲絲 review, PR #532 OQ1).
+# ``within_window`` later is a registry entry, not an if/elif chain (絲絲
+# review, PR #532 OQ1). ``next_action`` (P0.5-a slice A) joined here.
 DUE_CONDITION_KINDS = {
     "after_action": _find_after_action,
+    "next_action": _find_next_action,
 }
 
 

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -959,6 +959,12 @@ class LoomSession:
         self._auto_predict_enabled = bool(
             _memory_cfg.get("consolidation_dream", {}).get("auto_predict_enabled", False)
         )
+        # slice A (#537): the explicit `predict` tool — deliberate, confidence-
+        # varying wagers. Its own gate, default off, so nothing in the spine acts
+        # until DK flips it (same opt-in discipline as the heartbeat/reconcile).
+        self._predict_tool_enabled = bool(
+            _memory_cfg.get("consolidation_dream", {}).get("predict_tool_enabled", False)
+        )
         _gov_cfg = dict(_memory_cfg.get("governance", {}))
         # Issue #281 P3: lifecycle throttle is owned by [memory.lifecycle]
         # but also gates session.stop()'s run_decay_cycle path, so plumb
@@ -1168,6 +1174,7 @@ class LoomSession:
             make_convergent_dream_tool,
             make_dream_cycle_tool,
             make_memory_prune_tool,
+            make_predict_tool,
             make_prediction_reconcile_tool,
         )
 
@@ -1193,6 +1200,11 @@ class LoomSession:
         # that closes the Prediction Spine loop. Read-only by default (dry_run);
         # judges matured bets against runtime observation, writes a report.
         self.registry.register(make_prediction_reconcile_tool(db=self._db))
+        # Epic #528 (P0.5-a slice A): predict — the deliberate betting mouth.
+        # Gated (predict_tool_enabled, default off): registered only when DK has
+        # opted the spine in, so the tool never appears to the model otherwise.
+        if self._predict_tool_enabled:
+            self.registry.register(make_predict_tool(db=self._db))
 
         if self._telemetry is not None:
             self.registry.register(make_agent_health_tool(self._telemetry))

--- a/tests/test_next_action_due.py
+++ b/tests/test_next_action_due.py
@@ -1,0 +1,188 @@
+"""
+Prediction Spine — ``next_action`` due-condition (epic #528, P0.5-a slice A, #537).
+
+slice B's heartbeat bets *after* an action, so it has the ``call_id`` and uses
+``after_action``. The explicit ``predict`` tool bets *before* the action runs —
+there is no ``call_id`` yet. ``next_action`` closes that gap: a bet names the
+*session*, the *tool*, and an *after* timestamp, and settles against the first
+**terminal** ``action_records`` row for that (session, tool) created strictly
+after the anchor. Still I2-clean — ground truth is an ``action_records`` row.
+
+Contract pinned here (red first):
+
+* **strictly-after** — only an action created *after* the anchor settles the
+  bet; the predicting tool-call's own row (≤ anchor) never settles it.
+* **earliest wins** — the *next* action, not just any later one.
+* **session + tool scoped** — another session's, or another tool's, action does
+  not settle the bet.
+* **terminal-only** — a still-running action does not settle yet (``None`` →
+  reconcile records it ``not_settled``, never a free score; pairs with I4).
+* **I1 at the finder** — a ``next_action`` missing session/tool/after raises.
+* **registry, not if/elif** — registered in ``DUE_CONDITION_KINDS`` so dispatch
+  goes through ``find_settling_observation`` like every other kind.
+"""
+
+import json
+
+import pytest
+import pytest_asyncio
+
+from loom.core.memory.store import SQLiteStore
+from loom.core.memory.observation import (
+    DUE_CONDITION_KINDS,
+    find_settling_observation,
+)
+
+_TERMINAL_HISTORY = ["authorized", "executing", "observed", "committed", "memorialized"]
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test_next_action.db")
+
+
+@pytest_asyncio.fixture
+async def store(tmp_db):
+    s = SQLiteStore(tmp_db)
+    await s.initialize()
+    return s
+
+
+@pytest_asyncio.fixture
+async def db_conn(store):
+    async with store.connect() as db:
+        yield db
+
+
+async def _insert_action(
+    db, *, id, session="sess", tool="run_bash", final_state="memorialized",
+    created_at, history=None, duration_ms=120.0,
+):
+    states = history if history is not None else _TERMINAL_HISTORY
+    hist = [{"from": "x", "to": s, "ts": created_at} for s in states]
+    await db.execute(
+        "INSERT INTO action_records "
+        "(id, envelope_id, session_id, turn_index, tool_name, call_id, "
+        " final_state, duration_ms, state_history, created_at) "
+        "VALUES (?, 'env', ?, 0, ?, ?, ?, ?, ?, ?)",
+        (id, session, tool, f"call-{id}", final_state, duration_ms,
+         json.dumps(hist), created_at),
+    )
+    await db.commit()
+
+
+def _due(*, session="sess", tool="run_bash", after="2026-06-10T12:00:00+00:00"):
+    return {"kind": "next_action", "session_id": session, "tool": tool, "after": after}
+
+
+# ---------------------------------------------------------------------------
+# Registry / dispatch
+# ---------------------------------------------------------------------------
+
+class TestRegistered:
+    def test_next_action_in_dispatch_table(self):
+        assert "next_action" in DUE_CONDITION_KINDS
+        assert callable(DUE_CONDITION_KINDS["next_action"])
+
+    async def test_dispatches_through_find_settling(self, db_conn):
+        await _insert_action(db_conn, id="a1", created_at="2026-06-10T12:00:05+00:00")
+        ref = await find_settling_observation(db_conn, _due())
+        assert ref == "action:a1"
+
+
+# ---------------------------------------------------------------------------
+# Strictly-after + earliest-wins
+# ---------------------------------------------------------------------------
+
+class TestStrictlyAfter:
+    async def test_action_before_anchor_does_not_settle(self, db_conn):
+        """The predicting tool-call's own row (≤ anchor) must not settle the bet."""
+        await _insert_action(db_conn, id="before", created_at="2026-06-10T11:59:59+00:00")
+        assert await find_settling_observation(db_conn, _due()) is None
+
+    async def test_action_at_anchor_does_not_settle(self, db_conn):
+        await _insert_action(db_conn, id="at", created_at="2026-06-10T12:00:00+00:00")
+        assert await find_settling_observation(db_conn, _due()) is None
+
+    async def test_earliest_after_wins(self, db_conn):
+        await _insert_action(db_conn, id="later", created_at="2026-06-10T12:05:00+00:00")
+        await _insert_action(db_conn, id="next", created_at="2026-06-10T12:00:30+00:00")
+        ref = await find_settling_observation(db_conn, _due())
+        assert ref == "action:next"  # the *next* action, not just any later one
+
+
+# ---------------------------------------------------------------------------
+# Session + tool scoping
+# ---------------------------------------------------------------------------
+
+class TestScoping:
+    async def test_other_session_does_not_settle(self, db_conn):
+        await _insert_action(
+            db_conn, id="other", session="someone-else",
+            created_at="2026-06-10T12:00:05+00:00",
+        )
+        assert await find_settling_observation(db_conn, _due()) is None
+
+    async def test_other_tool_does_not_settle(self, db_conn):
+        await _insert_action(
+            db_conn, id="other-tool", tool="fetch_url",
+            created_at="2026-06-10T12:00:05+00:00",
+        )
+        assert await find_settling_observation(db_conn, _due(tool="run_bash")) is None
+
+    async def test_matches_named_tool_only(self, db_conn):
+        await _insert_action(db_conn, id="noise", tool="fetch_url",
+                             created_at="2026-06-10T12:00:03+00:00")
+        await _insert_action(db_conn, id="target", tool="run_bash",
+                             created_at="2026-06-10T12:00:05+00:00")
+        ref = await find_settling_observation(db_conn, _due(tool="run_bash"))
+        assert ref == "action:target"
+
+
+# ---------------------------------------------------------------------------
+# Terminal-only
+# ---------------------------------------------------------------------------
+
+class TestTerminalOnly:
+    async def test_running_action_does_not_settle_yet(self, db_conn):
+        """A non-terminal action is not settled — None, not a free score (I4)."""
+        await _insert_action(
+            db_conn, id="running", final_state="executing",
+            history=["authorized", "executing"],
+            created_at="2026-06-10T12:00:05+00:00",
+        )
+        assert await find_settling_observation(db_conn, _due()) is None
+
+    async def test_failed_terminal_action_settles(self, db_conn):
+        """A run-and-failed action (aborted→memorialized) IS settled — it's the
+        miss we want to score, not skip."""
+        await _insert_action(
+            db_conn, id="failed", final_state="memorialized",
+            history=["authorized", "executing", "aborted", "memorialized"],
+            created_at="2026-06-10T12:00:05+00:00",
+        )
+        assert await find_settling_observation(db_conn, _due()) == "action:failed"
+
+
+# ---------------------------------------------------------------------------
+# I1 at the finder
+# ---------------------------------------------------------------------------
+
+class TestRequiredFields:
+    async def test_missing_session_raises(self, db_conn):
+        with pytest.raises(ValueError):
+            await find_settling_observation(
+                db_conn, {"kind": "next_action", "tool": "run_bash", "after": "2026-06-10T12:00:00+00:00"},
+            )
+
+    async def test_missing_tool_raises(self, db_conn):
+        with pytest.raises(ValueError):
+            await find_settling_observation(
+                db_conn, {"kind": "next_action", "session_id": "sess", "after": "2026-06-10T12:00:00+00:00"},
+            )
+
+    async def test_missing_after_raises(self, db_conn):
+        with pytest.raises(ValueError):
+            await find_settling_observation(
+                db_conn, {"kind": "next_action", "session_id": "sess", "tool": "run_bash"},
+            )

--- a/tests/test_next_action_due.py
+++ b/tests/test_next_action_due.py
@@ -111,6 +111,43 @@ class TestStrictlyAfter:
         assert ref == "action:next"  # the *next* action, not just any later one
 
 
+class TestUtcIsoStringOrdering:
+    """絲絲 PR #540 P3: ``created_at > after`` is a SQLite *string* comparison,
+    so it only equals time order while every timestamp is the same-zone, fixed-
+    width ISO form. Pin that invariant — a future tz change (e.g. Asia/Taipei for
+    display) leaking into stored created_at would silently break next_action.
+    """
+
+    def test_utc_iso_lexicographic_order_equals_chronological(self):
+        from datetime import datetime, UTC, timedelta
+        base = datetime(2026, 6, 10, 12, 0, 0, tzinfo=UTC)
+        # spans second/minute/hour rollovers + sub-second precision — the spots
+        # naive string compare would trip if the field weren't zero-padded.
+        dts = [
+            base,
+            base + timedelta(microseconds=1),
+            base + timedelta(seconds=1),
+            base + timedelta(seconds=9),
+            base + timedelta(seconds=10),
+            base + timedelta(minutes=1),
+            base + timedelta(minutes=59, seconds=59),
+            base + timedelta(hours=1),
+        ]
+        isos = [d.isoformat() for d in dts]
+        assert sorted(isos) == isos                     # lexicographic == input
+        assert isos == [d.isoformat() for d in sorted(dts)]  # == chronological
+
+    async def test_finder_respects_anchor_across_second_rollover(self, db_conn):
+        """A bona-fide finder check at the rollover boundary the string compare
+        is most likely to fumble (…:09 vs …:10)."""
+        await _insert_action(db_conn, id="t09", created_at="2026-06-10T12:00:09+00:00")
+        await _insert_action(db_conn, id="t10", created_at="2026-06-10T12:00:10+00:00")
+        # anchored just after :09 — only :10 should settle
+        ref = await find_settling_observation(
+            db_conn, _due(after="2026-06-10T12:00:09.500000+00:00"))
+        assert ref == "action:t10"
+
+
 # ---------------------------------------------------------------------------
 # Session + tool scoping
 # ---------------------------------------------------------------------------

--- a/tests/test_predict_tool.py
+++ b/tests/test_predict_tool.py
@@ -1,0 +1,219 @@
+"""
+Prediction Spine — explicit ``predict`` tool (epic #528, P0.5-a slice A, #537).
+
+slice B's heartbeat only ever bets ``tool_success @ expect=True`` — flat, always
+optimistic, one-dimensional. The ``predict`` tool lets Loom make *deliberate*,
+confidence-varying, resolver-rich wagers ("this grep returns 0 rows", "output
+contains PASS", "this will be slow") — the non-trivial signal the §8 acceptance
+gate needs. It is the memory-layer sibling of ``prediction_reconcile``: SAFE,
+writes one ``pending`` bet, settled later by the existing reconcile via the new
+``next_action`` due-condition.
+
+Contract pinned here (red first):
+
+* **SAFE, named** — writes a meta-memory bet, drives no behaviour.
+* **next_action due** — built from the *call's* ``session_id``, the named
+  ``tool``, and an ``after`` anchor, so the existing reconcile settles it
+  against the next ``action_records`` row (I2-clean; no ``call_id`` needed).
+* **resolver fail-fast** — an unknown resolver kind is refused (no bet written):
+  P0 refuses to score what it cannot judge mechanically (I2), and refusing at
+  *write* time beats writing an unresolvable bet that silently rots.
+* **provenance** — an explicit bet is tagged distinctly from the heartbeat so
+  later analysis can tell deliberate wagers apart.
+* **round-trip** — predict → the tool runs → reconcile scores it against the
+  observed action.
+"""
+
+import json
+from datetime import datetime, timedelta
+
+import pytest
+import pytest_asyncio
+
+from loom.core.harness.middleware import ToolCall
+from loom.core.harness.permissions import TrustLevel
+from loom.core.memory.store import SQLiteStore
+from loom.core.memory.prediction import PredictionStore
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test_predict_tool.db")
+
+
+@pytest_asyncio.fixture
+async def store(tmp_db):
+    s = SQLiteStore(tmp_db)
+    await s.initialize()
+    return s
+
+
+@pytest_asyncio.fixture
+async def db_conn(store):
+    async with store.connect() as db:
+        yield db
+
+
+def _make_call(args: dict, *, session="s1") -> ToolCall:
+    return ToolCall(id="t1", tool_name="predict", args=args,
+                    trust_level=TrustLevel.SAFE, session_id=session)
+
+
+async def _insert_action(db, *, id, session, tool, created_at,
+                         final_state="memorialized", output=None, duration_ms=120.0):
+    states = ["authorized", "executing", "observed", "committed", "memorialized"]
+    hist = [{"from": "x", "to": s, "ts": created_at} for s in states]
+    await db.execute(
+        "INSERT INTO action_records "
+        "(id, envelope_id, session_id, turn_index, tool_name, call_id, "
+        " final_state, duration_ms, state_history, created_at) "
+        "VALUES (?, 'env', ?, 0, ?, ?, ?, ?, ?, ?)",
+        (id, session, tool, f"call-{id}", final_state, duration_ms,
+         json.dumps(hist), created_at),
+    )
+    await db.commit()
+
+
+async def _only_bet(db):
+    pending = await PredictionStore(db).list_by_status("pending")
+    assert len(pending) == 1
+    return pending[0]
+
+
+# ---------------------------------------------------------------------------
+# Shape
+# ---------------------------------------------------------------------------
+
+class TestToolShape:
+    def test_tool_is_safe_and_named(self):
+        from loom.core.memory.maintenance import make_predict_tool
+        tool = make_predict_tool(object())
+        assert tool.name == "predict"
+        assert tool.trust_level == TrustLevel.SAFE
+
+
+class TestWritesBet:
+    async def test_writes_pending_next_action_bet(self, db_conn):
+        from loom.core.memory.maintenance import make_predict_tool
+        tool = make_predict_tool(db_conn)
+        result = await tool.executor(_make_call({
+            "claim": "next run_bash returns 0 rows",
+            "tool": "run_bash",
+            "resolver": {"kind": "row_count", "expect": 0},
+        }))
+        assert result.success is True
+
+        bet = await _only_bet(db_conn)
+        assert bet.status == "pending"
+        assert bet.session_id == "s1"                       # from the call
+        assert bet.due_condition["kind"] == "next_action"
+        assert bet.due_condition["session_id"] == "s1"
+        assert bet.due_condition["tool"] == "run_bash"
+        assert bet.due_condition["after"]                   # anchor stamped
+        assert bet.resolver == {"kind": "row_count", "expect": 0}
+        assert bet.score is None
+
+    async def test_domain_defaults_to_tool(self, db_conn):
+        from loom.core.memory.maintenance import make_predict_tool
+        tool = make_predict_tool(db_conn)
+        await tool.executor(_make_call({
+            "claim": "x", "tool": "fetch_url",
+            "resolver": {"kind": "tool_success", "expect": True},
+        }))
+        assert (await _only_bet(db_conn)).domain == "fetch_url"
+
+    async def test_domain_overridable(self, db_conn):
+        from loom.core.memory.maintenance import make_predict_tool
+        tool = make_predict_tool(db_conn)
+        await tool.executor(_make_call({
+            "claim": "x", "tool": "run_bash", "domain": "git",
+            "resolver": {"kind": "tool_success", "expect": True},
+        }))
+        assert (await _only_bet(db_conn)).domain == "git"
+
+    async def test_explicit_bet_is_tagged_distinctly(self, db_conn):
+        """Provenance: an explicit wager must be tellable from the heartbeat's
+        ``auto:`` bets (which carry ``auto:implicit_tool_success``)."""
+        from loom.core.memory.maintenance import make_predict_tool
+        tool = make_predict_tool(db_conn)
+        await tool.executor(_make_call({
+            "claim": "x", "tool": "run_bash",
+            "resolver": {"kind": "tool_success", "expect": True},
+        }))
+        bet = await _only_bet(db_conn)
+        assert bet.context and not bet.context.startswith("auto:")
+
+
+# ---------------------------------------------------------------------------
+# Fail-fast validation — no half-written bets
+# ---------------------------------------------------------------------------
+
+class TestValidation:
+    async def test_unknown_resolver_kind_is_refused(self, db_conn):
+        """I2: P0 refuses to score what it cannot judge mechanically. Refuse at
+        write time rather than persist an unresolvable bet that silently rots."""
+        from loom.core.memory.maintenance import make_predict_tool
+        tool = make_predict_tool(db_conn)
+        result = await tool.executor(_make_call({
+            "claim": "vibes are good", "tool": "run_bash",
+            "resolver": {"kind": "vibe_check"},
+        }))
+        assert result.success is False
+        assert await PredictionStore(db_conn).list_by_status("pending") == []
+
+    async def test_missing_claim_is_refused(self, db_conn):
+        from loom.core.memory.maintenance import make_predict_tool
+        tool = make_predict_tool(db_conn)
+        result = await tool.executor(_make_call({
+            "tool": "run_bash", "resolver": {"kind": "tool_success"},
+        }))
+        assert result.success is False
+        assert await PredictionStore(db_conn).list_by_status("pending") == []
+
+    async def test_missing_tool_is_refused(self, db_conn):
+        from loom.core.memory.maintenance import make_predict_tool
+        tool = make_predict_tool(db_conn)
+        result = await tool.executor(_make_call({
+            "claim": "x", "resolver": {"kind": "tool_success"},
+        }))
+        assert result.success is False
+        assert await PredictionStore(db_conn).list_by_status("pending") == []
+
+    async def test_missing_resolver_is_refused(self, db_conn):
+        from loom.core.memory.maintenance import make_predict_tool
+        tool = make_predict_tool(db_conn)
+        result = await tool.executor(_make_call({"claim": "x", "tool": "run_bash"}))
+        assert result.success is False
+        assert await PredictionStore(db_conn).list_by_status("pending") == []
+
+
+# ---------------------------------------------------------------------------
+# Round-trip — predict → action → reconcile
+# ---------------------------------------------------------------------------
+
+class TestRoundTrip:
+    async def test_predict_then_reconcile_scores_the_bet(self, db_conn):
+        from loom.core.memory.maintenance import make_predict_tool
+        from loom.core.cognition.prediction_reconcile import run_prediction_reconciliation
+
+        tool = make_predict_tool(db_conn)
+        await tool.executor(_make_call({
+            "claim": "next run_bash will succeed",
+            "tool": "run_bash",
+            "resolver": {"kind": "tool_success", "expect": True},
+        }, session="sess-rt"))
+        bet = await _only_bet(db_conn)
+
+        # the predicted tool runs *after* the bet's anchor
+        after = datetime.fromisoformat(bet.due_condition["after"])
+        later = (after + timedelta(seconds=1)).isoformat()
+        await _insert_action(db_conn, id="ran", session="sess-rt",
+                             tool="run_bash", created_at=later)
+
+        report = await run_prediction_reconciliation(
+            PredictionStore(db_conn), db_conn, execute=True)
+        assert report.executed
+        scored = await PredictionStore(db_conn).get(bet.id)
+        assert scored.status == "reconciled"
+        assert scored.score == 0.0                     # predicted success, got success
+        assert scored.observation_ref == "action:ran"


### PR DESCRIPTION
## 為什麼

P0 + slice B 給了 spine **不隨意的心跳**——每個執行過的 tool 留一注平注 `tool_success @ True`。但這訊號一維:永遠賭成功,只量原始失敗率,信心不變化,撐不起 §8 acceptance gate 要的**非平凡訊號**。

slice A 補上**刻意的嘴**:讓 Loom 主動下信心有差異、resolver 有變化的賭。

> 「我預測下一個 grep 回 0 行」(`row_count, expect=0`)、「output 含 PASS」(`output_contains`)、「下次 git push 會成功」(`tool_success`)

## 改了什麼

- **`next_action` due-condition kind**(`observation.py`):顯式賭在「動作執行前」下,還沒有 `call_id`。改用 `session_id + tool + after` 錨點,對帳時找該 session 下、該 tool、`after` 之後**第一筆 terminal** `action_records` row 結算。`created_at > after` 天然排除 predict 自身那筆 call。`DUE_CONDITION_KINDS` 的一筆 registry entry,**I2 乾淨**(ground truth 仍是 action_records row)。
- **`make_predict_tool`**(`maintenance.py`):SAFE memory 層工具,與 `prediction_reconcile` 同層。**寫入前驗** resolver kind ∈ P0 白名單(fail-fast,不留會爛掉的 unresolvable 賭);explicit provenance tag(`explicit:predict_tool`)區別於 heartbeat 的 `auto:`。複用完整 7 resolver palette。
- **gate `predict_tool_enabled`**(預設 false):延續「每道 spine 能力各自 gate、預設關、非寄生」紀律,翻開才註冊進 session。`loom.toml.example` dual-write。

## 為何 event-settled 賭不在這個 PR(請 review 這個取捨)

DK 原構想含「接 EventTrigger 做事件結算賭」。摸接點查出兩件事:

1. **`TriggerEvaluator.emit()` 是幽靈** — 只在 `EventTrigger` docstring 提及,全 codebase 無實作。
2. **`on_event` 撞 I2 邊界**:reconcile 每個 score 必須指向 I2 白名單表(`action_records`/`session_log`)的 row,但外部事件(CI 完成、PR merge)**不是這兩張表的 row**。要嘛讓事件先落 observation row,要嘛放寬 I2 白名單——這是該 DK 刻意決定的取捨,不混進 slice A。

→ 另開 issue 追蹤;spec §10 Deferred + §12.3 記錄了這個 fork。

## 測試

- **TDD red→green**:`test_next_action_due.py`(finder 契約:strictly-after / earliest-wins / session+tool scoping / terminal-only / I1 required fields)+ `test_predict_tool.py`(shape / fail-fast validation / predict→action→reconcile round-trip)。
- 23 new tests;**136 spine 測試全綠**。

## Review 重點

- `next_action` 的 `created_at > after` 嚴格不等式——能否確實排除 predict 自身那筆 call?
- resolver fail-fast 在 write 時擋,而非 reconcile 時 skip——這個邊界對不對?
- gate 註冊式 vs 永遠註冊:把顯式工具也藏在 gate 後,會不會過度。

🤖 Generated with [Claude Code](https://claude.com/claude-code)