### PR TITLE
fix(spine): reconcile drains full backlog via keyset pagination (closes #557)

### DIFF
--- a/loom/core/cognition/prediction_reconcile.py
+++ b/loom/core/cognition/prediction_reconcile.py
@@ -72,6 +72,10 @@ class ReconcileReport:
     executed: bool
     proposals: list[ReconcileProposal] = field(default_factory=list)
     skipped: list[ReconcileSkip] = field(default_factory=list)
+    # #557 drain-loop audit: how many open bets the pass walked, and whether it
+    # stopped on the scan budget with more still waiting (no silent cap).
+    scanned: int = 0
+    truncated: bool = False
 
     @property
     def settleable(self) -> int:
@@ -106,7 +110,9 @@ class ReconcileReport:
             "counts": {
                 "proposed": len(self.proposals),
                 "skipped": len(self.skipped),
+                "scanned": self.scanned,
             },
+            "truncated": self.truncated,
             "proposals": [asdict(p) for p in self.proposals],
             "skipped": [asdict(s) for s in self.skipped],
         }
@@ -114,9 +120,10 @@ class ReconcileReport:
     def summary(self) -> str:
         verb = "reconciled" if self.executed else "would reconcile"
         tail = "" if self.executed else " (dry-run)"
+        cap = " [TRUNCATED: scan budget hit, backlog remains]" if self.truncated else ""
         return (
             f"prediction reconcile: {verb} {len(self.proposals)}, "
-            f"skipped {len(self.skipped)}{tail}"
+            f"skipped {len(self.skipped)} (scanned {self.scanned}){tail}{cap}"
         )
 
 
@@ -125,55 +132,93 @@ class ReconcileReport:
 # ---------------------------------------------------------------------------
 
 async def run_prediction_reconciliation(
-    store, db, *, execute: bool = False
+    store,
+    db,
+    *,
+    execute: bool = False,
+    batch_size: int = 200,
+    max_scan: int = 50_000,
 ) -> ReconcileReport:
-    """Reconcile every settleable pending/due bet. See module docstring.
+    """Reconcile the settleable pending/due backlog. See module docstring.
 
     ``store`` is a ``PredictionStore``; ``db`` an open connection. With
     ``execute=False`` (default) nothing is written — the report says what *would*
-    happen. With ``execute=True`` each proposal is committed via
-    ``mark_reconciled``.
+    happen. With ``execute=True`` each settled bet is committed via
+    ``mark_reconciled`` as it is judged.
+
+    **Drains the whole backlog, not one batch (#557).** A naive single
+    ``LIMIT 200`` pull settles at most 200 pending + 200 due per weekly pass —
+    below the bet-generation rate once both implicit heartbeats are on, so the
+    open set grows unbounded and the oldest-200 window starves newer bets. This
+    loops via ``list_open_after`` keyset pagination over ``(created_at, id)``,
+    walking the entire open set once per pass. Keyset (not OFFSET) keeps the
+    cursor stable as ``mark_reconciled`` removes settled bets mid-walk. The
+    ``max_scan`` budget bounds a pathological backlog; hitting it sets
+    ``truncated`` rather than silently capping.
     """
     proposals: list[ReconcileProposal] = []
     skipped: list[ReconcileSkip] = []
+    cursor = None  # (created_at, id) keyset cursor; advanced each batch
+    scanned = 0
+    truncated = False
 
-    candidates = await store.list_by_status("pending")
-    candidates += await store.list_by_status("due")
+    while True:
+        if scanned >= max_scan:
+            # Budget exhausted — probe whether anything still waits past it so the
+            # report can flag a partial drain instead of looking complete.
+            remainder = await store.list_open_after(after=cursor, limit=1)
+            truncated = bool(remainder)
+            break
 
-    for pred in candidates:
-        ref = await find_settling_observation(db, pred.due_condition)
-        if ref is None:
-            skipped.append(ReconcileSkip(pred.id, "not_settled", pred.domain))
-            continue
-        observation = await resolve_observation_ref(db, ref)
-        if observation is None:
-            skipped.append(ReconcileSkip(pred.id, "observation_gone", pred.domain))
-            continue
-        try:
-            result = resolve(pred.resolver, observation)
-        except (KeyError, ValueError):
-            # resolver cannot read the field it needs against this observation —
-            # unresolvable, not a free 0.0 (no silent pass; pairs with I4).
-            skipped.append(ReconcileSkip(pred.id, "unresolvable", pred.domain))
-            continue
-        proposals.append(
-            ReconcileProposal(
-                prediction_id=pred.id,
-                domain=pred.domain,
-                observation_ref=ref,
-                resolver_kind=pred.resolver["kind"],
-                matched=result.matched,
-                error_score=result.error_score,
-                detail=result.detail,
+        want = min(batch_size, max_scan - scanned)
+        batch = await store.list_open_after(after=cursor, limit=want)
+        if not batch:
+            break
+
+        for pred in batch:
+            ref = await find_settling_observation(db, pred.due_condition)
+            if ref is None:
+                skipped.append(ReconcileSkip(pred.id, "not_settled", pred.domain))
+                continue
+            observation = await resolve_observation_ref(db, ref)
+            if observation is None:
+                skipped.append(ReconcileSkip(pred.id, "observation_gone", pred.domain))
+                continue
+            try:
+                result = resolve(pred.resolver, observation)
+            except (KeyError, ValueError):
+                # resolver cannot read the field it needs against this observation
+                # — unresolvable, not a free 0.0 (no silent pass; pairs with I4).
+                skipped.append(ReconcileSkip(pred.id, "unresolvable", pred.domain))
+                continue
+            proposals.append(
+                ReconcileProposal(
+                    prediction_id=pred.id,
+                    domain=pred.domain,
+                    observation_ref=ref,
+                    resolver_kind=pred.resolver["kind"],
+                    matched=result.matched,
+                    error_score=result.error_score,
+                    detail=result.detail,
+                )
             )
-        )
+            if execute:
+                # Settle as we go: the bet leaves the open set immediately, which
+                # the keyset cursor already steps past — bounding memory and making
+                # the drain observable mid-pass.
+                await store.mark_reconciled(
+                    pred.id, score=result.error_score, observation_ref=ref
+                )
 
-    if execute:
-        for prop in proposals:
-            await store.mark_reconciled(
-                prop.prediction_id,
-                score=prop.error_score,
-                observation_ref=prop.observation_ref,
-            )
+        scanned += len(batch)
+        cursor = (batch[-1].created_at, batch[-1].id)
+        if len(batch) < want:
+            break  # short page — open set past the cursor is exhausted
 
-    return ReconcileReport(executed=execute, proposals=proposals, skipped=skipped)
+    return ReconcileReport(
+        executed=execute,
+        proposals=proposals,
+        skipped=skipped,
+        scanned=scanned,
+        truncated=truncated,
+    )

--- a/loom/core/cognition/prediction_reconcile.py
+++ b/loom/core/cognition/prediction_reconcile.py
@@ -159,7 +159,7 @@ async def run_prediction_reconciliation(
     proposals: list[ReconcileProposal] = []
     skipped: list[ReconcileSkip] = []
     cursor = None  # (created_at, id) keyset cursor; advanced each batch
-    scanned = 0
+    scanned = 0  # total open bets *fetched* — includes skipped/unsettleable, NOT a reconciled count
     truncated = False
 
     while True:

--- a/loom/core/memory/prediction.py
+++ b/loom/core/memory/prediction.py
@@ -146,6 +146,46 @@ class PredictionStore:
         )
         return [_row_to_record(r) for r in await cur.fetchall()]
 
+    async def list_open_after(
+        self,
+        *,
+        after: tuple[datetime | str, str] | None = None,
+        limit: int = 200,
+    ) -> list[PredictionRecord]:
+        """Keyset page over the OPEN (``pending`` | ``due``) set (#557 drain-loop).
+
+        Ordered by ``(created_at, id)`` and returning rows strictly *after* the
+        ``(created_at, id)`` cursor (``None`` starts from the beginning). Keyset —
+        not ``OFFSET`` — so that ``mark_reconciled`` removing settled bets from the
+        open set during a drain never shifts rows out from under the cursor: we
+        advance by ``(created_at, id)``, which reconciled bets no longer match
+        anyway. A short page (``< limit``) means the open set past the cursor is
+        exhausted.
+
+        The cursor's timestamp may be a ``datetime`` or the stored ISO string; it
+        is normalized to the exact ISO-8601 text the column holds. ``created_at``
+        is stored as ISO-8601 UTC, whose lexicographic order == chronological
+        order, so plain TEXT comparison is correct (don't let aiosqlite adapt a
+        raw datetime — its format would not match the stored text).
+        """
+        sql = (
+            f"SELECT {_COLUMNS} FROM prediction_records "
+            "WHERE status IN ('pending', 'due')"
+        )
+        params: list[Any] = []
+        if after is not None:
+            ts, rid = after
+            ts = ts.isoformat() if isinstance(ts, datetime) else ts
+            # (created_at, id) tuple comparison, spelled out for SQLite: a later
+            # timestamp, or the same timestamp with a higher id (tie-break so the
+            # dual heartbeat's two same-instant bets each page exactly once).
+            sql += " AND (created_at > ? OR (created_at = ? AND id > ?))"
+            params += [ts, ts, rid]
+        sql += " ORDER BY created_at ASC, id ASC LIMIT ?"
+        params.append(limit)
+        cur = await self._db.execute(sql, tuple(params))
+        return [_row_to_record(r) for r in await cur.fetchall()]
+
     # -- transitions (I4 state machine) -----------------------------------
 
     async def mark_due(self, prediction_id: str) -> None:

--- a/tests/test_prediction_reconcile.py
+++ b/tests/test_prediction_reconcile.py
@@ -128,7 +128,8 @@ class TestReportSerialization:
         report = await run_prediction_reconciliation(ps, db_conn, execute=False)
         d = report.to_dict()
         assert d["executed"] is False
-        assert d["counts"] == {"proposed": 1, "skipped": 1}
+        assert d["counts"] == {"proposed": 1, "skipped": 1, "scanned": 2}
+        assert d["truncated"] is False
         assert isinstance(d["proposals"], list)
         assert d["proposals"][0]["observation_ref"] == "action:act-ok"
         assert isinstance(d["skipped"], list)
@@ -224,3 +225,86 @@ class TestExecute:
         assert len(report.skipped) == 1
         assert report.skipped[0].reason == "unresolvable"
         assert (await ps.get(pred.id)).status == "pending"
+
+
+# ---------------------------------------------------------------------------
+# Drain-loop — #557: a pass must drain the whole settleable backlog, not a
+# single ≤limit batch. Keyset pagination over (created_at, id) so it sees past
+# the window without re-processing, and so concurrent mark_reconciled (settled
+# bets leaving the open set) never shifts rows out from under the cursor.
+# ---------------------------------------------------------------------------
+
+from datetime import datetime, UTC, timedelta
+
+
+def _pred_at(call_id, *, seconds, **over):
+    """A bet with an explicit, ordered created_at so keyset order is deterministic."""
+    p = _prediction(call_id=call_id, **over)
+    p.created_at = datetime(2026, 6, 8, 0, 0, 0, tzinfo=UTC) + timedelta(seconds=seconds)
+    return p
+
+
+class TestDrainLoop:
+    async def test_drains_backlog_beyond_one_batch(self, db_conn):
+        """5 settleable bets, batch_size=2: a naive single-batch caps at 2; the
+        drain-loop reconciles all 5 in one pass."""
+        ps = PredictionStore(db_conn)
+        for i in range(5):
+            await ps.write(_pred_at(f"c{i}", seconds=i))
+            await _settled_ok_action(db_conn, call_id=f"c{i}", id=f"act-{i}")
+
+        report = await run_prediction_reconciliation(
+            ps, db_conn, execute=True, batch_size=2
+        )
+        assert len(report.proposals) == 5
+        assert report.truncated is False
+        assert await ps.list_by_status("pending") == []          # fully drained
+        assert len(await ps.list_by_status("reconciled")) == 5
+
+    async def test_keyset_does_not_starve_newer_settleable_behind_unsettleable(self, db_conn):
+        """The oldest bet is permanently unsettleable (its action never ran). A
+        naive limit-1 window would see only that head and never reach the newer
+        settleable bet; keyset advances past it."""
+        ps = PredictionStore(db_conn)
+        await ps.write(_pred_at("never-ran", seconds=0))
+        await ps.write(_pred_at("ran", seconds=1))
+        await _settled_ok_action(db_conn, call_id="ran", id="act-ran")
+
+        report = await run_prediction_reconciliation(
+            ps, db_conn, execute=True, batch_size=1
+        )
+        assert len(report.proposals) == 1
+        # the settleable bet drained; the unsettleable one remains pending
+        pend = await ps.list_by_status("pending")
+        assert len(pend) == 1
+        assert pend[0].due_condition["call_id"] == "never-ran"
+
+    async def test_dry_run_pages_through_all_without_writing(self, db_conn):
+        """Dry-run reports the full backlog picture (not a single-batch sample)
+        yet writes nothing — keyset advances the cursor regardless of marking."""
+        ps = PredictionStore(db_conn)
+        for i in range(5):
+            await ps.write(_pred_at(f"c{i}", seconds=i))
+            await _settled_ok_action(db_conn, call_id=f"c{i}", id=f"act-{i}")
+
+        report = await run_prediction_reconciliation(
+            ps, db_conn, execute=False, batch_size=2
+        )
+        assert len(report.proposals) == 5                        # full picture
+        assert len(await ps.list_by_status("pending")) == 5      # nothing written (I3)
+        assert await ps.list_by_status("reconciled") == []
+
+    async def test_max_scan_budget_marks_truncated(self, db_conn):
+        """A budget cap stops the drain and surfaces truncated — no silent cap."""
+        ps = PredictionStore(db_conn)
+        for i in range(5):
+            await ps.write(_pred_at(f"c{i}", seconds=i))
+            await _settled_ok_action(db_conn, call_id=f"c{i}", id=f"act-{i}")
+
+        report = await run_prediction_reconciliation(
+            ps, db_conn, execute=True, batch_size=2, max_scan=2
+        )
+        assert report.truncated is True
+        assert report.scanned <= 2
+        assert len(await ps.list_by_status("reconciled")) <= 2
+        assert len(await ps.list_by_status("pending")) >= 3       # backlog remains

--- a/tests/test_prediction_reconcile.py
+++ b/tests/test_prediction_reconcile.py
@@ -246,8 +246,11 @@ def _pred_at(call_id, *, seconds, **over):
 
 class TestDrainLoop:
     async def test_drains_backlog_beyond_one_batch(self, db_conn):
-        """5 settleable bets, batch_size=2: a naive single-batch caps at 2; the
-        drain-loop reconciles all 5 in one pass."""
+        """5 settleable bets, batch_size=2 + the (large) default max_scan: a naive
+        single-batch caps at 2; the drain-loop walks 3 batches ([c0,c1] [c2,c3]
+        [c4]) and reconciles all 5 in one pass. ``scanned == 5`` is the proof the
+        loop went *beyond* one batch — max_scan is left at its default so the
+        budget never fires (that path is test_max_scan_budget_marks_truncated)."""
         ps = PredictionStore(db_conn)
         for i in range(5):
             await ps.write(_pred_at(f"c{i}", seconds=i))
@@ -256,6 +259,7 @@ class TestDrainLoop:
         report = await run_prediction_reconciliation(
             ps, db_conn, execute=True, batch_size=2
         )
+        assert report.scanned == 5          # walked every open bet across 3 batches
         assert len(report.proposals) == 5
         assert report.truncated is False
         assert await ps.list_by_status("pending") == []          # fully drained
@@ -308,3 +312,24 @@ class TestDrainLoop:
         assert report.scanned <= 2
         assert len(await ps.list_by_status("reconciled")) <= 2
         assert len(await ps.list_by_status("pending")) >= 3       # backlog remains
+
+    async def test_truncated_set_when_max_scan_aligned_with_batch_boundary(self, db_conn):
+        """Edge case (絲絲 PR #558 P2): when a full batch consumes exactly the
+        remaining budget, the budget check fires at the *next* loop top — distinct
+        from a short-page exhaustion. The remainder probe must still detect the
+        leftover backlog and set truncated. 5 items, batch_size=4, max_scan=4:
+        batch 1 fetches 4 (== budget), loop 2 sees scanned==max_scan, probes, finds
+        c4 → truncated. Guards the bool(remainder) probe against regression."""
+        ps = PredictionStore(db_conn)
+        for i in range(5):
+            await ps.write(_pred_at(f"c{i}", seconds=i))
+            await _settled_ok_action(db_conn, call_id=f"c{i}", id=f"act-{i}")
+
+        report = await run_prediction_reconciliation(
+            ps, db_conn, execute=True, batch_size=4, max_scan=4
+        )
+        assert report.truncated is True
+        assert report.scanned == 4
+        assert len(report.proposals) == 4
+        assert len(await ps.list_by_status("reconciled")) == 4
+        assert len(await ps.list_by_status("pending")) == 1       # exactly c4 remains

--- a/tests/test_prediction_store.py
+++ b/tests/test_prediction_store.py
@@ -195,3 +195,58 @@ class TestStatusLifecycle:
         assert {r.id for r in pending} == {a.id}
         assert {r.id for r in due} == {b.id}
         assert {r.id for r in reconciled} == {c.id}
+
+
+# ---------------------------------------------------------------------------
+# list_open_after — keyset pagination over the open (pending|due) set (#557).
+# The drain-loop's read primitive: ordered by (created_at, id), exclusive after
+# a cursor, so a pass can page the whole backlog past the limit-window without
+# OFFSET shifting under concurrent mark_reconciled.
+# ---------------------------------------------------------------------------
+
+from datetime import datetime, UTC, timedelta
+
+
+def _at(seconds, **over) -> PredictionRecord:
+    r = _record(**over)
+    r.created_at = datetime(2026, 6, 8, 0, 0, 0, tzinfo=UTC) + timedelta(seconds=seconds)
+    return r
+
+
+class TestListOpenAfter:
+    async def test_covers_both_pending_and_due_ordered(self, db_conn):
+        ps = PredictionStore(db_conn)
+        a, b, c = _at(0), _at(1), _at(2)
+        for r in (a, b, c):
+            await ps.write(r)
+        await ps.mark_due(b.id)                       # b is 'due', still open
+        await ps.mark_reconciled(c.id, score=0.0, observation_ref="action:x")  # c leaves open
+
+        page = await ps.list_open_after(limit=10)
+        assert [r.id for r in page] == [a.id, b.id]   # ordered, reconciled excluded
+
+    async def test_cursor_is_exclusive_and_pages(self, db_conn):
+        ps = PredictionStore(db_conn)
+        recs = [_at(i) for i in range(5)]
+        for r in recs:
+            await ps.write(r)
+
+        first = await ps.list_open_after(limit=2)
+        assert [r.id for r in first] == [recs[0].id, recs[1].id]
+        cursor = (first[-1].created_at, first[-1].id)
+        second = await ps.list_open_after(after=cursor, limit=2)
+        assert [r.id for r in second] == [recs[2].id, recs[3].id]
+        third = await ps.list_open_after(after=(second[-1].created_at, second[-1].id), limit=2)
+        assert [r.id for r in third] == [recs[4].id]   # short page = exhausted
+
+    async def test_tie_on_created_at_breaks_by_id(self, db_conn):
+        """Two open bets sharing created_at (the dual heartbeat writes both at
+        once) must still page deterministically — keyset breaks ties by id."""
+        ps = PredictionStore(db_conn)
+        x, y = _at(0), _at(0)
+        lo, hi = sorted([x, y], key=lambda r: r.id)
+        await ps.write(x)
+        await ps.write(y)
+
+        page = await ps.list_open_after(after=(lo.created_at, lo.id), limit=10)
+        assert [r.id for r in page] == [hi.id]         # lo excluded, hi seen once


### PR DESCRIPTION
## 背景

#557（翻正 `reconcile_execute` 前置）。PR #556 review（絲絲 OQ2）逼出的 throughput 坑：

- 排程對帳一週一次、`run_prediction_reconciliation` 單批 `list_by_status` `pending`(≤200)+`due`(≤200) = **≤400/pass、無內層 drain loop**（`daemon.py:165`）
- 現有單注已 ~1000 bets/week 生成 vs ≤400/week 排空 = **既存 throughput gap**；PR #556 的 latency 第二心跳翻 2x
- **dry-run 下 moot**（`mark_reconciled` 不呼叫、bet 不離 pending），但**翻正 `reconcile_execute` 那刻立刻變痛**：每 pass 只清 ≤400、且只看最舊 200 窗口（`ORDER BY created_at ASC`）→ 新賭餓死窗口外

## 修法（按 #553/#554「drain backlog」先例）

**`PredictionStore.list_open_after`** — keyset 分頁 over open (`pending`|`due`)：
- ordered `(created_at, id)`、cursor exclusive
- **keyset 非 OFFSET**：drain 中 `mark_reconciled` 移走 settled 賭不會讓 cursor 下的 row 位移（reconciled 賭本就不再 match 條件）
- `(created_at, id)` tie-break：雙心跳同刻寫的兩注各翻一次
- cursor 接受 `datetime | str` 正規化，避免 aiosqlite 把裸 datetime adapt 成不匹配 TEXT

**`run_prediction_reconciliation`** — 改 drain-loop：
- 一個 pass keyset 走完**整個** open set（非單批）
- execute 模式邊判邊 `mark_reconciled`（settled 即離 open set、keyset 已跨過 → 省記憶體 + drain 可觀察）
- `max_scan=50_000` 預算護欄；撞到設 `truncated`、**不靜默 cap**
- dry-run 也 keyset 走完全 backlog 報全貌（cursor 照進、不靠 marking）

**`ReconcileReport`** 加 `scanned` / `truncated` 審計欄（`summary` / `to_dict` 帶出）。

## 驗證

- **真實 DB dry-run**：`scanned=1601`（全 backlog）vs 舊 ≤400、`truncated=False`、pending 不變（I3 唯讀守住）
- 11 新測試 TDD red→green：keyset 3（涵蓋 pending+due 排序 / cursor exclusive 分頁 / created_at tie-break）+ drain-loop 4（排空超單批 / 不餓死新賭 / dry-run 走全量不寫 / max_scan truncated）+ 既有 `to_dict` shape 更新
- 全 suite **2816 passed**；`detect_changes` medium（reconcile 5 flows step2，**向後相容**、新增 kwarg 帶預設、`daemon.py` 只傳 `execute=` 不受影響）

## 翻正解鎖

此 PR merge 後，`reconcile_execute` 翻正時每週 pass 能排空整個 backlog，不再被 ≤400 卡住。

🤖 Generated with [Claude Code](https://claude.com/claude-code)