### PR TITLE
fix: provider runtime telemetry follow-ups (#469, #470)

### DIFF
--- a/loom.toml.example
+++ b/loom.toml.example
@@ -127,10 +127,12 @@ reminder_after_turns = 10
 #                                      # event before declaring a ttfb_timeout. Default 45s.
 #                                      # Set 0 to disable (e.g. if the backend buffers and emits
 #                                      # no early event on very heavy reasoning turns).
-# idle_event_timeout  = 0.0            # SSE watchdog: max seconds between events after the first
-#                                      # one before declaring an idle_timeout. Default 0 = off,
-#                                      # so long reasoning gaps don't false-trip; the overall
-#                                      # ``timeout`` above still bounds the request.
+# idle_event_timeout  = 300.0          # SSE watchdog: max seconds between events after the first
+#                                      # one before declaring an idle_timeout. Default 300s for
+#                                      # codex (#470): reasoning legitimately runs ~5 min, but a
+#                                      # true hang (observed 7.7-min silent stall) would otherwise
+#                                      # sit invisible until manual cancel. 300s converts it into
+#                                      # a structured idle_timeout. Set 0 to disable.
 
 # [providers.xai_oauth]
 # enabled          = true              # optional; explicit --model xai/... also registers it

--- a/loom/core/cognition/codex_responses_provider.py
+++ b/loom/core/cognition/codex_responses_provider.py
@@ -10,7 +10,6 @@ from . import vision as _vision
 from .responses_policy import normalize_reasoning_effort
 from .responses_sse import (
     DEFAULT_FIRST_EVENT_TIMEOUT,
-    DEFAULT_IDLE_EVENT_TIMEOUT,
     ResponsesProviderError,
     ResponsesStreamState,
     _ReasoningStreamWrapper,
@@ -91,6 +90,12 @@ class CodexResponsesProvider(LLMProvider):
     DEFAULT_MODEL = "gpt-5.5"
     DEFAULT_BASE_URL = "https://chatgpt.com/backend-api/codex/responses"
     DEFAULT_TIMEOUT = 600.0
+    # #470: codex reasoning legitimately runs ~5 min; a true hang (observed
+    # 7.7-min silent stall, turn_0b965add0990) would otherwise sit invisible
+    # because the shared idle default is 0/off. 300s converts the silent stall
+    # into a structured idle_timeout while leaving normal deep reasoning room.
+    # codex-specific — xai keeps the shared 0.0 default unless shown to need it.
+    DEFAULT_CODEX_IDLE_EVENT_TIMEOUT = 300.0
     SUPPORTS_MAX_OUTPUT_TOKENS = False
 
     def __init__(
@@ -112,7 +117,7 @@ class CodexResponsesProvider(LLMProvider):
             else first_event_timeout
         )
         self._idle_event_timeout = (
-            DEFAULT_IDLE_EVENT_TIMEOUT
+            self.DEFAULT_CODEX_IDLE_EVENT_TIMEOUT
             if idle_event_timeout is None or idle_event_timeout < 0
             else idle_event_timeout
         )

--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -1852,6 +1852,16 @@ class LoomSession:
                 logger.exception(
                     "ledger turn_start emit failed; continuing"
                 )
+        # #469 — bind the names the except/finally handlers read *before* the
+        # try, so a provider error raised during setup (ahead of the in-loop
+        # re-init below) still finds them. Replaces the defensive
+        # locals().get("_stream_retry"/"tool_count", 0) in the except block.
+        # _provider_error carries the caught ResponsesProviderError into the
+        # finally: by then the except has consumed sys.exc_info(), so the
+        # outcome derivation would otherwise misread the failure as "clean".
+        _provider_error: ResponsesProviderError | None = None
+        tool_count = 0
+        _stream_retry = 0
         try:
             self._current_origin = origin
 
@@ -2724,11 +2734,17 @@ class LoomSession:
                 stop_reason=_stop_reason,
             )
         except ResponsesProviderError as exc:
+            # #469 — record the failure so the finally below marks the turn
+            # "error" in the ledger instead of "clean". Streaming consumers see
+            # this as a TurnDropped; non-streaming router.chat() consumers still
+            # receive the raw ResponsesProviderError by design (they own their
+            # own error handling and don't pass through this generator).
+            _provider_error = exc
             logger.error("stream_turn: provider error: %s", exc)
             yield TurnDropped(
                 stop_reason=f"provider_{exc.failure_type}",
-                retry_count=locals().get("_stream_retry", 0),
-                tool_count=locals().get("tool_count", 0),
+                retry_count=_stream_retry,
+                tool_count=tool_count,
                 exhausted=True,
                 provider_error_detail=str(exc),
             )
@@ -2738,7 +2754,12 @@ class LoomSession:
                 if self._ledger_emitter is not None and _ledger_turn_token is not None:
                     import sys as _sys
                     _exc_type = _sys.exc_info()[0]
-                    if _exc_type is None:
+                    if _provider_error is not None:
+                        # #469 — provider error was caught above and turned into
+                        # a TurnDropped, so exc_info() is already cleared here;
+                        # without this branch the turn would record as "clean".
+                        _outcome = "error"
+                    elif _exc_type is None:
                         _outcome = "clean"
                     elif isinstance(_exc_type, type) and issubclass(
                         _exc_type, asyncio.CancelledError

--- a/tests/test_codex_responses_provider.py
+++ b/tests/test_codex_responses_provider.py
@@ -144,6 +144,22 @@ def test_codex_provider_default_timeout_is_600_seconds():
     assert overridden._timeout == 900.0
 
 
+def test_codex_provider_idle_event_timeout_defaults_to_300():
+    """#470: codex defaults idle_event_timeout to 300s so a silent reasoning
+    stall (observed 7.7-min hang) becomes a structured idle_timeout instead of
+    sitting invisible. xai keeps the shared 0/off default."""
+    provider = CodexResponsesProvider(model="codex/gpt-5.5")
+    assert provider._idle_event_timeout == 300.0
+    # Explicit config (wired from [providers.codex].idle_event_timeout) wins,
+    # including 0 to opt back out.
+    assert CodexResponsesProvider(
+        model="codex/gpt-5.5", idle_event_timeout=0.0
+    )._idle_event_timeout == 0.0
+    assert CodexResponsesProvider(
+        model="codex/gpt-5.5", idle_event_timeout=120.0
+    )._idle_event_timeout == 120.0
+
+
 def test_codex_provider_first_event_timeout_can_be_disabled():
     provider = CodexResponsesProvider(
         model="codex/gpt-5.5",

--- a/tests/test_ledger_session_wiring.py
+++ b/tests/test_ledger_session_wiring.py
@@ -188,6 +188,45 @@ async def test_emit_turn_end_links_to_turn_start(
         await session.stop()
 
 
+async def test_provider_error_turn_records_error_not_clean(
+    monkeypatch, tmp_path, session_module
+):
+    """#469 — a ResponsesProviderError is caught and turned into TurnDropped, so
+    by the time the finally derives the turn outcome from sys.exc_info() the
+    exception is already consumed. Without the explicit _provider_error flag the
+    turn would be misrecorded as ``clean``; it must be ``error``."""
+    from loom.core.cognition.responses_sse import ResponsesProviderError
+    from loom.core.events import TurnDropped
+
+    session = await _start_session(monkeypatch, tmp_path, session_module)
+    try:
+        async def _boom(*args, **kwargs):
+            raise ResponsesProviderError(
+                provider="codex", model="codex/gpt-5.5",
+                failure_type="idle_timeout", phase="reasoning",
+                detail="silent stall",
+            )
+            yield  # pragma: no cover — marks this an async generator
+
+        session.router.stream_chat = _boom
+
+        captured: list[str] = []
+        orig_end = session._emit_ledger_turn_end
+
+        async def _spy_end(turn_id, outcome, duration_ms):
+            captured.append(outcome)
+            return await orig_end(turn_id, outcome, duration_ms)
+
+        session._emit_ledger_turn_end = _spy_end
+
+        events = [ev async for ev in session.stream_turn("hello")]
+
+        assert any(isinstance(ev, TurnDropped) for ev in events)
+        assert captured == ["error"]
+    finally:
+        await session.stop()
+
+
 # ---------------------------------------------------------------------------
 # Step 5 cutover — _build_envelope_view delegates to LedgerEnvelopeProjector
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Batch of two #467 review follow-ups in the provider runtime telemetry area. (#468 — AnthropicProvider contract extraction — is deferred for now: it's a ~530-line refactor on the main chat path and the repo convention wants real-world multi-turn validation.)

## #469 — provider-error turns recorded as `clean`
`stream_turn()` catches `ResponsesProviderError` and yields `TurnDropped` (user-visible path correct). But the turn-end ledger outcome derives from `sys.exc_info()` in the `finally`, and the `except` block already consumed the exception — so `exc_info()` is `None` and the turn was recorded as `clean`. Provider failures looked like clean turns in the ledger.

**Fix:** explicit `_provider_error` flag set in the `except`, checked first in the `finally` → outcome `error`. Also: replaced the defensive `locals().get("_stream_retry"/"tool_count", 0)` with names bound before the `try`, and documented the streaming-vs-nonstreaming error contract inline.

**Test:** `test_provider_error_turn_records_error_not_clean` drives `stream_turn` with an injected `ResponsesProviderError`, spies the ledger `turn_end` outcome, asserts `error` (would be `clean` without the fix).

## #470 — codex idle watchdog default
The SSE idle watchdog defaults to 0/off for both providers, so post-first-event reasoning silence is invisible. A real 7.7-min silent stall (`turn_0b965add0990`) sat as a manual-cancel `abandoned`. Per the #470 decision, codex now defaults `idle_event_timeout = 300.0` (deep reasoning runs ~5 min; 300s converts a true hang into a structured `idle_timeout`), xai keeps 0/off. Knob was already wired in #467; this picks the codex default via `DEFAULT_CODEX_IDLE_EVENT_TIMEOUT` and dual-writes `loom.toml.example`.

**Test:** `test_codex_provider_idle_event_timeout_defaults_to_300` — default + explicit-override (incl. 0 opt-out).

Closes #469, closes #470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)