### PR TITLE
fix: drain convergent-dream backlog + harden diff-inventory (closes #553, #554)

### DIFF
--- a/loom/core/cognition/consolidation.py
+++ b/loom/core/cognition/consolidation.py
@@ -36,6 +36,7 @@ Design decisions
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
@@ -246,6 +247,127 @@ def _union_find_clusters(pairs: list[tuple[str, str]]) -> list[set[str]]:
 
 
 # ---------------------------------------------------------------------------
+# Cross-pass skip suppression (#553)
+# ---------------------------------------------------------------------------
+#
+# The dream re-derives the same clusters from the whole corpus every pass, so
+# without memory a per-pass cap leaves the overflow permanently unreachable and
+# stable skips get re-reviewed forever. We persist a *content-addressed*
+# signature for every cluster 絲絲 actually reviewed and skipped; later passes
+# filter those out (before the cap, so the backlog can drain). The signature
+# carries each member's ``updated_at``, so any edit to a member yields a new
+# signature and the cluster is automatically re-admitted for review.
+
+_META_KEY_SUPPRESSED = "consolidation_dream.suppressed_skips"
+_SUPPRESS_RETENTION_DAYS = 90.0   # aligns with the memory half-life
+
+
+def _cluster_signature(members) -> str:
+    """Stable, order-independent signature of a cluster's members.
+
+    Keyed by ``key@updated_at`` so a content change (which bumps ``updated_at``)
+    produces a different signature — the suppression auto-expires on edit.
+    """
+    parts = sorted(f"{m.key}@{m.updated_at.isoformat()}" for m in members)
+    return hashlib.sha256("\x00".join(parts).encode("utf-8")).hexdigest()
+
+
+async def load_suppressed_signatures(db) -> set[str]:
+    """Read the persisted skip-suppression set from ``memory_meta`` (#553).
+
+    Tolerant by contract: a missing or corrupt row reads as the empty set, so a
+    bad value can never wedge the dream into suppressing nothing-or-everything.
+    """
+    cursor = await db.execute(
+        "SELECT value FROM memory_meta WHERE key = ?", (_META_KEY_SUPPRESSED,)
+    )
+    row = await cursor.fetchone()
+    if not row or not row[0]:
+        return set()
+    try:
+        data = json.loads(row[0])
+    except (json.JSONDecodeError, TypeError):
+        return set()
+    if not isinstance(data, dict):
+        return set()
+    return {str(k) for k in data}
+
+
+async def record_suppressed_signatures(
+    db,
+    signatures: set[str],
+    *,
+    now: datetime | None = None,
+    retention_days: float = _SUPPRESS_RETENTION_DAYS,
+) -> None:
+    """Merge ``signatures`` into the persisted set, pruning stale entries (#553).
+
+    Stored as ``{signature: recorded_iso}``; entries older than
+    ``retention_days`` are dropped on write so dead signatures (whose facts have
+    since changed and will never recur) don't accumulate unboundedly.
+    """
+    now = now or datetime.now(UTC)
+    stamp = now.isoformat()
+
+    cursor = await db.execute(
+        "SELECT value FROM memory_meta WHERE key = ?", (_META_KEY_SUPPRESSED,)
+    )
+    row = await cursor.fetchone()
+    stored: dict[str, str] = {}
+    if row and row[0]:
+        try:
+            loaded = json.loads(row[0])
+            if isinstance(loaded, dict):
+                stored = {str(k): str(v) for k, v in loaded.items()}
+        except (json.JSONDecodeError, TypeError):
+            stored = {}
+
+    for sig in signatures:
+        stored[sig] = stamp
+
+    cutoff = now.timestamp() - retention_days * 86400.0
+    pruned: dict[str, str] = {}
+    for sig, recorded in stored.items():
+        try:
+            ts = datetime.fromisoformat(recorded).timestamp()
+        except (ValueError, TypeError):
+            ts = now.timestamp()   # unparseable stamp → treat as fresh, keep
+        if ts >= cutoff:
+            pruned[sig] = recorded
+
+    payload = json.dumps(pruned)
+    await db.execute(
+        "INSERT INTO memory_meta(key, value, updated_at) VALUES (?, ?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value, "
+        "updated_at = excluded.updated_at",
+        (_META_KEY_SUPPRESSED, payload, stamp),
+    )
+    await db.commit()
+
+
+def _genuine_skip_signatures(plan: "ConsolidationPlan") -> set[str]:
+    """Signatures of clusters 絲絲 reviewed and skipped — the stable judgments.
+
+    Excludes (a) non-skip verdicts and (b) diff-inventory tooling auto-skips
+    (``mergeable=False``): the latter is a tool failure, not a judgment, and
+    must be free to retry next pass (#554) rather than be buried by suppression.
+    """
+    sigs: set[str] = set()
+    for cluster in plan.clusters:
+        d = plan.decision_for(cluster.cluster_id)
+        if d is None or d.verdict != VERDICT_SKIP:
+            continue
+        if (
+            cluster.kind == KIND_MERGE
+            and cluster.diff is not None
+            and not cluster.diff.mergeable
+        ):
+            continue
+        sigs.add(_cluster_signature(cluster.members))
+    return sigs
+
+
+# ---------------------------------------------------------------------------
 # Step 2 — plan (read-only candidate discovery)
 # ---------------------------------------------------------------------------
 
@@ -255,6 +377,7 @@ async def build_plan(
     corpus_limit: int = 2000,
     min_similarity: float = 0.85,
     max_clusters: int = 20,
+    suppress_signatures: set[str] | None = None,
 ) -> ConsolidationPlan:
     """Scan the semantic store and propose merge / reconcile / clean clusters.
 
@@ -306,6 +429,16 @@ async def build_plan(
         )
     merge_groups.sort(key=_group_score, reverse=True)
 
+    # Drop clusters already adjudicated 'skip' in a prior pass — BEFORE the cap,
+    # so stable skips free quota for the backlog instead of permanently blocking
+    # it (#553). Content-addressed: re-admitted automatically when a member edits.
+    if suppress_signatures:
+        merge_groups = [
+            g for g in merge_groups
+            if _cluster_signature([by_key[k] for k in g if k in by_key])
+            not in suppress_signatures
+        ]
+
     if len(merge_groups) > max_clusters:
         plan.deferred_to_next_pass = len(merge_groups) - max_clusters
         plan.notes.append(
@@ -350,6 +483,10 @@ async def build_plan(
             if entry.key == c.existing.key or pair in seen_pairs:
                 continue
             seen_pairs.add(pair)
+            if suppress_signatures and _cluster_signature(
+                [c.existing, entry]
+            ) in suppress_signatures:
+                continue  # adjudicated 'skip' in a prior pass (#553)
             plan.clusters.append(CandidateCluster(
                 cluster_id=f"reconcile-{uuid.uuid4().hex[:8]}",
                 kind=KIND_RECONCILE,
@@ -369,6 +506,10 @@ async def build_plan(
         if not _is_stub(entry) or _is_dreaming(entry):
             continue
         if await semantic.resolve_redirect(entry.key) is None:
+            if suppress_signatures and _cluster_signature(
+                [entry]
+            ) in suppress_signatures:
+                continue  # adjudicated 'skip' in a prior pass (#553)
             plan.clusters.append(CandidateCluster(
                 cluster_id=f"clean-{uuid.uuid4().hex[:8]}",
                 kind=KIND_CLEAN,
@@ -419,8 +560,49 @@ Return ONLY the JSON object — no preamble, no markdown fences.
 """
 
 
-async def diff_inventory(cluster: CandidateCluster, llm_fn: LLMFn) -> DiffInventory:
-    """Run the LLM difference-inventory gate on a merge cluster (spec §6.4)."""
+async def diff_inventory(
+    cluster: CandidateCluster, llm_fn: LLMFn, *, max_attempts: int = 2,
+) -> DiffInventory:
+    """Run the LLM difference-inventory gate on a merge cluster (spec §6.4).
+
+    The gate is a hard fail-safe (#493): untrustworthy output never marks a
+    cluster mergeable. A single retry (``max_attempts=2``) absorbs *transient*
+    LLM format jitter — an exception, an unparseable body, a malformed
+    ``unique_by_key`` shape, or a key set that fails to cover the cluster — so a
+    large near-duplicate cluster isn't permanently stuck on one bad response
+    (#554). A clean verdict (mergeable true OR a real "both unique" false) is a
+    trustworthy answer and is returned on the first attempt — never retried.
+    Two bad attempts still fail safe.
+    """
+    last: DiffInventory | None = None
+    attempts = 0
+    for attempt in range(1, max(1, max_attempts) + 1):
+        attempts = attempt
+        result, retryable = await _diff_inventory_attempt(cluster, llm_fn)
+        if not retryable:
+            return result
+        last = result
+    # Exhausted retries on a transient-looking failure — annotate for
+    # observability (#554) so a maintainer can tell jitter from a structural
+    # limit (e.g. a cluster too large for one JSON response) and fail safe.
+    assert last is not None  # the loop runs ≥1 time, so a failure is recorded
+    suffix = f" (members={len(cluster.members)}, attempts={attempts})"
+    return DiffInventory(
+        unique_by_key=last.unique_by_key,
+        mergeable=False,
+        rationale=last.rationale + suffix,
+    )
+
+
+async def _diff_inventory_attempt(
+    cluster: CandidateCluster, llm_fn: LLMFn,
+) -> tuple[DiffInventory, bool]:
+    """One diff-inventory call. Returns ``(result, retryable)``.
+
+    ``retryable`` is True only for untrustworthy output (exception / unparseable
+    / malformed shape / coverage miss) — a clean parsed verdict is never
+    retryable, even when it is mergeable=False.
+    """
     facts_block = "\n".join(
         f'- key="{m.key}"  source="{m.source}"  value="{m.value}"'
         for m in cluster.members
@@ -434,11 +616,11 @@ async def diff_inventory(cluster: CandidateCluster, llm_fn: LLMFn) -> DiffInvent
     except Exception as exc:
         logger.warning("[convergent-dream] diff_inventory LLM failed: %s", exc)
         # Fail safe: if we cannot inventory differences, do NOT mark mergeable.
-        return DiffInventory(mergeable=False, rationale=f"diff-inventory unavailable: {exc}")
+        return DiffInventory(mergeable=False, rationale=f"diff-inventory unavailable: {exc}"), True
 
     data = _parse_json_object(raw)
     if data is None:
-        return DiffInventory(mergeable=False, rationale="diff-inventory output unparseable")
+        return DiffInventory(mergeable=False, rationale="diff-inventory output unparseable"), True
 
     # unique_by_key must be an object; a list/string/None would crash .items()
     # — fail safe rather than raise (Codex re-review #493).
@@ -447,7 +629,7 @@ async def diff_inventory(cluster: CandidateCluster, llm_fn: LLMFn) -> DiffInvent
         return DiffInventory(
             mergeable=False,
             rationale="diff-inventory unique_by_key was not an object — failing safe",
-        )
+        ), True
     unique_by_key = {str(k): str(v) for k, v in raw_ubk.items()}
     # Only an explicit JSON boolean true counts. bool("false") is True, so a
     # stringified verdict must NOT slip through — anything other than real
@@ -468,9 +650,10 @@ async def diff_inventory(cluster: CandidateCluster, llm_fn: LLMFn) -> DiffInvent
                 f"diff-inventory keys {sorted(unique_by_key)} did not cover "
                 f"cluster members {sorted(expected)} — failing safe"
             ),
-        )
+        ), True
 
-    return DiffInventory(unique_by_key=unique_by_key, mergeable=mergeable, rationale=rationale)
+    # Clean, covered verdict — a trustworthy answer, mergeable or not. Done.
+    return DiffInventory(unique_by_key=unique_by_key, mergeable=mergeable, rationale=rationale), False
 
 
 # ---------------------------------------------------------------------------
@@ -748,11 +931,16 @@ async def run_convergent_dream(
     non-stale merge clusters are then consolidated via ``execute_plan`` and the
     report gains an execution-outcome section.
     """
+    # Cross-pass skip suppression: filter clusters 絲絲 already reviewed and
+    # skipped so the deferred backlog can drain instead of looping forever (#553).
+    suppress = await load_suppressed_signatures(semantic._db)
+
     plan = await build_plan(
         semantic,
         corpus_limit=corpus_limit,
         min_similarity=min_similarity,
         max_clusters=max_clusters,
+        suppress_signatures=suppress,
     )
 
     # diff-inventory gate on merge clusters only (spec §6.4)
@@ -765,6 +953,11 @@ async def run_convergent_dream(
         batch_size=review_batch_size,
         max_review_clusters=max_review_clusters,
     )
+
+    # Persist this pass's genuine skip judgments so they don't re-surface (#553).
+    new_skips = _genuine_skip_signatures(plan)
+    if new_skips:
+        await record_suppressed_signatures(semantic._db, new_skips)
 
     execute_result = None
     if execute:

--- a/tests/test_convergent_dream_backlog.py
+++ b/tests/test_convergent_dream_backlog.py
@@ -1,0 +1,262 @@
+"""
+Tests for cross-pass skip suppression — draining the deferred backlog (#553).
+
+The convergent dream re-derives the same clusters from the whole corpus every
+pass. With a per-pass cap and no memory of prior verdicts, the overflow is
+labelled "deferred to next pass" but is in fact unreachable forever, and stable
+``skip`` clusters are re-reviewed every week for nothing.
+
+The fix is a *content-addressed* suppression set persisted in ``memory_meta``:
+a cluster 絲絲 reviewed and skipped is filtered out of later passes — until any
+member's content changes (the signature carries each member's ``updated_at``).
+Two judgments are deliberately NOT suppressed: a ``defer`` (ask again later) and
+a diff-inventory tooling auto-skip (should retry, #554).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import pytest_asyncio
+
+from loom.core.memory.store import SQLiteStore
+from loom.core.memory.semantic import SemanticEntry, SemanticMemory
+from loom.core.cognition.consolidation import (
+    KIND_MERGE,
+    build_plan,
+    run_convergent_dream,
+    _cluster_signature,
+    load_suppressed_signatures,
+    record_suppressed_signatures,
+    _META_KEY_SUPPRESSED,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror test_convergent_dream_readonly)
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = SQLiteStore(str(tmp_path / "test.db"))
+    await s.initialize()
+    return s
+
+
+@pytest_asyncio.fixture
+async def db_conn(store):
+    async with store.connect() as conn:
+        yield conn
+
+
+class _MarkerEmbeddings:
+    _BASIS = {
+        "GROUPA": [1.0, 0.0, 0.0, 0.0],
+        "GROUPB": [0.0, 1.0, 0.0, 0.0],
+        "GROUPC": [0.0, 0.0, 1.0, 0.0],
+    }
+
+    async def embed(self, texts):
+        out = []
+        for t in texts:
+            vec = [0.0, 0.0, 0.0, 1.0]
+            for marker, basis in self._BASIS.items():
+                if marker in t:
+                    vec = basis
+                    break
+            out.append(vec)
+        return out
+
+
+@pytest_asyncio.fixture
+async def semantic_emb(db_conn):
+    return SemanticMemory(db_conn, embedding_provider=_MarkerEmbeddings())
+
+
+async def _snapshot(db_conn):
+    cursor = await db_conn.execute(
+        "SELECT key, value, confidence, source, metadata, created_at, updated_at, "
+        "embedding FROM semantic_entries ORDER BY key"
+    )
+    return list(await cursor.fetchall())
+
+
+# ---------------------------------------------------------------------------
+# Signature — content-addressed, order-independent, updated_at-sensitive
+# ---------------------------------------------------------------------------
+
+class TestClusterSignature:
+    def test_order_independent(self):
+        from datetime import datetime, UTC
+        t = datetime(2026, 6, 14, tzinfo=UTC)
+        a = SemanticEntry(key="a", value="x", updated_at=t)
+        b = SemanticEntry(key="b", value="y", updated_at=t)
+        assert _cluster_signature([a, b]) == _cluster_signature([b, a])
+
+    def test_changes_when_member_updated_at_changes(self):
+        from datetime import datetime, UTC
+        a = SemanticEntry(key="a", value="x", updated_at=datetime(2026, 6, 14, tzinfo=UTC))
+        b1 = SemanticEntry(key="b", value="y", updated_at=datetime(2026, 6, 14, tzinfo=UTC))
+        b2 = SemanticEntry(key="b", value="y", updated_at=datetime(2026, 6, 15, tzinfo=UTC))
+        assert _cluster_signature([a, b1]) != _cluster_signature([a, b2])
+
+
+# ---------------------------------------------------------------------------
+# Persistence roundtrip + pruning
+# ---------------------------------------------------------------------------
+
+class TestSuppressionStore:
+    async def test_record_then_load_roundtrips(self, db_conn):
+        await record_suppressed_signatures(db_conn, {"sigA", "sigB"})
+        assert await load_suppressed_signatures(db_conn) == {"sigA", "sigB"}
+
+    async def test_record_accumulates_union(self, db_conn):
+        await record_suppressed_signatures(db_conn, {"sigA"})
+        await record_suppressed_signatures(db_conn, {"sigB"})
+        assert await load_suppressed_signatures(db_conn) == {"sigA", "sigB"}
+
+    async def test_empty_load_is_empty_set(self, db_conn):
+        assert await load_suppressed_signatures(db_conn) == set()
+
+    async def test_old_signatures_pruned_by_retention(self, db_conn):
+        from datetime import datetime, timedelta, UTC
+        t0 = datetime(2026, 1, 1, tzinfo=UTC)
+        await record_suppressed_signatures(db_conn, {"old"}, now=t0, retention_days=30)
+        later = t0 + timedelta(days=200)
+        await record_suppressed_signatures(db_conn, {"fresh"}, now=later, retention_days=30)
+        assert await load_suppressed_signatures(db_conn) == {"fresh"}
+
+    async def test_corrupt_value_loads_as_empty(self, db_conn):
+        await db_conn.execute(
+            "INSERT INTO memory_meta(key, value, updated_at) VALUES (?, ?, ?)",
+            (_META_KEY_SUPPRESSED, "not json", "2026-06-14T00:00:00"),
+        )
+        await db_conn.commit()
+        assert await load_suppressed_signatures(db_conn) == set()
+
+
+# ---------------------------------------------------------------------------
+# build_plan honours the suppression set (pre-cap, frees quota)
+# ---------------------------------------------------------------------------
+
+class TestBuildPlanSuppression:
+    async def _seed_three_pairs(self, semantic_emb):
+        for marker, p in [("GROUPA", "a"), ("GROUPB", "b"), ("GROUPC", "c")]:
+            await semantic_emb.upsert(SemanticEntry(key=f"{p}1", value=f"{marker} one", source="manual"))
+            await semantic_emb.upsert(SemanticEntry(key=f"{p}2", value=f"{marker} two", source="manual"))
+
+    async def test_suppressed_cluster_excluded(self, semantic_emb):
+        await semantic_emb.upsert(SemanticEntry(key="m1", value="GROUPA tea", source="manual"))
+        await semantic_emb.upsert(SemanticEntry(key="m2", value="GROUPA tea too", source="manual"))
+        plan = await build_plan(semantic_emb)
+        cluster = next(c for c in plan.clusters if c.kind == KIND_MERGE)
+        sig = _cluster_signature(cluster.members)
+
+        plan2 = await build_plan(semantic_emb, suppress_signatures={sig})
+        assert [c for c in plan2.clusters if c.kind == KIND_MERGE] == []
+
+    async def test_suppression_frees_cap_quota_so_backlog_drains(self, semantic_emb):
+        # 3 merge clusters, cap 2 → 1 normally deferred & unreachable. Suppress
+        # one stable-skip cluster and the other two BOTH fit under the cap.
+        await self._seed_three_pairs(semantic_emb)
+        baseline = await build_plan(semantic_emb, max_clusters=2)
+        assert baseline.deferred_to_next_pass == 1
+
+        # Signature of the GROUPC pair (read its members back).
+        full = await build_plan(semantic_emb, max_clusters=20)
+        c_cluster = next(
+            c for c in full.clusters
+            if c.kind == KIND_MERGE and set(c.member_keys) == {"c1", "c2"}
+        )
+        sig_c = _cluster_signature(c_cluster.members)
+
+        plan = await build_plan(semantic_emb, max_clusters=2, suppress_signatures={sig_c})
+        merge = [c for c in plan.clusters if c.kind == KIND_MERGE]
+        keys = {frozenset(c.member_keys) for c in merge}
+        assert frozenset({"c1", "c2"}) not in keys
+        assert frozenset({"a1", "a2"}) in keys
+        assert frozenset({"b1", "b2"}) in keys
+        assert plan.deferred_to_next_pass == 0
+
+
+# ---------------------------------------------------------------------------
+# run_convergent_dream — records genuine skips, drains across passes
+# ---------------------------------------------------------------------------
+
+def _combined_llm(self_review_response: str, mergeable: bool = True):
+    """diff-inventory → mergeable; self_review → the given verdict array."""
+    async def fn(messages):
+        sys = messages[0]["content"]
+        if "差異盤點" in sys:
+            return ('{"unique_by_key":{"m1":"","m2":"more"},'
+                    f'"mergeable":{"true" if mergeable else "false"},"rationale":"r"}}')
+        return self_review_response
+    return fn
+
+
+class TestRunDrainsBacklog:
+    async def _seed_pair(self, semantic_emb):
+        await semantic_emb.upsert(SemanticEntry(key="m1", value="GROUPA x", source="manual"))
+        await semantic_emb.upsert(SemanticEntry(key="m2", value="GROUPA y", source="manual"))
+
+    async def test_genuine_skip_recorded_and_suppressed_next_pass(self, semantic_emb, db_conn):
+        await self._seed_pair(semantic_emb)
+        skip = '[{"cluster_id":"%s","verdict":"skip","reason":"each carries unique content"}]'
+
+        # Pass 1: cluster proposed, 絲絲 skips it.
+        async def fn1(messages):
+            if "差異盤點" in messages[0]["content"]:
+                return '{"unique_by_key":{"m1":"","m2":"more"},"mergeable":true,"rationale":"r"}'
+            # echo whatever cluster_id is in the prompt
+            import re
+            cid = re.search(r'cluster_id="([^"]+)"', messages[-1]["content"]).group(1)
+            return skip % cid
+
+        plan1, _ = await run_convergent_dream(semantic_emb, fn1)
+        assert any(c.kind == KIND_MERGE for c in plan1.clusters)
+        assert await load_suppressed_signatures(db_conn) != set()
+
+        # Pass 2: same corpus, but the skipped cluster must not reappear.
+        plan2, _ = await run_convergent_dream(semantic_emb, fn1)
+        assert [c for c in plan2.clusters if c.kind == KIND_MERGE] == []
+
+    async def test_diff_inventory_auto_skip_not_suppressed(self, semantic_emb, db_conn):
+        # mergeable=false → self_review auto-skips WITHOUT consulting 絲絲. That
+        # is a tooling verdict, not a judgment — it must retry, not be buried.
+        await self._seed_pair(semantic_emb)
+        fn = _combined_llm("[]", mergeable=False)
+        plan1, _ = await run_convergent_dream(semantic_emb, fn)
+        assert await load_suppressed_signatures(db_conn) == set()
+        plan2, _ = await run_convergent_dream(semantic_emb, fn)
+        assert any(c.kind == KIND_MERGE for c in plan2.clusters)
+
+    async def test_defer_not_suppressed(self, semantic_emb, db_conn):
+        await self._seed_pair(semantic_emb)
+
+        async def fn(messages):
+            if "差異盤點" in messages[0]["content"]:
+                return '{"unique_by_key":{"m1":"","m2":"more"},"mergeable":true,"rationale":"r"}'
+            import re
+            cid = re.search(r'cluster_id="([^"]+)"', messages[-1]["content"]).group(1)
+            return '[{"cluster_id":"%s","verdict":"defer","reason":"fermenting"}]' % cid
+
+        await run_convergent_dream(semantic_emb, fn)
+        assert await load_suppressed_signatures(db_conn) == set()
+
+    async def test_recording_does_not_mutate_semantic_store(self, semantic_emb, db_conn):
+        # Read-only invariant: suppression state lives in memory_meta, never in
+        # semantic_entries.
+        await self._seed_pair(semantic_emb)
+        before = await _snapshot(db_conn)
+
+        async def fn(messages):
+            if "差異盤點" in messages[0]["content"]:
+                return '{"unique_by_key":{"m1":"","m2":"more"},"mergeable":true,"rationale":"r"}'
+            import re
+            cid = re.search(r'cluster_id="([^"]+)"', messages[-1]["content"]).group(1)
+            return '[{"cluster_id":"%s","verdict":"skip","reason":"unique"}]' % cid
+
+        await run_convergent_dream(semantic_emb, fn)
+        after = await _snapshot(db_conn)
+        assert before == after

--- a/tests/test_convergent_dream_diff_retry.py
+++ b/tests/test_convergent_dream_diff_retry.py
@@ -1,0 +1,106 @@
+"""
+Tests for diff-inventory gate robustness (#554).
+
+The gate must stay a hard fail-safe (spec #493 — never mark a cluster mergeable
+on untrustworthy output), but a *single* retry should absorb transient LLM
+format jitter so a large near-duplicate cluster isn't permanently stuck on one
+malformed response. A clean verdict (even mergeable=false) must NOT trigger a
+retry, and two bad responses must still fail safe.
+"""
+
+from __future__ import annotations
+
+from loom.core.cognition.consolidation import (
+    CandidateCluster,
+    KIND_MERGE,
+    diff_inventory,
+)
+from loom.core.memory.semantic import SemanticEntry
+
+
+def _cluster(*keys: str) -> CandidateCluster:
+    return CandidateCluster(
+        cluster_id="c1", kind=KIND_MERGE,
+        members=[SemanticEntry(key=k, value=f"val-{k}") for k in keys],
+    )
+
+
+class _SequenceLLM:
+    """Returns queued responses in order; records how many times it was called."""
+
+    def __init__(self, *responses: str):
+        self._responses = list(responses)
+        self.calls = 0
+
+    async def __call__(self, messages):
+        self.calls += 1
+        idx = min(self.calls - 1, len(self._responses) - 1)
+        return self._responses[idx]
+
+
+class TestDiffInventoryRetry:
+    async def test_retry_recovers_from_transient_unparseable(self):
+        good = ('{"unique_by_key": {"a": "", "b": "extra"}, '
+                '"mergeable": true, "rationale": "b subsumes a"}')
+        llm = _SequenceLLM("garbage not json", good)
+        diff = await diff_inventory(_cluster("a", "b"), llm)
+        assert diff.mergeable is True
+        assert llm.calls == 2
+
+    async def test_retry_recovers_from_transient_coverage_mismatch(self):
+        # First response drops a member key; second covers the cluster.
+        bad = '{"unique_by_key": {"a": ""}, "mergeable": true, "rationale": "r"}'
+        good = ('{"unique_by_key": {"a": "", "b": ""}, '
+                '"mergeable": true, "rationale": "r"}')
+        llm = _SequenceLLM(bad, good)
+        diff = await diff_inventory(_cluster("a", "b"), llm)
+        assert diff.mergeable is True
+        assert llm.calls == 2
+
+    async def test_two_bad_responses_still_fail_safe(self):
+        llm = _SequenceLLM("garbage", "still garbage")
+        diff = await diff_inventory(_cluster("a", "b"), llm)
+        assert diff.mergeable is False
+        assert llm.calls == 2
+        assert "unparseable" in diff.rationale
+
+    async def test_clean_false_verdict_does_not_retry(self):
+        # A parseable, covered "both unique" verdict is a real answer — the gate
+        # must accept it on the first call, not waste a retry.
+        resp = ('{"unique_by_key": {"a": "preference", "b": "complaint"}, '
+                '"mergeable": false, "rationale": "distinct insights"}')
+        llm = _SequenceLLM(resp, resp)
+        diff = await diff_inventory(_cluster("a", "b"), llm)
+        assert diff.mergeable is False
+        assert llm.calls == 1
+
+    async def test_clean_true_verdict_does_not_retry(self):
+        resp = ('{"unique_by_key": {"a": "", "b": "extra"}, '
+                '"mergeable": true, "rationale": "r"}')
+        llm = _SequenceLLM(resp, resp)
+        diff = await diff_inventory(_cluster("a", "b"), llm)
+        assert diff.mergeable is True
+        assert llm.calls == 1
+
+    async def test_retry_on_transient_exception_then_success(self):
+        good = ('{"unique_by_key": {"a": "", "b": "extra"}, '
+                '"mergeable": true, "rationale": "r"}')
+        calls = {"n": 0}
+
+        async def llm(messages):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("transient down")
+            return good
+
+        diff = await diff_inventory(_cluster("a", "b"), llm)
+        assert diff.mergeable is True
+        assert calls["n"] == 2
+
+    async def test_failure_rationale_carries_member_count(self):
+        # Observability (#554): the fail-safe rationale should say how big the
+        # cluster was so a maintainer can tell jitter from a structural limit.
+        llm = _SequenceLLM("garbage", "garbage")
+        diff = await diff_inventory(_cluster("a", "b", "c"), llm)
+        assert diff.mergeable is False
+        assert "members=3" in diff.rationale


### PR DESCRIPTION
源自 2026-06-14 整合夢手動把關日誌（`autonomy/circadian/journal/2026-06-14.md`）。經 code 驗證後拆成兩個問題、各自修復。Epic #491。

## #553 — deferred 簇永遠無法被後續 pass 觸及（真功能 bug）
`build_plan` 每輪從整個 corpus 全新導出簇、沒有任何「已裁決」記憶。配合 per-pass cap，溢出被標「deferred to next pass」但其實**被 deferred 到沒有任何 pass**；穩定 `skip` 簇每週重審、零進度 → deferred 計數恆不遞減（journal 觀察到的 132）。

**修法 — content-addressed skip 抑制**
- signature = `sha256(sorted("{key}@{updated_at}"))`，含 `updated_at` → 任一 member 內容變動自動 re-admit。
- 持久化在 `memory_meta`（`consolidation_dream.suppressed_skips`，90 天 retention prune）；**不碰 `semantic_entries`，read-only 不變式維持**。
- `build_plan` 在**套 cap 之前**過濾抑制簇 → 穩定 skip 退場、騰配額給積壓 → backlog 真正排空。
- **只抑制 絲絲 真正的 self-review skip**；`defer`（之後再評估）與 diff-inventory 工具失敗的 auto-skip（屬 #554，要重試）**不抑制**。

## #554 — diff-inventory gate 對大簇過脆（robustness，非 bug）
`unparseable` / `key-coverage miss` 兩條 fail-safe（spec #493）對大簇確定性觸發、永不恢復。**這是 fail-safe 照設計運作**，不是誤判——盤點失敗代表我們無法確認可合併。

**修法 — 提升韌性、不弱化安全保證**
- 單次重試吸收 transient LLM 格式抖動；**乾淨 verdict（含 mergeable=false）不重試**；兩次壞仍 fail-safe。
- **#493 精確覆蓋契約原封不動**（既有 10 個安全測試全綠）。
- 耗盡重試的 rationale 帶 `members=N, attempts=N`，方便分辨抖動 vs 結構極限。

## 兩個設計決定（可調）
1. **抑制在 read-only passes 也生效** → execute=true（~6/27）開啟前，每週 read-only 跑就逐輪排空 backlog。
2. **90 天 retention** → 對齊記憶半衰期；穩定 skip 90 天後重審一次，防永久埋葬。

## 驗證
- TDD：`tests/test_convergent_dream_diff_retry.py`(7) + `tests/test_convergent_dream_backlog.py`(13) red→green。
- 全測試 **2806 passed, 4 skipped**。
- `gitnexus detect_changes`：單檔、risk **low**、0 affected processes。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
