### PR TITLE
feat(spine): calibration self-monitoring / immune system (P0.5-b, #539)

### DIFF
--- a/docs/designs/58-生成認知整合-P0-收斂規格-Prediction-Spine.md
+++ b/docs/designs/58-生成認知整合-P0-收斂規格-Prediction-Spine.md
@@ -230,6 +230,28 @@ DK 原構想含「接 `EventTrigger` 做事件結算賭」。摸接點查出兩�
 
 這是該 DK 刻意決定的取捨,不混進 slice A。→ 獨立 issue,§10 Deferred 已列。
 
+### 12.4 P0.5-b — calibration 自我監測（免疫系統，#539）
+
+> **狀態**：機制開發中（本節為依據）。issue #539。
+> **動機**：DK 要全自動、不靠人讀 audit 報告。P0 的結構防線（I2/I6/I4/rolling 覆寫/namespaced 衰減）保證「**能寫什麼**」乾淨;缺的是「**有沒有寫歪**」的自我監測。免疫系統長在機制裡、不長在人身上。
+
+**唯讀分析層**，看顧 spine 自己的 `calibration:<domain>` 殘留。**不寫、不驅動行為、不需新 gate**（report-only 本就安全;延續「開關別再多」）。I5/I6 不退步:只讀 calibration + reconciled 記錄,不自創價值判斷、無 sentiment 通道。
+
+**首要驗收點（絲絲 #538 review）**:把「**沒意義的高 calibration**」報告出來。flat 隱式賭下多數 domain calibration 趨近 1.0,這種高分**不是 insight**（是 tool 本來就會成功）。用 domain-stats 區分「平凡趨平」vs「真訊號」。
+
+**本刀做（無狀態旗標,純函式 `assess_calibration_health(summaries, records)`）**:
+- `low_information`(趨平):`calibration_score ≥ HIGH_CAL` 且 `|valence| ≤ FLAT_VALENCE` 且 `n ≥ SAMPLE_FLOOR` → 高但無資訊,消費者不必關注。← **首要驗收點**
+- `sample_insufficient`:`n < SAMPLE_FLOOR` → 統計不穩,顯式提醒別讀 calibration_score。
+- `genuine_signal`:其餘（calibration 明顯偏離 1.0、或 valence 非平）→ 值得消費者注意。
+- `monoculture`（corpus 級）:reconciled 全是 `auto:` 隱式賭、零 `explicit:` → calibration 只在量 tool 可靠度、非預測技巧;**解釋了純 slice-B 階段為何全趨平**,等顯式賭流動後自清。
+
+**整合**:health 在 `run_calibration_pass` 內**一律計算**（唯讀,不受 `calibration_write_enabled` gate 影響）,掛進 `CalibrationReport.render()`,故 `prediction_reconcile` 工具/dream journal 自動顯示。
+
+**Deferred（門檻 + 進階旗標,6/17 真資料後）**:
+- `anomalous_jump`（異常跳變）:需 calibration **歷史快照**,但 rolling 覆寫銷毀歷史 → 要先決定怎麼留前值（讀覆寫前的 entry metadata 比對）。
+- `fragmentation`（domain 碎片化）:同義標籤分裂偵測太 fuzzy,需真資料校準 false-positive。
+- 門檻（`HIGH_CAL`/`FLAT_VALENCE`/`SAMPLE_FLOOR`）現為先驗保守值,觀察 1-2 週後依真分布調。
+
 ---
 
 *收斂：2026-06-07 | 來源：#57 四輪討論（DK / 絲絲 / CC / Codex）| 狀態：P0 拍板規格，issue 開發依據 | P0.5-a 補遺：2026-06-10*

--- a/loom/core/cognition/calibration.py
+++ b/loom/core/cognition/calibration.py
@@ -40,9 +40,16 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from loom.core.memory.ontology import DOMAIN_KNOWLEDGE, TEMPORAL_RECENT
 from loom.core.memory.semantic import SemanticEntry
+
+if TYPE_CHECKING:
+    # Forward-ref only: calibration_health imports SAMPLE_FLOOR from here, so a
+    # runtime import would cycle. The string annotation keeps the type precise
+    # without the import (絲絲 PR #542 P3).
+    from loom.core.cognition.calibration_health import CalibrationHealthReport
 
 # Below this many reconciled bets, a domain is "sample-insufficient": you have
 # not exercised it enough to trust its calibration, regardless of accuracy.
@@ -110,7 +117,7 @@ class CalibrationReport:
     summaries: list = field(default_factory=list)
     # P0.5-b (#539): the read-only health verdict over this snapshot. Optional so
     # existing constructions stay back-compatible; populated by run_calibration_pass.
-    health: object | None = None
+    health: "CalibrationHealthReport | None" = None
 
     def summary(self) -> str:
         verb = "wrote" if self.written else "would write (dry-run)"

--- a/loom/core/cognition/calibration.py
+++ b/loom/core/cognition/calibration.py
@@ -108,6 +108,9 @@ class CalibrationReport:
     """
     written: bool
     summaries: list = field(default_factory=list)
+    # P0.5-b (#539): the read-only health verdict over this snapshot. Optional so
+    # existing constructions stay back-compatible; populated by run_calibration_pass.
+    health: object | None = None
 
     def summary(self) -> str:
         verb = "wrote" if self.written else "would write (dry-run)"
@@ -124,14 +127,20 @@ class CalibrationReport:
                     f"(n={s.n}, error={s.error_score:.2f}, "
                     f"uncertainty={s.uncertainty:.2f}, valence={s.appraisal_valence:+.2f})"
                 )
+        if self.health is not None:
+            lines.append("")
+            lines.append(self.health.render())
         return "\n".join(lines)
 
     def to_dict(self) -> dict:
-        return {
+        out = {
             "written": self.written,
             "counts": {"domains": len(self.summaries)},
             "summaries": [s.to_dict() for s in self.summaries],
         }
+        if self.health is not None:
+            out["health"] = self.health.to_dict()
+        return out
 
 
 def _record_valence(record) -> float:
@@ -249,9 +258,18 @@ async def run_calibration_pass(
     default) computes the summaries for the journal but writes nothing (I3);
     ``execute=True`` persists them via :func:`write_calibration`.
     """
+    # Local import avoids a module-level cycle: calibration_health imports
+    # SAMPLE_FLOOR from here. The health pass is pure/read-only (spec §12.4) and
+    # computed unconditionally — it rides the report regardless of the write gate,
+    # so the immune verdict shows up in dry-run journals too.
+    from loom.core.cognition.calibration_health import assess_calibration_health
+
     records = await store.list_by_status(
         "reconciled", limit=_CALIBRATION_CORPUS_LIMIT
     )
     summaries = compute_calibration(records)
     await write_calibration(semantic, summaries, execute=execute)
-    return CalibrationReport(written=execute and bool(summaries), summaries=summaries)
+    health = assess_calibration_health(summaries, records)
+    return CalibrationReport(
+        written=execute and bool(summaries), summaries=summaries, health=health,
+    )

--- a/loom/core/cognition/calibration_health.py
+++ b/loom/core/cognition/calibration_health.py
@@ -1,0 +1,197 @@
+"""
+Prediction Spine — calibration self-monitoring (epic #528, P0.5-b, spec §12.4,
+issue #539).
+
+The spine's **immune system**. P0's structural defences (I2 only-observation,
+I6 no-sentiment, I4 unverified-doesn't-count, rolling overwrite, namespaced
+decay) keep "*what can be written*" clean. This layer watches "*was something
+meaningless written*" — so the integrity guarantee lives in the mechanism, not
+in DK reading audit reports by hand. That is the prerequisite for the full-auto
+calibration writes DK wants.
+
+It is **read-only**: it reads the per-domain :class:`CalibrationSummary` roll-up
+and the reconciled records that produced it, and emits a report. It writes
+nothing, drives no behaviour, and needs no gate (report-only is safe — any
+*self-correcting* action would be a separate, gated slice). I5/I6 do not regress:
+the only inputs are observation-derived calibration and the bets' own
+provenance; there is no channel through which a value judgment or user sentiment
+could enter.
+
+What it flags (stateless, this slice):
+
+* ``low_information`` — the headline (絲絲 #538). A domain whose calibration sits
+  ≈1.0 with flat valence and enough sample is *high but uninformative*: under
+  flat implicit betting most tools just succeed, and "the tool succeeded" is not
+  the insight "I predict well here". Told apart from genuine signal so a
+  consumer (P1/P2) isn't lured by a near-perfect score that means nothing.
+* ``sample_insufficient`` — ``n < SAMPLE_FLOOR``: the score is statistically
+  unstable; say so rather than let a noisy 1.0 be read as mastery.
+* ``genuine_signal`` — calibration meaningfully off 1.0, or a directional
+  valence lean: the domains worth attending to.
+* ``monoculture`` (corpus-level) — every reconciled bet is implicit (``auto:``),
+  none explicit. Calibration is then measuring tool reliability, not prediction
+  skill — which is *why* a slice-B-only phase flatlines. Self-clears once the
+  explicit ``predict`` tool's wagers flow.
+
+Deferred to a post-observation cut (thresholds tuned on real 1–2 week data):
+``anomalous_jump`` (needs a calibration history snapshot, which the rolling
+overwrite destroys) and ``fragmentation`` (synonym-split domain labels — too
+fuzzy to threshold without real data). The thresholds below are conservative
+a-priori values, not yet tuned.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from loom.core.cognition.calibration import SAMPLE_FLOOR
+
+# At/above this calibration_score a domain is "near-perfect". Combined with flat
+# valence and adequate sample, near-perfect reads as uninformative, not skilful.
+HIGH_CAL = 0.95
+# |appraisal_valence| at/below this = no directional surprise to appraise.
+FLAT_VALENCE = 0.05
+
+# Classifications (mutually exclusive per domain).
+LOW_INFORMATION = "low_information"
+SAMPLE_INSUFFICIENT = "sample_insufficient"
+GENUINE_SIGNAL = "genuine_signal"
+
+
+@dataclass
+class DomainHealth:
+    """One domain's calibration health verdict, with the numbers behind it."""
+    domain: str
+    classification: str
+    reason: str
+    n: int
+    calibration_score: float
+    uncertainty: float
+    appraisal_valence: float
+
+    def to_dict(self) -> dict:
+        return {
+            "domain": self.domain,
+            "classification": self.classification,
+            "reason": self.reason,
+            "n": self.n,
+            "calibration_score": round(self.calibration_score, 4),
+            "uncertainty": round(self.uncertainty, 4),
+            "appraisal_valence": round(self.appraisal_valence, 4),
+        }
+
+
+@dataclass
+class CalibrationHealthReport:
+    """Read-only health projection over one calibration snapshot."""
+    domains: list = field(default_factory=list)
+    monoculture: bool = False
+    monoculture_detail: str = ""
+
+    def low_information(self) -> list:
+        return [d for d in self.domains if d.classification == LOW_INFORMATION]
+
+    def sample_insufficient(self) -> list:
+        return [d for d in self.domains if d.classification == SAMPLE_INSUFFICIENT]
+
+    def genuine(self) -> list:
+        return [d for d in self.domains if d.classification == GENUINE_SIGNAL]
+
+    def summary(self) -> str:
+        return (
+            f"calibration health: {len(self.genuine())} genuine, "
+            f"{len(self.low_information())} low-info, "
+            f"{len(self.sample_insufficient())} thin-sample"
+            + (" — MONOCULTURE" if self.monoculture else "")
+        )
+
+    def render(self) -> str:
+        lines = [self.summary()]
+        if self.monoculture:
+            lines.append(f"  ⚠ monoculture: {self.monoculture_detail}")
+        for d in sorted(self.domains, key=lambda x: (x.classification, x.domain)):
+            lines.append(
+                f"  - [{d.classification}] {d.domain}: "
+                f"score={d.calibration_score:.2f} (n={d.n}, "
+                f"uncertainty={d.uncertainty:.2f}, valence={d.appraisal_valence:+.2f}) "
+                f"— {d.reason}"
+            )
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict:
+        return {
+            "monoculture": self.monoculture,
+            "monoculture_detail": self.monoculture_detail,
+            "counts": {
+                GENUINE_SIGNAL: len(self.genuine()),
+                LOW_INFORMATION: len(self.low_information()),
+                SAMPLE_INSUFFICIENT: len(self.sample_insufficient()),
+            },
+            "domains": [d.to_dict() for d in self.domains],
+        }
+
+
+def _classify(summary) -> tuple[str, str]:
+    """Verdict + human reason for one domain. Sample-sufficiency is checked
+    first: you cannot call a barely-sampled domain 'uninformative' (you haven't
+    looked enough), only 'unstable'."""
+    if summary.n < SAMPLE_FLOOR:
+        return SAMPLE_INSUFFICIENT, (
+            f"n={summary.n} < {SAMPLE_FLOOR}: calibration_score statistically "
+            "unstable — don't read it as mastery"
+        )
+    if summary.calibration_score >= HIGH_CAL and abs(summary.appraisal_valence) <= FLAT_VALENCE:
+        return LOW_INFORMATION, (
+            f"score≈{summary.calibration_score:.2f}, valence≈0: flatlined — high "
+            "but uninformative (the tool just succeeds; not an insight)"
+        )
+    return GENUINE_SIGNAL, (
+        "calibration meaningfully off 1.0 or non-flat valence — worth attention"
+    )
+
+
+def _detect_monoculture(records) -> tuple[bool, str]:
+    """True when every reconciled bet is implicit (``auto:``) with none explicit.
+
+    Only *reconciled* bets count (I4-adjacent): a pile of still-pending explicit
+    wagers must not 'clear' the flag before they actually settle into signal.
+    Below the sample floor, diversity is unjudgeable — don't cry wolf.
+    """
+    reconciled = [r for r in records if r.status == "reconciled" and r.score is not None]
+    n = len(reconciled)
+    if n < SAMPLE_FLOOR:
+        return False, f"too few reconciled bets ({n}) to judge diversity"
+    explicit = sum(1 for r in reconciled if (r.context or "").startswith("explicit:"))
+    if explicit == 0:
+        return True, (
+            f"all {n} reconciled bets are implicit (auto:) — calibration measures "
+            "tool reliability, not prediction skill; flat-near-1.0 is expected "
+            "until explicit wagers flow"
+        )
+    return False, f"{explicit}/{n} reconciled bets are explicit wagers"
+
+
+def assess_calibration_health(summaries, records) -> CalibrationHealthReport:
+    """Assess one calibration snapshot. Pure, read-only (spec §12.4).
+
+    ``summaries`` is the per-domain :class:`CalibrationSummary` roll-up;
+    ``records`` the reconciled :class:`PredictionRecord` corpus they came from
+    (used only for the corpus-level monoculture check). The two-argument
+    signature is the structural I6 guarantee — no sentiment channel exists.
+    """
+    domains = []
+    for s in summaries:
+        cls, reason = _classify(s)
+        domains.append(DomainHealth(
+            domain=s.domain,
+            classification=cls,
+            reason=reason,
+            n=s.n,
+            calibration_score=s.calibration_score,
+            uncertainty=s.uncertainty,
+            appraisal_valence=s.appraisal_valence,
+        ))
+    mono, detail = _detect_monoculture(records)
+    return CalibrationHealthReport(
+        domains=domains, monoculture=mono, monoculture_detail=detail,
+    )

--- a/loom/core/cognition/calibration_health.py
+++ b/loom/core/cognition/calibration_health.py
@@ -43,8 +43,15 @@ a-priori values, not yet tuned.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from loom.core.cognition.calibration import SAMPLE_FLOOR
+
+if TYPE_CHECKING:
+    # Annotation-only imports — kept out of runtime to avoid coupling the health
+    # layer's import graph to the record/summary modules (絲絲 PR #542 P3).
+    from loom.core.cognition.calibration import CalibrationSummary
+    from loom.core.memory.prediction import PredictionRecord
 
 # At/above this calibration_score a domain is "near-perfect". Combined with flat
 # valence and adequate sample, near-perfect reads as uninformative, not skilful.
@@ -131,7 +138,7 @@ class CalibrationHealthReport:
         }
 
 
-def _classify(summary) -> tuple[str, str]:
+def _classify(summary: "CalibrationSummary") -> tuple[str, str]:
     """Verdict + human reason for one domain. Sample-sufficiency is checked
     first: you cannot call a barely-sampled domain 'uninformative' (you haven't
     looked enough), only 'unstable'."""
@@ -150,7 +157,7 @@ def _classify(summary) -> tuple[str, str]:
     )
 
 
-def _detect_monoculture(records) -> tuple[bool, str]:
+def _detect_monoculture(records: "list[PredictionRecord]") -> tuple[bool, str]:
     """True when every reconciled bet is implicit (``auto:``) with none explicit.
 
     Only *reconciled* bets count (I4-adjacent): a pile of still-pending explicit
@@ -171,7 +178,10 @@ def _detect_monoculture(records) -> tuple[bool, str]:
     return False, f"{explicit}/{n} reconciled bets are explicit wagers"
 
 
-def assess_calibration_health(summaries, records) -> CalibrationHealthReport:
+def assess_calibration_health(
+    summaries: "list[CalibrationSummary]",
+    records: "list[PredictionRecord]",
+) -> CalibrationHealthReport:
     """Assess one calibration snapshot. Pure, read-only (spec §12.4).
 
     ``summaries`` is the per-domain :class:`CalibrationSummary` roll-up;

--- a/tests/test_calibration_health.py
+++ b/tests/test_calibration_health.py
@@ -139,6 +139,20 @@ class TestMonoculture:
         report = assess_calibration_health([_summary("run_bash")], records)
         assert report.monoculture is False
 
+    def test_summaries_with_empty_records_flag_monoculture_false(self):
+        """絲絲 PR #542 P2: a caller that computes summaries then hands records=[]
+        (the natural shape if the two are fetched separately) must not crash and
+        must not cry monoculture — diversity is unjudgeable with no records, while
+        each domain still classifies by its own n/score/valence."""
+        report = assess_calibration_health([
+            _summary("run_bash", n=20, error=0.0, valence=0.0),   # low_information
+            _summary("git_push", n=20, error=0.4, valence=-0.3),  # genuine
+        ], [])
+        assert report.monoculture is False
+        assert "too few" in report.monoculture_detail
+        assert _by_domain(report, "run_bash").classification == LOW_INFORMATION
+        assert _by_domain(report, "git_push").classification == GENUINE_SIGNAL
+
     def test_monoculture_ignores_unreconciled_records(self):
         """Only reconciled bets count toward the diversity judgment (I4-adjacent):
         a pile of pending explicit bets must not 'clear' monoculture before they

--- a/tests/test_calibration_health.py
+++ b/tests/test_calibration_health.py
@@ -1,0 +1,237 @@
+"""
+Prediction Spine — calibration self-monitoring (epic #528, P0.5-b, #539).
+
+The immune system: a *read-only* analyzer over the spine's own
+``calibration:<domain>`` residue that flags "did it write something
+meaningless?" so DK can let go without reading audit reports by hand. It writes
+nothing, drives no behaviour, needs no gate (report-only is safe), and invents
+no value judgment (I5) — its only inputs are calibration summaries and the
+reconciled records that produced them (no sentiment channel, I6).
+
+Contract pinned here (red first):
+
+* **low_information** (the headline, 絲絲 #538) — a domain whose calibration sits
+  ≈1.0 with flat valence and enough sample is *high but uninformative*: the tool
+  just succeeds, that isn't insight. It must be told apart from genuine signal.
+* **sample_insufficient** — ``n < SAMPLE_FLOOR``: the score is statistically
+  unstable; the report says so explicitly rather than letting a consumer read a
+  noisy 1.0.
+* **genuine_signal** — calibration meaningfully off 1.0, or non-flat valence:
+  the domains a consumer should actually attend to.
+* **monoculture** (corpus-level) — every reconciled bet is implicit (``auto:``),
+  none explicit: calibration is measuring tool reliability, not prediction
+  skill. This is *why* a slice-B-only phase flatlines, and it self-clears once
+  explicit wagers flow.
+* **I6** — the analyzer's signature admits only (summaries, records); there is
+  no parameter through which user sentiment could enter.
+"""
+
+import inspect
+
+import pytest
+import pytest_asyncio
+
+from loom.core.cognition.calibration import CalibrationSummary, SAMPLE_FLOOR, run_calibration_pass
+from loom.core.cognition.calibration_health import (
+    assess_calibration_health,
+    CalibrationHealthReport,
+    DomainHealth,
+    LOW_INFORMATION,
+    SAMPLE_INSUFFICIENT,
+    GENUINE_SIGNAL,
+)
+from loom.core.memory.prediction import PredictionRecord, PredictionStore
+from loom.core.memory.store import SQLiteStore
+from loom.core.memory.semantic import SemanticMemory
+
+
+def _summary(domain, *, n=10, error=0.0, valence=0.0):
+    """A CalibrationSummary with the fields the analyzer reads."""
+    return CalibrationSummary(
+        domain=domain,
+        n=n,
+        error_score=error,
+        uncertainty=max(error, max(0.0, (SAMPLE_FLOOR - n) / SAMPLE_FLOOR)),
+        appraisal_valence=valence,
+        calibration_score=1.0 - error,
+    )
+
+
+def _rec(*, domain="run_bash", context="auto:implicit_tool_success",
+         status="reconciled", score=0.0):
+    return PredictionRecord(
+        session_id="s", claim="c",
+        due_condition={"kind": "after_action", "call_id": "x"},
+        resolver={"kind": "tool_success", "expect": True},
+        domain=domain, context=context, status=status, score=score,
+    )
+
+
+def _by_domain(report, domain):
+    return next(d for d in report.domains if d.domain == domain)
+
+
+# ---------------------------------------------------------------------------
+# Per-domain classification
+# ---------------------------------------------------------------------------
+
+class TestLowInformation:
+    def test_flat_near_one_is_low_information(self):
+        """The headline: high calibration + flat valence + enough sample =
+        uninformative, not insight."""
+        report = assess_calibration_health([_summary("run_bash", n=20, error=0.0, valence=0.0)], [])
+        assert _by_domain(report, "run_bash").classification == LOW_INFORMATION
+
+    def test_low_information_listed_separately_from_genuine(self):
+        report = assess_calibration_health([
+            _summary("run_bash", n=20, error=0.0, valence=0.0),       # flat
+            _summary("git_push", n=20, error=0.4, valence=-0.3),      # signal
+        ], [])
+        assert {d.domain for d in report.low_information()} == {"run_bash"}
+        assert {d.domain for d in report.genuine()} == {"git_push"}
+
+    def test_high_score_but_non_flat_valence_is_genuine(self):
+        """≈1.0 calibration but a directional surprise lean is still signal —
+        not every near-perfect domain is uninformative."""
+        report = assess_calibration_health([_summary("fetch", n=20, error=0.02, valence=0.4)], [])
+        assert _by_domain(report, "fetch").classification == GENUINE_SIGNAL
+
+
+class TestSampleInsufficient:
+    def test_thin_sample_flagged_regardless_of_score(self):
+        report = assess_calibration_health([_summary("rare_tool", n=2, error=0.0, valence=0.0)], [])
+        assert _by_domain(report, "rare_tool").classification == SAMPLE_INSUFFICIENT
+
+    def test_sample_insufficiency_takes_priority_over_low_information(self):
+        """A thin-sample near-1.0 domain is 'unstable', not 'flatlined' — you
+        can't call it uninformative when you barely sampled it."""
+        report = assess_calibration_health([_summary("rare", n=1, error=0.0, valence=0.0)], [])
+        d = _by_domain(report, "rare")
+        assert d.classification == SAMPLE_INSUFFICIENT
+        assert d.classification != LOW_INFORMATION
+
+
+class TestGenuineSignal:
+    def test_meaningfully_off_one_is_genuine(self):
+        report = assess_calibration_health([_summary("model_of_dk", n=12, error=0.5, valence=-0.2)], [])
+        assert _by_domain(report, "model_of_dk").classification == GENUINE_SIGNAL
+
+
+# ---------------------------------------------------------------------------
+# Corpus-level monoculture
+# ---------------------------------------------------------------------------
+
+class TestMonoculture:
+    def test_all_auto_bets_is_monoculture(self):
+        records = [_rec(context="auto:implicit_tool_success") for _ in range(10)]
+        report = assess_calibration_health([_summary("run_bash")], records)
+        assert report.monoculture is True
+
+    def test_any_explicit_bet_clears_monoculture(self):
+        records = [_rec(context="auto:implicit_tool_success") for _ in range(9)]
+        records.append(_rec(context="explicit:predict_tool"))
+        report = assess_calibration_health([_summary("run_bash")], records)
+        assert report.monoculture is False
+
+    def test_too_few_reconciled_is_not_monoculture(self):
+        """Below the sample floor, diversity is unjudgeable — don't cry wolf."""
+        records = [_rec() for _ in range(SAMPLE_FLOOR - 1)]
+        report = assess_calibration_health([_summary("run_bash")], records)
+        assert report.monoculture is False
+
+    def test_monoculture_ignores_unreconciled_records(self):
+        """Only reconciled bets count toward the diversity judgment (I4-adjacent):
+        a pile of pending explicit bets must not 'clear' monoculture before they
+        actually settle."""
+        records = [_rec(context="auto:implicit_tool_success") for _ in range(10)]
+        records += [_rec(context="explicit:predict_tool", status="pending", score=None)
+                    for _ in range(5)]
+        report = assess_calibration_health([_summary("run_bash")], records)
+        assert report.monoculture is True
+
+
+# ---------------------------------------------------------------------------
+# Empty corpus + report shape
+# ---------------------------------------------------------------------------
+
+class TestEmptyAndShape:
+    def test_empty_corpus_is_inert(self):
+        report = assess_calibration_health([], [])
+        assert report.domains == []
+        assert report.monoculture is False
+        assert isinstance(report.render(), str)
+
+    def test_render_and_to_dict(self):
+        report = assess_calibration_health([
+            _summary("run_bash", n=20, error=0.0, valence=0.0),
+            _summary("git_push", n=20, error=0.4, valence=-0.3),
+        ], [_rec() for _ in range(10)])
+        text = report.render()
+        assert "run_bash" in text and "git_push" in text
+        d = report.to_dict()
+        assert d["counts"]["low_information"] == 1
+        assert d["counts"]["genuine_signal"] == 1
+        assert d["monoculture"] is True
+
+
+# ---------------------------------------------------------------------------
+# I6 — structural no-sentiment guarantee
+# ---------------------------------------------------------------------------
+
+class TestNoSentimentPath:
+    def test_signature_admits_only_summaries_and_records(self):
+        params = list(inspect.signature(assess_calibration_health).parameters)
+        assert params == ["summaries", "records"]
+
+
+# ---------------------------------------------------------------------------
+# Integration — run_calibration_pass carries the health verdict (read-only)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test_cal_health.db")
+
+
+@pytest_asyncio.fixture
+async def store(tmp_db):
+    s = SQLiteStore(tmp_db)
+    await s.initialize()
+    return s
+
+
+async def _seed_reconciled(ps, domain, *, score, n, context="auto:implicit_tool_success"):
+    for _ in range(n):
+        pred = PredictionRecord(
+            session_id="s", claim="bet",
+            due_condition={"kind": "after_action", "call_id": "c"},
+            resolver={"kind": "tool_success", "expect": True},
+            domain=domain, context=context,
+        )
+        await ps.write(pred)
+        await ps.mark_reconciled(pred.id, score=score, observation_ref="action:a1")
+
+
+class TestPassIntegration:
+    async def test_pass_attaches_health_even_in_dry_run(self, store):
+        """The immune verdict is read-only — it must ride the report regardless
+        of the write gate, so a dry-run (calibration_write off) journal shows it."""
+        async with store.connect() as db:
+            ps, sem = PredictionStore(db), SemanticMemory(db)
+            await _seed_reconciled(ps, "run_bash", score=0.0, n=8)  # flat near-1.0
+
+            report = await run_calibration_pass(ps, sem, execute=False)
+            assert report.written is False
+            assert report.health is not None
+            assert report.health.monoculture is True
+            assert report.health.low_information()[0].domain == "run_bash"
+            assert "calibration health" in report.render()
+
+    async def test_explicit_bets_clear_monoculture_in_pass(self, store):
+        async with store.connect() as db:
+            ps, sem = PredictionStore(db), SemanticMemory(db)
+            await _seed_reconciled(ps, "run_bash", score=0.0, n=6)
+            await _seed_reconciled(ps, "git", score=0.4, n=6,
+                                   context="explicit:predict_tool")
+            report = await run_calibration_pass(ps, sem, execute=False)
+            assert report.health.monoculture is False


### PR DESCRIPTION
## 為什麼

DK 的終極目標是**全自動、不靠人介入維持**——他的介入只在對話裡自然更新記憶,不做一次次強硬矯正。所以**防記憶污染的保證必須長在機制裡,不長在人身上**。

P0 已有的結構防線(I2 只認觀察 / I6 不認情緒 / I4 未驗證不計 / rolling 覆寫自我修正 / namespaced 衰減)保證「**能寫什麼**」乾淨。缺的是「**有沒有寫歪**」的自我監測——目前靠人讀 audit 報告,全自動下形同虛設。這個 PR 補上那隻**免疫系統**。

## 改了什麼

`loom/core/cognition/calibration_health.py` — **純唯讀分析器**,看顧 spine 自己的 `calibration:<domain>` 殘留。**不寫、不驅動行為、不需新 gate**(report-only 本就安全;延續你「開關別再多」),I5/I6 不退步(signature 只收 `(summaries, records)`,無 sentiment 通道)。

**首要驗收點(絲絲 #538 review)= `low_information` 旗標**:flat 隱式賭下多數 domain calibration 趨近 1.0,這種高分**不是 insight**(是 tool 本來就會成功)。用 domain-stats 區分:

| 旗標 | 條件 | 意義 |
|---|---|---|
| `low_information` | score≥0.95 + \|valence\|≤0.05 + n≥SAMPLE_FLOOR | 高但無資訊,消費者別被騙 |
| `sample_insufficient` | n < SAMPLE_FLOOR | 統計不穩,別讀 calibration_score |
| `genuine_signal` | 其餘(明顯偏離 1.0 / valence 非平) | 值得 P1/P2 消費者注意 |
| `monoculture`(corpus) | reconciled 全 `auto:`、零 `explicit:` | calibration 只在量 tool 可靠度;**解釋純 slice-B 為何全趨平**,顯式賭流動後自清 |

**整合**:health 在 `run_calibration_pass` 內**一律計算**(唯讀,不受 `calibration_write_enabled` gate 影響),掛進 `CalibrationReport.render()` → `prediction_reconcile` 工具/dream journal 自動顯示(dry-run 也看得到)。`health` 欄位 optional,既有 `CalibrationReport` 建構向後相容。

## 為何現在做(而非絲絲建議的觀察後)

我們把它拆成**機制先行、門檻後調**:失敗形狀(全 0-error 趨向 1.0 且低樣本 = 可疑)是**數學上先驗可知**、不需真資料;真資料(6/17)只負責調門檻。等於這週的產出**直接餵 6/17 的觀察報告**——把絲絲現在要肉眼判的「有意義 vs 趨平垃圾」變自動報告,給她的摘要更有方向性。

## Deferred(門檻 + 進階旗標,6/17 真資料後)

- `anomalous_jump`(異常跳變):需 calibration **歷史快照**,但 rolling 覆寫銷毀歷史 → 要先決定怎麼留前值。
- `fragmentation`(domain 碎片化):同義標籤分裂太 fuzzy,需真資料校準 false-positive。
- 門檻(HIGH_CAL/FLAT_VALENCE)現為先驗保守值。

## 測試

TDD red→green:`test_calibration_health.py` 15 測試(分類優先序、monoculture 只認 reconciled、空 corpus、I6 signature、`run_calibration_pass` 整合)。**全 suite 2700 passed**。detect_changes medium(純加法,CalibrationReport 加 optional 欄位,向後相容)。

## Review 重點

- `sample_insufficient` 優先於 `low_information`——「樣本太少不能叫它趨平,只能叫它不穩」這個優先序對不對?
- monoculture 只認 reconciled(排除 pending explicit 賭)——避免「一堆還沒結算的顯式賭假性清除 monoculture」,這個 I4-adjacent 邊界。
- health 一律計算、不 gate——唯讀就不該擋,但你看會不會在某些路徑變成噪音。
- deferred 的 jump-detection:rolling 覆寫銷毀歷史是真限制,留前值的方案你有偏好嗎?

🤖 Generated with [Claude Code](https://claude.com/claude-code)