### PR TITLE
feat(spine): split reconcile report by bet provenance (auto vs explicit) (#528)

### DIFF
--- a/loom/core/cognition/prediction_reconcile.py
+++ b/loom/core/cognition/prediction_reconcile.py
@@ -41,6 +41,10 @@ from loom.core.memory.resolvers import resolve
 # report split deliberate ``predict``-tool bets from the involuntary heartbeat so
 # the #560 nudge's effect on the ``auto:`` monoculture is observable at a glance.
 _KNOWN_PROVENANCE = ("auto", "explicit")
+# Fixed display order for the summary split (絲絲 PR #561 review): intentional,
+# not alphabetical — a future fourth provenance slots in here deliberately rather
+# than landing wherever ``sorted()`` happens to put it. ``other`` always trails.
+_PROVENANCE_DISPLAY_ORDER = (*_KNOWN_PROVENANCE, "other")
 
 
 def bet_provenance(context: str | None) -> str:
@@ -150,9 +154,10 @@ class ReconcileReport:
         # Provenance split rides on the proposed count so the dream journal shows
         # explicit-vs-auto flow inline (omitted when nothing settled).
         prov = self.provenance_counts()
+        ordered = [k for k in _PROVENANCE_DISPLAY_ORDER if k in prov]
         split = (
-            " (" + ", ".join(f"{k} {prov[k]}" for k in sorted(prov)) + ")"
-            if prov else ""
+            " (" + ", ".join(f"{k} {prov[k]}" for k in ordered) + ")"
+            if ordered else ""
         )
         return (
             f"prediction reconcile: {verb} {len(self.proposals)}{split}, "

--- a/loom/core/cognition/prediction_reconcile.py
+++ b/loom/core/cognition/prediction_reconcile.py
@@ -37,6 +37,21 @@ from loom.core.memory.resolvers import resolve
 # Report shape — the auditable projection 絲絲 reviews
 # ---------------------------------------------------------------------------
 
+# Bet provenance — coarse origin of a wager, by ``context`` prefix. Lets the
+# report split deliberate ``predict``-tool bets from the involuntary heartbeat so
+# the #560 nudge's effect on the ``auto:`` monoculture is observable at a glance.
+_KNOWN_PROVENANCE = ("auto", "explicit")
+
+
+def bet_provenance(context: str | None) -> str:
+    """Classify a bet by its ``context`` prefix: ``auto`` (heartbeat),
+    ``explicit`` (predict tool), or ``other`` (free-text / unset). Splitting on
+    the first ``:`` keeps it robust to the suffix (``auto:implicit_tool_success``
+    vs ``auto:implicit_duration_bucket`` both fold to ``auto``)."""
+    prefix = (context or "").split(":", 1)[0]
+    return prefix if prefix in _KNOWN_PROVENANCE else "other"
+
+
 @dataclass
 class ReconcileProposal:
     """One matured bet, judged. The unit of audit: *this* prediction was scored
@@ -48,6 +63,7 @@ class ReconcileProposal:
     matched: bool
     error_score: float
     detail: str = ""
+    provenance: str = "other"  # auto / explicit / other — see bet_provenance
 
 
 @dataclass
@@ -81,6 +97,15 @@ class ReconcileReport:
     def settleable(self) -> int:
         return len(self.proposals)
 
+    def provenance_counts(self) -> dict:
+        """Settled proposals grouped by bet provenance (auto / explicit / other).
+        The #560 nudge is meant to lift ``explicit`` off zero — this is the
+        number that says whether it's working. Only non-zero buckets appear."""
+        counts: dict[str, int] = {}
+        for p in self.proposals:
+            counts[p.provenance] = counts.get(p.provenance, 0) + 1
+        return counts
+
     def render(self) -> str:
         """Render as a 夢境鞏固-style body for the dream journal (slice 3.5).
 
@@ -111,6 +136,7 @@ class ReconcileReport:
                 "proposed": len(self.proposals),
                 "skipped": len(self.skipped),
                 "scanned": self.scanned,
+                "by_provenance": self.provenance_counts(),
             },
             "truncated": self.truncated,
             "proposals": [asdict(p) for p in self.proposals],
@@ -121,8 +147,15 @@ class ReconcileReport:
         verb = "reconciled" if self.executed else "would reconcile"
         tail = "" if self.executed else " (dry-run)"
         cap = " [TRUNCATED: scan budget hit, backlog remains]" if self.truncated else ""
+        # Provenance split rides on the proposed count so the dream journal shows
+        # explicit-vs-auto flow inline (omitted when nothing settled).
+        prov = self.provenance_counts()
+        split = (
+            " (" + ", ".join(f"{k} {prov[k]}" for k in sorted(prov)) + ")"
+            if prov else ""
+        )
         return (
-            f"prediction reconcile: {verb} {len(self.proposals)}, "
+            f"prediction reconcile: {verb} {len(self.proposals)}{split}, "
             f"skipped {len(self.skipped)} (scanned {self.scanned}){tail}{cap}"
         )
 
@@ -200,6 +233,7 @@ async def run_prediction_reconciliation(
                     matched=result.matched,
                     error_score=result.error_score,
                     detail=result.detail,
+                    provenance=bet_provenance(pred.context),
                 )
             )
             if execute:

--- a/tests/test_prediction_reconcile.py
+++ b/tests/test_prediction_reconcile.py
@@ -24,6 +24,7 @@ from loom.core.cognition.prediction_reconcile import (
     run_prediction_reconciliation,
     ReconcileReport,
     ReconcileProposal,
+    bet_provenance,
 )
 
 
@@ -102,6 +103,16 @@ class TestDryRunReportShape:
         assert prop.error_score == 0.0
         assert prop.detail  # non-empty resolver detail
 
+    async def test_proposal_carries_provenance_from_bet_context(self, db_conn):
+        ps = PredictionStore(db_conn)
+        pred = _prediction()
+        pred.context = "explicit:predict_tool"  # a deliberate wager, not a heartbeat
+        await ps.write(pred)
+        await _settled_ok_action(db_conn, id="act-1")
+
+        report = await run_prediction_reconciliation(ps, db_conn, execute=False)
+        assert report.proposals[0].provenance == "explicit"
+
     async def test_unsettled_bet_is_skipped_with_reason(self, db_conn):
         ps = PredictionStore(db_conn)
         await ps.write(_prediction(call_id="never-ran"))
@@ -128,13 +139,67 @@ class TestReportSerialization:
         report = await run_prediction_reconciliation(ps, db_conn, execute=False)
         d = report.to_dict()
         assert d["executed"] is False
-        assert d["counts"] == {"proposed": 1, "skipped": 1, "scanned": 2}
+        assert d["counts"] == {
+            "proposed": 1, "skipped": 1, "scanned": 2,
+            "by_provenance": {"other": 1},  # default-context bet (no auto:/explicit: prefix)
+        }
         assert d["truncated"] is False
         assert isinstance(d["proposals"], list)
         assert d["proposals"][0]["observation_ref"] == "action:act-ok"
         assert isinstance(d["skipped"], list)
         assert d["skipped"][0]["reason"] == "not_settled"
         assert d["skipped"][0]["domain"] == "cli"
+
+
+# ---------------------------------------------------------------------------
+# Provenance split — measure explicit (predict tool) vs auto (heartbeat) flow
+# so the nudge's effect on the monoculture is observable (#560 follow-up)
+# ---------------------------------------------------------------------------
+
+class TestBetProvenance:
+    def test_auto_heartbeat_contexts(self):
+        assert bet_provenance("auto:implicit_tool_success") == "auto"
+        assert bet_provenance("auto:implicit_duration_bucket") == "auto"
+
+    def test_explicit_predict_tool_context(self):
+        assert bet_provenance("explicit:predict_tool") == "explicit"
+
+    def test_unknown_or_missing_context_is_other(self):
+        assert bet_provenance("") == "other"
+        assert bet_provenance(None) == "other"
+        assert bet_provenance("freeform note") == "other"
+
+
+class TestProvenanceCounts:
+    def _prop(self, provenance):
+        return ReconcileProposal(
+            prediction_id="p", domain="cli", observation_ref="action:a",
+            resolver_kind="tool_success", matched=True, error_score=0.0,
+            provenance=provenance,
+        )
+
+    def test_summary_breaks_down_proposals_by_provenance(self):
+        report = ReconcileReport(
+            executed=False,
+            proposals=[self._prop("auto"), self._prop("auto"), self._prop("explicit")],
+            scanned=3,
+        )
+        # at-a-glance signal in the dream journal: is the nudge pulling bets?
+        assert "auto 2" in report.summary()
+        assert "explicit 1" in report.summary()
+
+    def test_to_dict_carries_by_provenance(self):
+        report = ReconcileReport(
+            executed=False,
+            proposals=[self._prop("auto"), self._prop("explicit")],
+            scanned=2,
+        )
+        assert report.to_dict()["counts"]["by_provenance"] == {"auto": 1, "explicit": 1}
+
+    def test_no_proposals_omits_breakdown(self):
+        # zero settled bets — keep the summary line clean, no "(auto 0, explicit 0)"
+        report = ReconcileReport(executed=False, proposals=[], scanned=0)
+        assert "auto" not in report.summary()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_prediction_reconcile.py
+++ b/tests/test_prediction_reconcile.py
@@ -201,6 +201,27 @@ class TestProvenanceCounts:
         report = ReconcileReport(executed=False, proposals=[], scanned=0)
         assert "auto" not in report.summary()
 
+    def test_render_carries_provenance_split(self):
+        # render() is what lands in the dream journal — pin that it inherits the
+        # split, so a future render() divergence from summary() can't drop it
+        # silently (絲絲 PR #561 review P3).
+        report = ReconcileReport(
+            executed=True,
+            proposals=[self._prop("auto"), self._prop("explicit")],
+            scanned=2,
+        )
+        assert "(auto 1, explicit 1)" in report.render()
+
+    def test_summary_display_order_is_fixed_not_alphabetical(self):
+        # auto before explicit before other — intentional order, and `other`
+        # trails even though it sorts last alphabetically too (絲絲 review P1).
+        report = ReconcileReport(
+            executed=True,
+            proposals=[self._prop("other"), self._prop("explicit"), self._prop("auto")],
+            scanned=3,
+        )
+        assert "(auto 1, explicit 1, other 1)" in report.summary()
+
 
 # ---------------------------------------------------------------------------
 # I3 at the function level — dry-run is read-only by construction


### PR DESCRIPTION
## 為什麼

#560 加了 nudge 邀請 agent 在自走 turn 下顯式 `predict` 賭，但 reconcile report **把所有結算的賭混在一起算** —— 沒辦法從報告看出 nudge 到底有沒有把 `explicit:` 拉離 0、還是 corpus 仍是純 `auto:` 心跳 monoculture。這就是 #560 開放點 3 留的 observation hook。

## 改什麼

- **`bet_provenance(context)`** —— 純分類函式，把賭的 context 前綴折成 `auto` / `explicit` / `other`（split on first `:`，所以 `auto:implicit_tool_success` 與 `auto:implicit_duration_bucket` 都折成 `auto`）
- **`ReconcileProposal.provenance`** 欄，loop 內從 `pred.context` 帶上
- **summary 內聯分流**：`prediction reconcile: reconciled 3 (auto 2, explicit 1), skipped 0 ...` —— dream journal 一眼看出 explicit 流動多少
- **`to_dict` counts** 加 `by_provenance`
- 零結算時**省略 breakdown**，空 pass 行保持乾淨

實測渲染：
```
reconciled 3 (auto 2, explicit 1), skipped 0 (scanned 3)
counts: {'proposed': 3, 'skipped': 0, 'scanned': 3, 'by_provenance': {'auto': 2, 'explicit': 1}}
空 corpus: would reconcile 0, skipped 0 (scanned 0) (dry-run)   ← 無 breakdown
```

## 為何重要（接 #560 討論）

這讓 nudge 的效果**從 dream journal 直接可量**，不必查 DB。也是判斷絲絲在 #560 review 提的 **P3「multi-turn 重複 nudge → redundant bet」**問題的前置 —— 要看「同 session_id 多個 bet resolver 是否高度重疊」，得先有 provenance + 分流的 corpus 視圖。先有量尺，再決定要不要調 nudge wording。

## 驗證

- TDD red→green：`TestBetProvenance`（分類矩陣）+ `TestProvenanceCounts`（summary/to_dict 分流、空 corpus 省略）+ `test_proposal_carries_provenance_from_bet_context`（端到端）
- `test_to_dict_shape` 既有 exact-match 斷言隨契約擴張更新（加 `by_provenance`）
- reconcile 21 passed、spine 廣掃（prediction/calibration/scheduled/convergent）**252 passed**
- `gitnexus detect_changes`：medium，但 5 個 affected processes **全是 `run_prediction_reconciliation` 自身**在其正常 reconcile flow —— medium 來自 dataclass 加欄位的圖噪音（所有 field property 重索引），非真實 blast radius；下游消費端已被 252 passed 覆蓋

## Signal-only

無行為改變、無新寫入 —— provenance 只是既有 `context` 欄（每個賭本就有）的投影。

相關：epic #528、#560（nudge）、#559（duration_bucket graded）、spec docs/designs/58 §5

🤖 Generated with [Claude Code](https://claude.com/claude-code)