### PR TITLE
fix: content-address session-compress fact keys (#550)

### DIFF
--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import hashlib
 import os
 import time
 import uuid
@@ -204,6 +205,32 @@ Output as flowing prose. Be dense and accurate. Do not include any preamble.
 """
 
 
+def _session_fact_key(session_id: str, ts: str, fact: str) -> str:
+    """Content-addressed key for a single session-compression fact.
+
+    The leaf is a hash of the fact *content*, not a positional index. This
+    makes re-compression idempotent: the same fact always maps to the same
+    key, so a second pass over the same session (e.g. a background
+    compaction in-flight while ``stop()`` runs its own compress, both
+    landing in the same second and thus sharing ``ts``) no longer collides
+    slot-by-slot. Identical facts coincide on an identical key *and* value
+    (a no-op upsert); distinct facts get distinct keys.
+
+    Root cause of the drain-supersede false-positive chain (pursuit
+    ``drain-supersede-fp-tracking``, 11 logged events): positional
+    ``fact:<i>`` keys plus a second-resolution ``ts`` turned a shifted
+    re-extraction (the admission gate drops facts the first pass already
+    wrote, shifting the remainder up one slot) into N spurious tier-1
+    ``supersede`` contradictions — each slot's old value equalled the
+    previous slot's new value, the "off-by-one chain".
+
+    The first three segments (``session:<id>:<ts>``) are unchanged, so
+    ``consolidation._is_session_sibling`` grouping still holds.
+    """
+    digest = hashlib.sha1(fact.encode("utf-8")).hexdigest()[:12]
+    return f"session:{session_id}:{ts}:fact:{digest}"
+
+
 async def compress_session(
     session_id: str,
     episodic: EpisodicMemory,
@@ -257,12 +284,15 @@ async def compress_session(
         )
         facts = [r.fact for r in admission_results if r.admitted]
 
-    # Use a timestamp suffix so repeated compressions don't overwrite each other
+    # Timestamp groups one compression's facts under a shared provenance
+    # prefix; the per-fact leaf is content-addressed (see _session_fact_key)
+    # so a repeated/concurrent compression in the same second is idempotent
+    # rather than a chain of false tier-1 supersede contradictions.
     ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
     source = f"session:{session_id}"
-    for i, fact in enumerate(facts):
+    for fact in facts:
         entry = SemanticEntry(
-            key=f"session:{session_id}:{ts}:fact:{i}",
+            key=_session_fact_key(session_id, ts, fact),
             value=fact,
             confidence=0.8,
             source=source,

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -844,6 +844,104 @@ class TestCompressWithGovernance:
 
 
 # ===========================================================================
+# 7b. Regression: content-addressed session-fact keys
+#     (pursuit drain-supersede-fp-tracking — 11 logged false positives)
+# ===========================================================================
+
+class TestSessionFactKeyContentAddressed:
+    """Root-cause fix for the drain-supersede false-positive chain.
+
+    The compress path used ``session:<id>:<ts>:fact:<i>`` — a *positional*
+    index plus a *second-resolution* timestamp. When the same session was
+    compressed twice in the same second (e.g. a background compaction
+    in-flight while ``stop()`` runs its own compress), the second pass
+    re-extracted a fact list shifted by one position (the admission gate
+    drops facts the first pass already wrote). Every positional slot then
+    held a different value → a chain of spurious tier-1 ``supersede``
+    contradictions. Content-addressed keys make re-extraction idempotent.
+    """
+
+    def test_key_is_deterministic_for_same_fact(self):
+        from loom.core.session import _session_fact_key
+
+        k1 = _session_fact_key("sess", "20260613T020407", "DK 偏好 TypeScript")
+        k2 = _session_fact_key("sess", "20260613T020407", "DK 偏好 TypeScript")
+        assert k1 == k2
+
+    def test_distinct_facts_get_distinct_keys(self):
+        from loom.core.session import _session_fact_key
+
+        ts = "20260613T020407"
+        k_a = _session_fact_key("sess", ts, "fact about news pipeline")
+        k_b = _session_fact_key("sess", ts, "fact about DK health")
+        assert k_a != k_b
+
+    def test_key_preserves_session_sibling_prefix(self):
+        """consolidation._is_session_sibling groups by the first three
+        segments (``session:<id>:<ts>``). The content hash lives in the
+        leaf, so sibling grouping must be unaffected."""
+        from loom.core.session import _session_fact_key
+        from loom.core.cognition.consolidation import _is_session_sibling
+
+        ts = "20260613T020407"
+        k_a = _session_fact_key("sess", ts, "fact A")
+        k_b = _session_fact_key("sess", ts, "fact B")
+        assert k_a.startswith(f"session:sess:{ts}:fact:")
+        assert _is_session_sibling(k_a, k_b)
+
+    @pytest.mark.asyncio
+    async def test_recompression_same_second_no_false_supersede(
+        self, db, semantic, episodic
+    ):
+        """The regression itself: two compressions of one session in the
+        same second, where the second pass re-extracts a list shifted by
+        one position, must NOT clobber/supersede the first pass's facts.
+
+        Under the old positional scheme this produced N same-key value
+        changes (the FP chain). With content-addressed keys, each distinct
+        fact owns its own key, so the union survives intact.
+        """
+        from loom.core.session import compress_session, _session_fact_key
+
+        session_id = "recompress-sess"
+        pinned_ts = "20260613T020407"
+
+        async def run_once(facts: list[str]) -> None:
+            await episodic.write(EpisodicEntry(
+                session_id=session_id, event_type="user",
+                content="some session content to compress",
+            ))
+            mock_router = MagicMock()
+            mock_response = MagicMock()
+            mock_response.text = "".join(f"FACT: {f}\n" for f in facts)
+            mock_router.chat = AsyncMock(return_value=mock_response)
+            with patch("loom.core.session.datetime") as mock_dt:
+                mock_dt.now.return_value.strftime.return_value = pinned_ts
+                await compress_session(
+                    session_id, episodic, semantic,
+                    mock_router, "test-model",
+                )
+
+        first = ["fact alpha about news", "fact beta about health",
+                 "fact gamma about circadian"]
+        # Shifted by one: alpha dropped (already stored), delta appended.
+        shifted = ["fact beta about health", "fact gamma about circadian",
+                   "fact delta about philosophy"]
+
+        await run_once(first)
+        await run_once(shifted)
+
+        # Every distinct fact must occupy its own content-addressed key,
+        # holding exactly its own value — no slot clobbered another fact.
+        for fact in set(first) | set(shifted):
+            entry = await semantic.get(
+                _session_fact_key(session_id, pinned_ts, fact)
+            )
+            assert entry is not None, f"fact lost: {fact!r}"
+            assert entry.value == fact
+
+
+# ===========================================================================
 # 8. Backward Compatibility
 # ===========================================================================
 


### PR DESCRIPTION
Closes #550.

## Problem

`compress_session` keyed session-compression facts by **positional index** under a **second-resolution timestamp**: `session:<id>:<ts>:fact:<i>`. Two compressions of the same session in the same second (a background `_compact_memory` in-flight while `stop()` runs its own un-locked compress) re-extract a fact list shifted one slot by the admission gate, so each positional slot holds a different value → a chain of false tier-1 `supersede` contradictions.

This is the "off-by-one chain" the `drain-supersede-fp-tracking` pursuit logged **11 times (0 true positives)** over 2026-06-10→13. Confirmed against `memory.db` (session `fe2e71b0:...:fact:1..5`, each `existing[N] == proposed[N-1]`). The detector is correct — a same-key value change *is* a real contradiction; the bug is that the compress path manufactured spurious same-key collisions.

## Fix

Content-address the leaf: `fact:<sha1(fact)[:12]>` via a new `_session_fact_key(session_id, ts, fact)`. Re-compression becomes idempotent — identical facts coincide on the same key+value (no-op upsert), distinct facts get distinct keys, so a shifted re-extraction never produces a same-key value change. The `session:<id>:<ts>` prefix is preserved, so `consolidation._is_session_sibling` grouping (first-3-segments) is unaffected.

## Tests (TDD red→green)

`tests/test_governance.py::TestSessionFactKeyContentAddressed`:
- content-addressed determinism (same fact → same key)
- distinct facts → distinct keys
- sibling-prefix preserved (`_is_session_sibling` still groups)
- same-second re-compression regression (shifted list → no false supersede, union survives)

138 tests green across blast radius (governance, compaction subscriber, integration, consolidation/reconcile). `gitnexus detect_changes`: 2 files, risk LOW, 0 affected processes.

## Follow-up (not in this PR)

`stop()`'s `compress_session` runs outside `_compaction_lock`. This fix makes the race *harmless*; serialising stop-compress under the lock would close the race itself. Worth a separate issue if we want belt-and-suspenders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)