### PR TITLE
fix: persist active model on session update (#475)

### DIFF
--- a/loom/core/memory/session_log.py
+++ b/loom/core/memory/session_log.py
@@ -286,16 +286,22 @@ class SessionLog:
         turn_count: int,
         last_active: str,
         title: str | None,
+        model: str | None = None,
     ) -> None:
         """Update metadata after each turn or on stop().
-        COALESCE(title, ?) preserves the title once it has been set."""
+
+        COALESCE(title, ?) preserves the title once it has been set.
+        ``model`` tracks the active model so the persisted row reflects what
+        actually served (tier escalation / ``/model``); COALESCE(?, model)
+        means omitting it (or passing None) keeps the stored value (#475)."""
         await self._db.execute(
             """
             UPDATE sessions
-            SET turn_count = ?, last_active = ?, title = COALESCE(title, ?)
+            SET turn_count = ?, last_active = ?, title = COALESCE(title, ?),
+                model = COALESCE(?, model)
             WHERE session_id = ?
             """,
-            (turn_count, last_active, title, session_id),
+            (turn_count, last_active, title, model, session_id),
         )
         await self._db.commit()
 

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1693,6 +1693,7 @@ class LoomSession:
                         turn_count=self._turn_index,
                         last_active=datetime.now(UTC).isoformat(),
                         title=title,
+                        model=self.current_model(),
                     )
                 except Exception as exc:
                     logger.warning("Session log update failed: %s", exc)

--- a/tests/test_session_log_model_update.py
+++ b/tests/test_session_log_model_update.py
@@ -1,0 +1,88 @@
+"""Tests for Issue #475 — persisted ``sessions.model`` must track the active model.
+
+``create_session`` writes the base/default model once at creation. After a tier
+escalation or a ``/model`` switch the model that actually serves diverges, but the
+persisted row never moved — so ``loom sessions list`` reported the wrong model
+(evidence: ledger session ``2bb9e21f`` served on codex/gpt-5.5 yet stored
+``minimax-m2.7``).
+
+Fix: ``update_session`` accepts an optional ``model`` and writes it through the
+same per-turn update path, with COALESCE so callers that omit it (and the
+existing positional callers) preserve the stored value.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import aiosqlite
+import pytest_asyncio
+
+from loom.core.memory.session_log import SessionLog
+
+
+@pytest_asyncio.fixture
+async def session_log(tmp_path: Path):
+    conn = await aiosqlite.connect(str(tmp_path / "sessions.db"))
+    await conn.executescript(
+        """
+        CREATE TABLE sessions (
+            session_id TEXT, model TEXT, title TEXT,
+            started_at TEXT, last_active TEXT, turn_count INTEGER DEFAULT 0
+        );
+        CREATE TABLE session_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            turn_index INTEGER NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT NOT NULL,
+            raw_json TEXT,
+            metadata TEXT NOT NULL DEFAULT '{}',
+            created_at TEXT NOT NULL
+        );
+        """
+    )
+    await conn.commit()
+    log = SessionLog(conn)
+    yield log
+    await conn.close()
+
+
+async def test_update_session_persists_active_model(session_log: SessionLog):
+    """A model passed to update_session lands in the persisted row."""
+    await session_log.create_session("s1", "minimax-m2.7", title=None)
+
+    await session_log.update_session(
+        "s1", turn_count=3, last_active="2026-06-11T00:00:00+00:00",
+        title="hi", model="codex/gpt-5.5",
+    )
+
+    row = await session_log.get_session("s1")
+    assert row["model"] == "codex/gpt-5.5"
+    assert row["turn_count"] == 3
+
+
+async def test_update_session_omitting_model_preserves_stored(session_log: SessionLog):
+    """Callers that don't pass model (e.g. legacy positional) keep the stored value."""
+    await session_log.create_session("s1", "minimax-m2.7", title=None)
+
+    # Legacy positional signature: (session_id, turn_count, last_active, title)
+    await session_log.update_session(
+        "s1", 1, "2026-06-11T00:00:00+00:00", None,
+    )
+
+    row = await session_log.get_session("s1")
+    assert row["model"] == "minimax-m2.7"
+
+
+async def test_update_session_none_model_does_not_clobber(session_log: SessionLog):
+    """Explicit model=None is a no-op on the stored model (COALESCE guard)."""
+    await session_log.create_session("s1", "minimax-m2.7", title=None)
+
+    await session_log.update_session(
+        "s1", turn_count=2, last_active="2026-06-11T00:00:00+00:00",
+        title=None, model=None,
+    )
+
+    row = await session_log.get_session("s1")
+    assert row["model"] == "minimax-m2.7"


### PR DESCRIPTION
Closes #475.

## Problem
`sessions.model` is written once at `create_session` using the base/default model, and `update_session` only touched `turn_count` / `last_active` / `title` — never `model`. So tier escalation and `/model` switches never reached the persisted record, and `loom sessions list` reported the wrong model. Evidence: ledger session `2bb9e21f` served on `codex/gpt-5.5` the whole time yet stored `minimax-m2.7`.

## Fix
- `update_session` gains an optional `model` param, written via `model = COALESCE(?, model)` so callers that omit it (incl. the legacy positional caller in `test_memory_facade`) preserve the stored value.
- The `stop()` call site passes `current_model()` — the #471 single-source-of-truth accessor — keeping the persistence layer aligned with the live identity surfaces converged in #474.

## Scope note
This persists on a clean `stop()`. Sessions killed without `stop()` still freeze at create-time values (the `turn_count=0` secondary observation in the issue — `2bb9e21f` was such a session). The deeper per-turn-vs-on-stop persistence question is left as a follow-up rather than expanded here, matching the issue's framing that model staleness is the clear fix.

## Tests
`tests/test_session_log_model_update.py` — 3 cases: model persists when passed, omitted model preserves stored value (legacy positional), explicit `None` is a no-op (COALESCE guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)