### PR TITLE
feat(circadian): emit circadian:weave_applied at dawn (#472)

### DIFF
--- a/loom.toml.example
+++ b/loom.toml.example
@@ -738,6 +738,23 @@ session_prefix = "daily-life"   # thread name → daily-life-YYYY-MM-DD
 #   { resource = "exec", action = "execute", selector = "workspace" },
 # ]
 
+# ── Example: subscribe to a circadian lifecycle event (issue #472) ────────────
+# Circadian emits these events from inside the daily lifecycle — no extra
+# wiring needed, just listen by name:
+#   • circadian:day_started   {date, thread_id, session_id}  — daily session opened
+#   • circadian:day_closed    {date, thread_id, closed_at}   — daily session closed
+#   • circadian:weave_applied {date, applied_from, rationale} — last night's
+#       weave_revise applied; the revised plan drives behaviour from this dawn
+# There is no built-in subscriber by design — add one only when you have a
+# real use (e.g. archive yesterday's pursuits when the day closes). Example:
+# [[autonomy.triggers]]
+# name          = "on_day_closed"
+# event         = "circadian:day_closed"
+# intent        = "Archive completed pursuits and note tomorrow's first thread."
+# trust_level   = "safe"
+# notify        = false
+# notify_thread = 0
+
 # ── Example: free-dream supplement (pair with [memory.dream]) ──────────────────
 # Themed rotation is owned by ``[memory.dream]`` (daemon-level, no LLM
 # intent). This schedule is the recommended complement: a single daily

--- a/loom.toml.example
+++ b/loom.toml.example
@@ -741,9 +741,9 @@ session_prefix = "daily-life"   # thread name → daily-life-YYYY-MM-DD
 # ── Example: subscribe to a circadian lifecycle event (issue #472) ────────────
 # Circadian emits these events from inside the daily lifecycle — no extra
 # wiring needed, just listen by name:
-#   • circadian:day_started   {date, thread_id, session_id}  — daily session opened
-#   • circadian:day_closed    {date, thread_id, closed_at}   — daily session closed
-#   • circadian:weave_applied {date, applied_from, rationale} — last night's
+#   • circadian:day_started    {date, thread_id, session_id}    — daily session opened
+#   • circadian:day_closed     {date, thread_id, closed_at}     — daily session closed
+#   • circadian:weave_applied  {date, applied_from, rationale}  — last night's
 #       weave_revise applied; the revised plan drives behaviour from this dawn
 # There is no built-in subscriber by design — add one only when you have a
 # real use (e.g. archive yesterday's pursuits when the day closes). Example:

--- a/loom/autonomy/circadian/lifecycle.py
+++ b/loom/autonomy/circadian/lifecycle.py
@@ -478,6 +478,25 @@ async def _deliver_phase_chime(
     reason = None if delivered else "no_today_session"
     _record_phase_outcome(anchor.name, outcome, reason, config.timezone)
 
+    # Issue #472: when dawn fires and last night's weave_revise actually
+    # applied, the revised plan starts driving behaviour *today* — that is the
+    # moment the change takes effect, so we emit the lifecycle event here.
+    # NB: the shipped weave_revise (PR4 #462) proposes-and-applies atomically
+    # in evening_closure — there is no separate dawn "confirm" step the
+    # original issue assumed, and therefore no distinct evening "proposed"
+    # state to emit. This single dawn-detected event is the honest "weave
+    # changed and is now in effect" signal. Subscribers wire in via
+    # [[autonomy.triggers]] on circadian:weave_applied; no internal subscriber
+    # lands here by design (issue #472 "不做").
+    if anchor.name == "dawn":
+        applied = _yesterday_applied_proposal(config.timezone)
+        if applied is not None:
+            await _emit(daemon.evaluator, "circadian:weave_applied", {
+                "date": _today_str(config.timezone),
+                "applied_from": applied.date,
+                "rationale": applied.rationale,
+            })
+
 
 def _compose_chime_intent(anchor: Anchor, config: CircadianConfig) -> str:
     """Stitch rhythm meaning + today's weave section into the chime body.
@@ -513,6 +532,19 @@ def _compose_chime_intent(anchor: Anchor, config: CircadianConfig) -> str:
     return "\n\n".join(parts)
 
 
+def _yesterday_applied_proposal(tz: str):
+    """Yesterday's evening_closure proposal *iff* it applied cleanly (i.e. it
+    landed under ``proposals/applied/``, not parked under ``conflicts/``).
+
+    Shared by the dawn chime「昨夜你改了什麼」layer and the
+    ``circadian:weave_applied`` emit (#472) so both read the same artifact.
+    Returns ``None`` when no clean revision happened overnight."""
+    yesterday = (
+        datetime.now(ZoneInfo(tz)) - timedelta(days=1)
+    ).strftime("%Y-%m-%d")
+    return load_proposal(proposal_path(yesterday, PROPOSALS_DIR / APPLIED_SUBDIR))
+
+
 def _yesterday_revision_report(tz: str) -> str | None:
     """Look up yesterday's evening_closure proposal artifact and turn it
     into the 「昨夜你改了什麼」 chime layer.
@@ -530,10 +562,9 @@ def _yesterday_revision_report(tz: str) -> str | None:
         datetime.now(ZoneInfo(tz)) - timedelta(days=1)
     ).strftime("%Y-%m-%d")
 
-    applied = proposal_path(yesterday, PROPOSALS_DIR / APPLIED_SUBDIR)
     conflict = proposal_path(yesterday, PROPOSALS_DIR / CONFLICTS_SUBDIR)
 
-    proposal = load_proposal(applied)
+    proposal = _yesterday_applied_proposal(tz)
     if proposal is not None:
         summary = "\n".join(f"- {line}" for line in proposal.summary_lines())
         return (

--- a/tests/test_circadian_phase_chime.py
+++ b/tests/test_circadian_phase_chime.py
@@ -753,3 +753,101 @@ class TestReloadRhythmAnchors:
         await daemon._on_trigger_fire(dawn, {})
         names = {t.name for t in daemon.evaluator.list()}
         assert "circadian:phase_pet" in names
+
+
+class TestWeaveAppliedEmit:
+    """Issue #472: dawn emits ``circadian:weave_applied`` when last night's
+    weave_revise actually applied (the revised plan starts driving today).
+    The shipped weave_revise proposes-and-applies atomically, so this single
+    dawn-detected event is the honest 'weave changed, now in effect' signal —
+    there is no separate evening 'proposed' event."""
+
+    def _write_applied_proposal(self, *, rationale: str = "養生：晚睡改早睡"):
+        """Persist yesterday's applied proposal artifact and return its date."""
+        from datetime import timedelta
+        from zoneinfo import ZoneInfo
+        from loom.autonomy.circadian.proposal import (
+            APPLIED_SUBDIR,
+            PROPOSALS_DIR,
+            Change,
+            WeaveProposal,
+            _save_proposal_toml,
+            proposal_path,
+        )
+
+        yesterday = (
+            datetime.now(ZoneInfo(TZ)) - timedelta(days=1)
+        ).strftime("%Y-%m-%d")
+        proposal = WeaveProposal(
+            date=yesterday, phase="evening_closure", based_on_mtime=0,
+            rationale=rationale,
+            changes=[Change(section="check_in", action="replace", new_body="x")],
+        )
+        _save_proposal_toml(proposal, proposal_path(yesterday, PROPOSALS_DIR / APPLIED_SUBDIR))
+        return yesterday
+
+    async def _spy_emits(self, daemon):
+        """Wrap the daemon's evaluator.emit to record (name, payload)."""
+        emitted: list[tuple[str, dict]] = []
+        orig = daemon.evaluator.emit
+
+        async def _rec(name, payload):
+            emitted.append((name, dict(payload)))
+            return await orig(name, payload)
+
+        daemon.evaluator.emit = _rec
+        return emitted
+
+    async def _fire(self, daemon, trigger_name):
+        trig = next(t for t in daemon.evaluator.list() if t.name == trigger_name)
+        await daemon._on_trigger_fire(trig, {})
+
+    async def test_dawn_emits_weave_applied_when_proposal_applied(self):
+        yesterday = self._write_applied_proposal(rationale="養生：晚睡改早睡")
+        daemon, _, _ = _make_daemon()
+        register_rhythm_anchors(daemon, CFG, [
+            Anchor(time="08:00", name="dawn", meaning="醒來"),
+        ])
+        await ensure_today_session(
+            datetime.now(timezone.utc), FakePlatform(), CFG, evaluator=FakeEvaluator()
+        )
+        emitted = await self._spy_emits(daemon)
+
+        await self._fire(daemon, "circadian:phase_dawn")
+
+        applied = [p for n, p in emitted if n == "circadian:weave_applied"]
+        assert len(applied) == 1
+        assert applied[0]["applied_from"] == yesterday
+        assert applied[0]["rationale"] == "養生：晚睡改早睡"
+        assert applied[0]["date"]  # today's stamp present
+
+    async def test_dawn_no_emit_when_no_proposal(self):
+        daemon, _, _ = _make_daemon()
+        register_rhythm_anchors(daemon, CFG, [
+            Anchor(time="08:00", name="dawn", meaning="醒來"),
+        ])
+        await ensure_today_session(
+            datetime.now(timezone.utc), FakePlatform(), CFG, evaluator=FakeEvaluator()
+        )
+        emitted = await self._spy_emits(daemon)
+
+        await self._fire(daemon, "circadian:phase_dawn")
+
+        assert not [n for n, _ in emitted if n == "circadian:weave_applied"]
+
+    async def test_non_dawn_phase_does_not_emit_weave_applied(self):
+        # Even with an applied proposal present, only dawn emits — other
+        # phases firing must not re-announce the weave change.
+        self._write_applied_proposal()
+        daemon, _, _ = _make_daemon()
+        register_rhythm_anchors(daemon, CFG, [
+            Anchor(time="11:00", name="curiosity", meaning="散步"),
+        ])
+        await ensure_today_session(
+            datetime.now(timezone.utc), FakePlatform(), CFG, evaluator=FakeEvaluator()
+        )
+        emitted = await self._spy_emits(daemon)
+
+        await self._fire(daemon, "circadian:phase_curiosity")
+
+        assert not [n for n, _ in emitted if n == "circadian:weave_applied"]


### PR DESCRIPTION
## 摘要

Dawn chime 偵測到昨夜 `weave_revise` 真的 apply 時，emit `circadian:weave_applied`——那份改過的織程此刻開始驅動今天的行為。補完 circadian 的內部事件 emit set，closes #472。

這是 milestone #14「Circadian Autonomy」一個月實測收官的一部分（#473/#464/#465/#472 一併收）。

## 架構發現（為什麼只有一個事件，不是 issue 寫的兩個）

issue #472 假設「evening propose → dawn confirm/apply」兩階段，各 emit 一次。但 PR4 (#462) 實際 ship 的 `weave_revise` 是 **evening_closure 當下原子 propose-and-apply**——沒有 dawn confirm 那步，也就沒有獨立的 evening「proposed」狀態。

所以誠實的做法是只 emit 一個 `circadian:weave_applied`，在 dawn 偵測到昨夜 applied proposal 時 fire（用既有 `daemon.evaluator`，零 tool plumbing）。硬要從 evening tool 再 emit 一個 `weave_proposed`，得把 evaluator 穿過 tool factory，為零 subscriber 的事件加管線 = 過度開發。

完整 emit 清單：`circadian:day_started` / `circadian:day_closed`（PR1 已有）+ `circadian:weave_applied`（本 PR）。**三者都 no 內部 subscriber by design**——未來要用就寫 `[[autonomy.triggers]]` 監聽（`loom.toml.example` 補了範例 + payload schema）。

## 改動

- **`lifecycle.py`**：`_deliver_phase_chime` dawn 分支加 emit；抽出 `_yesterday_applied_proposal()` 給「昨夜你改了什麼」chime layer 跟新 emit 共用（DRY）
- **`loom.toml.example`**：documented circadian lifecycle events + 訂閱範例
- **`tests`**：+3 個（dawn emit / 無 proposal 不 emit / 非 dawn phase 不 emit）

## 驗證

- `pytest -k "circadian or lifecycle or weave or proposal"` → 235 passed
- gitnexus impact（`_deliver_phase_chime` upstream）→ LOW，唯一 caller `_phase_handler` + tests
- gitnexus detect_changes → LOW，0 affected processes

## Review 重點（給 Loom Agent）

1. **emit 時機對不對**：weave 是 evening 寫檔的，事件卻在 dawn fire——這是刻意的（「開始驅動行為」的時刻 vs「寫檔」的時刻），但值得確認語義是否符合你對「applied」的直覺。
2. **payload 夠不夠**：`{date(今天), applied_from(昨天), rationale}`——未來 subscriber 會需要更多欄位嗎（例如 changes 摘要）？
3. **單一事件的取捨**：認不認同「不為湊兩個事件而加 tool plumbing」這個判斷。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
