### PR TITLE
feat(spine): latency heartbeat + 語義型擴張 spec（#528 acceptance gate 推進）

### DIFF
--- a/docs/designs/58-生成認知整合-P0-收斂規格-Prediction-Spine.md
+++ b/docs/designs/58-生成認知整合-P0-收斂規格-Prediction-Spine.md
@@ -90,6 +90,8 @@ P0 第一版**只支援可機械判定**的 resolver：
 - `row_count` / `result_count`
 - `duration_bucket`
 
+> ⚠️ **這些 resolver 在白名單裡，不代表都能用**：`output_contains` / `output_regex` / `file_digest_changed` / `row_count` 要的欄位（`output` / digest / `row_count`）**今天的 action observation 沒供應**，故對「動作結算」下注全部餓死、落 `unresolvable`。已可用的只有 `tool_success` / `final_state` / `duration_bucket`。餓死分析與「餵飽觀察面」提案見 `docs/designs/59`。
+
 **自由文字「氛圍下注」**：P0 可作旁註，**不納入 calibration 分數**。否則 I2 極易破——ground truth 會滑回 LLM 自我敘事 / 事後合理化。
 
 > （這就地處理了 #57 §9-1「預測解析度」：P0 先劃 minimal subset = 機械可對帳；軟判層 deferred。）

--- a/docs/designs/58-生成認知整合-P0-收斂規格-Prediction-Spine.md
+++ b/docs/designs/58-生成認知整合-P0-收斂規格-Prediction-Spine.md
@@ -182,7 +182,8 @@ expected_info_gain =
 | **P2 — exploration 臂（#464）** | drift 選向接 `uncertainty` landscape；`expected_info_gain` policy；dark-room 護欄定位 | P0 acceptance gate 通過 |
 | **P3 — 自我維持指標** | 把恆定變量從情緒擴到資源（cost / memory 矛盾度 / process 連續性 / trust）；#57 §9-6 指標清單 | P1 + P2 跑出實測 |
 | 軟判層 | 自由文字「氛圍下注」的 Critic 軟對帳（#57 §9-1 上層） | P0 機械對帳穩定後 |
-| **事件結算下注（`on_event` due）** | 對外部事件（CI 完成 / PR merge / 排程觸發）下注 + 結算 | **撞 I2 邊界**，見 §12.3 — 需先決定「事件如何落成 observation row」 |
+| **事件結算下注（`on_event` due）** | 對外部事件（CI 完成 / PR merge / 排程觸發）下注 + 結算 | **撞 I2 邊界**，見 §12.3 / #541 — 需先決定「事件如何落成 observation row」 |
+| **語義型觀察面擴張** | 餵飽 action observation（`output` / digest / `row_count`），讓 `output_contains` / `file_digest_changed` 等白名單 resolver 可對「動作結算」下注 | **撞 I2 邊界**，討論稿見 `docs/designs/59` — 同 (a)/(b) 取捨，傾向 (a) 先落可對帳 row |
 
 ---
 

--- a/docs/designs/59-生成認知整合-語義型觀察面擴張-Prediction-Spine.md
+++ b/docs/designs/59-生成認知整合-語義型觀察面擴張-Prediction-Spine.md
@@ -1,0 +1,127 @@
+# 生成認知整合 — 語義型觀察面擴張（Semantic Observation-Surface Expansion）
+
+> **狀態**：🟡 討論稿（四方輪替 review，**未定稿、不進 code**）
+> **上游**：epic #528 / P0 收斂規格 `docs/designs/58`（§4 resolver 白名單、§5 I2 硬約束、§10 Deferred）
+> **觸發**：P0 acceptance gate 觀察期實測——reliability 軸近乎退化（1570/1572 error=0.0），逼出「訊號從哪來」的真問題
+> **先行落地（本輪 code，非本文範圍）**：latency heartbeat（`duration_bucket @ <tool>@latency`），證明**不動觀察面**就能取非平凡訊號。本文談的是**下一階增量**——那一階非動觀察面不可。
+
+---
+
+## 0. 一句話
+
+Resolver 白名單（`docs/designs/58` §4）早就列了 `output_contains` / `output_regex` / `file_digest_changed` / `row_count`，但**action observation 不吐它們要的欄位**，所以這些 resolver 對「動作結算」的下注全部餓死。本文評估「把觀察面餵飽」這件事——它直接動到 spec 視為神聖的 **I2 ground-truth 邊界**，所以先討論、後動刀。
+
+---
+
+## 1. 問題：resolver 有嘴，observation 沒料
+
+P0 acceptance gate 觀察期（2026-06-10 → 06-21，1572 筆隱式下注）撈出來的事實：
+
+| 軸 | resolver | error_score 分佈 | 判讀 |
+|---|---|---|---|
+| reliability（已有） | `tool_success` | **1570×0.0 / 2×1.0** | 近乎退化——tool 幾乎都成功，naive prior「會成功」幾乎不會錯 |
+| latency（本輪先上） | `duration_bucket` | 0.00..1.00 跨 43 domain | 非平凡——`read_file` 永遠 fast、`recall` 0.57 銅板、媒體生成幾乎不 fast |
+
+latency 軸救起了「非平凡」，但它量的是**延遲**，不是**語義正確性**。真正貼近 #528 原意（「預測對不對」而非「有沒有失敗」）的，是這類賭：
+
+- 「這個 `write_file` 真的改了檔案內容」→ `file_digest_changed`
+- 「這個 `run_bash` 的輸出會含 `PASS`」→ `output_contains` / `output_regex`
+- 「這個 `recall` 會撈回 ≥1 筆」→ `row_count`
+
+**這些 resolver 都在白名單裡、`resolve()` 都能算**。卡點唯一：
+
+```python
+# loom/core/memory/observation.py :: _resolve_action()
+return {
+    "observation_ref": ...,
+    "tool_name": r[1],
+    "final_state": r[2],
+    "tool_success": not failed,
+    "duration_ms": r[3],
+}
+# ← 沒有 output / digest_before / digest_after / row_count
+```
+
+`resolve()` 對缺欄位的 observation 丟 `KeyError`（刻意——「不可觀測 ≠ 預測正確」，no-silent-pass，配 I4）。所以這些賭一律落 `unresolvable`，calibration 一筆都收不到。
+
+**`action_records` 表本身也沒存這些欄位**（25849 筆查證：無 output、無 digest 欄）。所以這不是「extractor 漏讀」，是**捕捉管線根本沒留下這份 ground truth**。
+
+---
+
+## 2. 為什麼這直接撞 I2
+
+I2（`docs/designs/58` §2 / §5）：**ground truth 只可來自 runtime observation 白名單表**——`OBSERVATION_SOURCES = ("action", "session_log")`，且 reconcile 每個 score 必指向白名單表的某個 row（#531 observation_ref 契約）。
+
+要讓語義型 resolver 可對帳，等於**擴張 ground-truth 的表面積**。這不是加個欄位那麼輕——它動到的正是「spine 拿什麼當真相」這條命脈。兩個風險：
+
+1. **把 LLM 自我敘事偷渡成 ground truth**。若 `output` 取的是 agent 事後對結果的「描述」而非工具的**原始 stdout/return**，I2 就破了——calibration 會學到「我覺得我做對了」而非「世界回了什麼」。
+2. **digest 的計算時點**。`file_digest_changed` 要 `digest_before` / `digest_after`，這要求捕捉**動作前後**的檔案狀態。若只在動作後算一次，等於沒有 before，resolver 退化。
+
+> 結論：擴張觀察面**可以做**，但**必須證明擴張進來的每個欄位仍是「世界回的」而非「agent 說的」**。這是本文 review 的核心審查點。
+
+---
+
+## 3. 兩條路（沿用 #541 的 (a)/(b) 框架）
+
+#541（事件結算下注）已經把同一張地圖畫好了，本文是它的「動作結算」對應版：
+
+### (a) 動作捕捉時多留一份可對帳觀察（傾向）
+
+在 lifecycle 捕捉縫，把工具的**原始輸出 / 檔案 digest** 落進一個 observation row（擴 `action_records` 欄，或新 observation 表），reconcile 照舊只讀白名單表。
+
+- ✅ **I2 純粹不變**：ground truth 仍只來自白名單表的 row，只是 row 變寬。
+- ✅ 對齊既有紀律——「要可對帳就得留下可審計的觀察」（#541 對 (a) 的同款論證）。
+- ⚠️ 代價：捕捉管線要負責持久化原始輸出。**大輸出**（bash 吐幾 MB、檔案內容）要決定**存摘要還是存全文**——傾向只存 **digest / 截斷前綴 / 命中布林**，不吞整包（呼應 `project_compression_belongs_in_autonomy_path`：tool-output 爆 context 是真風險）。
+
+### (b) 放寬 I2 白名單 / resolver 改吃別的來源
+
+讓 resolver 去讀 `session_log`（已有 `output`/`raw_json`）或新增 observation 來源。
+
+- ⚠️ `session_log` 的 `output` 是**對話輸出**不是**工具原始 return**——拿它對帳極易把 LLM 敘事當真相（撞風險 1）。
+- ⚠️ 動到 `OBSERVATION_SOURCES` = 動神聖邊界，blast radius 大。
+
+> **傾向 (a)**，理由同 #541：不破 I2，且「留下可審計觀察」本身是對的紀律。但**存什麼粒度**（digest-only vs 截斷前綴 vs 全文）是 (a) 內部待拍板的子決策——留給 review。
+
+---
+
+## 4. Per-tool resolver 映射（草案，待 review）
+
+擴張後，auto-predict 的隱式下注可依工具型別選 richer resolver（取代或並列現有的 reliability + latency 雙注）。**naive prior 不可偷看結果**——expect 必須是固定先驗，方差才來自「先驗對不對」：
+
+| 工具型別 | resolver | naive prior（expect） | 方差來源 |
+|---|---|---|---|
+| 變動類 `write_file` / `journal_append` / `memorize` | `file_digest_changed` | `True`（寫了就會變） | no-op 寫入（內容相同）、寫了但沒落盤 |
+| 執行類 `run_bash` | `output_regex`（錯誤樣式）/ `output_contains` | 視場景 | 命令靜默失敗、輸出不如預期 |
+| 讀取類 `recall` / `list_dir` / `read_file` | `row_count >= 1` | `True`（讀得到東西） | 空 recall、空目錄、檔案空 |
+
+> **開放問題（review 點）**：
+> - run_bash 的「先驗」難定——「輸出含 X」的 X 從哪來？可能 run_bash 這類**自由輸出工具退回只用 reliability + latency**，語義型只給「結構化結果工具」（write/read/recall）。
+> - 變動類用 `file_digest_changed` 需要 before-digest——這把「動作前快照」推進 lifecycle，成本與 TOCTTOU 要評（呼應 `feedback_snapshot_guards_inputs`）。
+
+---
+
+## 5. 與已落地件的關係
+
+- **latency heartbeat（本輪 code）**：證明「不動觀察面也能取非平凡訊號」。本文是**正交的下一階**——語義軸。兩軸可並存（domain 各自 namespace：`<tool>` / `<tool>@latency` / 未來 `<tool>@semantic`），`compute_calibration` 按 domain 分桶，互不污染。
+- **#541（事件結算下注）**：同一張 (a)/(b) 地圖的「外部事件」分支。本文是「動作結算」分支。兩者若都選 (a)，可共用「先落一筆可對帳 observation row」的同一套機制——**review 時值得一起看能不能收斂成單一 observation-row primitive**。
+- **I5 valence**：語義型 resolver 多半**無 good/bad 內在極性**（`file_digest_changed` 變了是好是壞？看不出來）→ 沿用 `_POLAR_RESOLVERS` 現制，valence=0，不讓 spine 自創價值判斷。
+
+---
+
+## 6. 待拍板（交 DK / Codex / 絲絲 輪替）
+
+1. **走 (a) 還是 (b)**？（傾向 a）
+2. (a) 下，原始輸出**存什麼粒度**？digest-only / 截斷前綴 / 命中布林 / 全文。
+3. `file_digest_changed` 要不要 before-snapshot？成本 vs 訊號值。
+4. run_bash 這類自由輸出工具**納不納**語義軸，還是只給結構化結果工具。
+5. 語義軸是**取代**現有雙注，還是**第三條並列**（三注/動作）？volume 與 reconcile backlog 影響（#553/#554 餘波）。
+6. 能否與 #541 收斂成**單一 observation-row primitive**（動作結算 + 事件結算共用）。
+
+---
+
+## 7. 不做 / 邊界（繼承 58 §11）
+
+- ❌ 不讓 `session_log` 的對話輸出冒充工具原始 return（I2）。
+- ❌ 不在擴張裡引入任何「軟判 / 氛圍」對帳（那是 58 §10 的軟判層，另案）。
+- ❌ 本階仍不接兩臂、不驅動行為——只是把 calibration 訊號從「延遲可預測性」加上「語義正確性」一軸。
+- ❌ 未過 review、未定稿前不進 code。

--- a/loom/core/harness/auto_predict.py
+++ b/loom/core/harness/auto_predict.py
@@ -4,8 +4,21 @@ Prediction Spine — auto-betting "mouth" (epic #528 P0.5-a slice B, issue #537)
 P0 built the spine's metabolism (store → reconcile → calibrate) but nothing made
 bets, so the reconcile schedule had an empty table to chew on. This module gives
 the spine its *involuntary heartbeat*: every tool action that actually executed
-leaves behind a flat implicit bet — "this tool will succeed" — which the existing
-reconcile settles against the very ``action_record`` the action produced.
+leaves behind implicit bets the existing reconcile settles against the very
+``action_record`` the action produced.
+
+Two orthogonal heartbeats ride the same seam:
+
+* **reliability** — "this tool will succeed" (``tool_success``, domain
+  ``<tool>``). The original P0.5-a bet.
+* **latency** — "this tool will respond fast (<1s)" (``duration_bucket``, domain
+  ``<tool>@latency``). Added for the #528 acceptance gate: the reliability bet is
+  near-degenerate (tools almost always succeed, so the residue is a flat row of
+  zeros), while latency genuinely varies per tool — ``read_file`` is always fast,
+  ``recall`` is a coin-flip — so it carries the non-trivial, per-domain variance
+  the calibration residue needs to be worth anything. Both settle against the
+  same action observation (``duration_ms`` is already on it), so the latency bet
+  needs no change to the I2 ground-truth surface.
 
 It is the harness-layer bridge (harness may import memory — the one-way arrow
 Platform → Cognition → Harness → Memory holds): an :class:`ActionRecord` in,
@@ -35,31 +48,53 @@ from loom.core.memory.prediction import PredictionRecord, PredictionStore
 
 logger = logging.getLogger(__name__)
 
-# Provenance tag on auto-generated bets — lets later analysis (and slice A's
-# explicit bets) tell the involuntary heartbeat apart from deliberate wagers.
+# Provenance tags on auto-generated bets — let later analysis (and slice A's
+# explicit bets) tell each involuntary heartbeat apart from deliberate wagers,
+# and from each other.
 _AUTO_CONTEXT = "auto:implicit_tool_success"
+_AUTO_DURATION_CONTEXT = "auto:implicit_duration_bucket"
+
+# The latency heartbeat lands in a sibling domain so its residue
+# (``calibration:<tool>@latency``) stays orthogonal to the reliability residue
+# (``calibration:<tool>``). compute_calibration groups purely by ``domain``, so
+# without this suffix a latency-miss would average into a success-miss and the
+# per-domain world-model fact would be meaningless.
+_LATENCY_DOMAIN_SUFFIX = "@latency"
+
+# The naive latency prior. "fast" is the maximum-likelihood global bucket
+# (~77% of all actions resolve <1s), so a per-tool ``duration_bucket=fast`` bet
+# is wrong exactly where a tool is *unpredictably* slow — that residual is the
+# non-trivial, per-domain variance the bare tool_success heartbeat can't produce.
+_LATENCY_PRIOR = "fast"
+
+
+def _betting_session(record: ActionRecord, *, enabled: bool) -> str | None:
+    """Shared eligibility gate for the involuntary heartbeats.
+
+    Returns the ``session_id`` a bet should be written under, or ``None`` when no
+    bet should be made: betting disabled, the record carries no call, the action
+    never reached ``EXECUTING`` (it didn't *try* — a denied/aborted action is not
+    a world-model miss), or the call is sessionless (a session-less bet settles
+    fine by call_id but is an orphan to per-session audit, and this writes at
+    volume — 絲絲 PR #538 P3). Both heartbeats share this exact contract.
+    """
+    if not enabled or record.call is None:
+        return None
+    executed = any(t.to_state == ActionState.EXECUTING for t in record.state_history)
+    if not executed:
+        return None
+    return record.call.session_id or None
 
 
 def implicit_bet_for(record: ActionRecord, *, enabled: bool) -> PredictionRecord | None:
     """Return the implicit ``tool_success`` bet for a terminal action, or ``None``.
 
-    ``None`` when betting is disabled, the record carries no call, or the action
-    never reached ``EXECUTING`` (it didn't try — see module docstring). Otherwise
-    a flat, pending, per-tool bet the existing reconcile pipeline will settle.
+    ``None`` when the action is ineligible (see :func:`_betting_session`).
+    Otherwise a flat, pending, per-tool bet the existing reconcile pipeline will
+    settle against the action_record being persisted.
     """
-    if not enabled or record.call is None:
-        return None
-
-    executed = any(t.to_state == ActionState.EXECUTING for t in record.state_history)
-    if not executed:
-        return None
-
-    # No session → no bet. A session-less bet would reconcile fine (it settles by
-    # call_id) but be an orphan to any per-session audit — and this writes
-    # autonomously at volume, so "don't bet rather than write orphan data" keeps
-    # the spine's own hygiene clean (絲絲 PR #538 P3). Drops the empty fallback.
-    session_id = record.call.session_id
-    if not session_id:
+    session_id = _betting_session(record, enabled=enabled)
+    if session_id is None:
         return None
 
     tool = record.call.tool_name
@@ -73,20 +108,63 @@ def implicit_bet_for(record: ActionRecord, *, enabled: bool) -> PredictionRecord
     )
 
 
+def implicit_duration_bet_for(
+    record: ActionRecord, *, enabled: bool
+) -> PredictionRecord | None:
+    """Return the implicit *latency* bet for a terminal action, or ``None``.
+
+    The second heartbeat (#528 acceptance-gate work). Same eligibility as
+    :func:`implicit_bet_for`, but it predicts the ``duration_bucket`` against the
+    naive ``fast`` prior and lands in a distinct ``<tool>@latency`` domain. This
+    is the axis that actually varies per tool — ``read_file`` is always fast,
+    ``recall`` is a coin-flip — so it's where the calibration residue stops being
+    a flat row of zeros. Settles against the same action observation (which
+    already carries ``duration_ms``), so it needs no change to the I2 surface.
+    """
+    session_id = _betting_session(record, enabled=enabled)
+    if session_id is None:
+        return None
+
+    tool = record.call.tool_name
+    return PredictionRecord(
+        session_id=session_id,
+        claim=f"{tool} will respond fast (<1s)",
+        due_condition={"kind": "after_action", "call_id": record.call.id},
+        resolver={"kind": "duration_bucket", "expect": _LATENCY_PRIOR},
+        domain=f"{tool}{_LATENCY_DOMAIN_SUFFIX}",
+        context=_AUTO_DURATION_CONTEXT,
+    )
+
+
 async def co_write_implicit_bet(db, record: ActionRecord, *, enabled: bool) -> bool:
-    """Persist the implicit bet for a terminal action; return whether one landed.
+    """Persist the implicit heartbeat bets for a terminal action.
+
+    Returns whether *any* bet landed. The two heartbeats — reliability
+    (``tool_success``) and latency (``duration_bucket``) — are written
+    independently so one failing never suppresses the other.
 
     The IO half, kept here (not inlined in the session) so it stays testable
-    without a Session. **Isolated**: a betting failure is swallowed + logged and
-    returns ``False`` — it must never crash the lifecycle persistence it rides
-    on, exactly like the action_record write it sits beside.
+    without a Session. **Isolated**: a betting failure is swallowed + logged — it
+    must never crash the lifecycle persistence it rides on, exactly like the
+    action_record write it sits beside.
     """
-    bet = implicit_bet_for(record, enabled=enabled)
-    if bet is None:
+    bets = [
+        bet
+        for bet in (
+            implicit_bet_for(record, enabled=enabled),
+            implicit_duration_bet_for(record, enabled=enabled),
+        )
+        if bet is not None
+    ]
+    if not bets:
         return False
-    try:
-        await PredictionStore(db).write(bet)
-        return True
-    except Exception:  # noqa: BLE001 — betting must never crash the pipeline
-        logger.debug("implicit bet write failed (suppressed)", exc_info=True)
-        return False
+
+    store = PredictionStore(db)
+    wrote = False
+    for bet in bets:
+        try:
+            await store.write(bet)
+            wrote = True
+        except Exception:  # noqa: BLE001 — betting must never crash the pipeline
+            logger.debug("implicit bet write failed (suppressed)", exc_info=True)
+    return wrote

--- a/tests/test_auto_predict.py
+++ b/tests/test_auto_predict.py
@@ -20,6 +20,15 @@ returns the bet to write, or ``None``. TDD-first contract:
 * **shape** — a flat ``tool_success`` bet, ``domain=tool_name``, born
   ``pending``, due ``after_action(call_id)`` so the existing reconcile settles it
   against the very action_record being persisted.
+
+A second, orthogonal heartbeat rides the same seam (#528 acceptance-gate work):
+``implicit_duration_bet_for`` predicts the *latency* bucket — the naive prior
+"this tool will respond fast (<1s)" against ``duration_bucket``. It shares every
+eligibility guard above but carries a distinct ``@latency`` domain so its residue
+(``calibration:<tool>@latency``) never blends into the reliability axis. The bare
+``tool_success`` bet is near-degenerate (tools almost always succeed); the latency
+bet is where per-domain variance lives — ``read_file`` is always fast (0 surprise),
+``recall`` is a coin-flip — exactly the non-trivial signal the P0 gate wants.
 """
 
 from datetime import datetime, UTC
@@ -30,7 +39,11 @@ import pytest_asyncio
 from loom.core.harness.lifecycle import ActionRecord, ActionState, StateTransition
 from loom.core.harness.middleware import ToolCall
 from loom.core.harness.permissions import TrustLevel
-from loom.core.harness.auto_predict import implicit_bet_for, co_write_implicit_bet
+from loom.core.harness.auto_predict import (
+    implicit_bet_for,
+    implicit_duration_bet_for,
+    co_write_implicit_bet,
+)
 from loom.core.memory.store import SQLiteStore
 from loom.core.memory.prediction import PredictionStore
 
@@ -110,6 +123,45 @@ class TestBetShape:
         assert implicit_bet_for(rec, enabled=True) is not None
 
 
+class TestDurationBetShape:
+    """The latency heartbeat — orthogonal axis, same eligibility, distinct domain."""
+
+    def test_duration_bucket_bet_shape(self):
+        rec = _record(tool="run_bash", session="sess-9", states=_EXECUTED)
+        bet = implicit_duration_bet_for(rec, enabled=True)
+        assert bet.resolver == {"kind": "duration_bucket", "expect": "fast"}
+        assert bet.due_condition == {"kind": "after_action", "call_id": "c1"}
+        # distinct @latency domain so it never blends into reliability calibration
+        assert bet.domain == "run_bash@latency"
+        assert bet.session_id == "sess-9"
+        assert bet.status == "pending"
+        assert bet.score is None
+        # distinct provenance from the tool_success heartbeat
+        assert bet.context == "auto:implicit_duration_bucket"
+        assert bet.context != implicit_bet_for(rec, enabled=True).context
+
+    def test_duration_bet_shares_eligibility_guards(self):
+        # gated
+        assert implicit_duration_bet_for(_record(states=_EXECUTED), enabled=False) is None
+        # executed-only
+        assert implicit_duration_bet_for(_record(states=_DENIED), enabled=True) is None
+        # callless
+        assert implicit_duration_bet_for(_record(states=_EXECUTED, call=False), enabled=True) is None
+        # sessionless
+        assert implicit_duration_bet_for(_record(states=_EXECUTED, session=""), enabled=True) is None
+
+    def test_latency_domain_is_orthogonal_to_reliability_domain(self):
+        """The two heartbeats must land in separate calibration domains, else
+        compute_calibration (groups by domain) blends latency-miss into
+        success-miss and the residue becomes meaningless."""
+        rec = _record(tool="fetch_url", states=_EXECUTED)
+        success = implicit_bet_for(rec, enabled=True)
+        latency = implicit_duration_bet_for(rec, enabled=True)
+        assert success.domain == "fetch_url"
+        assert latency.domain == "fetch_url@latency"
+        assert success.domain != latency.domain
+
+
 # ---------------------------------------------------------------------------
 # co_write_implicit_bet — the isolated IO half (no Session needed)
 # ---------------------------------------------------------------------------
@@ -127,15 +179,17 @@ async def store(tmp_db):
 
 
 class TestCoWrite:
-    async def test_executed_action_persists_one_pending_bet(self, store):
+    async def test_executed_action_persists_both_heartbeat_bets(self, store):
         async with store.connect() as db:
             rec = _record(tool="run_bash", states=_EXECUTED)
             wrote = await co_write_implicit_bet(db, rec, enabled=True)
             assert wrote is True
             pending = await PredictionStore(db).list_by_status("pending")
-            assert len(pending) == 1
-            assert pending[0].domain == "run_bash"
-            assert pending[0].context.startswith("auto:")
+            # both heartbeats: tool_success + duration_bucket
+            assert len(pending) == 2
+            domains = {p.domain for p in pending}
+            assert domains == {"run_bash", "run_bash@latency"}
+            assert all(p.context.startswith("auto:") for p in pending)
 
     async def test_disabled_persists_nothing(self, store):
         async with store.connect() as db:


### PR DESCRIPTION
## 背景

epic #528 P0 acceptance gate 觀察期實測（live `~/.loom/memory.db`，11 天 / 1572 筆隱式賭）暴露一個訊號品質問題：

| 軸 | resolver | error_score 分佈 | 判讀 |
|---|---|---|---|
| reliability（已有） | `tool_success` | **1570×0.0 / 2×1.0** | 近乎退化——tool 幾乎都成功，naive prior「會成功」幾乎不會錯 |

且全 1572 筆皆 `auto:implicit_tool_success`，**顯式 predict 工具至今 0 筆**。acceptance gate 的「非平凡」標準，bare tool_success 心跳扛不起。

**SDD 關鍵發現**：語義型 resolver（`output_contains` / `file_digest_changed`）對今天的 action observation **不可對帳**——`_resolve_action` 只吐 `{tool_name, final_state, tool_success, duration_ms}`，`action_records` 表（25849 筆）根本沒存 output/digest。今天可對帳的 richer resolver 只有 `final_state` / `duration_bucket`。

## Track 1（code）— 第二條正交心跳：latency

- `auto_predict.py` 加 `implicit_duration_bet_for`：`duration_bucket @ expect=fast`（全域 ML naive prior，~77% action <1s），`domain=<tool>@latency` **正交隔離**（`compute_calibration` 按 domain 分桶，不污染 reliability residue），settle 同一 action observation（`duration_ms` 已在）→ **零 I2-ground-truth 層改動**
- 抽共用 `_betting_session` eligibility gate（gated / executed-only / sessionless 三契約兩心跳共用）
- `co_write_implicit_bet` 寫雙注，兩注獨立 try/except 互不抑制
- 共用 `auto_predict_enabled` gate，**不加新 spine gate**（守觀察期後的 gate consolidation 意圖）

**真資料模擬證非平凡**：43 domain，error_score 跨 0.00..1.00，排序有意義——`read_file` 永遠 fast（0 surprise）、`recall` 0.57 銅板、媒體生成 / `spawn_agent` 幾乎不 fast（高 uncertainty → P2 exploration 磁鐵）。對比 reliability 軸的 1570/2 全零。

15 測試 TDD red→green；`detect_changes` **LOW / 0 process**（只動 `auto_predict.py` + test）。

## Track 2（doc，不進 code）— 語義型觀察面擴張討論稿

- `docs/designs/59`：餵飽 action observation 出 `output`/digest，讓 `output_contains` / `file_digest_changed` 等白名單 resolver 可對「動作結算」賭。寫清它**撞 I2 神聖邊界**、同 #541 的 (a) 事件先落可對帳 row / (b) 放寬白名單取捨（傾向 a）、per-tool resolver 映射草案、**6 個待拍板交四方輪替 review、未定稿**
- doc 58 §10 deferred 表加 cross-link（語義擴張 + #541）

## 後續（本 PR 不含）

- 翻正 `reconcile_execute` / `calibration_write_enabled` 讓 gate 真正可量測落地——**另行授權**
- doc 59 進 Codex / 絲絲 輪替 review

🤖 Generated with [Claude Code](https://claude.com/claude-code)