### PR TITLE
feat(spine): grade duration_bucket resolver by ordinal distance (#528)

### DIFF
--- a/loom/core/memory/resolvers.py
+++ b/loom/core/memory/resolvers.py
@@ -33,6 +33,9 @@ KNOWN_RESOLVERS = {
 
 # duration_bucket thresholds (ms). A bet names the bucket it expects.
 _DURATION_BUCKETS = (("fast", 1_000.0), ("medium", 10_000.0))  # else "slow"
+# Ordered bucket scale — distance between predicted/actual grades the error so a
+# one-bucket miss is half-wrong, not as wrong as a two-bucket miss (#528 §6).
+_DURATION_ORDER = ("fast", "medium", "slow")
 
 
 @dataclass
@@ -98,6 +101,18 @@ def resolve(resolver: dict, observation: dict) -> ResolverResult:
         error_score = 0.0 if matched else min(1.0, delta / max(1, abs(expect)))
         return ResolverResult(matched, error_score, f"expect={expect} actual={actual}")
 
-    # duration_bucket
+    # duration_bucket — graded by ordinal bucket distance (was binary). A flat
+    # match/no-match collapses the latency heartbeat to a near-constant 0.0
+    # corpus that can't carry the §8 non-triviality gate; distance/range keeps
+    # ``matched`` exact-hit only while letting error_score grade the magnitude.
     actual_bucket = _bucket_for(observation["duration_ms"])
-    return _binary(actual_bucket == resolver["expect"], f"bucket={actual_bucket}")
+    expect_bucket = resolver["expect"]
+    distance = abs(
+        _DURATION_ORDER.index(actual_bucket) - _DURATION_ORDER.index(expect_bucket)
+    )
+    error_score = distance / (len(_DURATION_ORDER) - 1)
+    return ResolverResult(
+        matched=actual_bucket == expect_bucket,
+        error_score=error_score,
+        detail=f"bucket={actual_bucket} expect={expect_bucket}",
+    )

--- a/tests/test_prediction_resolvers.py
+++ b/tests/test_prediction_resolvers.py
@@ -161,8 +161,22 @@ class TestDurationBucket:
             {"duration_ms": 200},
         )
         assert r.matched is True
+        assert r.error_score == 0.0
+
+    def test_bucket_off_by_one_is_graded(self):
+        """Graded by ordinal bucket distance (#528 acceptance-gate signal): a
+        fast-vs-medium miss is half-wrong, not the binary 1.0 a slow miss is.
+        Without this the latency heartbeat collapses to a near-constant 0.0
+        corpus that can't carry the §8 non-triviality gate."""
+        r = resolve(
+            {"kind": "duration_bucket", "expect": "fast"},
+            {"duration_ms": 5_000},  # medium — one bucket off
+        )
+        assert r.matched is False
+        assert r.error_score == 0.5
 
     def test_bucket_misses_expectation(self):
+        """Two buckets off (fast vs slow) is the max distance → still 1.0."""
         r = resolve(
             {"kind": "duration_bucket", "expect": "fast"},
             {"duration_ms": 60_000},


### PR DESCRIPTION
## 為什麼

`duration_bucket` resolver 之前是**二元**（中桶 → 0.0，否則 1.0）。這讓 #556 latency 心跳 —— 它本來就是為了「補非平凡 calibration 訊號」而加的 —— 仍塌成近常數 0.0 corpus。

對 live backlog（~1.7k 賭）跑一份 **read-only post-#558 dry-run（execute=False，不寫任何東西）** 證實了這點：

| | error_score 分佈 | graded(0,1)之間 |
|---|---|---|
| 改前 | `0.0 ×1714 / 1.0 ×7` | **0** |
| 改後 | `0.0 ×1732 / 1.0 ×6 / 0.5 ×7` | **7** |

每筆 latency 賭原本都二元；改後 `recall@latency`（medium vs fast，差一桶）落到 **0.5** 而非 1.0。

## 改什麼

依**桶序距離** `fast < medium < slow` 把 error 改成 graded：`distance / range → 0.0 / 0.5 / 1.0`，對齊既有的 graded `row_count` resolver（非新模式）。

- `matched` 維持**精確中桶才 True** → hit-rate 不被污染，只有 `error_score` 承載 magnitude
- `calibration.py` 既有 `mean_error = sum(errs)/n` 與 `valence = polarity × error_score` 直接吃 error_score → graded 值自動流進非平凡 mean，**無消費端改動**
- 一個無效 `expect` 桶名現在會 raise（被 reconcile 的 `except (KeyError, ValueError)` 收成 `unresolvable`），對齊 `final_state` 空 `expect_in` 的 no-silent-pass 先例

## 驗證

- TDD red→green：新增 `test_bucket_off_by_one_is_graded`（差一桶=0.5），exact-hit 補 `error_score == 0.0` pin
- resolver+auto_predict 38 passed；spine 全面 183 passed
- `gitnexus impact(resolve)`：**LOW**，唯一 direct caller `run_prediction_reconciliation`
- `gitnexus detect_changes`：只動 `resolvers.py` + 測試，0 個非預期 process

## 誠實的範圍

這是 acceptance-gate 非平凡化的**第一塊槓桿**，不是全部。latency 仍只佔 corpus ~4%（`tool_success` ~1677 筆、本質 ~99.6% 0.0 二元），所以 gate 還需要**顯式 `predict` 賭流動起來** —— 那是 epic #528 P0.5 下獨立追蹤的下一步。本 PR 刻意只做 resolver 一塊，獨立可驗、low-risk。

相關：epic #528、#556（latency 心跳）、#558（reconcile drain-loop）、spec docs/designs/58 §6

🤖 Generated with [Claude Code](https://claude.com/claude-code)