### PR TITLE
feat(spine): invite explicit predict bets on self-driven turns (#528)

### DIFF
--- a/loom/core/session.py
+++ b/loom/core/session.py
@@ -149,6 +149,7 @@ from loom.core.session_support import (  # noqa: F401  (re-export)
     _load_env,
     _parse_skill_frontmatter,
     _resolve_output_max_tokens,
+    prediction_nudge_body,
 )
 
 console = Console(highlight=False)
@@ -1994,6 +1995,18 @@ class LoomSession:
                     _log_record(record)
             self._pending_verdicts.clear()
             self._pending_pulses.clear()
+
+            # Epic #528 (P0.5-a follow-up): on self-driven turns invite one
+            # deliberate `predict` bet so explicit, confidence-varying wagers
+            # flow instead of the auto-heartbeat monoculture. Origin-gated to the
+            # autonomy path (never human chat) and suppressed when the predict
+            # tool isn't registered. Soft + behaviour-neutral (I5).
+            _nudge = prediction_nudge_body(
+                origin,
+                predict_tool_enabled=getattr(self, "_predict_tool_enabled", False),
+            )
+            if _nudge is not None:
+                _emit_reminder(_nudge)
 
             await self._memory.episodic.write(
                 EpisodicEntry(

--- a/loom/core/session_support.py
+++ b/loom/core/session_support.py
@@ -49,6 +49,43 @@ _OUTCOME_MARKERS: dict[str, str] = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Prediction Spine — autonomy-path betting nudge (epic #528, P0.5-a follow-up)
+# ---------------------------------------------------------------------------
+
+# Origins whose turns are Loom acting on its own (scheduled chime / daemon-planned
+# autonomy), as opposed to a human speaking (interactive / user / discord / mcp)
+# or a sub-agent doing context isolation (subagent). The betting nudge fires only
+# here — keeping the human chat path DK already steers free of spine prompting,
+# per the "emergent mechanisms live in the autonomy path" principle.
+_SELF_DRIVEN_ORIGINS = frozenset({"chime", "autonomy"})
+
+
+def prediction_nudge_body(origin: str, *, predict_tool_enabled: bool) -> str | None:
+    """The ``<system-reminder>`` body inviting one deliberate ``predict`` bet,
+    or ``None`` when this turn should not be nudged.
+
+    The ``predict`` tool (#537) is passive — nothing makes the agent use it, so
+    the corpus was a 100% ``auto:`` heartbeat monoculture. This invites a wager
+    on self-driven turns so explicit, confidence-varying bets actually flow (the
+    non-trivial signal the §8 acceptance gate needs). Suppressed when the tool is
+    not registered (``predict_tool_enabled`` off) and on every human / subagent
+    origin. Wording is optional + behaviour-neutral on purpose: a bet must never
+    change which action the agent takes (I5 — prediction has no path to output).
+    """
+    if not predict_tool_enabled or origin not in _SELF_DRIVEN_ORIGINS:
+        return None
+    return (
+        "You are acting autonomously this turn. Before your next consequential "
+        "tool call, consider placing one falsifiable `predict` bet about its "
+        "outcome — a concrete, mechanically-checkable claim (e.g. row_count, "
+        "tool_success, output_contains), not a vibe. The reconcile pass settles "
+        "it against what actually happens and folds it into your calibration. "
+        "This is optional and must not change which action you take — it only "
+        "sharpens your sense of where you predict well or poorly."
+    )
+
+
 def _clean_envelope_metadata_line(text: str, *, max_len: int = 140) -> str:
     line = " ".join(str(text or "").strip().split())
     if len(line) <= max_len:

--- a/tests/test_prediction_nudge.py
+++ b/tests/test_prediction_nudge.py
@@ -57,3 +57,14 @@ class TestNudgeSuppressed:
 
     def test_subagent_origin_not_nudged(self):
         assert prediction_nudge_body("subagent", predict_tool_enabled=True) is None
+
+    def test_missing_attr_falls_back_to_suppress(self):
+        """The stream_turn call site reads the flag via getattr(self, ..., False),
+        so a partially-constructed session that never set _predict_tool_enabled
+        suppresses the nudge rather than raising — mirrors the nearby
+        hasattr(self, "_legitimacy_guard") guard (絲絲 PR #560 review)."""
+        class _BareSession:  # no _predict_tool_enabled attribute
+            pass
+
+        enabled = getattr(_BareSession(), "_predict_tool_enabled", False)
+        assert prediction_nudge_body("autonomy", predict_tool_enabled=enabled) is None

--- a/tests/test_prediction_nudge.py
+++ b/tests/test_prediction_nudge.py
@@ -1,0 +1,59 @@
+"""
+Prediction Spine — autonomy-path betting nudge (epic #528, P0.5-a follow-up).
+
+The ``predict`` tool (#537 slice A) is a passive registry tool: nothing prompts
+the agent to use it, so the live corpus had **zero** explicit bets — a
+monoculture of ``auto:`` heartbeats that only measures raw tool reliability, not
+prediction skill. This nudge makes deliberate bets *flow* by softly inviting one
+each self-driven turn.
+
+Contract (pure function, no session state):
+  * fires ONLY on self-driven origins (chime / autonomy) — never human chat,
+    so the human path DK already steers stays unpolluted.
+  * gated on ``predict_tool_enabled`` — never nudge toward a tool that isn't
+    registered.
+  * optional + behaviour-neutral wording — preserves I5 (prediction has no
+    direct path to driving the action taken).
+"""
+
+from loom.core.session_support import prediction_nudge_body, _SELF_DRIVEN_ORIGINS
+
+
+class TestSelfDrivenOriginSet:
+    def test_self_driven_set_is_chime_and_autonomy(self):
+        # subagent is context-isolation, not a betting context; human-facing
+        # origins (interactive/user/discord/mcp) must stay out.
+        assert _SELF_DRIVEN_ORIGINS == frozenset({"chime", "autonomy"})
+
+
+class TestNudgeFires:
+    def test_chime_with_tool_enabled_nudges(self):
+        body = prediction_nudge_body("chime", predict_tool_enabled=True)
+        assert body is not None
+        assert "predict" in body.lower()
+
+    def test_autonomy_with_tool_enabled_nudges(self):
+        body = prediction_nudge_body("autonomy", predict_tool_enabled=True)
+        assert body is not None
+        assert "predict" in body.lower()
+
+    def test_nudge_is_optional_and_behaviour_neutral(self):
+        """I5: the bet must never change which action the agent takes."""
+        body = prediction_nudge_body("autonomy", predict_tool_enabled=True).lower()
+        assert "optional" in body
+        # explicitly disclaims steering the action
+        assert "must not change" in body or "without changing" in body
+
+
+class TestNudgeSuppressed:
+    def test_tool_disabled_suppresses_nudge(self):
+        # registering nothing → nudging toward an absent tool would be a dead end
+        assert prediction_nudge_body("chime", predict_tool_enabled=False) is None
+        assert prediction_nudge_body("autonomy", predict_tool_enabled=False) is None
+
+    def test_human_origins_never_nudged(self):
+        for origin in ("interactive", "user", "discord", "mcp"):
+            assert prediction_nudge_body(origin, predict_tool_enabled=True) is None
+
+    def test_subagent_origin_not_nudged(self):
+        assert prediction_nudge_body("subagent", predict_tool_enabled=True) is None


### PR DESCRIPTION
## 為什麼

`predict` 工具（#537 slice A）是 registry 裡的**被動工具** —— 沒有任何東西促使 agent 呼叫它。所以 live corpus 的 explicit 賭 = **0 筆**，是 100% `auto:` 心跳 monoculture，只量原始 tool 可靠度、非預測技巧。這正是 §8 acceptance gate 讀起來死平的根因（calibration 蓋在近常數 `tool_success` 上）。

> 接續 #559（duration_bucket graded）：那塊豐富了 latency 訊號的 magnitude，但 latency 只佔 corpus ~4%；要真正撐起 gate 非平凡，得讓**顯式賭流動起來**。本 PR 是 path B 的第二塊。

## 改什麼

在 `stream_turn` 的 once-per-turn setup 區注入一則 `<system-reminder>`，邀請 agent 在自走 turn 下一注。判斷抽成純函式 `prediction_nudge_body(origin, *, predict_tool_enabled)` 放 `session_support.py`（避開 god-object 測試路徑）。

**三道閘**：
- **origin ∈ {chime, autonomy}** —— 只在 autonomy 路徑。人類 chat（interactive/user/discord/mcp）與 subagent（context isolation）turn **永不 nudge**，讓 DK 已親自掌舵的路徑零污染。對齊「emergent 機制住 autonomy 路徑」原則。
- **`predict_tool_enabled` off → 抑制** —— 絕不 nudge 向未註冊的工具。
- **wording optional + behaviour-neutral**（"must not change which action you take"）—— 保全 **I5**：預測無路徑驅動 output。

注入點重用既有的 per-turn `_emit_reminder`，flag 用 `getattr` 讀（部分構造的 test session 沒這 attr），對齊鄰近 `hasattr(self, "_legitimacy_guard")` 防禦。

## 驗證

- TDD red→green：`tests/test_prediction_nudge.py` 覆蓋 fire/suppress 矩陣 + behaviour-neutral 文字契約（7 passed）
- session 57 passed、spine/autonomy/chime/resolver/calibration 廣掃 **321 passed**
- `gitnexus detect_changes`：**LOW**，0 affected processes（session.py + session_support.py，+50 行）
- re-export `from loom.core.session import prediction_nudge_body` OK

## 誠實的限制（請邊 review 邊一起想）

這是**邀請、非強制** —— agent 可能忽略它；且自走 turn 頻率本身有限（chime/排程），所以 bet 會流動但**慢**。這是相對「每 turn 全域 nudge」刻意的取捨，為了尊重 signal-only 哲學。能不能拉到足夠 explicit 賭去推動 gate，是 ramp 的觀察問題。

**想跟你討論的開放點：**
1. **頻率 vs 噪音**：目前每個自走 turn 都注入一次。多步 autonomy turn 只在 setup 注一次（非每 LLM-loop iteration），但若自走變密，要不要加「每 session / 每 N turn 一次」的節流？還是靠 reminder 夠輕就好？
2. **gaming 風險**：nudge 鼓勵下注，agent 會不會傾向下「穩贏」的安全賭（永遠 expect success）來讓 calibration 好看？這會把 explicit 賭也拉回 monoculture。要不要在 wording 補「bet where you're genuinely uncertain」？我刻意沒加，怕過度規訓 —— 想聽你的判斷。
3. **observation hook**：要不要順手讓 reconcile report 分流 `explicit:` vs `auto:` 的 count，好量這個 nudge 實際拉動多少？（本 PR 沒做，留 hook。）

相關：epic #528、#537（predict 工具）、#559（duration_bucket graded）、spec docs/designs/58 §6/§8

🤖 Generated with [Claude Code](https://claude.com/claude-code)