### PR TITLE
feat: create_discord_forum_post — autonomy forum publishing

### DIFF
--- a/autonomy/schedules.example.toml
+++ b/autonomy/schedules.example.toml
@@ -20,6 +20,11 @@
 # ``scope_grants`` — otherwise a GUARDED run gets denied. ``cron`` strings are
 # UTC (hand-convert from local time); the per-schedule ``timezone`` field is
 # currently a no-op.
+#
+# Discord forum publishing: a schedule with no bound thread can still publish
+# by creating a forum post via ``create_discord_forum_post`` (allowed_tools).
+# The target forum defaults to ``DISCORD_NEWS_FORUM_ID`` in ``.env``; pass
+# ``forum_channel_id`` to the tool to override. See 範例 4b below.
 
 # ── 範例 1: 每日記憶整理（dream + housekeeping） ─────────────────
 [[schedules]]
@@ -74,6 +79,26 @@ allowed_tools = ["write_file", "web_search"]
   type     = "discord_thread"
   id       = "REPLACE_WITH_THREAD_ID"   # 部署細節（非 secret）；放本檔不入 git
   fallback = "skip"
+
+# ── 範例 4b: 論壇發布（自建貼文，無需綁定討論串） ─────────────────
+# 一般 planner 排程（非 chime），跑在 autonomy session 上。寫完文件後呼叫
+# create_discord_forum_post 把「說明＋新聞文件」發成一則論壇貼文。
+# 論壇預設取 .env 的 DISCORD_NEWS_FORUM_ID。
+[[schedules]]
+name          = "news_forum_post"
+cron          = "0 1 * * *"
+intent        = """產製今日晨報，寫入 news/YYYY-MM-DD/ 後，呼叫
+  create_discord_forum_post(
+    title="YYYY-MM-DD 晨報",
+    content=<晨報導讀摘要>,
+    files=["news/YYYY-MM-DD/daily_briefing.md", ...其餘分軌檔],
+  )
+把說明文字＋新聞文件一次發成論壇貼文（forum 取 .env 預設）。"""
+trust_level   = "safe"
+allowed_tools = ["write_file", "web_search", "create_discord_forum_post"]
+scope_grants  = [
+  { resource = "path", action = "write", selector = "news" },
+]
 
 # ── 範例 5: event trigger（外部訊號觸發） ─────────────────────────
 [[triggers]]

--- a/autonomy/schedules.example.toml
+++ b/autonomy/schedules.example.toml
@@ -84,6 +84,11 @@ allowed_tools = ["write_file", "web_search"]
 # 一般 planner 排程（非 chime），跑在 autonomy session 上。寫完文件後呼叫
 # create_discord_forum_post 把「說明＋新聞文件」發成一則論壇貼文。
 # 論壇預設取 .env 的 DISCORD_NEWS_FORUM_ID。
+#
+# 註：create_discord_forum_post 本身是 GUARDED 工具。schedule 的
+# trust_level = "safe" 不會降低它的等級——autonomy session 會把 confirm 導到
+# Discord notify channel 按鈕，所以發布前仍走授權（與 schedule trust level 不衝突）。
+# 也因此 schedule 必須在 allowed_tools 明列它才會被授權。
 [[schedules]]
 name          = "news_forum_post"
 cron          = "0 1 * * *"
@@ -93,9 +98,10 @@ intent        = """產製今日晨報，寫入 news/YYYY-MM-DD/ 後，呼叫
     content=<晨報導讀摘要>,
     files=["news/YYYY-MM-DD/daily_briefing.md", ...其餘分軌檔],
   )
-把說明文字＋新聞文件一次發成論壇貼文（forum 取 .env 預設）。"""
+把說明文字＋新聞文件一次發成論壇貼文（forum 取 .env 預設），
+再用 read_discord_forum（list 模式）確認貼文出現在論壇清單。"""
 trust_level   = "safe"
-allowed_tools = ["write_file", "web_search", "create_discord_forum_post"]
+allowed_tools = ["write_file", "web_search", "create_discord_forum_post", "read_discord_forum"]
 scope_grants  = [
   { resource = "path", action = "write", selector = "news" },
 ]

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -2791,6 +2791,23 @@ async def _discord_with_autonomy(
     session = LoomSession(model=model, db_path=db)
     await session.start()
 
+    # The autonomy session has no bound thread, so the per-thread Discord
+    # tools aren't registered here. Give it the one tool that creates its own
+    # destination: a forum post. This is the publish path for schedules like
+    # the daily morning briefing (forum from DISCORD_NEWS_FORUM_ID). We only
+    # register it — per-schedule `allowed_tools` does the authorize/revoke.
+    import os as _os
+
+    from loom.platform.discord.tools import make_create_discord_forum_post_tool
+    _forum_id = _os.getenv("DISCORD_NEWS_FORUM_ID")
+    session.registry.register(
+        make_create_discord_forum_post_tool(
+            bot._client,
+            session.workspace,
+            default_forum_id=int(_forum_id) if _forum_id else None,
+        )
+    )
+
     # Patch autonomy session's confirm → Discord notify channel button,
     # same as thread sessions. Without this, GUARDED tool confirmations
     # fall through to the CLI prompt (Allow? [y/N]:) on shutdown.

--- a/loom/platform/cli/main.py
+++ b/loom/platform/cli/main.py
@@ -2792,21 +2792,27 @@ async def _discord_with_autonomy(
     await session.start()
 
     # The autonomy session has no bound thread, so the per-thread Discord
-    # tools aren't registered here. Give it the one tool that creates its own
-    # destination: a forum post. This is the publish path for schedules like
-    # the daily morning briefing (forum from DISCORD_NEWS_FORUM_ID). We only
-    # register it — per-schedule `allowed_tools` does the authorize/revoke.
-    import os as _os
-
-    from loom.platform.discord.tools import make_create_discord_forum_post_tool
-    _forum_id = _os.getenv("DISCORD_NEWS_FORUM_ID")
-    session.registry.register(
-        make_create_discord_forum_post_tool(
-            bot._client,
-            session.workspace,
-            default_forum_id=int(_forum_id) if _forum_id else None,
-        )
+    # tools aren't registered here. Give it the two that create / verify their
+    # own destination: forum publish + forum read. This is the publish path
+    # for schedules like the daily morning briefing. We only register —
+    # per-schedule `allowed_tools` does the authorize/revoke. Gated on
+    # DISCORD_NEWS_FORUM_ID: unset ⇒ don't register (honest tool-not-found
+    # rather than a runtime error inside a schedule run).
+    from loom.platform.discord.tools import (
+        make_create_discord_forum_post_tool,
+        make_read_discord_forum_tool,
+        resolve_news_forum_id,
     )
+    _forum_id = resolve_news_forum_id()
+    if _forum_id is not None:
+        session.registry.register(
+            make_create_discord_forum_post_tool(
+                bot._client, session.workspace, default_forum_id=_forum_id,
+            )
+        )
+        session.registry.register(
+            make_read_discord_forum_tool(bot._client, default_forum_id=_forum_id)
+        )
 
     # Patch autonomy session's confirm → Discord notify channel button,
     # same as thread sessions. Without this, GUARDED tool confirmations

--- a/loom/platform/discord/bot.py
+++ b/loom/platform/discord/bot.py
@@ -97,9 +97,12 @@ from loom.platform.cli.ui import (
 from loom.autonomy.chime import ChimeRequest, format_chime_content
 from loom.platform.discord.tools import (
     make_add_discord_reaction_tool,
+    make_create_discord_forum_post_tool,
+    make_read_discord_forum_tool,
     make_send_discord_embed_tool,
     make_send_discord_file_tool,
     make_send_discord_select_tool,
+    resolve_news_forum_id,
 )
 from loom.platform.discord.reactions import REACTION
 
@@ -694,6 +697,25 @@ class LoomDiscordBot:
         session.perm.authorize("send_discord_embed")
         session.perm.authorize("send_discord_select")
         session.perm.authorize("add_discord_reaction")
+
+        # Forum publish + read (issue: thread-session 絲絲 also needs to post to
+        # and verify the news forum, not just the autonomy daemon). Gated on
+        # DISCORD_NEWS_FORUM_ID being configured. The read tool is SAFE and
+        # pre-authorized like the other read-ish Discord tools; the publish
+        # tool stays GUARDED and is *not* pre-authorized — creating a public
+        # forum post warrants the human confirm button, unlike sending a file
+        # into the current thread.
+        _forum_id = resolve_news_forum_id()
+        if _forum_id is not None:
+            session.registry.register(
+                make_create_discord_forum_post_tool(
+                    self._client, session.workspace, default_forum_id=_forum_id,
+                )
+            )
+            session.registry.register(
+                make_read_discord_forum_tool(self._client, default_forum_id=_forum_id)
+            )
+            session.perm.authorize("read_discord_forum")
 
         confirm_fn = self._make_confirm_fn(thread_id)
         for mw in session._pipeline._middlewares:

--- a/loom/platform/discord/tools.py
+++ b/loom/platform/discord/tools.py
@@ -25,6 +25,11 @@ _SELECT_DESCRIPTION_MAX = 100
 _SELECT_TIMEOUT_DEFAULT = 60
 _SELECT_TIMEOUT_MAX = 600  # 10 min — anything longer is almost certainly a bug
 
+# Discord forum-post hard limits.
+_FORUM_TITLE_MAX = 100      # thread name cap (same as any thread)
+_MESSAGE_CONTENT_MAX = 2000  # per-message content cap
+_FORUM_FILES_MAX = 10       # attachments per message
+
 def make_send_discord_file_tool(client: discord.Client, thread_id: int, workspace: Path) -> ToolDefinition:
     async def executor(call: ToolCall) -> ToolResult:
         import discord as _discord
@@ -470,6 +475,230 @@ def make_send_discord_select_tool(
                 },
             },
             "required": ["title", "options"],
+        },
+        executor=executor,
+    )
+
+
+def _validate_forum_post_args(args: dict[str, Any], *, has_default_forum: bool) -> str | None:
+    """Return an error string if forum-post args are unusable, else None.
+
+    Mirrors ``_validate_select_args`` — fail before touching Discord so the
+    agent gets a clean tool error instead of a 400 from the API. An
+    over-length title is *not* rejected here; the executor truncates it to
+    the thread-name cap (matches how the agent often pastes a date + headline
+    without counting characters).
+    """
+    title = args.get("title")
+    if not isinstance(title, str) or not title.strip():
+        return "Missing or empty 'title'."
+
+    content = args.get("content")
+    if not isinstance(content, str) or not content:
+        return "Missing or empty 'content'."
+
+    if args.get("forum_channel_id") is None and not has_default_forum:
+        return "No forum channel — pass 'forum_channel_id' or set DISCORD_NEWS_FORUM_ID."
+
+    files = args.get("files")
+    if files is not None and not isinstance(files, list):
+        return "'files' must be a list of workspace-relative paths."
+
+    tags = args.get("tags")
+    if tags is not None and not isinstance(tags, list):
+        return "'tags' must be a list of tag names."
+
+    return None
+
+
+def _chunk_content(content: str, size: int = _MESSAGE_CONTENT_MAX) -> list[str]:
+    """Split ``content`` into ≤``size`` pieces, preferring newline boundaries.
+
+    Returns at least one chunk (possibly empty) so the post always carries an
+    initial body. Greedy line-packing keeps paragraphs intact where possible;
+    a single over-long line is hard-split as a fallback.
+    """
+    if len(content) <= size:
+        return [content]
+
+    chunks: list[str] = []
+    buf = ""
+    for line in content.splitlines(keepends=True):
+        while len(line) > size:
+            # Single line longer than a whole message — hard-split it.
+            if buf:
+                chunks.append(buf)
+                buf = ""
+            chunks.append(line[:size])
+            line = line[size:]
+        if len(buf) + len(line) > size:
+            chunks.append(buf)
+            buf = line
+        else:
+            buf += line
+    if buf:
+        chunks.append(buf)
+    return chunks or [""]
+
+
+def make_create_discord_forum_post_tool(
+    client: discord.Client,
+    workspace: Path,
+    *,
+    default_forum_id: int | None = None,
+) -> ToolDefinition:
+    """Tool factory for ``create_discord_forum_post``.
+
+    Unlike the other Discord tools (bound to one thread), this one **creates**
+    a new forum post (= a thread inside a ``ForumChannel``) on demand. It is
+    the publish path for autonomy schedules that have no bound thread — e.g.
+    the daily morning briefing. The forum is taken from ``forum_channel_id``
+    when supplied, else ``default_forum_id`` (wired from
+    ``DISCORD_NEWS_FORUM_ID``).
+
+    Long bodies are split across the post + follow-up messages (Discord caps a
+    single message at 2000 chars). Files are validated workspace-relative,
+    exactly like ``make_send_discord_file_tool``.
+    """
+    async def executor(call: ToolCall) -> ToolResult:
+        import discord as _discord
+
+        err = _validate_forum_post_args(
+            call.args, has_default_forum=default_forum_id is not None
+        )
+        if err:
+            return ToolResult(call.id, call.tool_name, False, error=err)
+
+        raw_fid = call.args.get("forum_channel_id")
+        try:
+            forum_id = int(raw_fid) if raw_fid is not None else int(default_forum_id)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return ToolResult(call.id, call.tool_name, False, error="Invalid 'forum_channel_id'.")
+
+        # Resolve workspace-relative files up front — reject escapes before we
+        # publish anything (a half-created post would be worse).
+        file_paths: list[Path] = []
+        for rel in call.args.get("files", []) or []:
+            target = (workspace / str(rel)).resolve()
+            if not target.is_relative_to(workspace):
+                return ToolResult(
+                    call.id, call.tool_name, False,
+                    error=f"Cannot attach files outside the workspace: {rel}",
+                )
+            if not target.exists() or not target.is_file():
+                return ToolResult(
+                    call.id, call.tool_name, False,
+                    error=f"File not found or is a directory: {rel}",
+                )
+            file_paths.append(target)
+
+        forum = client.get_channel(forum_id)
+        if forum is None:
+            try:
+                forum = await client.fetch_channel(forum_id)
+            except Exception as e:  # NotFound / Forbidden / HTTPException
+                return ToolResult(
+                    call.id, call.tool_name, False,
+                    error=f"Forum channel {forum_id} not found or inaccessible: {e}",
+                )
+        if not isinstance(forum, _discord.ForumChannel):
+            return ToolResult(
+                call.id, call.tool_name, False,
+                error=f"Channel {forum_id} is not a forum channel ({type(forum).__name__}).",
+            )
+
+        title: str = call.args["title"].strip()[:_FORUM_TITLE_MAX]
+        chunks = _chunk_content(call.args["content"])
+
+        # Match requested tag names against the forum's available tags
+        # (case-insensitive); unknown names are dropped rather than erroring.
+        applied_tags = []
+        requested = {str(t).lower() for t in (call.args.get("tags") or [])}
+        if requested:
+            applied_tags = [
+                t for t in getattr(forum, "available_tags", [])
+                if t.name.lower() in requested
+            ]
+
+        first_files = [_discord.File(str(p)) for p in file_paths[:_FORUM_FILES_MAX]]
+        try:
+            created = await forum.create_thread(
+                name=title,
+                # Forum posts require a non-empty body; zero-width space is the
+                # graceful floor when the agent passes empty content.
+                content=chunks[0] or "​",
+                files=first_files,
+                applied_tags=applied_tags,
+            )
+        except Exception as e:
+            return ToolResult(call.id, call.tool_name, False, error=f"Failed to create forum post: {e}")
+
+        thread = created.thread
+
+        # Remaining body chunks + overflow files go in as follow-up messages.
+        try:
+            for chunk in chunks[1:]:
+                await thread.send(chunk)
+            overflow = file_paths[_FORUM_FILES_MAX:]
+            for i in range(0, len(overflow), _FORUM_FILES_MAX):
+                batch = [_discord.File(str(p)) for p in overflow[i:i + _FORUM_FILES_MAX]]
+                await thread.send(files=batch)
+        except Exception as e:
+            # The post exists; report partial success so the agent doesn't retry
+            # the whole thing and double-post.
+            return ToolResult(
+                call.id, call.tool_name, True,
+                output={
+                    "thread_id": thread.id,
+                    "jump_url": getattr(thread, "jump_url", None),
+                    "warning": f"Post created but a follow-up message failed: {e}",
+                },
+            )
+
+        return ToolResult(
+            call.id, call.tool_name, True,
+            output={"thread_id": thread.id, "jump_url": getattr(thread, "jump_url", None)},
+        )
+
+    return ToolDefinition(
+        name="create_discord_forum_post",
+        description=(
+            "Create a new post in a Discord forum channel — a titled thread "
+            "with a body, used to publish standalone artifacts (e.g. a daily "
+            "news briefing) when you have no bound thread to write into. Long "
+            "bodies are split automatically across follow-up messages. Attach "
+            "workspace files via 'files' (e.g. a generated image). The forum "
+            "defaults to DISCORD_NEWS_FORUM_ID; pass 'forum_channel_id' to "
+            "target a different forum. Returns {thread_id, jump_url}."
+        ),
+        trust_level=TrustLevel.GUARDED,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": f"Post title / thread name (truncated to {_FORUM_TITLE_MAX} chars).",
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Post body. Split automatically if over 2000 chars.",
+                },
+                "forum_channel_id": {
+                    "type": "integer",
+                    "description": "Optional. Forum channel id; defaults to DISCORD_NEWS_FORUM_ID.",
+                },
+                "files": {
+                    "type": "array",
+                    "description": "Optional workspace-relative file paths to attach.",
+                    "items": {"type": "string"},
+                },
+                "tags": {
+                    "type": "array",
+                    "description": "Optional forum tag names (matched case-insensitively; unknowns ignored).",
+                    "items": {"type": "string"},
+                },
+            },
+            "required": ["title", "content"],
         },
         executor=executor,
     )

--- a/loom/platform/discord/tools.py
+++ b/loom/platform/discord/tools.py
@@ -6,6 +6,8 @@ Provides capabilities to send files and rich embeds directly to the Discord thre
 from __future__ import annotations
 
 import asyncio
+import logging
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -15,6 +17,31 @@ if TYPE_CHECKING:
 from loom.core.harness.registry import ToolDefinition
 from loom.core.harness.permissions import TrustLevel
 from loom.core.harness.middleware import ToolCall, ToolResult
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_news_forum_id() -> int | None:
+    """Read ``DISCORD_NEWS_FORUM_ID`` from env as an int, else ``None``.
+
+    Shared by the autonomy-session and per-thread-session wiring so both
+    decide "register the forum tools at all?" identically: a missing or
+    malformed value means **don't register** (an honest tool-not-found at
+    call time, matching how other env-gated tools behave) rather than a
+    runtime error deep inside a schedule run.
+    """
+    raw = os.getenv("DISCORD_NEWS_FORUM_ID")
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "DISCORD_NEWS_FORUM_ID is set but not a valid int: %r — "
+            "forum tools will not be registered",
+            raw,
+        )
+        return None
 
 
 # Discord SelectMenu hard limits — surface as constants so callers and tests
@@ -607,7 +634,9 @@ def make_create_discord_forum_post_tool(
                 error=f"Channel {forum_id} is not a forum channel ({type(forum).__name__}).",
             )
 
-        title: str = call.args["title"].strip()[:_FORUM_TITLE_MAX]
+        raw_title: str = call.args["title"].strip()
+        title = raw_title[:_FORUM_TITLE_MAX]
+        title_truncated = len(raw_title) > _FORUM_TITLE_MAX
         chunks = _chunk_content(call.args["content"])
 
         # Match requested tag names against the forum's available tags
@@ -616,7 +645,7 @@ def make_create_discord_forum_post_tool(
         requested = {str(t).lower() for t in (call.args.get("tags") or [])}
         if requested:
             applied_tags = [
-                t for t in getattr(forum, "available_tags", [])
+                t for t in forum.available_tags
                 if t.name.lower() in requested
             ]
 
@@ -651,13 +680,20 @@ def make_create_discord_forum_post_tool(
                 output={
                     "thread_id": thread.id,
                     "jump_url": getattr(thread, "jump_url", None),
+                    "title": title,
+                    "title_truncated": title_truncated,
                     "warning": f"Post created but a follow-up message failed: {e}",
                 },
             )
 
         return ToolResult(
             call.id, call.tool_name, True,
-            output={"thread_id": thread.id, "jump_url": getattr(thread, "jump_url", None)},
+            output={
+                "thread_id": thread.id,
+                "jump_url": getattr(thread, "jump_url", None),
+                "title": title,
+                "title_truncated": title_truncated,
+            },
         )
 
     return ToolDefinition(
@@ -699,6 +735,153 @@ def make_create_discord_forum_post_tool(
                 },
             },
             "required": ["title", "content"],
+        },
+        executor=executor,
+    )
+
+
+def make_read_discord_forum_tool(
+    client: discord.Client,
+    *,
+    default_forum_id: int | None = None,
+) -> ToolDefinition:
+    """Tool factory for ``read_discord_forum`` — the verify side of
+    ``create_discord_forum_post``.
+
+    Two modes:
+    - **list** (no ``thread_id``): the most recent posts in the forum, so the
+      agent can confirm its own post landed (title / id / url / created_at).
+      Active threads plus recent archived threads, newest first.
+    - **detail** (``thread_id`` given): that post's title, url, and starter
+      message body — so the agent can read back what it actually published.
+
+    Read-only ⇒ ``TrustLevel.SAFE``. Forum defaults to DISCORD_NEWS_FORUM_ID.
+    """
+    async def executor(call: ToolCall) -> ToolResult:
+        import discord as _discord
+
+        raw_fid = call.args.get("forum_channel_id")
+        try:
+            forum_id = int(raw_fid) if raw_fid is not None else (
+                int(default_forum_id) if default_forum_id is not None else None
+            )
+        except (TypeError, ValueError):
+            return ToolResult(call.id, call.tool_name, False, error="Invalid 'forum_channel_id'.")
+        if forum_id is None:
+            return ToolResult(
+                call.id, call.tool_name, False,
+                error="No forum channel — pass 'forum_channel_id' or set DISCORD_NEWS_FORUM_ID.",
+            )
+
+        # Detail mode: read one post back.
+        thread_id = call.args.get("thread_id")
+        if thread_id is not None:
+            try:
+                tid = int(thread_id)
+            except (TypeError, ValueError):
+                return ToolResult(call.id, call.tool_name, False, error="Invalid 'thread_id'.")
+            thread = client.get_channel(tid)
+            if thread is None:
+                try:
+                    thread = await client.fetch_channel(tid)
+                except Exception as e:
+                    return ToolResult(
+                        call.id, call.tool_name, False,
+                        error=f"Post {tid} not found or inaccessible: {e}",
+                    )
+            # The starter message of a forum post shares the thread's id.
+            content = ""
+            try:
+                msg = getattr(thread, "starter_message", None)
+                if msg is None:
+                    msg = await thread.fetch_message(tid)
+                content = msg.content if msg else ""
+            except Exception:
+                content = ""
+            return ToolResult(
+                call.id, call.tool_name, True,
+                output={
+                    "thread_id": getattr(thread, "id", tid),
+                    "title": getattr(thread, "name", None),
+                    "jump_url": getattr(thread, "jump_url", None),
+                    "content": content,
+                },
+            )
+
+        # List mode: recent posts in the forum.
+        limit = call.args.get("limit", 10)
+        try:
+            limit = max(1, min(int(limit), 50))
+        except (TypeError, ValueError):
+            limit = 10
+
+        forum = client.get_channel(forum_id)
+        if forum is None:
+            try:
+                forum = await client.fetch_channel(forum_id)
+            except Exception as e:
+                return ToolResult(
+                    call.id, call.tool_name, False,
+                    error=f"Forum channel {forum_id} not found or inaccessible: {e}",
+                )
+        if not isinstance(forum, _discord.ForumChannel):
+            return ToolResult(
+                call.id, call.tool_name, False,
+                error=f"Channel {forum_id} is not a forum channel ({type(forum).__name__}).",
+            )
+
+        def _row(t, *, archived: bool) -> dict[str, Any]:
+            created = getattr(t, "created_at", None)
+            return {
+                "thread_id": getattr(t, "id", None),
+                "title": getattr(t, "name", None),
+                "jump_url": getattr(t, "jump_url", None),
+                "created_at": created.isoformat() if created else None,
+                "archived": archived,
+            }
+
+        posts: list[dict[str, Any]] = [_row(t, archived=False) for t in list(forum.threads)]
+        try:
+            async for t in forum.archived_threads(limit=limit):
+                posts.append(_row(t, archived=True))
+        except Exception:
+            # Missing read-history permission etc. — active threads still useful.
+            pass
+
+        # Newest first; None created_at sinks to the bottom deterministically.
+        posts.sort(key=lambda p: p["created_at"] or "", reverse=True)
+        return ToolResult(
+            call.id, call.tool_name, True,
+            output={"forum_channel_id": forum_id, "count": len(posts[:limit]), "posts": posts[:limit]},
+        )
+
+    return ToolDefinition(
+        name="read_discord_forum",
+        description=(
+            "Read a Discord forum channel — list its most recent posts "
+            "(title / id / url / created_at, newest first), or pass "
+            "'thread_id' to read one post's title and starter-message body. "
+            "Use this to verify a post you created with "
+            "create_discord_forum_post actually landed. Forum defaults to "
+            "DISCORD_NEWS_FORUM_ID; pass 'forum_channel_id' to read another."
+        ),
+        trust_level=TrustLevel.SAFE,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "forum_channel_id": {
+                    "type": "integer",
+                    "description": "Optional. Forum channel id; defaults to DISCORD_NEWS_FORUM_ID.",
+                },
+                "thread_id": {
+                    "type": "integer",
+                    "description": "Optional. If given, read this post's body instead of listing.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "List mode only. Max posts to return (1–50, default 10).",
+                },
+            },
         },
         executor=executor,
     )

--- a/tests/test_discord_forum_post_tool.py
+++ b/tests/test_discord_forum_post_tool.py
@@ -19,8 +19,11 @@ from loom.core.harness.permissions import TrustLevel
 from loom.platform.discord.tools import (
     _FORUM_TITLE_MAX,
     _MESSAGE_CONTENT_MAX,
+    _chunk_content,
     _validate_forum_post_args,
     make_create_discord_forum_post_tool,
+    make_read_discord_forum_tool,
+    resolve_news_forum_id,
 )
 
 
@@ -146,6 +149,36 @@ async def test_overlong_title_truncated_on_post(tmp_path: Path):
     )
     assert res.success
     assert len(forum.create_thread.await_args.kwargs["name"]) == _FORUM_TITLE_MAX
+    # The agent is told its title was clipped (review P3).
+    assert res.output["title_truncated"] is True
+    assert len(res.output["title"]) == _FORUM_TITLE_MAX
+
+
+async def test_short_title_not_flagged_truncated(tmp_path: Path):
+    forum, _ = _forum_with_thread()
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=forum)
+
+    tool = make_create_discord_forum_post_tool(
+        client, tmp_path, default_forum_id=1515
+    )
+    res = await tool.executor(_call({"title": "短標題", "content": "c"}))
+    assert res.success
+    assert res.output["title_truncated"] is False
+
+
+async def test_get_channel_none_falls_back_to_fetch(tmp_path: Path):
+    forum, thread = _forum_with_thread()
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=None)
+    client.fetch_channel = AsyncMock(return_value=forum)
+
+    tool = make_create_discord_forum_post_tool(
+        client, tmp_path, default_forum_id=1515
+    )
+    res = await tool.executor(_call({"title": "t", "content": "c"}))
+    assert res.success
+    client.fetch_channel.assert_awaited_once_with(1515)
 
 
 async def test_long_content_splits_into_followups(tmp_path: Path):
@@ -255,3 +288,179 @@ def test_tool_definition_metadata(tmp_path: Path):
     assert tool.trust_level == TrustLevel.GUARDED
     assert "title" in tool.input_schema["required"]
     assert "content" in tool.input_schema["required"]
+
+
+# ── _chunk_content boundaries (review P3) ────────────────────────────────────
+
+
+def test_chunk_empty_returns_single_empty():
+    assert _chunk_content("") == [""]
+
+
+def test_chunk_exactly_at_limit_stays_one():
+    s = "a" * _MESSAGE_CONTENT_MAX
+    chunks = _chunk_content(s)
+    assert len(chunks) == 1
+    assert chunks[0] == s
+
+
+def test_chunk_single_long_line_hard_split():
+    # A single line with no newlines, 2.5× the cap → 3 chunks, all ≤ cap.
+    s = "x" * (_MESSAGE_CONTENT_MAX * 2 + _MESSAGE_CONTENT_MAX // 2)
+    chunks = _chunk_content(s)
+    assert len(chunks) == 3
+    assert all(len(c) <= _MESSAGE_CONTENT_MAX for c in chunks)
+    assert "".join(chunks) == s
+
+
+def test_chunk_prefers_newline_boundaries():
+    line = "a" * (_MESSAGE_CONTENT_MAX - 10) + "\n"
+    chunks = _chunk_content(line + line)  # two lines, each near the cap
+    assert len(chunks) == 2
+    assert all(len(c) <= _MESSAGE_CONTENT_MAX for c in chunks)
+
+
+# ── resolve_news_forum_id (review P2 — env-gated registration) ───────────────
+
+
+def test_resolve_forum_id_unset(monkeypatch):
+    monkeypatch.delenv("DISCORD_NEWS_FORUM_ID", raising=False)
+    assert resolve_news_forum_id() is None
+
+
+def test_resolve_forum_id_valid(monkeypatch):
+    monkeypatch.setenv("DISCORD_NEWS_FORUM_ID", "1515038365085470781")
+    assert resolve_news_forum_id() == 1515038365085470781
+
+
+def test_resolve_forum_id_malformed_returns_none(monkeypatch):
+    monkeypatch.setenv("DISCORD_NEWS_FORUM_ID", "not-an-int")
+    assert resolve_news_forum_id() is None
+
+
+# ── read_discord_forum ───────────────────────────────────────────────────────
+
+
+def _read_call(args: dict) -> ToolCall:
+    return ToolCall(
+        tool_name="read_discord_forum",
+        args=args,
+        trust_level=TrustLevel.SAFE,
+        session_id="test-session",
+    )
+
+
+def _post(tid: int, name: str, created_iso: str):
+    from datetime import datetime
+
+    t = MagicMock()
+    t.id = tid
+    t.name = name
+    t.jump_url = f"https://discord.com/channels/1/2/{tid}"
+    t.created_at = datetime.fromisoformat(created_iso)
+    return t
+
+
+def _async_iter(items):
+    async def _gen(*a, **k):
+        for it in items:
+            yield it
+
+    return _gen
+
+
+async def test_read_lists_recent_posts_newest_first():
+    forum = MagicMock(spec=discord.ForumChannel)
+    forum.threads = [_post(1, "舊文", "2026-06-10T00:00:00+00:00")]
+    forum.archived_threads = _async_iter(
+        [_post(2, "新文", "2026-06-13T00:00:00+00:00")]
+    )
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=forum)
+
+    tool = make_read_discord_forum_tool(client, default_forum_id=1515)
+    res = await tool.executor(_read_call({}))
+    assert res.success
+    assert res.output["count"] == 2
+    assert res.output["posts"][0]["thread_id"] == 2  # newest first
+    assert res.output["posts"][0]["archived"] is True
+
+
+async def test_read_archived_permission_error_still_returns_active():
+    forum = MagicMock(spec=discord.ForumChannel)
+    forum.threads = [_post(1, "active", "2026-06-13T00:00:00+00:00")]
+
+    def _boom(*a, **k):
+        raise discord.Forbidden(MagicMock(), "no perms")
+
+    forum.archived_threads = _boom
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=forum)
+
+    tool = make_read_discord_forum_tool(client, default_forum_id=1515)
+    res = await tool.executor(_read_call({}))
+    assert res.success
+    assert res.output["count"] == 1
+
+
+async def test_read_detail_returns_starter_body():
+    starter = MagicMock()
+    starter.content = "晨報內文"
+    thread = MagicMock()
+    thread.id = 999
+    thread.name = "晨報"
+    thread.jump_url = "https://discord.com/channels/1/2/999"
+    thread.starter_message = starter
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=thread)
+
+    tool = make_read_discord_forum_tool(client, default_forum_id=1515)
+    res = await tool.executor(_read_call({"thread_id": 999}))
+    assert res.success
+    assert res.output["content"] == "晨報內文"
+    assert res.output["title"] == "晨報"
+
+
+async def test_read_detail_fetches_message_when_no_starter_cache():
+    msg = MagicMock()
+    msg.content = "fetched body"
+    thread = MagicMock()
+    thread.id = 999
+    thread.name = "t"
+    thread.jump_url = "u"
+    thread.starter_message = None
+    thread.fetch_message = AsyncMock(return_value=msg)
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=thread)
+
+    tool = make_read_discord_forum_tool(client, default_forum_id=1515)
+    res = await tool.executor(_read_call({"thread_id": 999}))
+    assert res.success
+    assert res.output["content"] == "fetched body"
+    thread.fetch_message.assert_awaited_once_with(999)
+
+
+async def test_read_non_forum_channel_clean_error():
+    not_forum = MagicMock(spec=discord.TextChannel)
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=not_forum)
+
+    tool = make_read_discord_forum_tool(client, default_forum_id=1515)
+    res = await tool.executor(_read_call({}))
+    assert not res.success
+    assert "forum" in res.error.lower()
+
+
+async def test_read_missing_forum_id_clean_error():
+    client = MagicMock()
+    tool = make_read_discord_forum_tool(client, default_forum_id=None)
+    res = await tool.executor(_read_call({}))
+    assert not res.success
+    assert "forum" in res.error.lower()
+
+
+def test_read_tool_definition_metadata():
+    client = MagicMock()
+    tool = make_read_discord_forum_tool(client, default_forum_id=1)
+    assert tool.name == "read_discord_forum"
+    assert tool.trust_level == TrustLevel.SAFE

--- a/tests/test_discord_forum_post_tool.py
+++ b/tests/test_discord_forum_post_tool.py
@@ -1,0 +1,257 @@
+"""`create_discord_forum_post` tool — validation + lifecycle contract tests.
+
+The agent's contract: every code path returns a clean ToolResult, no
+exceptions leak out. Live forum posting (real ForumChannel.create_thread,
+real message splitting on the wire) is mocked here; the visual side still
+wants one manual verification run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from loom.core.harness.middleware import ToolCall
+from loom.core.harness.permissions import TrustLevel
+from loom.platform.discord.tools import (
+    _FORUM_TITLE_MAX,
+    _MESSAGE_CONTENT_MAX,
+    _validate_forum_post_args,
+    make_create_discord_forum_post_tool,
+)
+
+
+def _call(args: dict) -> ToolCall:
+    return ToolCall(
+        tool_name="create_discord_forum_post",
+        args=args,
+        trust_level=TrustLevel.GUARDED,
+        session_id="test-session",
+    )
+
+
+# ── Validation ─────────────────────────────────────────────────────────────
+
+
+def test_validate_rejects_missing_title():
+    err = _validate_forum_post_args({"content": "hi"}, has_default_forum=True)
+    assert err and "title" in err.lower()
+
+
+def test_validate_rejects_empty_title():
+    err = _validate_forum_post_args(
+        {"title": "  ", "content": "hi"}, has_default_forum=True
+    )
+    assert err and "title" in err.lower()
+
+
+def test_validate_rejects_missing_content():
+    err = _validate_forum_post_args({"title": "t"}, has_default_forum=True)
+    assert err and "content" in err.lower()
+
+
+def test_validate_rejects_no_forum_id_without_default():
+    err = _validate_forum_post_args(
+        {"title": "t", "content": "c"}, has_default_forum=False
+    )
+    assert err and "forum" in err.lower()
+
+
+def test_validate_accepts_explicit_forum_id_without_default():
+    err = _validate_forum_post_args(
+        {"title": "t", "content": "c", "forum_channel_id": 123},
+        has_default_forum=False,
+    )
+    assert err is None
+
+
+def test_validate_rejects_non_list_files():
+    err = _validate_forum_post_args(
+        {"title": "t", "content": "c", "files": "a.png"}, has_default_forum=True
+    )
+    assert err and "files" in err.lower()
+
+
+def test_validate_rejects_non_list_tags():
+    err = _validate_forum_post_args(
+        {"title": "t", "content": "c", "tags": "news"}, has_default_forum=True
+    )
+    assert err and "tags" in err.lower()
+
+
+def test_validate_accepts_overlong_title():
+    # Over-length title is truncated at execution, not rejected.
+    err = _validate_forum_post_args(
+        {"title": "x" * (_FORUM_TITLE_MAX + 50), "content": "c"},
+        has_default_forum=True,
+    )
+    assert err is None
+
+
+# ── Lifecycle (mocked Discord) ───────────────────────────────────────────────
+
+
+def _forum_with_thread():
+    """A mock ForumChannel whose create_thread returns (thread, message)."""
+    thread = MagicMock()
+    thread.id = 999
+    thread.jump_url = "https://discord.com/channels/1/2/999"
+    thread.send = AsyncMock()
+
+    created = MagicMock()
+    created.thread = thread
+    created.message = MagicMock()
+
+    forum = MagicMock(spec=discord.ForumChannel)
+    forum.available_tags = []
+    forum.create_thread = AsyncMock(return_value=created)
+    return forum, thread
+
+
+async def test_happy_path_returns_thread_id_and_url(tmp_path: Path):
+    forum, thread = _forum_with_thread()
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=forum)
+
+    tool = make_create_discord_forum_post_tool(
+        client, tmp_path, default_forum_id=1515
+    )
+    res = await tool.executor(_call({"title": "晨報", "content": "今天的新聞"}))
+
+    assert res.success, res.error
+    assert res.output["thread_id"] == 999
+    assert res.output["jump_url"] == thread.jump_url
+    forum.create_thread.assert_awaited_once()
+    # Title + first chunk land on the post itself.
+    kwargs = forum.create_thread.await_args.kwargs
+    assert kwargs["name"] == "晨報"
+    assert kwargs["content"] == "今天的新聞"
+    # Short content → no follow-up sends.
+    thread.send.assert_not_awaited()
+
+
+async def test_overlong_title_truncated_on_post(tmp_path: Path):
+    forum, _ = _forum_with_thread()
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=forum)
+
+    tool = make_create_discord_forum_post_tool(
+        client, tmp_path, default_forum_id=1515
+    )
+    res = await tool.executor(
+        _call({"title": "y" * (_FORUM_TITLE_MAX + 30), "content": "c"})
+    )
+    assert res.success
+    assert len(forum.create_thread.await_args.kwargs["name"]) == _FORUM_TITLE_MAX
+
+
+async def test_long_content_splits_into_followups(tmp_path: Path):
+    forum, thread = _forum_with_thread()
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=forum)
+
+    tool = make_create_discord_forum_post_tool(
+        client, tmp_path, default_forum_id=1515
+    )
+    # 2.5 messages worth of content → 1 on the post + 2 follow-ups.
+    content = "a" * (_MESSAGE_CONTENT_MAX * 2 + 100)
+    res = await tool.executor(_call({"title": "t", "content": content}))
+
+    assert res.success
+    assert thread.send.await_count == 2
+
+
+async def test_explicit_forum_id_overrides_default(tmp_path: Path):
+    forum, _ = _forum_with_thread()
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=forum)
+
+    tool = make_create_discord_forum_post_tool(
+        client, tmp_path, default_forum_id=1515
+    )
+    await tool.executor(
+        _call({"title": "t", "content": "c", "forum_channel_id": 777})
+    )
+    client.get_channel.assert_called_once_with(777)
+
+
+async def test_non_forum_channel_clean_error(tmp_path: Path):
+    # A plain text channel is not a forum → clean tool error, no exception.
+    not_forum = MagicMock(spec=discord.TextChannel)
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=not_forum)
+
+    tool = make_create_discord_forum_post_tool(
+        client, tmp_path, default_forum_id=1515
+    )
+    res = await tool.executor(_call({"title": "t", "content": "c"}))
+    assert not res.success
+    assert "forum" in res.error.lower()
+
+
+async def test_channel_not_found_clean_error(tmp_path: Path):
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=None)
+    client.fetch_channel = AsyncMock(side_effect=discord.NotFound(MagicMock(), "nope"))
+
+    tool = make_create_discord_forum_post_tool(
+        client, tmp_path, default_forum_id=1515
+    )
+    res = await tool.executor(_call({"title": "t", "content": "c"}))
+    assert not res.success
+    assert res.error
+
+
+async def test_missing_forum_id_clean_error(tmp_path: Path):
+    client = MagicMock()
+    tool = make_create_discord_forum_post_tool(
+        client, tmp_path, default_forum_id=None
+    )
+    res = await tool.executor(_call({"title": "t", "content": "c"}))
+    assert not res.success
+    assert "forum" in res.error.lower()
+
+
+async def test_file_outside_workspace_rejected(tmp_path: Path):
+    forum, _ = _forum_with_thread()
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=forum)
+
+    tool = make_create_discord_forum_post_tool(
+        client, tmp_path, default_forum_id=1515
+    )
+    res = await tool.executor(
+        _call({"title": "t", "content": "c", "files": ["../escape.png"]})
+    )
+    assert not res.success
+    assert "workspace" in res.error.lower()
+    forum.create_thread.assert_not_awaited()
+
+
+async def test_attaches_workspace_file(tmp_path: Path):
+    forum, _ = _forum_with_thread()
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=forum)
+    (tmp_path / "quote.png").write_bytes(b"img")
+
+    tool = make_create_discord_forum_post_tool(
+        client, tmp_path, default_forum_id=1515
+    )
+    res = await tool.executor(
+        _call({"title": "t", "content": "c", "files": ["quote.png"]})
+    )
+    assert res.success
+    # File rides along on the post creation.
+    assert forum.create_thread.await_args.kwargs.get("files")
+
+
+def test_tool_definition_metadata(tmp_path: Path):
+    client = MagicMock()
+    tool = make_create_discord_forum_post_tool(client, tmp_path, default_forum_id=1)
+    assert tool.name == "create_discord_forum_post"
+    assert tool.trust_level == TrustLevel.GUARDED
+    assert "title" in tool.input_schema["required"]
+    assert "content" in tool.input_schema["required"]


### PR DESCRIPTION
## 背景

絲絲的 `morning_briefing` 排程每天產製四軌新聞晨報，但**從未真的貼進任何討論串**。

探索發現關鍵問題：autonomy daemon 的 session（`_discord_with_autonomy`）**沒有註冊任何 Discord 工具**——只有 per-thread session（`bot.py:_start_session`）會註冊 `send_discord_file` 等。所以 `morning_briefing` 的 `allowed_tools` 裡那個 `send_discord_file` 是「authorized 但不存在」，晨報只能透過 `Notification(REPORT)` 的截斷文字 body 送達 notify channel。

## 改動

新工具 **`create_discord_forum_post`**：不像其他 Discord 工具綁定單一 thread，它**自建目的地**（在 `ForumChannel` 裡開一則貼文）。把**說明文字（content）＋新聞文件（files）**一次發成論壇貼文。

- **`loom/platform/discord/tools.py`**：新 factory + `_validate_forum_post_args` + `_chunk_content`，GUARDED tier，沿用 `make_send_discord_file_tool` 既有模式。內文 >2000 字自動切塊（優先換行邊界），檔案 workspace-relative 驗證防越界，建立貼文夾帶 ≤10 檔、超過走 follow-up，forum tag 名稱 case-insensitive 比對。
- **`loom/platform/cli/main.py`**：在 autonomy session 註冊此工具，forum 取自 `DISCORD_NEWS_FORUM_ID`。只註冊、不 pre-authorize——授權/撤銷交給每條排程的 `allowed_tools`（`daemon.py:392`）。
- **`autonomy/schedules.example.toml`**：範例 4b + `.env` 說明，維持 onboarding spec 完整。
- **`tests/test_discord_forum_post_tool.py`**：18 個契約測試（validation + mocked lifecycle，TDD red→green）。

> 本機 gitignored config（不入此 PR）：`.env` 新增 `DISCORD_NEWS_FORUM_ID`；`autonomy/schedules.toml` 的 `morning_briefing` 改走此工具發布（content=導讀摘要、files=四軌+總摘要 .md）。

## 行為要點

- 非 ForumChannel / 找不到頻道 / 缺 forum id → 乾淨 ToolResult，不漏例外
- 貼文建好後 follow-up 失敗 → partial success（含 warning），避免 agent 重試導致重複貼文

## 測試

- `tests/test_discord_forum_post_tool.py`：18 passed
- 全套：2765 passed, 4 skipped

## 待人工驗證

論壇實際發布的視覺/分段效果由絲絲在 Discord 上 review + 試跑確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)